### PR TITLE
Add feature to hide window into system tray in Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,9 @@
 - Fixed the pixelated app icon on the top left of the window.
 - Fixed the blurred tray icon.
 - Fixed that the redundant description appears in the pinned start menu on Windows 7.
-- The main window is now minimized to system tray on close
-- Added Option to toggle minimize/restore on click on system tray icon
 
 #### OS X
 - Fixed that two icons appear on a notification.
-- Added Option to hide Window from dock on close
 
 ### Improvements
 - Added shortcuts
@@ -42,14 +39,18 @@
 - Added the tooltip text for the tray icon in order to show count of unread channels/mantions.
 - Added the option to launch the application on login.
 - Added the option to blink the taskbar icon when a new message has arrived.
+- The main window is now minimized to system tray on close
+- Added Option to toggle minimize/restore on click on system tray icon
 - Added installers (experimental)
 
 #### OS X
 - Added colored badges to the menu icon when there are unread channels/mentions.
+- Added Option to hide Window from dock on close
 
 #### Linux
 - Added the option to show the icon on menu bar. (requires libappindicator1 on Ubuntu)
 - Added the option to launch the application on login.
+- Added Option to hide Window into tray icon on close
 
 
 ## Release v1.2.1 (Beta)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -124,7 +124,7 @@ The Settings Page is available from the **File** menu under **Settings** (Click 
         This option allows such images to be rendered, but please be careful for security.
    - **Start app on login** (Windows, Linux)
       - This option starts the application when you login.
