### PR TITLE
Edit teams in settings window

### DIFF
--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -97,15 +97,22 @@ var SettingsPage = React.createClass({
     }
   },
   render: function() {
+
+    var buttonStyle = {
+      marginTop: 20,
+    };
+
     var teams_row = (
     <Row>
+      <Col md={ 4 }>
+      <h2>Teams</h2>
+      </Col>
+      <Col md={ 8 }>
+      <Button className="pull-right" style={ buttonStyle } bsSize="small" onClick={ this.handleShowTeamForm }>
+        <Glyphicon glyph="plus" />
+      </Button>
+      </Col>
       <Col md={ 12 }>
-      <h2>
-                Teams
-                <Button className="pull-right" bsSize="small" onClick={ this.handleShowTeamForm }>
-                  <Glyphicon glyph="plus" />
-                </Button>
-              </h2>
       <TeamList teams={ this.state.teams } showAddTeamForm={ this.state.showAddTeamForm } onTeamsChange={ this.handleTeamsChange } />
       </Col>
     </Row>

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -28,6 +28,11 @@ var SettingsPage = React.createClass({
     } catch (e) {
       config = settings.loadDefault();
     }
+
+    this.setState({
+      showAddTeamForm: false
+    });
+
     return config;
   },
   handleTeamsChange: function(teams) {
@@ -75,12 +80,28 @@ var SettingsPage = React.createClass({
       trayIconTheme: this.refs.trayIconTheme.getValue()
     });
   },
+  handleShowTeamForm: function() {
+    if (!this.state.showAddTeamForm) {
+      this.setState({
+        showAddTeamForm: true
+      });
+    } else {
+      this.setState({
+        showAddTeamForm: false
+      });
+    }
+  },
   render: function() {
     var teams_row = (
     <Row>
       <Col md={ 12 }>
-      <h2>Teams</h2>
-      <TeamList teams={ this.state.teams } onTeamsChange={ this.handleTeamsChange } />
+      <h2>
+        Teams
+        <Button className="pull-right" bsSize="small" onClick={ this.handleShowTeamForm }>
+          <Glyphicon glyph="plus" />
+        </Button>
+      </h2>
+      <TeamList teams={ this.state.teams } showAddTeamForm={ this.state.showAddTeamForm } onTeamsChange={ this.handleTeamsChange } />
       </Col>
     </Row>
     );
@@ -128,6 +149,11 @@ var SettingsPage = React.createClass({
 });
 
 var TeamList = React.createClass({
+  getInitialState: function() {
+    return {
+      showTeamListItemNew: false
+    };
+  },
   handleTeamRemove: function(index) {
     console.log(index);
     var teams = this.props.teams;
@@ -149,10 +175,18 @@ var TeamList = React.createClass({
         <TeamListItem index={ i } key={ "teamListItem" + i } name={ team.name } url={ team.url } onTeamRemove={ handleTeamRemove } />
         );
     });
+
+    var addTeamForm;
+    if (this.props.showAddTeamForm) {
+      addTeamForm = <TeamListItemNew onTeamAdd={ this.handleTeamAdd } />;
+    } else {
+      addTeamForm = '';
+    }
+
     return (
       <ListGroup class="teamList">
         { teamNodes }
-        <TeamListItemNew onTeamAdd={ this.handleTeamAdd } />
+        { addTeamForm }
       </ListGroup>
       );
   }

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -189,7 +189,12 @@ var TeamList = React.createClass({
     }
 
     this.setState({
-      showTeamListItemNew: false
+      showTeamListItemNew: false,
+      team: {
+        url: '',
+        name: '',
+        index: false
+      }
     });
 
     this.props.onTeamsChange(teams);
@@ -288,7 +293,12 @@ var TeamListItemNew = React.createClass({
       url: this.state.url.trim(),
       index: this.state.index,
     });
-    this.setState(this.getInitialState());
+
+    this.setState({
+      name: '',
+      url: '',
+      index: ''
+    });
   },
   handleNameChange: function(e) {
     console.log('name');

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -42,7 +42,7 @@ var SettingsPage = React.createClass({
 
     this.handleSave(false);
   },
-  handleSave: function(backToIndex) {
+  handleSave: function(toIndex) {
     var config = {
       teams: this.state.teams,
       hideMenuBar: this.state.hideMenuBar,
@@ -58,7 +58,7 @@ var SettingsPage = React.createClass({
       currentWindow.setMenuBarVisibility(!config.hideMenuBar);
     }
 
-    if (typeof backToIndex == 'undefined' || backToIndex) {
+    if (typeof toIndex == 'undefined' || toIndex) {
       backToIndex();
     }
   },
@@ -101,11 +101,11 @@ var SettingsPage = React.createClass({
     <Row>
       <Col md={ 12 }>
       <h2>
-        Teams
-        <Button className="pull-right" bsSize="small" onClick={ this.handleShowTeamForm }>
-          <Glyphicon glyph="plus" />
-        </Button>
-      </h2>
+                Teams
+                <Button className="pull-right" bsSize="small" onClick={ this.handleShowTeamForm }>
+                  <Glyphicon glyph="plus" />
+                </Button>
+              </h2>
       <TeamList teams={ this.state.teams } showAddTeamForm={ this.state.showAddTeamForm } onTeamsChange={ this.handleTeamsChange } />
       </Col>
     </Row>
@@ -209,7 +209,8 @@ var TeamList = React.createClass({
       };
 
       return (
-        <TeamListItem index={ i } key={ "teamListItem" + i } name={ team.name } url={ team.url } onTeamRemove={ handleTeamRemove } onTeamEditing={ handleTeamEditing } />
+        <TeamListItem index={ i } key={ "teamListItem" + i } name={ team.name } url={ team.url } onTeamRemove={ handleTeamRemove } onTeamEditing={ handleTeamEditing }
+        />
         );
     });
 
@@ -295,7 +296,8 @@ var TeamListItemNew = React.createClass({
     });
   },
   shouldEnableAddButton: function() {
-    return (this.state.name.trim() !== '' || this.props.teamName !== '') && (this.state.url.trim() !== '' || this.props.teamUrl !== '');
+    return (this.state.name.trim() !== '' || this.props.teamName !== '')
+      && (this.state.url.trim() !== '' || this.props.teamUrl !== '');
   },
   render: function() {
 
@@ -326,7 +328,9 @@ var TeamListItemNew = React.createClass({
             <input type="url" className="form-control" id="inputTeamURL" placeholder="https://example.com/team" value={ this.state.url } onChange={ this.handleURLChange } />
           </div>
           { ' ' }
-          <Button type="submit" disabled={ !this.shouldEnableAddButton() }>{ btnAddText }</Button>
+          <Button type="submit" disabled={ !this.shouldEnableAddButton() }>
+            { btnAddText }
+          </Button>
         </form>
       </ListGroupItem>
       );

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -99,19 +99,11 @@ var SettingsPage = React.createClass({
   render: function() {
 
     var buttonStyle = {
-      marginTop: 20,
+      marginTop: 20
     };
 
     var teams_row = (
     <Row>
-      <Col md={ 4 }>
-      <h2>Teams</h2>
-      </Col>
-      <Col md={ 8 }>
-      <Button className="pull-right" style={ buttonStyle } bsSize="small" onClick={ this.handleShowTeamForm }>
-        <Glyphicon glyph="plus" />
-      </Button>
-      </Col>
       <Col md={ 12 }>
       <TeamList teams={ this.state.teams } showAddTeamForm={ this.state.showAddTeamForm } onTeamsChange={ this.handleTeamsChange } />
       </Col>
@@ -146,6 +138,16 @@ var SettingsPage = React.createClass({
 
     return (
       <Grid className="settingsPage">
+        <Row>
+          <Col xs={ 4 } sm={ 1 } md={ 2 } lg={ 2 }>
+          <h2>Teams</h2>
+          </Col>
+          <Col xs={ 4 } sm={ 2 } md={ 1 } lg={ 1 } mdPull={ 1 }>
+          <Button className="pull-right" style={ buttonStyle } bsSize="small" onClick={ this.handleShowTeamForm }>
+            <Glyphicon glyph="plus" />
+          </Button>
+          </Col>
+        </Row>
         { teams_row }
         { options_row }
         <Row>


### PR DESCRIPTION
The users can now edit their configured teams in settings window. I only tested it on windows. I also did changes on the UI for adding teams, because I think on this way it's much clearer how to add a team and how to edit a team. This related to #3.

`npm test`ran successfully except this `prettify`. I don't know if I got it right, but I called the command `npm run prettify`and I doesn't get an error there.

Cheers