### PR TITLE
Revert pull #219 "Workaround: Invalidate cache of the main page on load"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ Release date: TBD
 - Changed display of unread messages on the team tabbar, they are now shown as bold text
 - Reload only the selected tab and keep its URL on "Reload" and "Clear Cache and Reload".
 - Disabled `eval()` function for security improvements.
-- Invalidate cache before load, to make server upgrades easy
 - Removed misleading shortcuts from tray menu, as they didn't work
 - Ctrl/Command+F puts cursor in search box to search in current channel.
 - Add access to settings through tray menu

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -324,8 +324,7 @@ var MattermostView = React.createClass({
 
     webview.addEventListener('did-fail-load', function(e) {
       console.log(thisObj.props.name, 'webview did-fail-load', e);
-      if (e.errorCode === -3 || // An operation was aborted (due to user action).
-        e.errorCode === -300) { //The operation was aborted to invalidate application cache
+      if (e.errorCode === -3) { // An operation was aborted (due to user action).
         return;
       }
 
@@ -357,13 +356,6 @@ var MattermostView = React.createClass({
       } else {
         // if the link is external, use default browser.
         shell.openExternal(e.url);
-      }
-    });
-
-    webview.addEventListener("did-start-loading", function() {
-      if (!webview.cacheInvalidated) {
-        webview.reloadIgnoringCache();
-        webview.cacheInvalidated = true;
       }
     });
 


### PR DESCRIPTION
First of all, please read `CONTRIBUTING.md`

---

- [x] Complete [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [x] Execute `npm run prettify` to format codes
- [x] Write about environment which you tested
  - Ubuntu Linux

The problem we were hitting should have been resolved on the server side! No workaround needed anymore.

This reverts commit 58dfda760ea933d4708041c0dfe4b50de7b1ea21.

Revert "Fix error handler which showed an error on reload, as the cancel event was triggered after the cacheInvalidated property has been set to true"

This reverts commit 93263aea3a4160b7b0954f5e17e74dce5ba4b42d.

Revert "Workaround for bad cache handling in mattermost platform, fixes #212"

This reverts commit 61bf5344bfac076397a27503ee8153da5c9565fe.