### PR TITLE
Do not place windows off screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Release date: TBD
 
 ### Bug Fixes
 
+#### All Platforms
+- Do not place the application window outside of the viewable area anymore, if the display it has been on has been removed
+
 #### Windows
 - Fixed an issue where an unexpected window appears while install/uninstalling
 


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

This fixes an issue where a window could be placed off screen which happend when the display it was previously on has been disconnected before launching the application.

> The application will always be placed on an existing screen.

https://github.com/mattermost/desktop/issues/378

**Test Cases**
* Have 2 monitors
* Place the app on one of them
* Close the app
* Start the app -> It should be exactly were it was when you closed it
* Close the app
* Disable the monitor
* Start the app -> It should be on your main screen

**Additional Notes**
I do not check if the window fits onto the screen , so if you plug in another monitor with a smaller resolution the window might not fit the screen (which I actually didn't test, might as well be covered by electron).