### PR TITLE
Add simple README for Linux packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         },
         {
           "from": "resources/linux",
-          "filter": "create_desktop_file.sh"
+          "filter": ["create_desktop_file.sh", "README.md"]
         }
       ]
     },

--- a/resources/linux/README.md
+++ b/resources/linux/README.md
@@ -3,31 +3,26 @@
 ## Table of Contents
 
 - [Install](#install)
-- [Usage](#usage)
+- [User Guide](#user-guide)
 - [Contributing](#contributing)
 - [License](#license)
 
 
 ## Install
 
-If you were installed the application via package managers, you don't have to do
-anymore. It's ready to use in your system, so please follow [usage](#usage)
-instruction.
+If you installed the application via a package manager, it's ready to use in your system. Please follow the [User Guide](#user-guide) for further information.
 
-First, locate the extracted directory into your desired directory (e.g.
-`/opt/mattermost-desktop-<VERSION>`).
-
+Otherwise, first locate the extracted directory in your desired directory (e.g. `/opt/mattermost-desktop-<VERSION>`) and follow the steps below.
 
 ### Desktop launcher
 
-Execute the script file to create `Mattermost.desktop` file.
+Execute the script file to create a `Mattermost.desktop` file.
 
 ```
 /opt/mattermost-desktop-<VERSION>/create_desktop_file.sh
 ```
 
-Then move it into appropreate directory of your desktop environment. For
-example, it's `~/.local/share/applications/` for current user on Ubuntu Unity.
+Then move it to the appropriate directory of your desktop environment. For example, on Ubuntu Unity it's `~/.local/share/applications/` for the current user.
 
 ```
 mv Mattermost.desktop ~/.local/share/applications/
@@ -35,8 +30,7 @@ mv Mattermost.desktop ~/.local/share/applications/
 
 ### Terminal command
 
-Set `PATH` environment variable to enable launching from terminal.
-For example, you can append following line into `~/.bashrc`.
+Set a `PATH` environment variable to enable launching from the terminal. For example, you can append the following line into `~/.bashrc`.
 
 ```sh
 # assuming that /opt/mattermost-desktop-<VERSION>/mattermost-desktop is the executable file.
@@ -49,24 +43,24 @@ Alternatively, you can also create a symbolic link for the application.
 sudo ln -s /opt/mattermost-desktop-<VERSION>/mattermost-desktop /usr/local/bin/
 ```
 
-## Usage
+You're now all set! See the [User Guide](#user-guide) below for instructions.
+
+
+## User Guide
 
 After launching, you need to configure the application to interact with your team.
 
-1. If you don't see "Settings" page, select **File** -> **Settings...** from the menu bar.
+1. If you don't see a page titled "Settings", select **File** > **Settings...** from the menu bar.
 2. Click **Add new team** next to the right of Team Management section.
 3. Enter **Name** and a valid **URL**, which begins with either `http://` or `https://`.
 4. Click **Add**.
 
-
-### More guides
-
-Available at [Mattermost Documentation](https://docs.mattermost.com/help/apps/desktop-guide.html).
+More guides are available at [Mattermost Documentation](https://docs.mattermost.com/help/apps/desktop-guide.html).
 
 
 ## Contributing
 
-See [the contribute file](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md).
+See [contributing guidlines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md) for reporting bugs, features or submitting pull requests.
 
 
 ## License

--- a/resources/linux/README.md
+++ b/resources/linux/README.md
@@ -61,7 +61,7 @@ More guides are available at [Mattermost Documentation](https://docs.mattermost.
 
 ## Contributing
 
-See [contributing guidlines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md) for reporting bugs, features or submitting pull requests.
+See [contributing guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md) for reporting bugs, features or submitting pull requests.
 
 
 ## License

--- a/resources/linux/README.md
+++ b/resources/linux/README.md
@@ -66,4 +66,4 @@ See [contributing guidelines](https://github.com/mattermost/desktop/blob/master/
 
 ## License
 
-Apache Lisence, Version 2.0
+Apache License, Version 2.0

--- a/resources/linux/README.md
+++ b/resources/linux/README.md
@@ -54,6 +54,7 @@ After launching, you need to configure the application to interact with your tea
 2. Click **Add new team** next to the right of Team Management section.
 3. Enter **Name** and a valid **URL**, which begins with either `http://` or `https://`.
 4. Click **Add**.
+5. Click **Save**.
 
 More guides are available at [Mattermost Documentation](https://docs.mattermost.com/help/apps/desktop-guide.html).
 

--- a/resources/linux/README.md
+++ b/resources/linux/README.md
@@ -1,0 +1,74 @@
+# Mattermost Desktop for Linux
+
+## Table of Contents
+
+- [Install](#install)
+- [Usage](#usage)
+- [Contributing](#contributing)
+- [License](#license)
+
+
+## Install
+
+If you were installed the application via package managers, you don't have to do
+anymore. It's ready to use in your system, so please follow [usage](#usage)
+instruction.
+
+First, locate the extracted directory into your desired directory (e.g.
+`/opt/mattermost-desktop-<VERSION>`).
+
+
+### Desktop launcher
+
+Execute the script file to create `Mattermost.desktop` file.
+
+```
+/opt/mattermost-desktop-<VERSION>/create_desktop_file.sh
+```
+
+Then move it into appropreate directory of your desktop environment. For
+example, it's `~/.local/share/applications/` for current user on Ubuntu Unity.
+
+```
+mv Mattermost.desktop ~/.local/share/applications/
+```
+
+### Terminal command
+
+Set `PATH` environment variable to enable launching from terminal.
+For example, you can append following line into `~/.bashrc`.
+
+```sh
+# assuming that /opt/mattermost-desktop-<VERSION>/mattermost-desktop is the executable file.
+export PATH=$PATH:/opt/mattermost-desktop-<VERSION>
+```
+
+Alternatively, you can also create a symbolic link for the application.
+
+```sh
+sudo ln -s /opt/mattermost-desktop-<VERSION>/mattermost-desktop /usr/local/bin/
+```
+
+## Usage
+
+After launching, you need to configure the application to interact with your team.
+
+1. If you don't see "Settings" page, select **File** -> **Settings...** from the menu bar.
+2. Click **Add new team** next to the right of Team Management section.
+3. Enter **Name** and a valid **URL**, which begins with either `http://` or `https://`.
+4. Click **Add**.
+
+
+### More guides
+
+Available at [Mattermost Documentation](https://docs.mattermost.com/help/apps/desktop-guide.html).
+
+
+## Contributing
+
+See [the contribute file](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md).
+
+
+## License
+
+Apache Lisence, Version 2.0


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Added a README file for linux. It's included at the top directory of extracted packages. And it focuses on quick instruction for first use.

**Issue link**
#376 

**Test Cases**
N/A

**Additional Notes**
N/A
