### PR TITLE
Make unread badge configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 #### Linux
  - Added an option to make the taskbar icon flash on new messages
 
+#### OS X
+- Added an option to toggle the red dot icon for unread messages (default is on).
+
+#### Windows
+- Added an option to toogle the red dot icon for unread messages (default is on).
+
+
 ### Bug Fixes
 
 
@@ -53,7 +60,7 @@ Release date: 2016-07-18
     - Ctrl+Tab or Alt+Command+Right (Menu Bar -> Window -> Select Next Team): Switch to the next window.
     - Ctrl+Shift+Tab or Alt+Command+Left (Menu Bar -> Window -> Select Previous Team): Switch to the previous window.
     - Right click on the tray item, to see an overview of all your teams. You can also select one and jump right into it.
-  - Added **Help** to the Menu Bar, which includes
+- Added **Help** to the Menu Bar, which includes
     - Link to [**Mattermost Docs**](docs.mattermost.com)
     - Field to indicate the application version number.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -128,6 +128,8 @@ The Settings Page is available from the **File** menu under **Settings** (Click 
       - This option hides the window from the dock, if the window is closed
    - **Toggle window visibility when clicking on the tray icon** (Windows)
       - If checked, then a click on the system tray icon leads to a toggling of the minimized/maximized state of the window
+   - **Show the red badge for unread messages.** (Windows, OS X)
+      - If this is checked it will show the red dot on your task bar when you have unread messages.
 
 
 ## Menu Bar

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -484,7 +484,7 @@ var showUnreadBadgeWindows = function(unreadCount, mentionCount) {
   if (mentionCount > 0) {
     const dataURL = badge.createDataURL(mentionCount.toString());
     sendBadge(dataURL, 'You have unread mentions (' + mentionCount + ')');
-  } else if (unreadCount > 0) {
+  } else if (unreadCount > 0 && config.showUnreadBadge) {
     const dataURL = badge.createDataURL('•');
     sendBadge(dataURL, 'You have unread channels (' + unreadCount + ')');
   } else {
@@ -495,7 +495,7 @@ var showUnreadBadgeWindows = function(unreadCount, mentionCount) {
 var showUnreadBadgeOSX = function(unreadCount, mentionCount) {
   if (mentionCount > 0) {
     remote.app.dock.setBadge(mentionCount.toString());
-  } else if (unreadCount > 0) {
+  } else if (unreadCount > 0 && config.showUnreadBadge) {
     remote.app.dock.setBadge('•');
   } else {
     remote.app.dock.setBadge('');
@@ -531,7 +531,6 @@ var showUnreadBadge = function(unreadCount, mentionCount) {
       showUnreadBadgeOSX(unreadCount, mentionCount);
       break;
     case 'linux':
-      console.log(unreadCount);
       showUnreadBadgeLinux(unreadCount, mentionCount);
       break;
     default:

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -67,7 +67,8 @@ var SettingsPage = React.createClass({
       toggleWindowOnTrayIconClick: this.state.toggleWindowOnTrayIconClick,
       notifications: {
         flashWindow: this.state.notifications.flashWindow
-      }
+      },
+      showUnreadBadge: this.state.showUnreadBadge
     };
     settings.writeFileSync(this.props.configFile, config);
     if (process.platform === 'win32' || process.platform === 'linux') {
@@ -150,6 +151,11 @@ var SettingsPage = React.createClass({
       }
     });
   },
+  handleShowUnreadBadge: function() {
+    this.setState({
+      showUnreadBadge: this.refs.showUnreadBadge.getChecked()
+    });
+  },
   render: function() {
     var teams_row = (
     <Row>
@@ -190,6 +196,11 @@ var SettingsPage = React.createClass({
     if (process.platform === 'win32') {
       options.push(<Input key="inputToggleWindowOnTrayIconClick" id="inputToggleWindowOnTrayIconClick" ref="toggleWindowOnTrayIconClick" type="checkbox" label="Toggle window visibility when clicking on the tray icon."
                      checked={ this.state.toggleWindowOnTrayIconClick } onChange={ this.handleChangeToggleWindowOnTrayIconClick } />);
+    }
+
+    if (process.platform === 'darwin' || process.platform === 'win32') {
+      options.push(<Input key="inputShowUnreadBadge" id="inputShowUnreadBadge" ref="showUnreadBadge" type="checkbox" label="Show red badge on taskbar icon to indicate unread messages. Regardless of this setting, mentions are always indicated with a red badge and item count on the taskbar icon."
+                     checked={ this.state.showUnreadBadge } onChange={ this.handleShowUnreadBadge } />);
     }
 
     var options_row = (options.length > 0) ? (

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -30,7 +30,8 @@ var loadDefault = function(version) {
         version: 1,
         notifications: {
           flashWindow: 0 // 0 = flash never, 1 = only when idle (after 10 seconds), 2 = always
-        }
+        },
+        showUnreadBadge: true
       };
   }
 }

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -180,5 +180,15 @@ describe('browser/settings.html', function() {
           .isExisting('#notificationsRow').should.eventually.equal(expected)
       });
     });
+
+    describe('Show red icon for unread', function() {
+      it('should appear on darwin or win32', function() {
+        const expected = (process.platform === 'darwin' || process.platform === 'win32');
+        env.addClientCommands(this.app.client);
+        return this.app.client
+          .loadSettingsPage()
+          .isExisting('#inputShowUnreadBadge').should.eventually.equal(expected)
+      });
+    });
   });
 });


### PR DESCRIPTION
Adds a new setting that shows the red dot indicatior on the task bar for unread messages when activated. Default is false.

We may want to check the wording I've choose, we might be able to come up with something better.
