### PR TITLE
Add show window option

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -119,6 +119,8 @@ The Settings Page is available from the **File** menu under **Settings** (Click 
       - This option hides the menu bar. Press "Alt" to show it.
    - **Show Icon on Menu Bar** (OS X)
       - The icon apeears on menu bar to indicate whether there are new messages or mention.
+   - **Show and set focus to the window whether there are new messages or mention**
+      - This option show and set focus to the window whether there are new messages or metion.
    - **Allow insecure contents**
       - If your team is hosted on `https://`, images with `http://` are not rendered by default.
         This option allows such images to be rendered, but please be careful for security.

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -385,7 +385,9 @@ var MattermostView = React.createClass({
           thisObj.handleUnreadCountChange(unreadCount, mentionCount, isUnread, isMentioned);
           if (config.showWindowOnNewMessage === true) {
             var win = remote.getCurrentWindow();
-            win.show();
+            if (!win.isFocused()) {
+              win.show();
+            }
           }
           break;
         case 'onNotificationClick':

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -383,6 +383,10 @@ var MattermostView = React.createClass({
           var isUnread = event.args[2];
           var isMentioned = event.args[3];
           thisObj.handleUnreadCountChange(unreadCount, mentionCount, isUnread, isMentioned);
+          if (config.showWindowOnNewMessage === true) {
+            var win = remote.getCurrentWindow();
+            win.show();
+          }
           break;
         case 'onNotificationClick':
           thisObj.props.onNotificationClick();

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -68,6 +68,7 @@ var SettingsPage = React.createClass({
       showTrayIcon: this.state.showTrayIcon,
       trayIconTheme: this.state.trayIconTheme,
       disablewebsecurity: this.state.disablewebsecurity,
+      showWindowOnNewMessage: this.state.showWindowOnNewMessage,
       version: settings.version,
       minimizeToTray: this.state.minimizeToTray,
       toggleWindowOnTrayIconClick: this.state.toggleWindowOnTrayIconClick,
@@ -102,6 +103,11 @@ var SettingsPage = React.createClass({
   handleChangeDisableWebSecurity: function() {
     this.setState({
       disablewebsecurity: this.refs.disablewebsecurity.getChecked()
+    });
+  },
+  handleChangeShowWindowOnNewMessage: function() {
+    this.setState({
+      showWindowOnNewMessage: this.refs.showWindowOnNewMessage.getChecked()
     });
   },
   handleChangeHideMenuBar: function() {
@@ -182,6 +188,8 @@ var SettingsPage = React.createClass({
     }
     options.push(<Input key="inputDisableWebSecurity" id="inputDisableWebSecurity" ref="disablewebsecurity" type="checkbox" label="Allow mixed content (Enabling allows both secure and insecure content, images and scripts to render and execute. Disabling allows only secure content.)"
                    checked={ this.state.disablewebsecurity } onChange={ this.handleChangeDisableWebSecurity } />);
+    options.push(<Input key="inputShowWindowOnNewMessage" id="inputShowWindowOnNewMessage" ref="showWindowOnNewMessage" type="checkbox" label="Show and set focus to the window whether there are new messages or mention"
+                   checked={ this.state.showWindowOnNewMessage } onChange={ this.handleChangeShowWindowOnNewMessage } />);
     //OSX has an option in the Dock, to set the app to autostart, so we choose to not support this option for OSX
     if (process.platform === 'win32' || process.platform === 'linux') {
       options.push(<Input key="inputAutoStart" id="inputAutoStart" ref="autostart" type="checkbox" label="Start app on login." checked={ this.state.autostart } onChange={ this.handleChangeAutoStart }

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -27,6 +27,7 @@ var loadDefault = function(version) {
         trayIconTheme: '',
         disablewebsecurity: true,
         toggleWindowOnTrayIconClick: false,
+        showWindowOnNewMessage: false,
         version: 1,
         notifications: {
           flashWindow: 0 // 0 = flash never, 1 = only when idle (after 10 seconds), 2 = always

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -171,6 +171,26 @@ describe('browser/settings.html', function() {
       });
     });
 
+    describe('Show window on new message', function() {
+      [true, false].forEach(function(v) {
+        it(`should be saved and loaded: ${v}`, function() {
+          env.addClientCommands(this.app.client);
+          return this.app.client
+            .loadSettingsPage()
+            .isSelected('#inputShowWindowOnNewMessage input').then((isSelected) => {
+              if (isSelected !== v) {
+                return this.app.client.click('#inputShowWindowOnNewMessage input')
+              }
+            })
+            .click('#btnSave')
+            .pause(1000).then(() => {
+              const saved_config = JSON.parse(fs.readFileSync(env.configFilePath, 'utf8'));
+              saved_config.showWindowOnNewMessage.should.equal(v);
+            })
+        });
+      });
+    });
+
     describe('Notifications', function() {
       it('should appear on win32', function() {
         const expected = (process.platform === 'win32');


### PR DESCRIPTION
Hi.

I added an option to show and set focus to the window whether there are new messages or mention.

---
- [x] Complete [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [x] Execute `npm run prettify` to format codes
- [x] Write about environment which you tested
  - Tested on OS X 10.11.4
