### PR TITLE
Release Testing Guide proposal

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -20,7 +20,7 @@ To contribute to the process of testing the Mattermost Desktop App:
     - SCREENSHOT IF APPLICABLE
   2. See [example of Mattermost Desktop issue](https://github.com/mattermost/desktop/issues/63)
 5. When your testing is complete, open a GitHub Issue announcing your device has been verified
-  1. Open an issue [using template for announcing a platform has been tested](https://github.com/mattermost/platform/issues/2275).
+  1. Open an issue [using template for announcing a platform has been tested](https://github.com/mattermost/desktop/issues/70).
   
 # THANK YOU!
 We highly appreciate your help improving the quality of the Mattermost Desktop App for the entire community. 

--- a/TESTING.md
+++ b/TESTING.md
@@ -33,7 +33,7 @@ The following chart summarizes the operating systems which the Mattermost Deskto
 
 | Version | OS | Issues | Tester | Date |
 |:--- |:--- |:--- |:--- |:--- |
-| 1.07 | Windows 7 SP1 64-bit | [#63](https://github.com/mattermost/desktop/issues/63) | [@it33](https://github.com/it33) | 2016-03-12 |
+| 1.0.7 | Windows 7 SP1 64-bit | [#63](https://github.com/mattermost/desktop/issues/63) | [@it33](https://github.com/it33) | 2016-03-12 |
 
 ## Testing Guides by Operating System
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -22,12 +22,12 @@ To contribute to the process of testing the Mattermost Desktop App:
 5. When your testing is complete, open a GitHub Issue announcing your device has been verified
   1. Open an issue [using template for announcing a platform has been tested](https://github.com/mattermost/desktop/issues/70).
   
-# THANK YOU!
+## THANK YOU!
 We highly appreciate your help improving the quality of the Mattermost Desktop App for the entire community. 
 
 Your testing contribution, including GitHub username, will be listed under the [Verified Operating Systems](TESTING.md#verified-operation-systems) section of this document.
 
-# Verified Operating Systems 
+## Verified Operating Systems 
 
 The following chart summarizes the operating systems which the Mattermost Desktop App releases have been tested:
 
@@ -35,11 +35,11 @@ The following chart summarizes the operating systems which the Mattermost Deskto
 |:--- |:--- |:--- |:--- |:--- |
 | 1.07 | Windows 7 SP1 64-bit | [#63](https://github.com/mattermost/desktop/issues/63) | [@it33](https://github.com/it33) | 2016-03-12 |
 
-# Testing Guides by Operating System
+## Testing Guides by Operating System
 
 The following guides offer operating system specific instructions for testing the Mattermost Desktop application.
 
-## Windows Testing Guide
+### Windows Testing Guide
 
 1. Install the Mattermost desktop application following the [step-by-step Windows setup guide](docs/setup.md#step-by-step-windows-setup) to connect to the `https://pre-release.mattermost.com/core` team site.
 2. Verify [Start Menu and Task Bar shortcuts open the application as documented.](docs/setup.md#start-menu-and-task-bar-shortcuts).

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,47 @@
+# Mattermost Desktop App Testing
+
+## Release Testing Guide
+
+To contribute to the process of testing the Mattermost Desktop App: 
+
+1. If you haven't already, create an account on https://pre-release.mattermost.com/core
+  - Set your username to be the same as your GitHub username
+2. Follow the testing guide for your platform
+  - [Windows Testing Guide](#windows-testing-guide)
+3. Go to the [Public Test Channel](https://pre-release.mattermost.com/core/channels/public-test-channel) and try the following: 
+  1. Post the message with information on what you're testing, for example: `Testing Mattermost Desktop App 1.07 on Windows 7 SP1 64-bit`
+  2. Reply to the post by clicking on "**...**" then "**Reply**" with `This is a comment including files` and upload five (5) files including at least one image, one sound file and one video clip from your Android device.
+  3. Search for the word "Desktop" and click "Jump" on the search result of your own post in Step 3.1. Click into the preview of the files you uploaded and try to download each one.
+4. For any bugs found, please [file an issue report for each](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md#issue). 
+  1. Please include: 
+    - STEPS TO REPRODUCE
+    - MATTERMOST DESKTOP APP VERSION
+    - OPERATING SYSTEM VERSION 
+    - SCREENSHOT IF APPLICABLE
+  2. See [example of Mattermost Desktop issue](https://github.com/mattermost/desktop/issues/63)
+5. When your testing is complete, open a GitHub Issue announcing your device has been verified
+  1. Open an issue [using template for announcing a platform has been tested](https://github.com/mattermost/platform/issues/2275).
+  
+# THANK YOU!
+We highly appreciate your help improving the quality of the Mattermost Desktop App for the entire community. 
+
+Your testing contribution, including GitHub username, will be listed under the [Verified Operating Systems](TESTING.md#verified-operation-systems) section of this document.
+
+# Verified Operating Systems 
+
+The following chart summarizes the operating systems which the Mattermost Desktop App releases have been tested:
+
+| Version | OS | Issues | Tester | Date |
+|:--- |:--- |:--- |:--- |:--- |
+| 1.07 | Windows 7 SP1 64-bit | [#63](https://github.com/mattermost/desktop/issues/63) | [@it33](https://github.com/it33) | 2016-03-12 |
+
+# Testing Guides by Operating System
+
+The following guides offer operating system specific instructions for testing the Mattermost Desktop application.
+
+## Windows Testing Guide
+
+1. Install the Mattermost desktop application following the [step-by-step Windows setup guide](docs/setup.md#step-by-step-windows-setup) to connect to the `https://pre-release.mattermost.com/core` team site.
+2. Verify [Start Menu and Task Bar shortcuts open the application as documented.](docs/setup.md#start-menu-and-task-bar-shortcuts).
+3. Verify [Menu Bar options work as documented](docs/setup.md#menu-bar).
+4. Follow the [Release Testing Guide](#release-testing-guide) to file issues and report completion of testing.

--- a/TESTING.md
+++ b/TESTING.md
@@ -10,7 +10,7 @@ To contribute to the process of testing the Mattermost Desktop App:
   - [Windows Testing Guide](#windows-testing-guide)
 3. Go to the [Public Test Channel](https://pre-release.mattermost.com/core/channels/public-test-channel) and try the following: 
   1. Post the message with information on what you're testing, for example: `Testing Mattermost Desktop App 1.07 on Windows 7 SP1 64-bit`
-  2. Reply to the post by clicking on "**...**" then "**Reply**" with `This is a comment including files` and upload five (5) files including at least one image, one sound file and one video clip from your Android device.
+  2. Reply to the post by clicking on "**...**" then "**Reply**" with `This is a comment including files` and upload five (5) files including at least one image, one sound file and one video clip from your computer.
   3. Search for the word "Desktop" and click "Jump" on the search result of your own post in Step 3.1. Click into the preview of the files you uploaded and try to download each one.
 4. For any bugs found, please [file an issue report for each](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md#issue). 
   1. Please include: 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -51,7 +51,7 @@ The Settings Page is available from the **File** menu under **Settings** (Click 
 - **Hide Menu Bar** 
    1. Under **Options** enable this option to hide the menu bar by default. Press "Alt" to show the Menu Bar. 
 
-### Top Menu
+### Menu Bar
 
 Click the `Alt` key to toggle the menu on and off. 
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,4 +1,4 @@
-# Electron-Mattermost Setup Guides
+# Mattermost Desktop Setup Guides
 
 ## Step-by-step Windows setup
 
@@ -30,11 +30,28 @@ To set up the Mattermost desktop application for Windows 7, 8 and 10:
 
 ## Help 
 
+The Mattermost desktop application offers: 
+
+- Connectivity to one or more Mattermost team sites and multiple Mattermost servers
+- Shortcuts from Start Menu and Windows Task Bar
+- Icon notifications from Windows Task Bar
+- Desktop notifications
+
 See the Mattermost [help documention](http://docs.mattermost.com/help/getting-started/signing-in.html) for how to use the Mattermost team site. 
 
-The Mattermost application works in place of a web browser to access your different Mattermost Team Sites, and is controled by a menu bar available from the top of the application. 
+### Settings Page
 
-### Top Menu: 
+The Settings Page is available from the **File** menu under **Settings** (Click `Alt` to show the menu if it's not visible). This page manages connections to team sites and other settings. 
+
+- **Add a Team Site**: 
+   1. Under **Teams** section, enter **Name** for team name to show in top tab
+   2. Enter **URL** for the team site location. For example: `https://example.com/teamname` then click **Add**.
+- **Delete a Team Site**: 
+   1. Delete a Team Site by clicking the "x" next to the URL of the team site you wish to delete. 
+- **Hide Menu Bar** 
+   1. Under **Options** enable this option to hide the menu bar by default. Press "Alt" to show the Menu Bar. 
+
+### Top Menu
 
 Click the `Alt` key to toggle the menu on and off. 
 
@@ -56,6 +73,19 @@ Below lists menu options (shortcut keys are listed in brackets):
   - **Clear Cache and Reload** (Ctrl+Shift+R) - Clear cached content in application and reload page
   - **Toggle Full Screen** (F11) - Toggle application from window to full screen and back
   - **Toggle Developer Tools** (Ctrl+Shift+I) - Turn on and off sidebar showing developer tools
+
+### Notifications 
+
+Mattermost lets users configure [desktop notifications](http://docs.mattermost.com/help/getting-started/configuring-notifications.html#desktop-notifications) to alert users to new events in a team site. 
+
+For the Mattermost Windows application, these appear as ballon notifications from the task bar on Windows 7 and Windows 8.1, and as a "toast" pop-up on Windows 10. 
+
+### Start Menu and Task Bar shortcuts
+
+If pinned to the Windows Start Menu in Step 3 of the setup procedure, a shortcut to the Mattermost desktop application should be available from the Start Menu by pressing the Windows Key. 
+
+If pinned to the Windows Task Bar in Step 3 of the setup procedure, a shortcut to the Mattermost desktop application should be available from the Windows Task Bar.
+
 
 ## Step-by-step OS X setup
 For OS X 10.11 El Capitan. An older version of OS X has similar way.

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -72,7 +72,7 @@ var SettingsPage = React.createClass({
 
     var options = [];
     if (process.platform === 'win32' || process.platform === 'linux') {
-      options.push(<Input ref="hideMenuBar" type="checkbox" label="Hide menubar (Press Alt to show menubar)" checked={ this.state.hideMenuBar } onChange={ this.handleChangeHideMenuBar } />);
+      options.push(<Input ref="hideMenuBar" type="checkbox" label="Hide Menu Bar (Press Alt to show Menu Bar)" checked={ this.state.hideMenuBar } onChange={ this.handleChangeHideMenuBar } />);
     }
     var options_row = (options.length > 0) ? (
       <Row>


### PR DESCRIPTION
Proposing changes to enable community testing of Mattermost Desktop app: 

- Adding documentation for Windows functionality 
- Adding guide for community members to help test releases
- Rename "menubar" to "Menu Bar" 

Based [on Android App Testing guide](https://github.com/mattermost/android/blob/master/TESTING.md). 

I'd propose if this PR is accepted to in future: 

- Open [Help Wanted] issues for community members to help test Windows 8 and Windows 10
- Document Mac functionality and testing guides, and post [Help Wanted] issues as well
- Decide which Linux platforms are supported and add documentation and testing guides 