### PR TITLE
Update build scripts and gh draft

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -28,8 +28,7 @@ dependencies:
     - tar zcvf $CIRCLE_ARTIFACTS/mattermost-desktop-linux-ia32.tar.gz -C release mattermost-desktop-linux-ia32
     - tar zcvf $CIRCLE_ARTIFACTS/mattermost-desktop-linux-x64.tar.gz -C release mattermost-desktop-linux-x64
     - cp release/*.deb $CIRCLE_ARTIFACTS/
-    - cp release/windows-installer-ia32/mattermost-setup-ia32.exe $CIRCLE_ARTIFACTS/
-    - cp release/windows-installer-x64/mattermost-setup-x64.exe $CIRCLE_ARTIFACTS/
+    - cp -r release/windows-installer-x64/ $CIRCLE_ARTIFACTS/
 
 test:
   post:

--- a/circle/make_draft.sh
+++ b/circle/make_draft.sh
@@ -54,3 +54,6 @@ deploy linux-ia32 tar.gz
 deploy linux-x64 tar.gz
 upload mattermost-desktop-$RELEASE_TAG-linux-i386.deb release/mattermost-desktop-$RELEASE_TAG-i386.deb
 upload mattermost-desktop-$RELEASE_TAG-linux-amd64.deb release/mattermost-desktop-$RELEASE_TAG-amd64.deb
+upload RELEASE release/windows-installer-x64/RELEASE
+upload Mattermost.exe release/windows-installer-x64/Mattermost.exe
+upload mattermost-desktop-$RELEASE_TAG-full.nupkg release/windows-installer-x64/mattermost-desktop-$RELEASE_TAG-full.nupkg


### PR DESCRIPTION
This will hopefully build and create drafts with the needed files for the auto installer for windows. I settled for x64 as x32 shouldn't be needed in most cases.
See https://github.com/mattermost/desktop/pull/162