### PR TITLE
Fix linux tray settings

### DIFF
--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -168,7 +168,7 @@ var SettingsPage = React.createClass({
                      onChange={ this.handleChangeHideMenuBar } />);
     }
     if (process.platform === 'darwin' || process.platform === 'linux') {
-      options.push(<Input key="inputShowTrayIcon" id="inputShowTrayIcon" ref="showTrayIcon" type="checkbox" label="Show icon on menu bar (Need to restart the application)" checked={ this.state.showTrayIcon }
+      options.push(<Input key="inputShowTrayIcon" id="inputShowTrayIcon" ref="showTrayIcon" type="checkbox" label={ process.platform === 'darwin' ? "Show icon on menu bar (need to restart the application)" : "Show icon in notification area (need to restart the application)" } checked={ this.state.showTrayIcon }
                      onChange={ this.handleChangeShowTrayIcon } />);
     }
     if (process.platform === 'linux') {

--- a/src/main.js
+++ b/src/main.js
@@ -407,7 +407,7 @@ app.on('ready', function() {
     if (shouldShowTrayIcon()) {
       const tray_menu = require('./main/menus/tray').createMenu(mainWindow, config);
       trayIcon.setContextMenu(tray_menu);
-      if (process.platform === 'darwin') {
+      if (process.platform === 'darwin' || process.platform === 'linux') {
         // store the information, if the tray was initialized, for checking in the settings, if the application
         // was restarted after setting "Show icon on menu bar"
         if (trayIcon)


### PR DESCRIPTION
- [x] Complete [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [x] Execute `npm run prettify` to format codes
- [x] Write about environment which you tested
  - Operating system: Linux, xubuntu 16.04.1 LTS (xfce 4.12)

This is a small PR to fix a couple of minor issues with the settings page on Linux.

- The option "Leave app running in notification area when the window is closed" was never enabled, even after restarting the app, because the check in `main.js` that sets `trayWasVisible` was not running.
- Additionally, one of the settings was wrongly named, referring to the "menu bar" when it should have said "notification area", so I've updated this too.

