### PR TITLE
Bump dependency to get rid of windows copy bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Release date: TBD
 ### Improvements
 
 #### Windows
+ - Copying a links address and pasting it inside the app now works
 
 #### macOS
 

--- a/src/package.json
+++ b/src/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "auto-launch": "^4.0.1",
     "bootstrap": "^3.3.7",
-    "electron-context-menu": "^0.5.0",
+    "electron-context-menu": "^0.6.0",
     "electron-squirrel-startup": "^1.0.0",
     "os-locale": "^1.4.0",
     "react": "^15.3.0",


### PR DESCRIPTION
This should fix the windows copy bug.
I haven't tested it yet, but if upstream/@jnugh did it's job right it should be fine ;)