### PR TITLE
Implement basic autoupdate

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "vinyl-named": "^1.1.0",
     "webdriverio": "^3.3.0",
     "webpack": "^1.12.15",
-    "webpack-stream": "^3.1.0"
+    "webpack-stream": "^3.1.0",
+    "electron-gh-releases": "^2.0.3"
   },
   "build": {
     "app-bundle-id": "com.mattermost.desktop",

--- a/src/auto-updater.js
+++ b/src/auto-updater.js
@@ -1,0 +1,75 @@
+const app = require('electron').app
+const autoUpdater = require('electron').autoUpdater
+const Menu = require('electron').Menu
+const GhReleases = require('electron-gh-releases')
+
+var state = 'checking'
+
+let options = {
+  repo: 'mattermost/desktop',
+  currentVersion: app.getVersion()
+}
+
+const updater = new GhReleases(options)
+
+exports.initialize = function() {
+  if (process.mas) return
+
+  // When an update has been downloaded
+  updater.on('update-downloaded', (info) => {
+    setStateAndUpdate('installed')
+  })
+
+  exports.checkForUpdates();
+}
+
+exports.checkForUpdates = function() {
+  // Check for updates
+  // `status` returns true if there is a new update available
+  updater.check((err, status) => {
+    if (!err && status) {
+      setStateAndUpdate('checking')
+        // Download the update
+      updater.download()
+    }
+    else {
+      setStateAndUpdate('no-update')
+    }
+  })
+}
+
+exports.quitAndInstall = function() {
+  // Restart the app and install the update
+  if (state === 'installed')
+    updater.install()
+}
+
+function setStateAndUpdate(newState) {
+  state = newState
+  updateMenu()
+}
+
+function updateMenu() {
+  if (process.mas) return
+
+  var menu = Menu.getApplicationMenu()
+  if (!menu) return
+
+  menu.items.forEach(function(item) {
+    if (item.submenu) {
+      item.submenu.items.forEach(function(item) {
+        switch (item.key) {
+          case 'checkForUpdate':
+            item.visible = state === 'no-update'
+            break
+          case 'checkingForUpdate':
+            item.visible = state === 'checking'
+            break
+          case 'restartToUpdate':
+            item.visible = state === 'installed'
+            break
+        }
+      })
+    }
+  })
+}

--- a/src/main.js
+++ b/src/main.js
@@ -26,6 +26,7 @@ const ipc = electron.ipcMain;
 const nativeImage = electron.nativeImage;
 const fs = require('fs');
 const path = require('path');
+const autoUpdater = require('./auto-updater');
 
 var settings = require('./common/settings');
 var certificateStore = require('./main/certificateStore').load(path.resolve(app.getPath('userData'), 'certificate.json'));
@@ -184,6 +185,7 @@ allowProtocolDialog.init(mainWindow);
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 app.on('ready', function() {
+  autoUpdater.initialize()
   if (shouldShowTrayIcon()) {
     // set up tray icon
     trayIcon = new Tray(trayImages.normal);

--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -2,6 +2,7 @@
 
 const electron = require('electron');
 const Menu = electron.Menu;
+const autoUpdater = require('./../../auto-updater');
 
 var createTemplate = function(mainWindow) {
   var app_name = electron.app.getName();
@@ -158,7 +159,26 @@ var createTemplate = function(mainWindow) {
     submenu: [{
       label: `Version ${electron.app.getVersion()}`,
       enabled: false
-    }, ]
+    }, {
+      label: 'Checking for Update',
+      enabled: false,
+      key: 'checkingForUpdate'
+    }, {
+      label: 'Check for Update',
+      visible: false,
+      key: 'checkForUpdate',
+      click: function() {
+        autoUpdater.checkForUpdates()
+      }
+    }, {
+      label: 'Restart and Install Update',
+      enabled: true,
+      visible: false,
+      key: 'restartToUpdate',
+      click: function() {
+        autoUpdater.quitAndInstall()
+      }
+    }]
   });
   return template;
 };


### PR DESCRIPTION
This will add autoupdate for windows and possibly osx via [electron-gh-releases](https://github.com/jenslind/electron-gh-releases)

I can't really work on the OSX side of things.

Windows is done and works, you just need to build an installer and upload them to the github releases. Like I did [here](https://github.com/Razzeee/desktop/releases)

OSX is missing the 'auto-updater.json' and probably the signing, see documentation [here](https://github.com/jenslind/electron-gh-releases/blob/master/docs/2.x/how-to.md#publishing-a-new-release-on-github)
There is also an package to simplify the osx part of the release: https://github.com/jenslind/electron-release

![update](https://cloud.githubusercontent.com/assets/5943908/15980545/d0d75bdc-2f6c-11e6-8985-f0bbfb3d20da.png)
