### PR TITLE
Fix Notification shim not working when clicking

### DIFF
--- a/src/browser/js/notification.js
+++ b/src/browser/js/notification.js
@@ -52,7 +52,7 @@ function override(eventHandlers) {
     defineReadProperty(event);
     Notification.prototype.__defineSetter__(event, function(originalCallback) {
       this.notification[event] = function() {
-        callbackevent = {
+        const callbackevent = {
           preventDefault: function() {
             this.isPrevented = true;
           }


### PR DESCRIPTION
In v3.4.0-rc1, clicking notification doesn't open the application. So I fixed the javascript error.
The code is also used in old versions, so probably this was caused by upgrading Electron.

Tested on Windows 10.

Testing:

1. Send a message from other users.
2. The app shows a desktop notification.
3. Click the notification.
4. The app comes back to front and switches to the applicable tab and channel.

https://circleci.com/gh/yuya-oc/desktop/45#artifacts