### PR TITLE
Add CTRL+SHIFT+MINUS as a shortcut for zooming out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Release date: TBD
  - "Cannot connect to Mattermost" is now on top of the page
  - Suppressed verbose error which is related to certificates
  - Clear cache on desktop app update: The application cache will be purged whenever the desktop app version changes
+ - Added CTRL+SHIFT+MINUS as a shortcut for zooming out
 
 #### Windows
  - Copying a links address and pasting it inside the app now works

--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -120,6 +120,11 @@ function createTemplate(mainWindow, config) {
       role: 'zoomin'
     }, {
       role: 'zoomout'
+    }, {
+      label: 'Zoom Out (hidden)',
+      accelerator: 'CmdOrCtrl+Shift+-',
+      visible: false,
+      role: 'zoomout'
     }, separatorItem, {
       label: 'Toggle Developer Tools',
       accelerator: (() => {


### PR DESCRIPTION
Refers to https://github.com/mattermost/desktop/issues/301.
I haven't updated the `CHANGELOG.md` nor the `doc/*.md` as I saw the `CTRL+SHIFT+PLUS` shortcut isn't documented as well and is more here for user experience consistency.

---
- [x] Complete [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [x] Execute `npm run prettify` to format codes
- [x] Update `CHANGELOG.md` and/or `doc/*.md` if it's necessary.
- [x] Write about environment which you tested
  - Ubuntu 16.04 LTS
