### PR TITLE
Use default electron implementation for zoomin, zoomout and resetzoom

### DIFF
--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -386,9 +386,6 @@ var MattermostView = React.createClass({
     webview.addEventListener("dom-ready", function() {
       // webview.openDevTools();
 
-      // In order to apply the zoom level to webview.
-      webFrame.setZoomLevel(parseInt(localStorage.getItem('zoomLevel')));
-
       // Use 'Meiryo UI' and 'MS Gothic' to prevent CJK fonts on Windows(JP).
       if (process.platform === 'win32') {
         var applyCssFile = function(cssFile) {
@@ -661,22 +658,6 @@ var showUnreadBadge = function(unreadCount, mentionCount) {
     default:
   }
 }
-
-if (!localStorage.getItem('zoomLevel')) {
-  localStorage.setItem('zoomLevel', 0);
-}
-webFrame.setZoomLevel(parseInt(localStorage.getItem('zoomLevel')));
-
-ipcRenderer.on('zoom-in', (event, increment) => {
-  const zoomLevel = webFrame.getZoomLevel() + increment
-  webFrame.setZoomLevel(zoomLevel);
-  localStorage.setItem('zoomLevel', zoomLevel);
-});
-
-ipcRenderer.on('zoom-reset', (event) => {
-  webFrame.setZoomLevel(0);
-  localStorage.setItem('zoomLevel', 0);
-});
 
 ReactDOM.render(
   <MainPage teams={ config.teams } onUnreadCountChange={ showUnreadBadge } />,

--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -112,30 +112,16 @@ var createTemplate = function(mainWindow, config) {
     }, {
       role: 'togglefullscreen'
     }, separatorItem, {
-      label: 'Actual Size',
-      accelerator: 'CmdOrCtrl+0',
-      click: () => {
-        mainWindow.webContents.send('zoom-reset');
-      }
+      role: 'resetzoom'
     }, {
-      label: 'Zoom In',
-      accelerator: 'CmdOrCtrl+Plus',
-      click: () => {
-        mainWindow.webContents.send('zoom-in', 1);
-      }
+      role: 'zoomin'
     }, {
       label: 'Zoom In (hidden)',
       accelerator: 'CmdOrCtrl+=',
       visible: false,
-      click: () => {
-        mainWindow.webContents.send('zoom-in', 1);
-      }
+      role: 'zoomin'
     }, {
-      label: 'Zoom Out',
-      accelerator: 'CmdOrCtrl+-',
-      click: () => {
-        mainWindow.webContents.send('zoom-in', -1);
-      }
+      role: 'zoomout'
     }, separatorItem, {
       label: 'Toggle Developer Tools',
       accelerator: (function() {


### PR DESCRIPTION
This is a possible followup to https://github.com/mattermost/desktop/pull/187

The three zoom related menu items are now handled by electron itself.