-   - **Leave app running in notification area when the window is closed** (OS X)
+   - **Leave app running in notification area when the window is closed** (OS X, Linux)
       - This option hides the window from the dock, if the window is closed
    - **Toggle window visibility when clicking on the tray icon** (Windows)
       - If checked, then a click on the system tray icon leads to a toggling of the minimized/maximized state of the window

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -27,16 +27,17 @@ function backToIndex() {
 
 var SettingsPage = React.createClass({
   getInitialState: function() {
-    var config;
+    var initialState;
     try {
-      config = settings.readFileSync(this.props.configFile);
+      initialState = settings.readFileSync(this.props.configFile);
     } catch (e) {
-      config = settings.loadDefault();
+      initialState = settings.loadDefault();
     }
 
-    config.showAddTeamForm = false;
+    initialState.showAddTeamForm = false;
+    initialState.trayWasVisible = remote.getCurrentWindow().trayWasVisible;
 
-    return config;
+    return initialState;
   },
   componentDidMount: function() {
     if (process.platform === 'win32' || process.platform === 'linux') {
@@ -45,13 +46,6 @@ var SettingsPage = React.createClass({
         self.setState({
           autostart: enabled
         });
-      });
-    }
-
-    if (process.platform === 'darwin') {
-      var currentWindow = remote.getCurrentWindow();
-      this.setState({
-        trayWasVisible: currentWindow.trayWasVisible
       });
     }
   },
@@ -188,7 +182,7 @@ var SettingsPage = React.createClass({
                    />);
     }
 
-    if (process.platform === 'darwin') {
+    if (process.platform === 'darwin' || process.platform === 'linux') {
       options.push(<Input key="inputMinimizeToTray" id="inputMinimizeToTray" ref="minimizeToTray" type="checkbox" label={ this.state.trayWasVisible || !this.state.showTrayIcon ? "Leave app running in notification area when the window is closed" : "Leave app running in notification area when the window is closed (available on next restart)" } disabled={ !this.state.showTrayIcon || !this.state.trayWasVisible } checked={ this.state.minimizeToTray }
                      onChange={ this.handleChangeMinimizeToTray } />);
     }

--- a/src/main.js
+++ b/src/main.js
@@ -232,7 +232,7 @@ app.on('ready', function() {
 
     trayIcon.setToolTip(app.getName());
     trayIcon.on('click', function() {
-      if (process.platform === 'win32') {
+      if (process.platform === 'win32' || process.platform === 'linux') {
         if (mainWindow.isHidden || mainWindow.isMinimized()) {
           mainWindow.show();
           mainWindow.isHidden = false;
@@ -407,7 +407,13 @@ app.on('ready', function() {
           mainWindow.isHidden = true;
           break;
         case 'linux':
-          mainWindow.minimize();
+          if (config.minimizeToTray) {
+            mainWindow.hide();
+            mainWindow.isHidden = true;
+          }
+          else {
+            mainWindow.minimize();
+          }
           break;
         case 'darwin':
           mainWindow.hide();

--- a/src/main.js
+++ b/src/main.js
@@ -160,7 +160,6 @@ app.on('browser-window-created', function(event, window) {
 // For OSX, show hidden mainWindow when clicking dock icon.
 app.on('activate', function(event) {
   mainWindow.show();
-  mainWindow.isHidden = false;
 });
 
 app.on('before-quit', function() {
@@ -233,9 +232,8 @@ app.on('ready', function() {
     trayIcon.setToolTip(app.getName());
     trayIcon.on('click', function() {
       if (process.platform === 'win32' || process.platform === 'linux') {
-        if (mainWindow.isHidden || mainWindow.isMinimized()) {
+        if (!mainWindow.isVisible() || mainWindow.isMinimized()) {
           mainWindow.show();
-          mainWindow.isHidden = false;
           mainWindow.focus();
         }
         else if (config.toggleWindowOnTrayIconClick) {
@@ -246,18 +244,14 @@ app.on('ready', function() {
         }
       }
       else if (process.platform === 'darwin') {
-        if (mainWindow.isHidden || mainWindow.isMinimized()) {
+        if (!mainWindow.isVisible() || mainWindow.isMinimized()) {
           mainWindow.show();
-          mainWindow.isHidden = false;
           mainWindow.focus();
           app.dock.show();
         }
         else {
           mainWindow.focus();
         }
-      }
-      else {
-        mainWindow.focus();
       }
     });
 
@@ -267,7 +261,6 @@ app.on('ready', function() {
     trayIcon.on('balloon-click', function() {
       if (process.platform === 'win32' || process.platform === 'darwin') {
         mainWindow.show();
-        mainWindow.isHidden = false;
       }
 
       if (process.platform === 'darwin') {
@@ -404,12 +397,10 @@ app.on('ready', function() {
       switch (process.platform) {
         case 'win32':
           mainWindow.hide();
-          mainWindow.isHidden = true;
           break;
         case 'linux':
           if (config.minimizeToTray) {
             mainWindow.hide();
-            mainWindow.isHidden = true;
           }
           else {
             mainWindow.minimize();
@@ -419,7 +410,6 @@ app.on('ready', function() {
           mainWindow.hide();
           if (config.minimizeToTray) {
             app.dock.hide();
-            mainWindow.isHidden = true;
           }
           break;
         default:

--- a/src/main.js
+++ b/src/main.js
@@ -231,27 +231,18 @@ app.on('ready', function() {
 
     trayIcon.setToolTip(app.getName());
     trayIcon.on('click', function() {
-      if (process.platform === 'win32' || process.platform === 'linux') {
-        if (!mainWindow.isVisible() || mainWindow.isMinimized()) {
-          mainWindow.show();
-          mainWindow.focus();
-        }
-        else if (config.toggleWindowOnTrayIconClick) {
-          mainWindow.minimize();
-        }
-        else {
-          mainWindow.focus();
-        }
-      }
-      else if (process.platform === 'darwin') {
-        if (!mainWindow.isVisible() || mainWindow.isMinimized()) {
-          mainWindow.show();
-          mainWindow.focus();
+      if (!mainWindow.isVisible() || mainWindow.isMinimized()) {
+        mainWindow.show();
+        mainWindow.focus();
+        if (process.platform === 'darwin') {
           app.dock.show();
         }
-        else {
-          mainWindow.focus();
-        }
+      }
+      else if ((process.platform === 'win32') && config.toggleWindowOnTrayIconClick) {
+        mainWindow.minimize();
+      }
+      else {
+        mainWindow.focus();
       }
     });
 

--- a/src/main/menus/tray.js
+++ b/src/main/menus/tray.js
@@ -15,7 +15,6 @@ function createTemplate(mainWindow, config) {
         click: (item, focusedWindow) => {
           mainWindow.show(); // for OS X
           mainWindow.webContents.send('switch-tab', i);
-          mainWindow.isHidden = false;
 
           if (process.platform === 'darwin') {
             app.dock.show();

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -152,8 +152,8 @@ describe('browser/settings.html', function() {
     });
 
     describe('Minimize to tray', function() {
-      it('should appear on darwin', function() {
-        const expected = (process.platform === 'darwin');
+      it('should appear on darwin or linux', function() {
+        const expected = (process.platform === 'darwin' || process.platform === 'linux');
         env.addClientCommands(this.app.client);
         return this.app.client
           .loadSettingsPage()


### PR DESCRIPTION
For Linux in #178.

- The feature can be enabled when the tray icon is enabled as similar to OS X.
- Some refactoring for related parts.

I hope that it's tested on all platforms to check degrading.

---

- [x] Complete [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [x] Execute `npm run prettify` to format codes
- [x] Write about environment which you tested
  - Ubuntu 14.04/Unity installed libappindicator1
