### PR TITLE
Disable search in current team `CTRL+SHIFT+S`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ Release date: TBD
 - Disabled `eval()` function for security improvements.
 - Removed misleading shortcuts from tray menu, as they didn't work
 - Ctrl/Command+S puts cursor in search box to search in current team.
-- Shift+Ctrl/Command+S puts cursor in search box to search in current channel.
 - Add access to settings through tray menu
 - Removed unclear desktop notifications when failed to load tabs.
 - Reload automatically the failed tab when the computer becomes online.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -153,7 +153,6 @@ Below lists menu options (shortcut keys are listed in brackets, `Ctrl` becomes `
   - **Paste** (Ctrl+V) - Pastes text from clipboard
   - **Select All** (Ctrl+A) - Select all text in input box
   - **Search in Team** (Ctrl+S) - Puts cursor in search box to search in the current team
-  - **Search in Channel** (Shift+Ctrl+S) - Puts cursor in search box to search in current channel
 - **View**
   - **Reload** (Ctrl+R) - Reload page from the server
   - **Clear Cache and Reload** (Ctrl+Shift+R) - Clear cached content in application and reload page

--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -77,14 +77,6 @@ var createTemplate = function(mainWindow, config) {
           focusedWindow.webContents.send('activate-search-box');
         }
       }
-    }, {
-      label: 'Search in Channel',
-      accelerator: 'Shift+CmdOrCtrl+S',
-      click: (item, focusedWindow) => {
-        if (focusedWindow) {
-          focusedWindow.webContents.send('activate-search-box-in-channel');
-        }
-      }
     }]
   });
   template.push({


### PR DESCRIPTION
Due to #293
Need to revert when DM search works properly.

This just removed the menu, so just confirmation is enough.