### PR TITLE
Updates to menu bar

### DIFF
--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -36,7 +36,7 @@ var createTemplate = function(mainWindow, config) {
   }, separatorItem, {
     role: 'quit'
   }] : [{
-    label: 'Settings',
+    label: 'Settings...',
     accelerator: 'CmdOrCtrl+,',
     click: function(item, focusedWindow) {
       mainWindow.loadURL('file://' + __dirname + '/browser/settings.html');
@@ -229,9 +229,9 @@ var createTemplate = function(mainWindow, config) {
   template.push({
     label: '&Help',
     submenu: [{
-      label: `${app_name} Docs`,
+      label: `Learn More...`,
       click: function() {
-        electron.shell.openExternal('http://docs.mattermost.com');
+        electron.shell.openExternal('https://docs.mattermost.com/help/apps/desktop-guide.html');
       }
     }, {
       type: 'separator'


### PR DESCRIPTION
- [X] Complete [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [X] Execute `npm run prettify` to format codes
- [X] Write about environment which you tested
  - N/A

----

Proposed updates to menu bar:
 - Change 'Help > Mattermost Docs' to 'Help > Learn More' and link to newly submitted desktop docs on docs.mattermost.com [to be merged within the next 48 hours]
 - Change 'Settings' and 'Learn More' to include '...' as they open a new page. This is standard to other desktop apps