### PR TITLE
Add simpler httpBasicAuth implementation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -49,6 +49,18 @@ var mainWindow = null;
 var trayIcon = null;
 var willAppQuit = false;
 
+app.on('login', function (event, webContents, request, authInfo, callback) {
+  event.preventDefault();
+  var readlineSync = require('readline-sync');
+  console.log("HTTP basic auth requiring login, please provide login data.");
+  var username = readlineSync.question('Username: ');
+  var password = readlineSync.question('Password: ', {
+    hideEchoBack: true 
+  });
+  console.log("Replacing default auth behaviour.");
+  callback(username, password);
+});
+
 // Quit when all windows are closed.
 app.on('window-all-closed', function() {
   // On OS X it is common for applications and their menu bar

--- a/src/main.js
+++ b/src/main.js
@@ -49,13 +49,13 @@ var mainWindow = null;
 var trayIcon = null;
 var willAppQuit = false;
 
-app.on('login', function (event, webContents, request, authInfo, callback) {
+app.on('login', function(event, webContents, request, authInfo, callback) {
   event.preventDefault();
   var readlineSync = require('readline-sync');
   console.log("HTTP basic auth requiring login, please provide login data.");
   var username = readlineSync.question('Username: ');
   var password = readlineSync.question('Password: ', {
-    hideEchoBack: true 
+    hideEchoBack: true
   });
   console.log("Replacing default auth behaviour.");
   callback(username, password);

--- a/src/package.json
+++ b/src/package.json
@@ -15,6 +15,7 @@
     "react": "^0.14.3",
     "react-bootstrap": "^0.28.1",
     "react-dom": "^0.14.3",
+    "readline-sync": "^1.4.1",
     "yargs": "^3.31.0"
   }
 }


### PR DESCRIPTION
As per discussion in #56

Tested on Linux 64-bit (Ubuntu 15.10 to be precise).
Mattermost Desktop version 1.07, Mattermost server version 1.4 (with HTTP basic auth)
