### PR TITLE
Remove accelerators from tray menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Release date: TBD
 - Reload only the selected tab and keep its URL on "Reload" and "Clear Cache and Reload".
 - Disabled `eval()` function for security improvements.
 - Invalidate cache before load, to make server upgrades easy
+- Removed misleading shortcuts from tray menu, as they didn't work
 
 #### Windows
 - Update Mattermost icon for desktop notifications in Windows 10.

--- a/src/main/menus/tray.js
+++ b/src/main/menus/tray.js
@@ -11,7 +11,6 @@ function createTemplate(mainWindow, config) {
     ...config.teams.slice(0, 9).map((team, i) => {
       return {
         label: team.name,
-        accelerator: `CmdOrCtrl+${i + 1}`,
         click: (item, focusedWindow) => {
           mainWindow.show(); // for OS X
           mainWindow.webContents.send('switch-tab', i);


### PR DESCRIPTION
As spotted in #239 
Those accelerators are now gone from the tray menu