### PR TITLE
Issue 302: Download desktop app download folder, instead of defaulting to Macintosh HD

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -386,7 +386,8 @@ app.on('ready', function() {
 
       if (savePath) {
         item.setSavePath(savePath);
-      } else {
+      }
+      else {
         item.cancel();
       }
     });

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,8 @@ const {
   ipcMain,
   nativeImage,
   dialog,
-  systemPreferences
+  systemPreferences,
+  session
 } = require('electron');
 
 process.on('uncaughtException', (error) => {
@@ -374,6 +375,22 @@ app.on('ready', function() {
   }
   window_options.title = app.getName();
   mainWindow = new BrowserWindow(window_options);
+
+  if (process.platform === 'darwin') {
+    session.defaultSession.on('will-download', (event, item, webContents) => {
+      var filename = item.getFilename();
+      var savePath = dialog.showSaveDialog({
+        title: filename,
+        defaultPath: require('os').homedir() + '/Downloads/' + filename
+      });
+
+      if (savePath) {
+        item.setSavePath(savePath);
+      } else {
+        item.cancel();
+      }
+    });
+  }
 
   mainWindow.webContents.on('crashed', () => {
     console.log('The application has crashed.');


### PR DESCRIPTION
First of all, please read `CONTRIBUTING.md`

---

- [x] Complete [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [x] Execute `npm run prettify` to format codes
- [x] Write about environment which you tested
  - OSX 10.12.1

On Mac, a download in desktop app defaulted to Macintosh HD instead of the download folder