### PR TITLE
Fix "Leave app running in notification area" checkbox not working on macOS

### DIFF
--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -123,9 +123,7 @@ const SettingsPage = React.createClass({
     });
   },
   handleChangeMinimizeToTray() {
-    var shouldMinimizeToTray =
-      (process.platform !== 'darwin' || !this.refs.showTrayIcon.props.checked) &&
-      !this.refs.minimizeToTray.props.checked;
+    const shouldMinimizeToTray = this.state.showTrayIcon && !this.refs.minimizeToTray.props.checked;
 
     this.setState({
       minimizeToTray: shouldMinimizeToTray

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -20,6 +20,7 @@ function loadDefault(version) {
       showTrayIcon: false,
       trayIconTheme: '',
       disablewebsecurity: true,
+      minimizeToTray: false,
       toggleWindowOnTrayIconClick: false,
       version: 1,
       notifications: {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fix that "Leave app running in notification area when application window is closed" was not working on macOS.

It seems that the issue was introduced in #371 by mistake.

Tested on macOS 10.12.

**Issue link**
#382 

**Test Cases**
Try to enable/disable the setting. And the behavior should be changed in accordance with the setting.

**Additional Notes**
Artifacts: https://circleci.com/gh/yuya-oc/desktop/105#artifacts
The failed test case is not related to this change.