### PR TITLE
Fix webview doesn't get focus correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Release date: TBD
 
 ### Bug Fixes
 - Fixed an issue where the maximized state of the app window was lost in some cases.
+- Fixed an issue some shortcuts didn't work when switching applications or tabs in some cases.
 
 #### Windows
 - Fixed pixelated application icons in top left of the window.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "electron-builder": "5.2.1",
     "electron-connect": "^0.4.4",
     "electron-packager": "^7.0.1",
-    "electron-prebuilt": "1.2.7",
+    "electron-prebuilt": "1.2.8",
     "electron-winstaller": "^2.2.0",
     "esformatter": "^0.9.6",
     "esformatter-jsx": "^7.0.1",

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -82,10 +82,8 @@ var MainPage = React.createClass({
     });
 
     var focusListener = function() {
-      var webview = document.getElementById('mattermostView' + thisObj.state.key);
-      webview.focus();
-
       thisObj.handleOnTeamFocused(thisObj.state.key);
+      thisObj.refs[`mattermostView${thisObj.state.key}`].focusOnWebView();
     };
 
     var currentWindow = remote.getCurrentWindow();
@@ -94,14 +92,17 @@ var MainPage = React.createClass({
       currentWindow.removeListener('focus', focusListener);
     });
   },
+  componentDidUpdate: function() {
+    this.refs[`mattermostView${this.state.key}`].focusOnWebView();
+  },
   handleSelect: function(key) {
     const newKey = (this.props.teams.length + key) % this.props.teams.length;
     this.setState({
       key: newKey
     });
-    this.handleOnTeamFocused(key);
+    this.handleOnTeamFocused(newKey);
 
-    var webview = document.getElementById('mattermostView' + key);
+    var webview = document.getElementById('mattermostView' + newKey);
     ipcRenderer.send('update-title', {
       title: webview.getTitle()
     });
@@ -450,6 +451,13 @@ var MattermostView = React.createClass({
     webContents.session.clearCache(() => {
       webContents.reload();
     });
+  },
+  focusOnWebView: function() {
+    const webview = ReactDOM.findDOMNode(this.refs.webview);
+    if (!webview.getWebContents().isFocused()) {
+      webview.focus();
+      webview.getWebContents().focus();
+    }
   },
   render: function() {
     const errorView = this.state.errorInfo ? (<ErrorView id={ this.props.id + '-fail' } style={ this.props.style } className="errorView" errorInfo={ this.state.errorInfo }></ErrorView>) : null;


### PR DESCRIPTION
For #231.

`webview.focus()` was used to focus on the `<webview>`, but it's a DOM element function. So only the tag was focused in the host window, and its `webContents` was not focused. As the result, the shortcuts related to Mattermost UI didn't work in some cases.
Electron is upgraded to 1.2.8 because of `webContents.isFocused()`.

## Tested environment
Windows 10 and OS X 10.11.6.

## Shortcuts
- Ctrl+F (provided by the app)
- Ctrl+K (provided by mattermost UI)

## Test conditions
- After clicking application window.
- After clicking a tab.