### PR TITLE
Hide window to system tray on minimize/close in Windows/OSX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 #### OS X
 - Fixed that two icons appear on a notification.
-- The main window is now hidden from dock on close
+- Added Option to hide Window from dock on close
 
 ### Improvements
 - Added shortcuts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,12 @@
 #### Windows
 - Fixed the pixelated app icon on the top left of the window.
 - Fixed the blurred tray icon.
-- Added Option to minimize Window to system tray on close
+- The main window is now minimized to system tray on close
 - Added Option to toggle minimize/restore on click on system tray icon
 
 #### OS X
 - Fixed that two icons appear on a notification.
-- Added Option to hide Window from dock on close
+- The main window is now hidden from dock on close
 
 ### Improvements
 - Added shortcuts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 #### OS X
 - Fixed that two icons appear on a notification.
+- Added Option to hide Window from dock on close
 
 ### Improvements
 - Added shortcuts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 #### Windows
 - Fixed the pixelated app icon on the top left of the window.
 - Fixed the blurred tray icon.
+- Added Option to minimize Window to system tray on close
+- Added Option to toggle minimize/restore on click on system tray icon
 
 #### OS X
 - Fixed that two icons appear on a notification.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -124,7 +124,7 @@ The Settings Page is available from the **File** menu under **Settings** (Click 
         This option allows such images to be rendered, but please be careful for security.
    - **Start app on login** (Windows, Linux)
       - This option starts the application when you login.
-   - **Leave app running in notification area when the window is closed** (Windows)
+   - **Leave app running in notification area when the window is closed** (Windows, OS X)
       - This option hides the window to the system tray, if the window is closed
    - **Toggle window visibility when clicking on the tray icon** (Windows)
       - If checked, then a click on the system tray icon leads to a toggling of the minimized/maximized state of the window

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -124,6 +124,8 @@ The Settings Page is available from the **File** menu under **Settings** (Click 
         This option allows such images to be rendered, but please be careful for security.
    - **Start app on login** (Windows, Linux)
       - This option starts the application when you login.
+   - **Leave app running in notification area when the window is closed** (OS X)
+      - This option hides the window from the dock, if the window is closed
    - **Toggle window visibility when clicking on the tray icon** (Windows)
       - If checked, then a click on the system tray icon leads to a toggling of the minimized/maximized state of the window
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -124,8 +124,6 @@ The Settings Page is available from the **File** menu under **Settings** (Click 
         This option allows such images to be rendered, but please be careful for security.
    - **Start app on login** (Windows, Linux)
       - This option starts the application when you login.
-   - **Leave app running in notification area when the window is closed** (Windows, OS X)
-      - This option hides the window to the system tray, if the window is closed
    - **Toggle window visibility when clicking on the tray icon** (Windows)
       - If checked, then a click on the system tray icon leads to a toggling of the minimized/maximized state of the window
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -124,6 +124,10 @@ The Settings Page is available from the **File** menu under **Settings** (Click 
         This option allows such images to be rendered, but please be careful for security.
    - **Start app on login** (Windows, Linux)
       - This option starts the application when you login.
+   - **Leave app running in notification area when the window is closed** (Windows)
+      - This option hides the window to the system tray, if the window is closed
+   - **Toggle window visibility when clicking on the tray icon** (Windows)
+      - If checked, then a click on the system tray icon leads to a toggling of the minimized/maximized state of the window
 
 
 ## Menu Bar

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -117,27 +117,14 @@ var SettingsPage = React.createClass({
     });
   },
   handleChangeMinimizeToTray: function() {
-    var isChecked = this.refs.minimizeToTray.getChecked();
     this.setState({
-      minimizeToTray: isChecked
+      minimizeToTray: this.refs.minimizeToTray.getChecked()
     });
-
-    if (!isChecked) {
-      this.setState({
-        toggleWindowOnTrayIconClick: false
-      });
-    }
   },
   handleChangeToggleWindowOnTrayIconClick: function() {
-    if (this.refs.minimizeToTray.getChecked()) {
-      this.setState({
-        toggleWindowOnTrayIconClick: this.refs.toggleWindowOnTrayIconClick.getChecked()
-      });
-    } else {
-      this.setState({
-        toggleWindowOnTrayIconClick: false
-      });
-    }
+    this.setState({
+      toggleWindowOnTrayIconClick: this.refs.toggleWindowOnTrayIconClick.getChecked()
+    });
   },
   toggleShowTeamForm: function() {
     this.setState({
@@ -186,7 +173,7 @@ var SettingsPage = React.createClass({
       options.push(<Input key="inputMinimizeToTray" id="inputMinimizeToTray" ref="minimizeToTray" type="checkbox" label="Leave app running in notification area when the window is closed"
                      checked={ this.state.minimizeToTray } onChange={ this.handleChangeMinimizeToTray } />);
       options.push(<Input key="inputToggleWindowOnTrayIconClick" id="inputToggleWindowOnTrayIconClick" ref="toggleWindowOnTrayIconClick" type="checkbox" label="Toggle window visibility when clicking on the tray icon."
-                     disabled={ !this.state.minimizeToTray } checked={ this.state.toggleWindowOnTrayIconClick } onChange={ this.handleChangeToggleWindowOnTrayIconClick } />);
+                     checked={ this.state.toggleWindowOnTrayIconClick } onChange={ this.handleChangeToggleWindowOnTrayIconClick } />);
     }
     var options_row = (options.length > 0) ? (
       <Row>

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -47,6 +47,19 @@ var SettingsPage = React.createClass({
         });
       });
     }
+
+    if (process.platform === 'darwin') {
+      var currentWindow = remote.getCurrentWindow();
+      if (currentWindow.tray) {
+        this.setState({
+          trayWasVisible: true
+        });
+      } else {
+        this.setState({
+          trayWasVisible: false
+        });
+      }
+    }
   },
   handleTeamsChange: function(teams) {
     this.setState({
@@ -181,8 +194,8 @@ var SettingsPage = React.createClass({
     }
 
     if (process.platform === 'darwin') {
-      options.push(<Input key="inputMinimizeToTray" id="inputMinimizeToTray" ref="minimizeToTray" type="checkbox" label="Leave app running in notification area when the window is closed"
-                     disabled={ !this.state.showTrayIcon } checked={ this.state.minimizeToTray } onChange={ this.handleChangeMinimizeToTray } />);
+      options.push(<Input key="inputMinimizeToTray" id="inputMinimizeToTray" ref="minimizeToTray" type="checkbox" label={ this.state.trayWasVisible || !this.state.showTrayIcon ? "Leave app running in notification area when the window is closed" : "Leave app running in notification area when the window is closed (available on next restart)" } disabled={ !this.state.showTrayIcon || !this.state.trayWasVisible } checked={ this.state.minimizeToTray }
+                     onChange={ this.handleChangeMinimizeToTray } />);
     }
 
     if (process.platform === 'win32') {

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -132,11 +132,11 @@ var SettingsPage = React.createClass({
     if (this.refs.minimizeToTray.getChecked()) {
       this.setState({
         toggleWindowOnTrayIconClick: this.refs.toggleWindowOnTrayIconClick.getChecked()
-      });    
+      });
     } else {
       this.setState({
         toggleWindowOnTrayIconClick: false
-      });    
+      });
     }
   },
   toggleShowTeamForm: function() {
@@ -185,7 +185,8 @@ var SettingsPage = React.createClass({
     if (process.platform === 'win32') {
       options.push(<Input key="inputMinimizeToTray" id="inputMinimizeToTray" ref="minimizeToTray" type="checkbox" label="Minimize app to tray." checked={ this.state.minimizeToTray } onChange={ this.handleChangeMinimizeToTray }
                    />);
-      options.push(<Input key="inputToggleWindowOnTrayIconClick" id="inputToggleWindowOnTrayIconClick" ref="toggleWindowOnTrayIconClick" type="checkbox" label="Toggle window visibility when clicking on the tray icon." disabled={ !this.state.minimizeToTray } checked={ this.state.toggleWindowOnTrayIconClick } onChange={ this.handleChangeToggleWindowOnTrayIconClick }/>);
+      options.push(<Input key="inputToggleWindowOnTrayIconClick" id="inputToggleWindowOnTrayIconClick" ref="toggleWindowOnTrayIconClick" type="checkbox" label="Toggle window visibility when clicking on the tray icon."
+                     disabled={ !this.state.minimizeToTray } checked={ this.state.toggleWindowOnTrayIconClick } onChange={ this.handleChangeToggleWindowOnTrayIconClick } />);
     }
     var options_row = (options.length > 0) ? (
       <Row>

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -61,7 +61,6 @@ var SettingsPage = React.createClass({
       trayIconTheme: this.state.trayIconTheme,
       disablewebsecurity: this.state.disablewebsecurity,
       version: settings.version,
-      minimizeToTray: this.state.minimizeToTray,
       toggleWindowOnTrayIconClick: this.state.toggleWindowOnTrayIconClick,
       notifications: {
         flashWindow: this.state.notifications.flashWindow
@@ -106,12 +105,6 @@ var SettingsPage = React.createClass({
     this.setState({
       showTrayIcon: shouldShowTrayIcon
     });
-
-    if (process.platform === 'darwin' && !shouldShowTrayIcon) {
-      this.setState({
-        minimizeToTray: false
-      });
-    }
   },
   handleChangeTrayIconTheme: function() {
     this.setState({
@@ -121,14 +114,6 @@ var SettingsPage = React.createClass({
   handleChangeAutoStart: function() {
     this.setState({
       autostart: this.refs.autostart.getChecked()
-    });
-  },
-  handleChangeMinimizeToTray: function() {
-    var shouldMinimizeToTray = (process.platform !== 'darwin' || this.refs.showTrayIcon.getChecked())
-    && this.refs.minimizeToTray.getChecked();
-
-    this.setState({
-      minimizeToTray: shouldMinimizeToTray
     });
   },
   handleChangeToggleWindowOnTrayIconClick: function() {
@@ -179,18 +164,12 @@ var SettingsPage = React.createClass({
       options.push(<Input key="inputAutoStart" id="inputAutoStart" ref="autostart" type="checkbox" label="Start app on login." checked={ this.state.autostart } onChange={ this.handleChangeAutoStart }
                    />);
     }
-    if (process.platform === 'win32') {
-      options.push(<Input key="inputMinimizeToTray" id="inputMinimizeToTray" ref="minimizeToTray" type="checkbox" label="Leave app running in notification area when the window is closed"
-                     checked={ this.state.minimizeToTray } onChange={ this.handleChangeMinimizeToTray } />);
-    } else if (process.platform === 'darwin') {
-      options.push(<Input key="inputMinimizeToTray" id="inputMinimizeToTray" ref="minimizeToTray" type="checkbox" label="Leave app running in notification area when the window is closed"
-                     disabled={ !this.state.showTrayIcon } checked={ this.state.minimizeToTray } onChange={ this.handleChangeMinimizeToTray } />);
-    }
 
     if (process.platform === 'win32') {
       options.push(<Input key="inputToggleWindowOnTrayIconClick" id="inputToggleWindowOnTrayIconClick" ref="toggleWindowOnTrayIconClick" type="checkbox" label="Toggle window visibility when clicking on the tray icon."
                      checked={ this.state.toggleWindowOnTrayIconClick } onChange={ this.handleChangeToggleWindowOnTrayIconClick } />);
     }
+
     var options_row = (options.length > 0) ? (
       <Row>
         <Col md={ 12 }>

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -62,6 +62,7 @@ var SettingsPage = React.createClass({
       disablewebsecurity: this.state.disablewebsecurity,
       version: settings.version,
       minimizeToTray: this.state.minimizeToTray,
+      toggleWindowOnTrayIconClick: this.state.toggleWindowOnTrayIconClick,
       notifications: {
         flashWindow: this.state.notifications.flashWindow
       }
@@ -116,9 +117,27 @@ var SettingsPage = React.createClass({
     });
   },
   handleChangeMinimizeToTray: function() {
+    var isChecked = this.refs.minimizeToTray.getChecked();
     this.setState({
-      minimizeToTray: this.refs.minimizeToTray.getChecked()
+      minimizeToTray: isChecked
     });
+
+    if (!isChecked) {
+      this.setState({
+        toggleWindowOnTrayIconClick: false
+      });
+    }
+  },
+  handleChangeToggleWindowOnTrayIconClick: function() {
+    if (this.refs.minimizeToTray.getChecked()) {
+      this.setState({
+        toggleWindowOnTrayIconClick: this.refs.toggleWindowOnTrayIconClick.getChecked()
+      });    
+    } else {
+      this.setState({
+        toggleWindowOnTrayIconClick: false
+      });    
+    }
   },
   toggleShowTeamForm: function() {
     this.setState({
@@ -166,6 +185,7 @@ var SettingsPage = React.createClass({
     if (process.platform === 'win32') {
       options.push(<Input key="inputMinimizeToTray" id="inputMinimizeToTray" ref="minimizeToTray" type="checkbox" label="Minimize app to tray." checked={ this.state.minimizeToTray } onChange={ this.handleChangeMinimizeToTray }
                    />);
+      options.push(<Input key="inputToggleWindowOnTrayIconClick" id="inputToggleWindowOnTrayIconClick" ref="toggleWindowOnTrayIconClick" type="checkbox" label="Toggle window visibility when clicking on the tray icon." disabled={ !this.state.minimizeToTray } checked={ this.state.toggleWindowOnTrayIconClick } onChange={ this.handleChangeToggleWindowOnTrayIconClick }/>);
     }
     var options_row = (options.length > 0) ? (
       <Row>

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -61,6 +61,7 @@ var SettingsPage = React.createClass({
       trayIconTheme: this.state.trayIconTheme,
       disablewebsecurity: this.state.disablewebsecurity,
       version: settings.version,
+      minimizeToTray: this.state.minimizeToTray,
       toggleWindowOnTrayIconClick: this.state.toggleWindowOnTrayIconClick,
       notifications: {
         flashWindow: this.state.notifications.flashWindow
@@ -101,9 +102,16 @@ var SettingsPage = React.createClass({
     });
   },
   handleChangeShowTrayIcon: function() {
+    var shouldShowTrayIcon = this.refs.showTrayIcon.getChecked();
     this.setState({
-      showTrayIcon: this.refs.showTrayIcon.getChecked()
+      showTrayIcon: shouldShowTrayIcon
     });
+
+    if (process.platform === 'darwin' && !shouldShowTrayIcon) {
+      this.setState({
+        minimizeToTray: false
+      });
+    }
   },
   handleChangeTrayIconTheme: function() {
     this.setState({
@@ -113,6 +121,14 @@ var SettingsPage = React.createClass({
   handleChangeAutoStart: function() {
     this.setState({
       autostart: this.refs.autostart.getChecked()
+    });
+  },
+  handleChangeMinimizeToTray: function() {
+    var shouldMinimizeToTray = (process.platform !== 'darwin' || this.refs.showTrayIcon.getChecked())
+    && this.refs.minimizeToTray.getChecked();
+
+    this.setState({
+      minimizeToTray: shouldMinimizeToTray
     });
   },
   handleChangeToggleWindowOnTrayIconClick: function() {
@@ -162,6 +178,11 @@ var SettingsPage = React.createClass({
     if (process.platform === 'win32' || process.platform === 'linux') {
       options.push(<Input key="inputAutoStart" id="inputAutoStart" ref="autostart" type="checkbox" label="Start app on login." checked={ this.state.autostart } onChange={ this.handleChangeAutoStart }
                    />);
+    }
+
+    if (process.platform === 'darwin') {
+      options.push(<Input key="inputMinimizeToTray" id="inputMinimizeToTray" ref="minimizeToTray" type="checkbox" label="Leave app running in notification area when the window is closed"
+                     disabled={ !this.state.showTrayIcon } checked={ this.state.minimizeToTray } onChange={ this.handleChangeMinimizeToTray } />);
     }
 
     if (process.platform === 'win32') {

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -102,9 +102,16 @@ var SettingsPage = React.createClass({
     });
   },
   handleChangeShowTrayIcon: function() {
+    var shouldShowTrayIcon = this.refs.showTrayIcon.getChecked();
     this.setState({
-      showTrayIcon: this.refs.showTrayIcon.getChecked()
+      showTrayIcon: shouldShowTrayIcon
     });
+
+    if (process.platform === 'darwin' && !shouldShowTrayIcon) {
+      this.setState({
+        minimizeToTray: false
+      });
+    }
   },
   handleChangeTrayIconTheme: function() {
     this.setState({
@@ -117,8 +124,11 @@ var SettingsPage = React.createClass({
     });
   },
   handleChangeMinimizeToTray: function() {
+    var shouldMinimizeToTray = (process.platform !== 'darwin' || this.refs.showTrayIcon.getChecked())
+    && this.refs.minimizeToTray.getChecked();
+
     this.setState({
-      minimizeToTray: this.refs.minimizeToTray.getChecked()
+      minimizeToTray: shouldMinimizeToTray
     });
   },
   handleChangeToggleWindowOnTrayIconClick: function() {
@@ -172,6 +182,12 @@ var SettingsPage = React.createClass({
     if (process.platform === 'win32') {
       options.push(<Input key="inputMinimizeToTray" id="inputMinimizeToTray" ref="minimizeToTray" type="checkbox" label="Leave app running in notification area when the window is closed"
                      checked={ this.state.minimizeToTray } onChange={ this.handleChangeMinimizeToTray } />);
+    } else if (process.platform === 'darwin') {
+      options.push(<Input key="inputMinimizeToTray" id="inputMinimizeToTray" ref="minimizeToTray" type="checkbox" label="Leave app running in notification area when the window is closed"
+                     disabled={ !this.state.showTrayIcon } checked={ this.state.minimizeToTray } onChange={ this.handleChangeMinimizeToTray } />);
+    }
+
+    if (process.platform === 'win32') {
       options.push(<Input key="inputToggleWindowOnTrayIconClick" id="inputToggleWindowOnTrayIconClick" ref="toggleWindowOnTrayIconClick" type="checkbox" label="Toggle window visibility when clicking on the tray icon."
                      checked={ this.state.toggleWindowOnTrayIconClick } onChange={ this.handleChangeToggleWindowOnTrayIconClick } />);
     }

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -162,6 +162,8 @@ var SettingsPage = React.createClass({
     if (process.platform === 'win32' || process.platform === 'linux') {
       options.push(<Input key="inputAutoStart" id="inputAutoStart" ref="autostart" type="checkbox" label="Start app on login." checked={ this.state.autostart } onChange={ this.handleChangeAutoStart }
                    />);
+    }
+    if (process.platform === 'win32') {
       options.push(<Input key="inputMinimizeToTray" id="inputMinimizeToTray" ref="minimizeToTray" type="checkbox" label="Minimize app to tray." checked={ this.state.minimizeToTray } onChange={ this.handleChangeMinimizeToTray }
                    />);
     }

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -183,8 +183,8 @@ var SettingsPage = React.createClass({
                    />);
     }
     if (process.platform === 'win32') {
-      options.push(<Input key="inputMinimizeToTray" id="inputMinimizeToTray" ref="minimizeToTray" type="checkbox" label="Minimize app to tray." checked={ this.state.minimizeToTray } onChange={ this.handleChangeMinimizeToTray }
-                   />);
+      options.push(<Input key="inputMinimizeToTray" id="inputMinimizeToTray" ref="minimizeToTray" type="checkbox" label="Leave app running in notification area when the window is closed"
+                     checked={ this.state.minimizeToTray } onChange={ this.handleChangeMinimizeToTray } />);
       options.push(<Input key="inputToggleWindowOnTrayIconClick" id="inputToggleWindowOnTrayIconClick" ref="toggleWindowOnTrayIconClick" type="checkbox" label="Toggle window visibility when clicking on the tray icon."
                      disabled={ !this.state.minimizeToTray } checked={ this.state.toggleWindowOnTrayIconClick } onChange={ this.handleChangeToggleWindowOnTrayIconClick } />);
     }

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -50,15 +50,9 @@ var SettingsPage = React.createClass({
 
     if (process.platform === 'darwin') {
       var currentWindow = remote.getCurrentWindow();
-      if (currentWindow.tray) {
-        this.setState({
-          trayWasVisible: true
-        });
-      } else {
-        this.setState({
-          trayWasVisible: false
-        });
-      }
+      this.setState({
+        trayWasVisible: currentWindow.trayWasVisible
+      });
     }
   },
   handleTeamsChange: function(teams) {

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -61,6 +61,7 @@ var SettingsPage = React.createClass({
       trayIconTheme: this.state.trayIconTheme,
       disablewebsecurity: this.state.disablewebsecurity,
       version: settings.version,
+      minimizeToTray: this.state.minimizeToTray,
       notifications: {
         flashWindow: this.state.notifications.flashWindow
       }
@@ -114,6 +115,11 @@ var SettingsPage = React.createClass({
       autostart: this.refs.autostart.getChecked()
     });
   },
+  handleChangeMinimizeToTray: function() {
+    this.setState({
+      minimizeToTray: this.refs.minimizeToTray.getChecked()
+    });
+  },
   toggleShowTeamForm: function() {
     this.setState({
       showAddTeamForm: !this.state.showAddTeamForm
@@ -155,6 +161,8 @@ var SettingsPage = React.createClass({
     //OSX has an option in the Dock, to set the app to autostart, so we choose to not support this option for OSX
     if (process.platform === 'win32' || process.platform === 'linux') {
       options.push(<Input key="inputAutoStart" id="inputAutoStart" ref="autostart" type="checkbox" label="Start app on login." checked={ this.state.autostart } onChange={ this.handleChangeAutoStart }
+                   />);
+      options.push(<Input key="inputMinimizeToTray" id="inputMinimizeToTray" ref="minimizeToTray" type="checkbox" label="Minimize app to tray." checked={ this.state.minimizeToTray } onChange={ this.handleChangeMinimizeToTray }
                    />);
     }
     var options_row = (options.length > 0) ? (

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -101,9 +101,8 @@ var SettingsPage = React.createClass({
     });
   },
   handleChangeShowTrayIcon: function() {
-    var shouldShowTrayIcon = this.refs.showTrayIcon.getChecked();
     this.setState({
-      showTrayIcon: shouldShowTrayIcon
+      showTrayIcon: this.refs.showTrayIcon.getChecked()
     });
   },
   handleChangeTrayIconTheme: function() {

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -27,6 +27,7 @@ var loadDefault = function(version) {
         trayIconTheme: '',
         disablewebsecurity: true,
         minimizeToTray: false,
+        toggleWindowOnTrayIconClick: false,
         version: 1,
         notifications: {
           flashWindow: 0 // 0 = flash never, 1 = only when idle (after 10 seconds), 2 = always

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -26,6 +26,7 @@ var loadDefault = function(version) {
         showTrayIcon: false,
         trayIconTheme: '',
         disablewebsecurity: true,
+        minimizeToTray: false,
         version: 1,
         notifications: {
           flashWindow: 0 // 0 = flash never, 1 = only when idle (after 10 seconds), 2 = always
@@ -38,7 +39,7 @@ var upgradeV0toV1 = function(config_v0) {
   var config = loadDefault(1);
   config.teams.push({
     name: 'Primary team',
-    url: config_v0.url
+    url: config_v0.url    
   });
   return config;
 };

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -26,7 +26,6 @@ var loadDefault = function(version) {
         showTrayIcon: false,
         trayIconTheme: '',
         disablewebsecurity: true,
-        minimizeToTray: true,
         toggleWindowOnTrayIconClick: false,
         version: 1,
         notifications: {

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -26,7 +26,7 @@ var loadDefault = function(version) {
         showTrayIcon: false,
         trayIconTheme: '',
         disablewebsecurity: true,
-        minimizeToTray: false,
+        minimizeToTray: true,
         toggleWindowOnTrayIconClick: false,
         version: 1,
         notifications: {

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -39,7 +39,7 @@ var upgradeV0toV1 = function(config_v0) {
   var config = loadDefault(1);
   config.teams.push({
     name: 'Primary team',
-    url: config_v0.url    
+    url: config_v0.url
   });
   return config;
 };

--- a/src/main.js
+++ b/src/main.js
@@ -241,10 +241,22 @@ app.on('ready', function() {
           mainWindow.focus();
         }
       }
+      else if (process.platform === 'darwin') {
+        if (mainWindow.isHidden || mainWindow.isMinimized()) {
+          mainWindow.show();
+          mainWindow.isHidden = false;
+          mainWindow.focus();
+          app.dock.show();
+        }
+        else {
+          mainWindow.focus();
+        }
+      }
       else {
         mainWindow.focus();
       }
     });
+
     trayIcon.on('right-click', () => {
       trayIcon.popUpContextMenu();
     });
@@ -380,7 +392,14 @@ app.on('ready', function() {
           mainWindow.minimize();
           break;
         case 'darwin':
-          mainWindow.hide();
+          if (config.minimizeToTray) {
+            mainWindow.hide();
+            app.dock.hide();
+            mainWindow.isHidden = true;
+          }
+          else {
+            mainWindow.minimize();
+          }
           break;
         default:
       }

--- a/src/main.js
+++ b/src/main.js
@@ -234,7 +234,7 @@ app.on('ready', function() {
             mainWindow.show();
             mainWindow.isHidden = false;
           }
-          else {
+          else if (config.toggleWindowOnTrayIconClick) {
             mainWindow.hide();
             mainWindow.isHidden = true;
           }

--- a/src/main.js
+++ b/src/main.js
@@ -261,12 +261,15 @@ app.on('ready', function() {
       trayIcon.popUpContextMenu();
     });
     trayIcon.on('balloon-click', function() {
-      if (process.platform === 'win32') {
-        if (config.minimizeToTray) {
-          mainWindow.show();
-          mainWindow.isHidden = false;
-        }
+      if (process.platform === 'win32' || process.platform === 'darwin') {
+        mainWindow.show();
+        mainWindow.isHidden = false;
       }
+
+      if (process.platform === 'darwin') {
+        app.dock.show();
+      }
+
       mainWindow.focus();
     });
     ipcMain.on('notified', function(event, arg) {
@@ -380,26 +383,16 @@ app.on('ready', function() {
       event.preventDefault();
       switch (process.platform) {
         case 'win32':
-          if (config.minimizeToTray) {
-            mainWindow.hide();
-            mainWindow.isHidden = true;
-          }
-          else {
-            mainWindow.minimize();
-          }
+          mainWindow.hide();
+          mainWindow.isHidden = true;
           break;
         case 'linux':
           mainWindow.minimize();
           break;
         case 'darwin':
-          if (config.minimizeToTray) {
-            mainWindow.hide();
-            app.dock.hide();
-            mainWindow.isHidden = true;
-          }
-          else {
-            mainWindow.minimize();
-          }
+          mainWindow.hide();
+          app.dock.hide();
+          mainWindow.isHidden = true;
           break;
         default:
       }

--- a/src/main.js
+++ b/src/main.js
@@ -391,8 +391,10 @@ app.on('ready', function() {
           break;
         case 'darwin':
           mainWindow.hide();
-          app.dock.hide();
-          mainWindow.isHidden = true;
+          if (config.minimizeToTray) {
+            app.dock.hide();
+            mainWindow.isHidden = true;
+          }
           break;
         default:
       }

--- a/src/main.js
+++ b/src/main.js
@@ -233,12 +233,13 @@ app.on('ready', function() {
           if (mainWindow.isHidden) {
             mainWindow.show();
             mainWindow.isHidden = false;
-          } else {
+          }
+          else {
             mainWindow.hide();
             mainWindow.isHidden = true;
           }
         }
-      }      
+      }
       mainWindow.focus();
     });
     trayIcon.on('right-click', () => {
@@ -367,9 +368,10 @@ app.on('ready', function() {
           if (config.minimizeToTray) {
             mainWindow.hide();
             mainWindow.isHidden = true;
-          } else {
+          }
+          else {
             mainWindow.minimize();
-          }        
+          }
           break;
         case 'linux':
           mainWindow.minimize();
@@ -387,7 +389,7 @@ app.on('ready', function() {
       if (config.minimizeToTray) {
         mainWindow.hide();
         mainWindow.isHidden = true;
-      }  
+      }
     });
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -227,12 +227,14 @@ app.on('ready', function() {
 
     trayIcon.setToolTip(app.getName());
     trayIcon.on('click', function() {
+      mainWindow.show();
       mainWindow.focus();
     });
     trayIcon.on('right-click', () => {
       trayIcon.popUpContextMenu();
     });
     trayIcon.on('balloon-click', function() {
+      mainWindow.show();
       mainWindow.focus();
     });
     ipcMain.on('notified', function(event, arg) {
@@ -346,6 +348,8 @@ app.on('ready', function() {
       event.preventDefault();
       switch (process.platform) {
         case 'win32':
+          mainWindow.hide();
+          break;
         case 'linux':
           mainWindow.minimize();
           break;

--- a/src/main.js
+++ b/src/main.js
@@ -359,9 +359,12 @@ app.on('ready', function() {
     const tray_menu = require('./main/menus/tray').createDefault(mainWindow);
     trayIcon.setContextMenu(tray_menu);
     if (process.platform === 'darwin') {
-      // store a reference to the tray icon, for checking in the settings, if the application
+      // store the information, if the tray was initialized, for checking in the settings, if the application
       // was restarted after setting "Show icon on menu bar"
-      mainWindow.tray = trayIcon;
+      if (trayIcon)
+        mainWindow.trayWasVisible = true;
+      else
+        mainWindow.trayWasVisible = false;
     }
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -229,18 +229,21 @@ app.on('ready', function() {
     trayIcon.setToolTip(app.getName());
     trayIcon.on('click', function() {
       if (process.platform === 'win32') {
-        if (config.minimizeToTray) {
-          if (mainWindow.isHidden) {
-            mainWindow.show();
-            mainWindow.isHidden = false;
-          }
-          else if (config.toggleWindowOnTrayIconClick) {
-            mainWindow.hide();
-            mainWindow.isHidden = true;
-          }
+        if (mainWindow.isHidden || mainWindow.isMinimized()) {
+          mainWindow.show();
+          mainWindow.isHidden = false;
+          mainWindow.focus();
+        }
+        else if (config.toggleWindowOnTrayIconClick) {
+          mainWindow.minimize();
+        }
+        else {
+          mainWindow.focus();
         }
       }
-      mainWindow.focus();
+      else {
+        mainWindow.focus();
+      }
     });
     trayIcon.on('right-click', () => {
       trayIcon.popUpContextMenu();
@@ -383,15 +386,6 @@ app.on('ready', function() {
       }
     }
   });
-
-  if (process.platform === 'win32') {
-    mainWindow.on('minimize', function() {
-      if (config.minimizeToTray) {
-        mainWindow.hide();
-        mainWindow.isHidden = true;
-      }
-    });
-  }
 
   // App should save bounds when a window is closed.
   // However, 'close' is not fired in some situations(shutdown, ctrl+c)

--- a/src/main.js
+++ b/src/main.js
@@ -358,6 +358,11 @@ app.on('ready', function() {
   if (shouldShowTrayIcon()) {
     const tray_menu = require('./main/menus/tray').createDefault(mainWindow);
     trayIcon.setContextMenu(tray_menu);
+    if (process.platform === 'darwin') {
+      // store a reference to the tray icon, for checking in the settings, if the application
+      // was restarted after setting "Show icon on menu bar"
+      mainWindow.tray = trayIcon;
+    }
   }
 
   // Open the DevTools.

--- a/src/main/menus/tray.js
+++ b/src/main/menus/tray.js
@@ -11,6 +11,12 @@ function createDefault(mainWindow) {
     label: `Open ${app.getName()}`,
     click: () => {
       mainWindow.show();
+      mainWindow.isHidden = false;
+
+      if (process.platform === 'darwin') {
+        app.dock.show();
+        mainWindow.focus();
+      }
     }
   }, {
     type: 'separator'

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -161,6 +161,16 @@ describe('browser/settings.html', function() {
       });
     });
 
+    describe('Toggle window visibility when clicking on the tray icon', function() {
+      it('should appear win32', function() {
+        const expected = (process.platform === 'win32');
+        env.addClientCommands(this.app.client);
+        return this.app.client
+          .loadSettingsPage()
+          .isExisting('#inputToggleWindowOnTrayIconClick').should.eventually.equal(expected)
+      });
+    });
+
     describe('Notifications', function() {
       it('should appear on win32', function() {
         const expected = (process.platform === 'win32');

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -151,6 +151,16 @@ describe('browser/settings.html', function() {
       });
     });
 
+    describe('Minimize to tray', function() {
+      it('should appear win32', function() {
+        const expected = (process.platform === 'win32');
+        env.addClientCommands(this.app.client);
+        return this.app.client
+          .loadSettingsPage()
+          .isExisting('#inputMinimizeToTray').should.eventually.equal(expected)
+      });
+    });
+
     describe('Notifications', function() {
       it('should appear on win32', function() {
         const expected = (process.platform === 'win32');

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -151,6 +151,16 @@ describe('browser/settings.html', function() {
       });
     });
 
+    describe('Minimize to tray', function() {
+      it('should appear on darwin', function() {
+        const expected = (process.platform === 'darwin');
+        env.addClientCommands(this.app.client);
+        return this.app.client
+          .loadSettingsPage()
+          .isExisting('#inputMinimizeToTray').should.eventually.equal(expected)
+      });
+    });
+
     describe('Toggle window visibility when clicking on the tray icon', function() {
       it('should appear on win32', function() {
         const expected = (process.platform === 'win32');

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -152,8 +152,8 @@ describe('browser/settings.html', function() {
     });
 
     describe('Minimize to tray', function() {
-      it('should appear win32', function() {
-        const expected = (process.platform === 'win32');
+      it('should appear on win32 and darwin', function() {
+        const expected = (process.platform === 'win32' || process.platform === 'darwin');
         env.addClientCommands(this.app.client);
         return this.app.client
           .loadSettingsPage()
@@ -162,7 +162,7 @@ describe('browser/settings.html', function() {
     });
 
     describe('Toggle window visibility when clicking on the tray icon', function() {
-      it('should appear win32', function() {
+      it('should appear on win32', function() {
         const expected = (process.platform === 'win32');
         env.addClientCommands(this.app.client);
         return this.app.client

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -151,16 +151,6 @@ describe('browser/settings.html', function() {
       });
     });
 
-    describe('Minimize to tray', function() {
-      it('should appear on win32 and darwin', function() {
-        const expected = (process.platform === 'win32' || process.platform === 'darwin');
-        env.addClientCommands(this.app.client);
-        return this.app.client
-          .loadSettingsPage()
-          .isExisting('#inputMinimizeToTray').should.eventually.equal(expected)
-      });
-    });
-
     describe('Toggle window visibility when clicking on the tray icon', function() {
       it('should appear on win32', function() {
         const expected = (process.platform === 'win32');


### PR DESCRIPTION
Added an option to hide the Window on minimize/close to the system tray.
if this option is enabled, a click on the system tray would also toggle the window.

This addresses #178 at least partially (just for Windows and OSX currently)
---

- [x] Complete [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [x] Execute `npm run prettify` to format codes
- [x] Write about environment which you tested
  - Tested on Windows 10
  - Tested on OS X 10.11.6 Beta
