### PR TITLE
Fix ApplicationUserModelID in the start menu shortcut

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mattermost-desktop",
+  "name": "mattermost",
   "productName": "Mattermost",
   "version": "3.4.0",
   "description": "Mattermost Desktop application for Windows, Mac and Linux",

--- a/src/main.js
+++ b/src/main.js
@@ -30,6 +30,7 @@ if (process.platform === 'win32') {
   }
 }
 
+app.setAppUserModelId('com.squirrel.mattermost.Mattermost'); // Use explicit AppUserModelID
 require('electron-squirrel-startup');
 
 const fs = require('fs');

--- a/src/package.json
+++ b/src/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mattermost-desktop",
+  "name": "mattermost",
   "productName": "Mattermost",
   "desktopName": "Mattermost.desktop",
   "version": "3.4.0",


### PR DESCRIPTION
For #287

To correctly show the application name in toast notifications on latest Windows 10, the shortcut which has "ApplicationUserModelID" is necessary. The application expected `com.squirrel.mattermost.Mattermost` due to electron-winstaller and Squirrel. But probably the package name of `package.json`, `mattermost-desktop` was used when creating the shortcut. Unfortunately I was not sure what was actually used, so I explicitly fixed the ID.

This might affect the internal name of .deb packages. It's not critical for now, but if the server provided .deb packages, they might conflict.

When testing this PR, please use installers. If the problem is not solved, please try uninstalling the existing app.

Tested on Windows 10 RS1

https://circleci.com/gh/yuya-oc/desktop/26#artifacts