### PR TITLE
Change window title to the one thats set from the platform for the cu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Release date: TBD
 ### Improvements
 
 #### All platforms
+- Show current channel/team in window title
 - Changed display of unread messages on the team tabbar, they are now shown as bold text
 - Reload only the selected tab and keep its URL on "Reload" and "Clear Cache and Reload".
 - Disabled `eval()` function for security improvements.

--- a/src/browser/index.html
+++ b/src/browser/index.html
@@ -3,7 +3,6 @@
 
 <head>
   <meta charset="UTF-8">
-  <title>Mattermost</title>
   <link rel="stylesheet" href="modules/bootstrap/css/bootstrap.min.css">
 </head>
 

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -201,8 +201,9 @@ var MainPage = React.createClass({
         thisObj.handleSelect(index);
       }
       var id = 'mattermostView' + index;
-      return (<MattermostView key={ id } id={ id } style={ thisObj.visibleStyle(thisObj.state.key === index) } src={ team.url } name={ team.name } onUnreadCountChange={ handleUnreadCountChange }
-                onNotificationClick={ handleNotificationClick } ref={ id } />)
+      var is_active = thisObj.state.key === index;
+      return (<MattermostView key={ id } id={ id } style={ thisObj.visibleStyle(is_active) } src={ team.url } name={ team.name } onUnreadCountChange={ handleUnreadCountChange }
+                onNotificationClick={ handleNotificationClick } ref={ id } active={ is_active } />)
     });
     var views_row = (<Row>
                        { views }
@@ -409,9 +410,11 @@ var MattermostView = React.createClass({
     });
 
     webview.addEventListener('page-title-updated', function(event) {
-      ipcRenderer.send('update-title', {
-        title: event.title
-      });
+      if (thisObj.props.active) {
+        ipcRenderer.send('update-title', {
+          title: event.title
+        });
+      }
     });
 
     webview.addEventListener('console-message', (e) => {

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -94,6 +94,11 @@ var MainPage = React.createClass({
       key: newKey
     });
     this.handleOnTeamFocused(key);
+
+    var webview = document.getElementById('mattermostView' + key);
+    ipcRenderer.send('update-title', {
+      title: webview.getTitle()
+    });
   },
   handleUnreadCountChange: function(index, unreadCount, mentionCount, isUnread, isMentioned) {
     var unreadCounts = this.state.unreadCounts;
@@ -401,6 +406,12 @@ var MattermostView = React.createClass({
           thisObj.props.onNotificationClick();
           break;
       }
+    });
+
+    webview.addEventListener('page-title-updated', function(event) {
+      ipcRenderer.send('update-title', {
+        title: event.title
+      });
     });
 
     webview.addEventListener('console-message', (e) => {

--- a/src/main.js
+++ b/src/main.js
@@ -229,6 +229,11 @@ app.on('ready', function() {
       }
     }
   });
+
+  ipcMain.on('update-title', function(event, arg) {
+    mainWindow.setTitle(arg.title);
+  });
+
   if (shouldShowTrayIcon()) {
     // set up tray icon
     trayIcon = new Tray(trayImages.normal);

--- a/test/modules/test.html
+++ b/test/modules/test.html
@@ -1,5 +1,9 @@
 <html>
 
+<head>
+  <title>Mattermost Desktop testing html</title>
+</head>
+
 <body>
   <h1>window.open() test</h1>
   <p>


### PR DESCRIPTION
As specified here: https://mattermost.uservoice.com/forums/306457-general/suggestions/14974134-windows-mattermost-client-make-us-of-the-window-c

## Known bug 
(I would like some help here)
~~- If you change your team, via the tabs, it doesn't change the title. You first need to select some channel in the new team.~~

~~I fall back to the app name now in this case
Possible solution is to go grab the title on a switch, but might need some custom code.~~

~~- If you have multiple teams and and are in team a, if a channel title in team b changes, it will be set as window title~~