### PR TITLE
Fix the app window pops up second to foreground when a new message is received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Mattermost Desktop Application Changelog
 
+## Release v3.4.1
+
+Release date: TBD
+
+### Bug Fixes
+
+#### macOS
+ - Fixed an issue where the app window pops up second to foreground when a new message is received
+
+----
+
 ## Release v3.4.0
 
 Release date: September 22, 2016

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Release date: TBD
 
 ### Bug Fixes
 
-#### macOS
+#### OS X
  - Fixed an issue where the app window pops up second to foreground when a new message is received
 
 ----

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -113,8 +113,10 @@ var MainPage = React.createClass({
       }
     });
   },
-  componentDidUpdate: function() {
-    this.refs[`mattermostView${this.state.key}`].focusOnWebView();
+  componentDidUpdate: function(prevProps, prevState) {
+    if (prevState.key !== this.state.key) { // i.e. When tab has been changed
+      this.refs[`mattermostView${this.state.key}`].focusOnWebView();
+    }
   },
   handleSelect: function(key) {
     const newKey = (this.props.teams.length + key) % this.props.teams.length;


### PR DESCRIPTION
For #314, Tested on macOS 10.12.

The issue was probably caused by #262. When a new messages is arrived, the PR try to update focus by `componentDidUpdate`. On macOS, somehow the function changes window order.
Possibly it's a bug of electron, but this is important for us. So I made this PR against to `release-3.4` branch to make v3.4.1.

**Test**
https://circleci.com/gh/yuya-oc/desktop/57#artifacts

For testing, we need regression for #262. Please follow [the test for #262](https://github.com/mattermost/desktop/pull/262#issuecomment-244218427).

> TEST 1:
> 
> 1) Have two windows open side-by-side: one for Desktop and another for text editor
> 2) Click on the text editor
> 3) Click on the webview of the Desktop app
> 4) Hit "CTRL+K"
> 
> Expected: Channel picker UI appears
> 5) Hit "CTRL+S"
> 
> Expected: Focus set to the search box
> TEST 2:
> 
> 1) Open the desktop app, and add two teams so that you have two active tabs
> 2) Switch tabs
> 3) Hit "CTRL+K"
>
> Expected: Channel picker UI appears
> 4) Hit "CTRL+S"
>
> Expected: Focus set to the search box

**Known degrading**
If you click the tab twice or click the tab bar where there is no tab, the focus is not set correctly (#231). But it would not be critical than this.