### PR TITLE
Update Electron to 1.4.12 for Certificate Transparency Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "chai-as-promised": "^5.3.0",
     "cross-env": "^3.1.2",
     "devtron": "^1.3.0",
-    "electron": "1.4.6",
+    "electron": "1.4.12",
     "electron-builder": "^7.11.2",
     "electron-connect": "~0.6.0",
     "eslint": "^3.4.0",


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Electron 1.4.6 (1.4.0-1.4.11) has an issue where some HTTPS connection will start to fail after a certain date (January 14th, 2017 9:00 PM PST).

**Issue link**
http://electron.atom.io/blog/2016/12/09/certificate-transparency-fix

**Test Cases**
Set computer's clock and add https://symbeta.symantec.com/welcome/ as a team URL.

**Additional Notes**
Artifacts: https://circleci.com/gh/yuya-oc/desktop/110#artifacts