### PR TITLE
Add access to settings through tray menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 
 test-results.xml
 test_config.json
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Release date: TBD
 - Invalidate cache before load, to make server upgrades easy
 - Removed misleading shortcuts from tray menu, as they didn't work
 - Ctrl/Command+F puts cursor in search box to search in current channel.
+- Add access to settings through tray menu
 
 #### Windows
 - Added an option to toogle the red dot icon for unread messages (default is on).

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -78,7 +78,7 @@ You have to configure the application to interact with your teams.
    - Windows: Press `Alt` key to bring up the menu at the top of the window, then click `File -> Settings`.
    - OS X: Click `Mattermost` from the menu at the top of the screen, then click `Preferences...`.
    - Linux: Click `File -> Settings` on the menu.
-   - If tray menu : Right-click on tray icon and click `Settings`
+   - All : right-click on tray icon and click `Settings`
 
 2. Press `+` button next to the "Teams" label.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -78,6 +78,7 @@ You have to configure the application to interact with your teams.
    - Windows: Press `Alt` key to bring up the menu at the top of the window, then click `File -> Settings`.
    - OS X: Click `Mattermost` from the menu at the top of the screen, then click `Preferences...`.
    - Linux: Click `File -> Settings` on the menu.
+   - If tray menu : Right-click on tray icon and click `Settings`
 
 2. Press `+` button next to the "Teams" label.
 

--- a/src/main/menus/tray.js
+++ b/src/main/menus/tray.js
@@ -29,6 +29,14 @@ function createTemplate(mainWindow, config) {
     }), {
       type: 'separator'
     }, {
+      label: 'Settings',
+      click: () => {
+        mainWindow.loadURL('file://' + __dirname + '/browser/settings.html');
+        mainWindow.show();
+      }
+    }, {
+      type: 'separator'
+    }, {
       role: 'quit'
     }
   ];

--- a/src/main/menus/tray.js
+++ b/src/main/menus/tray.js
@@ -12,12 +12,7 @@ function createTemplate(mainWindow, config) {
       return {
         label: team.name,
         click: (item, focusedWindow) => {
-          if (mainWindow.isMinimized()) {
-            mainWindow.restore();
-          }
-          else {
-            mainWindow.show();
-          }
+          showOrRestore(mainWindow);
           mainWindow.webContents.send('switch-tab', i);
 
           if (process.platform === 'darwin') {
@@ -32,7 +27,7 @@ function createTemplate(mainWindow, config) {
       label: 'Settings',
       click: () => {
         mainWindow.loadURL('file://' + __dirname + '/browser/settings.html');
-        mainWindow.show();
+        showOrRestore(mainWindow);
       }
     }, {
       type: 'separator'
@@ -46,6 +41,10 @@ function createTemplate(mainWindow, config) {
 var createMenu = function(mainWindow, config) {
   return Menu.buildFromTemplate(createTemplate(mainWindow, config));
 };
+
+function showOrRestore(window) {
+  window.isMinimized() ? window.restore() : window.show()
+}
 
 module.exports = {
   createMenu: createMenu


### PR DESCRIPTION
Hello,

Here is a small change to allow settings from tray menu. It's really usefull when your using frameless window (coming in another PR) to gain space.

I've tested on Linux Mint 17.

Regards,
