### PR TITLE
Adds a setting to launch the app on system login

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,21 @@
 const electron = require('electron');
 const app = electron.app; // Module to control application life.
 
-if (require('electron-squirrel-startup')) app.quit();
+if (process.platform === 'win32') {
+  var cmd = process.argv[1];
+  if (cmd === '--squirrel-uninstall') {
+    var AutoLaunch = require('auto-launch');
+    var appLauncher = new AutoLaunch({
+      name: 'Mattermost'
+    });
+    appLauncher.isEnabled().then(function(enabled) {
+      if (enabled)
+        appLauncher.disable();
+    });
+  }
+}
+
+require('electron-squirrel-startup');
 
 const BrowserWindow = electron.BrowserWindow; // Module to create native browser window.
 const Menu = electron.Menu;

--- a/src/package.json
+++ b/src/package.json
@@ -13,6 +13,7 @@
     "electron-connect": "^0.3.3"
   },
   "dependencies": {
+    "auto-launch": "^2.0.1",
     "bootstrap": "^3.3.6",
     "os-locale": "^1.4.0",
     "react": "^15.0.1",


### PR DESCRIPTION
![login](https://cloud.githubusercontent.com/assets/5943908/15982253/3a344a8e-2f83-11e6-9a58-cb45a316d3a6.png)

Is this something you would accept as a PR? It's done via https://github.com/Teamwork/node-auto-launch which should work on all three platforms, I only tested windows so far.

However, this has one problem. if you uninstall the app, you will end up with the autostart entry abandoned. (at least on windows)
I wrote code, that should handle it, but it doesn't work and I don't see why.