### PR TITLE
Implement installers via electron-builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,5 +86,10 @@ $ npm run package:linux
 $ npm run package:all (Packages for all platform)
 ```
 
+Create a windows installer with the following command. It will appear in the `release\windows-installer` directory.
+```
+$ npm run installer
+```
+
 ## Contributing
 Please see [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -193,7 +193,7 @@ function makePackage(platform, arch, callback) {
     icon: 'resources/icon',
     "version-string": {
       CompanyName: packageJson.author.name,
-      LegalCopyright: 'Copyright (c) 2015 ' + packageJson.author.name,
+      LegalCopyright: 'Copyright (c) 2015 - 2016' + packageJson.author.name,
       FileDescription: packageJson.description,
       OriginalFilename: packageJson.productName + '.exe',
       ProductVersion: packageJson.version,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "package:osx": "gulp package:osx",
     "package:linux": "gulp build && build --platform linux --arch all -d deb",
     "package:all": "gulp package:all",
-    "prettify": "gulp prettify"
+    "prettify": "gulp prettify",
+    "installer": "node ./script/installer.js"
   },
   "devDependencies": {
     "babel-core": "^6.7.5",
@@ -33,10 +34,12 @@
     "babel-preset-react": "^6.5.0",
     "chromedriver": "^2.20.0",
     "del": "^2.2.0",
-    "electron-builder": "^3.11.0",
+    "electron-builder": "3.20.0",
     "electron-connect": "^0.3.7",
     "electron-packager": "^7.0.1",
     "electron-prebuilt": "0.37.8",
+    "electron-squirrel-startup": "^1.0.0",
+    "electron-winstaller": "^2.2.0",
     "esformatter": "^0.9.3",
     "esformatter-jsx": "^5.0.0",
     "gulp": "^3.9.0",
@@ -47,6 +50,7 @@
     "json-loader": "^0.5.4",
     "mocha": "^2.3.4",
     "mocha-circleci-reporter": "0.0.1",
+    "rimraf": "^2.5.2",
     "should": "^8.0.1",
     "style-loader": "^0.13.0",
     "through2": "^2.0.1",
@@ -56,11 +60,13 @@
     "webpack-stream": "^3.1.0"
   },
   "build": {
+    "app-bundle-id": "com.mattermost.desktop",
+    "app-category-type": "public.app-category.productivity",
     "linux": {
       "synopsis": "Mattermost Desktop"
     }
   },
-  "directories":{
+  "directories": {
     "buildResources": "resources",
     "app": "dist",
     "output": "release"

--- a/script/installer.js
+++ b/script/installer.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+const createWindowsInstaller = require('electron-winstaller').createWindowsInstaller
+const path = require('path')
+const rimraf = require('rimraf')
+
+deleteOutputFolder()
+  .then(getInstallerConfig)
+  .then(createWindowsInstaller)
+  .catch((error) => {
+    console.error(error.message || error)
+    process.exit(1)
+  })
+
+function getInstallerConfig() {
+  const rootPath = path.join(__dirname, '..')
+  const outPath = path.join(rootPath, 'release')
+
+  return Promise.resolve({
+    appDirectory: path.join(outPath, 'Mattermost-win32-x64'),
+    iconUrl: 'https://raw.githubusercontent.com/mattermost/desktop/master/resources/icon.ico',
+    //loadingGif: path.join(rootPath, 'assets', 'img', 'loading.gif'),
+    noMsi: true,
+    outputDirectory: path.join(outPath, 'windows-installer'),
+    setupExe: 'Mattermost.exe',
+    setupIcon: path.join(rootPath, 'resources', 'icon.ico'),
+    skipUpdateIcon: true,
+    exe: 'Mattermost.exe'
+  })
+}
+
+function deleteOutputFolder() {
+  return new Promise((resolve, reject) => {
+    rimraf(path.join(__dirname, '..', 'out', 'windows-installer'), (error) => {
+      error ? reject(error) : resolve()
+    })
+  })
+}

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,9 @@
 
 const electron = require('electron');
 const app = electron.app; // Module to control application life.
+
+if (require('electron-squirrel-startup')) app.quit();
+
 const BrowserWindow = electron.BrowserWindow; // Module to create native browser window.
 const Menu = electron.Menu;
 const Tray = electron.Tray;


### PR DESCRIPTION
Hey,

this might be totally wrong, as I'm a fist time node user. And so far I could only test win.
The installation of the exe seems to work fine, but there is no shortcut anywhere to be found. Uninstall also seems to work fine.

Would be very cool, if other people could build it for osx/linux and let the maintainer know if it works.

Cheers