### PR TITLE
Remove failed-to-load notification and reload the error tab on online event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Release date: TBD
 - Removed misleading shortcuts from tray menu, as they didn't work
 - Ctrl/Command+F puts cursor in search box to search in current channel.
 - Add access to settings through tray menu
+- Removed unclear desktop notifications when failed to load tabs.
+- Reload automatically the failed tab when the computer becomes online.
 
 #### Windows
 - Added an option to toogle the red dot icon for unread messages (default is on).

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -329,20 +329,18 @@ var MattermostView = React.createClass({
         return;
       }
 
-      // should use permanent way to indicate
-      var did_fail_load_notification = new Notification(`Failed to load "${thisObj.props.name}"`, {
-        body: `ErrorCode: ${e.errorCode}`,
-        icon: '../resources/appicon.png'
-      });
       thisObj.setState({
         errorInfo: e
       });
-      setTimeout(() => {
-        thisObj.setState({
-          errorInfo: null
-        });
-        webview.reload();
-      }, 30000);
+      const reload = () => {
+        window.removeEventListener('online', reload);
+        thisObj.reload();
+      };
+      if (navigator.onLine) {
+        setTimeout(reload, 30000);
+      } else {
+        window.addEventListener('online', reload);
+      }
     });
 
     // Open link in browserWindow. for exmaple, attached files.
@@ -442,10 +440,16 @@ var MattermostView = React.createClass({
     });
   },
   reload: function() {
+    this.setState({
+      errorInfo: null
+    });
     var webview = ReactDOM.findDOMNode(this.refs.webview);
     webview.reload();
   },
   clearCacheAndReload() {
+    this.setState({
+      errorInfo: null
+    });
     var webContents = ReactDOM.findDOMNode(this.refs.webview).getWebContents();
     webContents.session.clearCache(() => {
       webContents.reload();


### PR DESCRIPTION
- [x] Complete [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [x] Execute `npm run prettify` to format codes
- [x] Write about environment which you tested
  - OS X 10.11.5

----

For #243.

This PR removes the notification when tabs failed to load the server (Please see #243). Then if the application is offline, the tab reloads automatically when the application becomes online.