### PR TITLE
Bold unread tabitem if there are unread messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Release v1.4.0 (Beta)
 
 ### Improvements
+- Changed display of unread messages on the team tabbar, they are now shown as bold text
 
 ### Bug Fixes
 

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -219,30 +219,16 @@ var TabBar = React.createClass({
     var tabs = this.props.teams.map(function(team, index) {
       var unreadCount = 0;
       var badgeStyle = {
-        unread: {
-          background: '#383838',
-          float: 'right',
-          color: 'white',
-          textAlign: 'center',
-          marginTop: '5px',
-          width: '10px',
-          height: '10px',
-          marginLeft: '5px',
-          borderRadius: '50%',
-        },
-
-        mention: {
-          background: '#f1342c',
-          float: 'right',
-          color: 'white',
-          minWidth: '19px',
-          fontSize: '12px',
-          textAlign: 'center',
-          lineHeight: '20px',
-          height: '19px',
-          marginLeft: '5px',
-          borderRadius: '50%',
-        }
+        background: '#FF1744',
+        float: 'right',
+        color: 'white',
+        minWidth: '19px',
+        fontSize: '12px',
+        textAlign: 'center',
+        lineHeight: '20px',
+        height: '19px',
+        marginLeft: '5px',
+        borderRadius: '50%',
       };
 
       if (thisObj.props.unreadCounts[index] > 0) {
@@ -262,18 +248,25 @@ var TabBar = React.createClass({
 
       var badge;
       if (mentionCount != 0) {
-        badge = (<div style={ badgeStyle.mention }>
+        badge = (<div style={ badgeStyle }>
                    { mentionCount }
                  </div>);
-      } else if (unreadCount > 0) {
-        badge = (<div style={ badgeStyle.unread }></div>);
       }
-      var id = 'teamTabItem' + index;
-      return (<NavItem className="teamTabItem" key={ id } id={ id } eventKey={ index }>
-                { team.name }
-                { ' ' }
-                { badge }
-              </NavItem>);
+      if (unreadCount == 0) {
+        var id = 'teamTabItem' + index;
+        return (<NavItem className="teamTabItem" key={ id } id={ id } eventKey={ index }>
+                  { team.name }
+                  { ' ' }
+                  { badge }
+                </NavItem>);
+      } else {
+        var id = 'teamTabItem' + index;
+        return (<NavItem className="teamTabItem" key={ id } id={ id } eventKey={ index }>
+                  <b>{ team.name }</b>
+                  { ' ' }
+                  { badge }
+                </NavItem>);
+      }
     });
     return (
       <Nav id={ this.props.id } bsStyle="tabs" activeKey={ this.props.activeKey } onSelect={ this.props.onSelect }>


### PR DESCRIPTION
Not sure if this is something we want, but I feel like we should speak the same language everywhere we try to let the user know, that he has unread messages.

![tabbar](https://cloud.githubusercontent.com/assets/5943908/17034039/21311990-4f81-11e6-8220-647dc2b18e39.png)

Tested on Win10