### PR TITLE
disableWebSecurity -> allowDisplayingInsecureContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Release date: TBD
 ### Bug Fixes
  - Fixed wrong cursor for "Edit" and "Remove" in Setting page
  - Fixed an issue where "Zoom in/out" does not properly work
+ - YouTube preview works, even if mixed content is allowed
 
 #### Windows
  - The accelerator of "Redo" is now shown as `Ctrl+Y`

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "chai-as-promised": "^5.3.0",
     "cross-env": "^3.1.2",
     "devtron": "^1.3.0",
-    "electron": "1.4.2",
+    "electron": "1.4.6",
     "electron-builder": "^7.11.2",
     "electron-connect": "~0.6.0",
     "eslint": "^3.4.0",

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -392,10 +392,10 @@ var MattermostView = React.createClass({
     var self = this;
     var webview = ReactDOM.findDOMNode(this.refs.webview);
 
-    // This option disables the same-origin policy and allows js/css/plugins not only content like images.
+    // This option allows insecure content, when set to true it is possible to
+    // load content via HTTP while the mattermost server serves HTTPS
     if (config.disablewebsecurity === true) {
-      // webview.setAttribute('disablewebsecurity', false) disables websecurity. (electron's bug?)
-      webview.setAttribute('disablewebsecurity', true);
+      webview.setAttribute('webpreferences', 'allowDisplayingInsecureContent');
     }
 
     webview.addEventListener('did-fail-load', (e) => {

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -92,7 +92,9 @@ describe('browser/settings.html', function desc() {
     describe('Allow mixed content', () => {
       [true, false].forEach((v) => {
         it(`should be saved and loaded: ${v}`, () => {
+          const webPreferences = v ? 'allowDisplayingInsecureContent' : '';
           env.addClientCommands(this.app.client);
+
           return this.app.client.
             loadSettingsPage().
             scroll('#inputDisableWebSecurity').
@@ -107,19 +109,19 @@ describe('browser/settings.html', function desc() {
               const savedConfig = JSON.parse(fs.readFileSync(env.configFilePath, 'utf8'));
               savedConfig.disablewebsecurity.should.equal(v);
             }).
-            getAttribute('.mattermostView', 'disablewebsecurity').then((disablewebsecurity) => { // confirm actual behavior
+            getAttribute('.mattermostView', 'webpreferences').then((disablewebsecurity) => { // confirm actual behavior
               // disablewebsecurity is an array of String
               disablewebsecurity.forEach((d) => {
-                v.toString().should.equal(d);
+                d.should.equal(webPreferences);
               });
             }).then(() => {
               return this.app.restart();
             }).then(() => {
               env.addClientCommands(this.app.client);
               return this.app.client. // confirm actual behavior
-                getAttribute('.mattermostView', 'disablewebsecurity').then((disablewebsecurity) => { // disablewebsecurity is an array of String
+                getAttribute('.mattermostView', 'webpreferences').then((disablewebsecurity) => { // disablewebsecurity is an array of String
                   disablewebsecurity.forEach((d) => {
-                    v.toString().should.equal(d);
+                    d.should.equal(webPreferences);
                   });
                 }).
                 loadSettingsPage().


### PR DESCRIPTION
Allow mixed content does not use disableWebSecurity anymore.

We don't use a sledgehammer to crack a nut when this gets merged. Disabling security features is usually a bad idea - in this case we do not need to disable all security features to reach the goal.
As of electron 1.4.5 we can disable only certain security features as we need to.

This also fixes the youtube preview issue which was related to the disabled CORS security feature.

---

- [x] Complete [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [x] Execute `npm run prettify` to format codes
- [x] Update `CHANGELOG.md` and/or `doc/*.md` if it's necessary.
- [x] Write about environment which you tested
  - Ubuntu 16.10 Unity

