### PR TITLE
Workaround: Invalidate cache of the main page on load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Release date: TBD
 - Changed display of unread messages on the team tabbar, they are now shown as bold text
 - Reload only the selected tab and keep its URL on "Reload" and "Clear Cache and Reload".
 - Disabled `eval()` function for security improvements.
+- Invalidate cache before load, to make server upgrades easy
 
 #### Windows
 - Update Mattermost icon for desktop notifications in Windows 10.

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -313,7 +313,7 @@ var MattermostView = React.createClass({
     webview.addEventListener('did-fail-load', function(e) {
       console.log(thisObj.props.name, 'webview did-fail-load', e);
       if (e.errorCode === -3 || // An operation was aborted (due to user action).
-        webview.cacheInvalidated) { //The operation was aborted to invalidate application cache
+        e.errorCode === -300) { //The operation was aborted to invalidate application cache
         return;
       }
 

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -312,7 +312,8 @@ var MattermostView = React.createClass({
 
     webview.addEventListener('did-fail-load', function(e) {
       console.log(thisObj.props.name, 'webview did-fail-load', e);
-      if (e.errorCode === -3) { // An operation was aborted (due to user action).
+      if (e.errorCode === -3 || // An operation was aborted (due to user action).
+        webview.cacheInvalidated) { //The operation was aborted to invalidate application cache
         return;
       }
 
@@ -346,6 +347,13 @@ var MattermostView = React.createClass({
       } else {
         // if the link is external, use default browser.
         shell.openExternal(e.url);
+      }
+    });
+
+    webview.addEventListener("did-start-loading", function() {
+      if (!webview.cacheInvalidated) {
+        webview.reloadIgnoringCache();
+        webview.cacheInvalidated = true;
       }
     });
 


### PR DESCRIPTION
This PR will add a cache invalidating page reload to each webview as a workaround.
Mattermost platform does not send an `Expires`/`Cache-Control` header, therefore the cache is not being re validated upon load in most cases.
If the cache is beeing invalidated depends on heuristics https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.2.2

In a browser session, the user is used to hit the reload button when something does not work. In the mattermost app, reload does not reload the embedded webviews.

I added a call to `webview.reloadIgnoringCache` right after the `did-start-loading` event is being fired to force the webview to re fetch the main page, as this results in a load cancel and therefore in a `did-fail-load` I extended the handler for that, so that no error is shown.

---

- [x] Complete [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [x] Execute `npm run prettify` to format codes
- [x] Write about environment which you tested
  - Ubuntu 16.04
