### PR TITLE
Add simple validation for Name and URL in the settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Release date: TBD
 - Added back/forward features for the current tab.
   - Windows and Linux: Alt+Left, Alt+Right
   - OS X: Command+[, Command+]
+- Added simple validation for Name and URL in the settings page.
 
 #### Windows
 - Added an option to toogle the red dot icon for unread messages (default is on).


### PR DESCRIPTION
For #181.

Tested on Windows 10. The appearance is below.

<img width="592" alt="2016-09-06 23 22 13" src="https://cloud.githubusercontent.com/assets/1412057/18277512/b8b066c2-7489-11e6-9861-2b51aab43e6c.png">


It's only for the appearance of html, so I think it's enough if we have one tester. Artifacts are available at https://circleci.com/gh/yuya-oc/desktop/7#artifacts