### PR TITLE
Rename electron-mattermost to Mattermost at implementation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,8 @@ Following points are very helpful to understand the problem.
 * How to reproduce, step-by-step
 * Expected behavior (or what is wrong)
 * Screenshots (for GUI issues)
-* electron-mattermost version
-* OS
+* Application version
+* Operating system
 * Mattermost version
 
 ## Feature idea

--- a/README.md
+++ b/README.md
@@ -23,28 +23,32 @@ Originally created as "electron-mattermost" by Yuya Ochiai. Developed using [Ele
 
 ### Pre-packaged
 You don't have to install any other software.
-Packages are available on the [releases page](http://github.com/yuya-oc/electron-mattermost/releases).
+Packages are available on the [releases page](http://github.com/mattermost/desktop/releases).
 
 ## Usage
 
 ### Installation
 Detailed guides are available at [docs/setup.md](docs/setup.md).
 
-1. Download and unarchive a file from [release page](http://github.com/yuya-oc/electron-mattermost/releases).
-2. Launch `electron-mattermost` in the unarchived folder.
-3. After first launching, please input name and URL for your Mattermost team. For example, `myteam : http://mattermost.example.com/team`.
+1. Download and unarchive a file from [release page](http://github.com/mattermost/desktop/releases).
+2. Launch `Mattermost` in the unarchived folder.
+3. After first launching, please input name and URL for your Mattermost team. For example, `myteam : https://mattermost.example.com/team`.
 
 ### Quit
 Ctrl or Command + Q to quit.
 
 ### Configuration
 You can show the dialog from menu bar.
-(On Windows, please press Alt key to show the menu bar.)
+(Please press Alt key to show the menu bar if it disappers.)
 
 Configuration will be saved into Electron's userData directory:
-* `%APPDATA%\electron-mattermost` on Windows
-* `~/Library/Application Support/electron-mattermost` on OS X
-* `~/.config/electron-mattermost` on Linux
+
+* `%APPDATA%\Mattermost` on Windows
+* `~/Library/Application Support/Mattermost` on OS X
+* `~/.config/Mattermost` on Linux
+
+*When you upgrade from electron-mattermost, please copy `config.json` from `electron-mattermost`.
+Otherwise, you have to configure again.*
 
 ## Testing and Development
 Node.js is required to test this app.

--- a/circle.yml
+++ b/circle.yml
@@ -16,14 +16,16 @@ dependencies:
   post:
     - mkdir -p ~/.electron
     - docker run --rm -it -v `pwd`:/home/xclient/electron-mattermost -v ~/.electron:/home/xclient/.electron yuyaoc/em-builder:dev ./electron-mattermost/docker/package_in_docker.sh
-    - mv release/electron-mattermost-win32-ia32 release/electron-mattermost-win32
-    - mv release/electron-mattermost-win32-x64  release/electron-mattermost-win64
-    - mv release/electron-mattermost-darwin-x64 release/electron-mattermost-osx
-    - cd release && zip -9 -r $CIRCLE_ARTIFACTS/electron-mattermost-win32.zip electron-mattermost-win32
-    - cd release && zip -9 -r $CIRCLE_ARTIFACTS/electron-mattermost-win64.zip electron-mattermost-win64
-    - tar zcvf $CIRCLE_ARTIFACTS/electron-mattermost-osx.tar.gz -C release electron-mattermost-osx
-    - tar zcvf $CIRCLE_ARTIFACTS/electron-mattermost-linux-ia32.tar.gz -C release electron-mattermost-linux-ia32
-    - tar zcvf $CIRCLE_ARTIFACTS/electron-mattermost-linux-x64.tar.gz -C release electron-mattermost-linux-x64
+    - mv release/Mattermost-win32-ia32 release/mattermost-desktop-win32
+    - mv release/Mattermost-win32-x64  release/mattermost-desktop-win64
+    - mv release/Mattermost-darwin-x64 release/mattermost-desktop-osx
+    - mv release/Mattermost-linux-ia32 release/mattermost-desktop-linux-ia32
+    - mv release/Mattermost-linux-x64  release/mattermost-desktop-linux-x64
+    - cd release && zip -9 -r $CIRCLE_ARTIFACTS/mattermost-desktop-win32.zip mattermost-desktop-win32
+    - cd release && zip -9 -r $CIRCLE_ARTIFACTS/mattermost-desktop-win64.zip mattermost-desktop-win64
+    - tar zcvf $CIRCLE_ARTIFACTS/mattermost-desktop-osx.tar.gz -C release mattermost-desktop-osx
+    - tar zcvf $CIRCLE_ARTIFACTS/mattermost-desktop-linux-ia32.tar.gz -C release mattermost-desktop-linux-ia32
+    - tar zcvf $CIRCLE_ARTIFACTS/mattermost-desktop-linux-x64.tar.gz -C release mattermost-desktop-linux-x64
 
 test:
   override:

--- a/circle/make_draft.sh
+++ b/circle/make_draft.sh
@@ -15,9 +15,9 @@ make_zip()
 {
   OLDDIR=`pwd`
   ARCH=$1
-  cp -r release/electron-mattermost-$ARCH /tmp/electron-mattermost-$CIRCLE_TAG-$ARCH
+  cp -r release/mattermost-desktop-$ARCH /tmp/mattermost-desktop-$CIRCLE_TAG-$ARCH
   cd /tmp
-  zip -9 -r electron-mattermost-$CIRCLE_TAG-$ARCH.zip electron-mattermost-$CIRCLE_TAG-$ARCH
+  zip -9 -r mattermost-desktop-$CIRCLE_TAG-$ARCH.zip mattermost-desktop-$CIRCLE_TAG-$ARCH
   cd $OLDDIR
 }
 
@@ -25,9 +25,9 @@ make_tar_gz()
 {
   OLDDIR=`pwd`
   ARCH=$1
-  cp -r release/electron-mattermost-$ARCH /tmp/electron-mattermost-$CIRCLE_TAG-$ARCH
+  cp -r release/mattermost-desktop-$ARCH /tmp/mattermost-desktop-$CIRCLE_TAG-$ARCH
   cd /tmp
-  tar zcvf electron-mattermost-$CIRCLE_TAG-$ARCH.tar.gz electron-mattermost-$CIRCLE_TAG-$ARCH
+  tar zcvf mattermost-desktop-$CIRCLE_TAG-$ARCH.tar.gz mattermost-desktop-$CIRCLE_TAG-$ARCH
   cd $OLDDIR
 }
 
@@ -40,7 +40,7 @@ deploy()
     "tar.gz" ) make_tar_gz $ARCH ;;
     "*" ) echo "Invalid ARCHIVE_FORMAT: $ARCHIVE_FORMAT" && exit 1 ;;
   esac
-  FILE=electron-mattermost-$CIRCLE_TAG-$ARCH.$ARCHIVE_FORMAT
+  FILE=mattermost-desktop-$CIRCLE_TAG-$ARCH.$ARCHIVE_FORMAT
   upload "$FILE" /tmp/$FILE
 }
 

--- a/circle/make_draft.sh
+++ b/circle/make_draft.sh
@@ -3,6 +3,7 @@ set -ex
 wget -q https://github.com/aktau/github-release/releases/download/v0.6.2/linux-amd64-github-release.tar.bz2
 tar jxvf linux-amd64-github-release.tar.bz2
 GITHUB_RELEASE=`pwd`/bin/linux/amd64/github-release
+RELEASE_TAG=${CIRCLE_TAG#v}
 
 upload()
 {
@@ -15,9 +16,9 @@ make_zip()
 {
   OLDDIR=`pwd`
   ARCH=$1
-  cp -r release/mattermost-desktop-$ARCH /tmp/mattermost-desktop-$CIRCLE_TAG-$ARCH
+  cp -r release/mattermost-desktop-$ARCH /tmp/mattermost-desktop-$RELEASE_TAG-$ARCH
   cd /tmp
-  zip -9 -r mattermost-desktop-$CIRCLE_TAG-$ARCH.zip mattermost-desktop-$CIRCLE_TAG-$ARCH
+  zip -9 -r mattermost-desktop-$RELEASE_TAG-$ARCH.zip mattermost-desktop-$RELEASE_TAG-$ARCH
   cd $OLDDIR
 }
 
@@ -25,9 +26,9 @@ make_tar_gz()
 {
   OLDDIR=`pwd`
   ARCH=$1
-  cp -r release/mattermost-desktop-$ARCH /tmp/mattermost-desktop-$CIRCLE_TAG-$ARCH
+  cp -r release/mattermost-desktop-$ARCH /tmp/mattermost-desktop-$RELEASE_TAG-$ARCH
   cd /tmp
-  tar zcvf mattermost-desktop-$CIRCLE_TAG-$ARCH.tar.gz mattermost-desktop-$CIRCLE_TAG-$ARCH
+  tar zcvf mattermost-desktop-$RELEASE_TAG-$ARCH.tar.gz mattermost-desktop-$RELEASE_TAG-$ARCH
   cd $OLDDIR
 }
 
@@ -40,7 +41,7 @@ deploy()
     "tar.gz" ) make_tar_gz $ARCH ;;
     "*" ) echo "Invalid ARCHIVE_FORMAT: $ARCHIVE_FORMAT" && exit 1 ;;
   esac
-  FILE=mattermost-desktop-$CIRCLE_TAG-$ARCH.$ARCHIVE_FORMAT
+  FILE=mattermost-desktop-$RELEASE_TAG-$ARCH.$ARCHIVE_FORMAT
   upload "$FILE" /tmp/$FILE
 }
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,10 +1,10 @@
-# Electron-Mattermost Setup Guides
+# Mattermost Desktop Setup Guides
 
 ## Step-by-step Windows setup
 
-To set up the Mattermost desktop application for Windows 7, 8 and 10: 
+To set up the Mattermost desktop application for Windows 7, 8 and 10:
 
-1. Download [the latest release](https://github.com/yuya-oc/electron-mattermost/releases) of electron-attermost  
+1. Download [the latest release](https://github.com/mattermost/desktop/releases) of Mattermost Desktop
 
    Find the file ending in `-win64.zip` if you're running a x64 version of Windows and `-win32.zip` if you're running an older 32-bit version.
 
@@ -12,11 +12,11 @@ To set up the Mattermost desktop application for Windows 7, 8 and 10:
 
    A new directory should be created on your PC.
 
-3. Go to `/electron-mattermost...` directory and find the file named `electron-mattermost` 
+3. Go to `/mattermost-desktop...` directory and find the file named `Mattermost`
 
-   - Right-click the file and select "Pin to Taskbar" to make the application available from your Windows task bar. 
-   - Right-click the file and select "Pin to Start Menu" to make the application available from your Windows Start menu. 
-   - Double-click the file to open the application. 
+   - Right-click the file and select "Pin to Taskbar" to make the application available from your Windows task bar.
+   - Right-click the file and select "Pin to Start Menu" to make the application available from your Windows Start menu.
+   - Double-click the file to open the application.
 
 4. After opening the application, press `Alt` key to bring up the menu at the top of the window, then click `File -> Settings`
 
@@ -28,26 +28,26 @@ To set up the Mattermost desktop application for Windows 7, 8 and 10:
 
    To quit, use `Ctrl+Q`
 
-## Help 
+## Help
 
-See the Mattermost [help documention](http://docs.mattermost.com/help/getting-started/signing-in.html) for how to use the Mattermost team site. 
+See the Mattermost [help documention](http://docs.mattermost.com/help/getting-started/signing-in.html) for how to use the Mattermost team site.
 
-The Mattermost application works in place of a web browser to access your different Mattermost Team Sites, and is controled by a menu bar available from the top of the application. 
+The Mattermost application works in place of a web browser to access your different Mattermost Team Sites, and is controled by a menu bar available from the top of the application.
 
-### Top Menu: 
+### Top Menu:
 
-Click the `Alt` key to toggle the menu on and off. 
+Click the `Alt` key to toggle the menu on and off.
 
-Below lists menu options (shortcut keys are listed in brackets): 
+Below lists menu options (shortcut keys are listed in brackets):
 
 - **File**
-  - **About electron-mattermost** - Shows version information for Mattermost desktop application 
+  - **About Mattermost** - Shows version information for Mattermost desktop application
   - **Settings** - Opens setting menu to add new team sites and configure shortcut key options
-  - **Quit** (Ctrl+Q) - Exits the application 
+  - **Quit** (Ctrl+Q) - Exits the application
 - **Edit**
-  - **Undo** (Ctrl+Z) - Reverses previous action 
+  - **Undo** (Ctrl+Z) - Reverses previous action
   - **Redo** (Ctrl+Shift+Z) - Replays most recent action
-  - **Cut** (Ctrl+X) - Cuts selected text 
+  - **Cut** (Ctrl+X) - Cuts selected text
   - **Copy** (Ctrl+C) - Copies selected text
   - **Paste** (Ctrl+V) - Pastes text from clipboard
   - **Select All** (Ctrl+A) - Select all text in input box
@@ -60,7 +60,7 @@ Below lists menu options (shortcut keys are listed in brackets):
 ## Step-by-step OS X setup
 For OS X 10.11 El Capitan. An older version of OS X has similar way.
 
-1. Download [the latest release](https://github.com/yuya-oc/electron-mattermost/releases) of electron-mattermost  
+1. Download [the latest release](https://github.com/mattermost/desktop/releases) of Mattermost Desktop
 
    Find the file ending in `-osx.tar.gz`.
 
@@ -68,13 +68,13 @@ For OS X 10.11 El Capitan. An older version of OS X has similar way.
 
    A new directory should be created on your Mac.
 
-3. Go to `/electron-mattermost...` directory and right-click on `electron-mattermost` package and select "Open"
+3. Go to `/mattermost-desktop...` directory and right-click on `Mattermost` package and select "Open"
 
    If you see a dialog to confirm the application, select "Open".
 
-   You should see a new application called **electron-mattermost** open.
+   You should see a new application called **Mattermost Desktop** open.
 
-4. Click `electron-mattermost` from the menu at the top of the screen, then click `Settings`
+4. Click `Mattermost` from the menu at the top of the screen, then click `Settings`
 
 5. For each Mattermost team you'd like to use, enter its **Name** and **URL** then click **Add**
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -148,7 +148,6 @@ function makePackage(platform, arch, callback) {
   var packageJson = require('./src/package.json');
   packager({
     dir: './dist',
-    name: packageJson.name,
     platform: platform,
     arch: arch,
     version: require('./package.json').devDependencies['electron-prebuilt'],
@@ -160,10 +159,10 @@ function makePackage(platform, arch, callback) {
     "version-string": {
       CompanyName: packageJson.author,
       LegalCopyright: 'Copyright (c) 2015 ' + packageJson.author,
-      FileDescription: packageJson.name,
-      OriginalFilename: packageJson.name + '.exe',
+      FileDescription: packageJson.description,
+      OriginalFilename: packageJson.productName + '.exe',
       ProductVersion: packageJson.version,
-      ProductName: packageJson.name,
+      ProductName: packageJson.productName,
       InternalName: packageJson.name
     }
   }, function(err, appPath) {
@@ -200,6 +199,7 @@ gulp.task('sync-meta', function() {
   var appPackageJson = require('./src/package.json');
   var packageJson = require('./package.json');
   appPackageJson.name = packageJson.name;
+  appPackageJson.productName = packageJson.productName;
   appPackageJson.version = packageJson.version;
   appPackageJson.description = packageJson.description;
   appPackageJson.author = packageJson.author;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "electron-mattermost",
+  "name": "mattermost-desktop",
+  "productName": "Mattermost",
   "version": "1.0.7",
-  "description": "Electron-based desktop application for Mattermost",
+  "description": "Mattermost Desktop application for Windows, Mac and Linux",
   "main": "main.js",
   "author": "Yuya Ochiai",
   "license": "MIT",

--- a/src/browser/index.html
+++ b/src/browser/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <title>electron-mattermost</title>
+  <title>Mattermost</title>
   <link rel="stylesheet" href="modules/bootstrap/css/bootstrap.min.css">
 </head>
 

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -221,7 +221,7 @@ var MattermostView = React.createClass({
       var currentURL = url.parse(webview.getURL());
       var destURL = url.parse(e.url);
       if (currentURL.host === destURL.host) {
-        window.open(e.url, 'electron-mattermost');
+        window.open(e.url, 'Mattermost');
       } else {
         // if the link is external, use default browser.
         require('shell').openExternal(e.url);

--- a/src/main.js
+++ b/src/main.js
@@ -49,9 +49,6 @@ var mainWindow = null;
 var trayIcon = null;
 var willAppQuit = false;
 
-// For toast notification on windows
-app.setAppUserModelId('yuya-oc.electron-mattermost');
-
 // Quit when all windows are closed.
 app.on('window-all-closed', function() {
   // On OS X it is common for applications and their menu bar

--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "electron-mattermost",
+  "name": "mattermost-desktop",
+  "productName": "Mattermost",
   "version": "1.0.7",
-  "description": "Electron-based desktop application for Mattermost",
+  "description": "Mattermost Desktop application for Windows, Mac and Linux",
   "main": "main.js",
   "author": "Yuya Ochiai",
   "license": "MIT",

--- a/test/browser_test.js
+++ b/test/browser_test.js
@@ -30,7 +30,7 @@ var options = {
   }
 };
 
-describe('electron-mattermost', function() {
+describe('mattermost-desktop', function() {
   this.timeout(10000);
 
   var chromedriver;


### PR DESCRIPTION
This PR rename the application at implementation.

* npm package name (package.json: name) is "mattermost-desktop"
* display name (package.json: productName) is "Mattermost"

As the result, configuration directory will be different from `electron-mattermost`. To take over the configuration, users have to copy `config.json`. When releasing the next version, we must announce this point.