### PR TITLE
Fix confused cursor in HiDPI

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -64,6 +64,12 @@ const assetsDir = path.resolve(app.getAppPath(), 'assets');
 // be closed automatically when the JavaScript object is garbage collected.
 var mainWindow = null;
 
+// Fix confused cursor in HiDPI
+// https://github.com/electron/electron/issues/7655#issuecomment-259688853
+if (process.platform === 'win32') {
+  app.commandLine.appendSwitch('enable-use-zoom-for-dsf', 'false');
+}
+
 var argv = require('yargs').parse(process.argv.slice(1));
 
 const electronConnect = argv.livereload ? require('electron-connect') : null;


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fix the issue where the mouse cursor is randomly incorrect when DPI is higher than 100% on Windows.

It was introduced by upgrading Electron in #307.

**Issue link**
https://github.com/mattermost/desktop/pull/307#issuecomment-251397637
https://github.com/electron/electron/issues/7655

**Test Cases**
Set DPI higher than 100%, e.g. 150%, 175%. Then move mouse cursor across messages in a channel.

Background should not blink.

**Additional Notes**
Artifacts: https://circleci.com/gh/yuya-oc/desktop/103#artifacts