### PR TITLE
Ubuntu Unity counter badge

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "electron-builder": "5.2.1",
     "electron-connect": "^0.3.7",
     "electron-packager": "^7.0.1",
-    "electron-prebuilt": "1.2.2",
+    "electron-prebuilt": "1.2.6",
     "electron-winstaller": "^2.2.0",
     "esformatter": "^0.9.3",
     "esformatter-jsx": "^5.0.0",

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -508,13 +508,9 @@ var showUnreadBadgeOSX = function(unreadCount, mentionCount) {
 }
 
 var showUnreadBadgeLinux = function(unreadCount, mentionCount) {
-  /*if (mentionCount > 0) {
-    remote.app.dock.setBadge(mentionCount.toString());
-  } else if (unreadCount > 0) {
-    remote.app.dock.setBadge('•');
-  } else {
-    remote.app.dock.setBadge('');
-  }*/
+  if (remote.app.isUnityRunning()) {
+    remote.app.setBadgeCount(mentionCount);
+  }
 
   ipcRenderer.send('update-unread', {
     unreadCount: unreadCount,
@@ -531,7 +527,6 @@ var showUnreadBadge = function(unreadCount, mentionCount) {
       showUnreadBadgeOSX(unreadCount, mentionCount);
       break;
     case 'linux':
-      console.log(unreadCount);
       showUnreadBadgeLinux(unreadCount, mentionCount);
       break;
     default:

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mattermost-desktop",
   "productName": "Mattermost",
+  "desktopName": "Mattermost.desktop",
   "version": "1.3.0",
   "description": "Mattermost Desktop application for Windows, Mac and Linux",
   "main": "main.js",


### PR DESCRIPTION
Implements #176 by using the new setBadgeCount API in electron 1.2.6
---

- [x] Complete [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [x] Execute `npm run prettify` to format codes
- [x] Write about environment which you tested
  - Ubuntu 16.04 running Unity
