### PR TITLE
Save autostart settings always when saving options

### DIFF
--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -73,20 +73,33 @@ var SettingsPage = React.createClass({
       currentWindow.setAutoHideMenuBar(config.hideMenuBar);
       currentWindow.setMenuBarVisibility(!config.hideMenuBar);
 
-      var autostart = this.state.autostart;
-      appLauncher.isEnabled().then(function(enabled) {
-        if (enabled && !autostart) {
-          appLauncher.disable();
-        } else if (!enabled && autostart) {
-          appLauncher.enable();
-        }
-      });
     }
 
-    ipcRenderer.send('update-menu', config);
-    ipcRenderer.send('update-config');
-
-    backToIndex();
+    if (process.platform === 'win32' || process.platform === 'linux') {
+      appLauncher.isEnabled().then((enabled) => {
+        if (enabled) {
+          if (this.state.autostart) {
+            return appLauncher.enable();
+          } else {
+            return appLauncher.disable();
+          }
+        } else if (this.state.autostart) {
+          return appLauncher.enable();
+        }
+      }).then((err) => {
+        if (err) {
+          console.log(err);
+          // should save new config if error exists.
+        }
+        ipcRenderer.send('update-menu', config);
+        ipcRenderer.send('update-config');
+        backToIndex();
+      });
+    } else {
+      ipcRenderer.send('update-menu', config);
+      ipcRenderer.send('update-config');
+      backToIndex();
+    }
   },
   handleCancel: function() {
     backToIndex();


### PR DESCRIPTION
For [the issue reported in #230](https://github.com/mattermost/desktop/pull/230#issuecomment-246700060).
When upgrading node-auto-launch, registry info was not updated because the logic updated the info when the option was changed. So now the settings UI saves the autostart info when pressing 'Save' button.