### PR TITLE
Add missing padding-bottom in Settings UI

### DIFF
--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -243,7 +243,7 @@ var SettingsPage = React.createClass({
         <Navbar className="navbar-fixed-top" style={ settingsPage.navbar }>
           <h1 style={ settingsPage.heading }>Settings</h1>
         </Navbar>
-        <Grid className="settingsPage" style={ { 'padding-top': '100px' } }>
+        <Grid className="settingsPage" style={ { 'padding-top': '100px', 'padding-bottom': '70px' } }>
           <Row>
             <Col md={ 10 } xs={ 8 }>
             <h2 style={ settingsPage.sectionHeading }>Team Management</h2>
@@ -258,10 +258,6 @@ var SettingsPage = React.createClass({
           <div>
             <hr />
           </div>
-          <Row>
-            <Col md={ 12 }>
-            </Col>
-          </Row>
         </Grid>
         <Navbar className="navbar-fixed-bottom">
           <div className='text-right' style={ settingsPage.footer }>


### PR DESCRIPTION
For #278.

In Bootstrap, when using `navbar-fixed-bottom` footer, the main content needs `padding-bottom`. It was missing in the PR, so [the issue](https://github.com/mattermost/desktop/pull/278#issuecomment-246703583) was found.

https://circleci.com/gh/yuya-oc/desktop/20#artifacts