### PR TITLE
Use a fitting border color for the taskbar badge status

### DIFF
--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -461,10 +461,10 @@ var showUnreadBadgeWindows = function(unreadCount, mentionCount) {
   };
 
   if (mentionCount > 0) {
-    const dataURL = badge.createDataURL(mentionCount.toString(), "#FF1744"); // Material Red A400
+    const dataURL = badge.createDataURL(mentionCount.toString(), "#FF1744", "#580817"); // Material Red A400
     sendBadge(dataURL, 'You have unread mention (' + mentionCount + ')');
   } else if (unreadCount > 0) {
-    const dataURL = badge.createDataURL('•', "#00e5ff"); // Material Cyan A400
+    const dataURL = badge.createDataURL('•', "#00e5ff", "#06545D"); // Material Cyan A400
     sendBadge(dataURL, 'You have unread channels');
   } else {
     sendBadge(null, 'You have no unread messages');

--- a/src/browser/js/badge.js
+++ b/src/browser/js/badge.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var createDataURL = function(text, color) {
+var createDataURL = function(text, color, circleColor) {
   const scale = 2; // should rely display dpi
   const size = 16 * scale;
   const canvas = document.createElement('canvas');
@@ -13,6 +13,8 @@ var createDataURL = function(text, color) {
   ctx.beginPath();
   ctx.arc(size / 2, size / 2, size / 2, 0, Math.PI * 2);
   ctx.fill();
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = circleColor;
   ctx.stroke();
 
   // text


### PR DESCRIPTION
Looks like this for unread.
![example](https://cloud.githubusercontent.com/assets/5943908/15450227/fc5ec082-1f96-11e6-91ba-fb73fc750577.png)

Couldn't test mentions, as I can't mention myself :/