### PR TITLE
Flash Window also without systray icon

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -218,6 +218,13 @@ allowProtocolDialog.init(mainWindow);
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 app.on('ready', function() {
+  ipcMain.on('notified', function(event, arg) {
+    if (process.platform === 'win32' || process.platform === 'linux') {
+      if (config.notifications.flashWindow === 2) {
+        mainWindow.flashFrame(true);
+      }
+    }
+  });
   if (shouldShowTrayIcon()) {
     // set up tray icon
     trayIcon = new Tray(trayImages.normal);
@@ -261,12 +268,6 @@ app.on('ready', function() {
       mainWindow.focus();
     });
     ipcMain.on('notified', function(event, arg) {
-      if (process.platform === 'win32' || process.platform === 'linux') {
-        if (config.notifications.flashWindow === 2) {
-          mainWindow.flashFrame(true);
-        }
-      }
-
       if (process.platform === 'win32') {
         // On Windows 8.1 and Windows 8, a shortcut with a Application User Model ID must be installed to the Start screen.
         // In current version, use tray balloon for notification


### PR DESCRIPTION
As mentioned in pull request [#200](https://github.com/mattermost/desktop/pull/200#issuecomment-234721964) flashing the mattermost window only worked right now, when you have the systray icon enabled.

Since the setting (and also logically) the systray has nothing to do with the flashing window, this pull request now fixes this behavior, so that the window will flash as long as the setting is turned on (no matter what the systray setting is).

*PS: Sorry for the typo in the commit message, only saw it after I opened the pull request.*

---

- [x] Complete [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [x] Execute `npm run prettify` to format codes
- [x] Write about environment which you tested
  - Archlinux x64

