### PR TITLE
Propose updating text for mixed content option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This release contains a security update and it is highly recommended that users 
 
 ### Improvements
 - Improve the style for tab badges.
-- Add **Allow insecure contents** option to render images with `http://`.
+- Add **Allow mixed content** option to render images with `http://`.
 - Add the login dialog for http authentication.
 
 #### OS X

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -88,7 +88,7 @@ var SettingsPage = React.createClass({
       options.push(<Input key="inputShowTrayIcon" ref="showTrayIcon" type="checkbox" label="Show Icon on Menu Bar (Need to restart the application)" checked={ this.state.showTrayIcon } onChange={ this.handleChangeShowTrayIcon }
                    />);
     }
-    options.push(<Input key="inputDisableWebSecurity" ref="disablewebsecurity" type="checkbox" label="Allow insecure contents (This allows not only insecure images, but also insecure scripts)"
+    options.push(<Input key="inputDisableWebSecurity" ref="disablewebsecurity" type="checkbox" checked="checked" label="Allow mixed content. Enabling allows both secure and insecure content, images and scripts to render and execute. Disabling allows only secure content.)"
                    checked={ this.state.disablewebsecurity } onChange={ this.handleChangeDisableWebSecurity } />);
     var options_row = (options.length > 0) ? (
       <Row>


### PR DESCRIPTION
When this option is enabled using Mattermost on desktop and web has about the same risks. 

Therefore, propose we use the same defaults and also similar language? 

It would make the application potentially more usable by non-technical people. 

In future, this option might be pre-configured by an IT admin, and they can choose which default to use if it's an important part of their system security.