### PR TITLE
Bump prebuild to 1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "electron-builder": "3.20.0",
     "electron-connect": "^0.3.7",
     "electron-packager": "^7.0.1",
-    "electron-prebuilt": "1.2.1",
+    "electron-prebuilt": "1.2.2",
     "electron-winstaller": "^2.2.0",
     "esformatter": "^0.9.3",
     "esformatter-jsx": "^5.0.0",


### PR DESCRIPTION
The icon seemed to be lost, at least when running it on windows just for dev purpose.
It might probably get injected by the build scripts, but not sure if that's good enough for us.