### PR TITLE
CTRL/CMD+F on Desktop app puts cursor in Mattermost search box filtered to channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Release date: TBD
 - Reload only the selected tab and keep its URL on "Reload" and "Clear Cache and Reload".
 - Disabled `eval()` function for security improvements.
 - Invalidate cache before load, to make server upgrades easy
+- Ctrl/Command+F puts cursor in search box to search in current channel.
 
 #### Windows
 - Update Mattermost icon for desktop notifications in Windows 10.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -149,6 +149,7 @@ Below lists menu options (shortcut keys are listed in brackets, `Ctrl` becomes `
   - **Copy** (Ctrl+C) - Copies selected text
   - **Paste** (Ctrl+V) - Pastes text from clipboard
   - **Select All** (Ctrl+A) - Select all text in input box
+  - **Search in Channel** (Ctrl+F) - Puts cursor in search box to search in current channel
 - **View**
   - **Reload** (Ctrl+R) - Reload page from the server
   - **Clear Cache and Reload** (Ctrl+Shift+R) - Clear cached content in application and reload page

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -75,6 +75,12 @@ var MainPage = React.createClass({
       this.refs[`mattermostView${this.state.key}`].clearCacheAndReload();
     });
 
+    // activate search box in current tab
+    ipcRenderer.on('activate-search-box', (event) => {
+      let webview = document.getElementById('mattermostView' + thisObj.state.key);
+      webview.send('activate-search-box');
+    });
+
     var focusListener = function() {
       var webview = document.getElementById('mattermostView' + thisObj.state.key);
       webview.focus();

--- a/src/browser/webview/mattermost.js
+++ b/src/browser/webview/mattermost.js
@@ -127,3 +127,16 @@ notification.override({
     ipc.sendToHost('onNotificationClick');
   }
 });
+
+// get the last of href for the current channel in the sidebar.
+function getCurrentChannelString() {
+  const active_channel_link = document.querySelector('.active a.sidebar-channel');
+  const url_elements = active_channel_link.href.split('/');
+  return url_elements[url_elements.length - 1];
+}
+
+ipc.on('activate-search-box', (event) => {
+  const search_box = document.getElementsByClassName('search-bar')[0]; // should use id
+  search_box.focus();
+  console.log(getCurrentChannelString());
+});

--- a/src/browser/webview/mattermost.js
+++ b/src/browser/webview/mattermost.js
@@ -136,7 +136,11 @@ function getCurrentChannelString() {
 }
 
 ipc.on('activate-search-box', (event) => {
-  const search_box = document.getElementsByClassName('search-bar')[0]; // should use id
+  const search_boxes = document.getElementsByClassName('search-bar'); // should use id
+  if (search_boxes.length === 0) {
+    return;
+  }
+  const search_box = search_boxes[0];
   search_box.focus();
-  console.log(getCurrentChannelString());
+  search_box.value = `in:${getCurrentChannelString()} `;
 });

--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -69,7 +69,15 @@ var createTemplate = function(mainWindow, config) {
       role: 'paste'
     }, {
       role: 'selectall'
-    }, ]
+    }, separatorItem, {
+      label: 'Search in Current Channel',
+      accelerator: 'CmdOrCtrl+F',
+      click: (item, focusedWindow) => {
+        if (focusedWindow) {
+          focusedWindow.webContents.send('activate-search-box');
+        }
+      }
+    }]
   });
   template.push({
     label: '&View',

--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -70,7 +70,7 @@ var createTemplate = function(mainWindow, config) {
     }, {
       role: 'selectall'
     }, separatorItem, {
-      label: 'Search in Current Channel',
+      label: 'Search in Channel',
       accelerator: 'CmdOrCtrl+F',
       click: (item, focusedWindow) => {
         if (focusedWindow) {


### PR DESCRIPTION
- [x] Complete [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [x] Execute `npm run prettify` to format codes
- [x] Write about environment which you tested
  - Operating system: OS X 10.11.6

----

For #229. `Ctrl/CMD+F` puts cursor in the search box and fill `in:[channel_handle] ` to filter with current channel.

This is not related to operating system, so only need testers.