### PR TITLE
Linux tray icon theme settings regression fix

### DIFF
--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -1,5 +1,6 @@
 const React = require('react');
-const {Button, Checkbox, Col, FormGroup, Grid, Navbar, Row} = require('react-bootstrap');
+const ReactDOM = require('react-dom');
+const {Button, Checkbox, Col, FormGroup, FormControl, ControlLabel, Grid, Navbar, Row} = require('react-bootstrap');
 
 const {ipcRenderer, remote} = require('electron');
 const AutoLaunch = require('auto-launch');
@@ -114,7 +115,7 @@ const SettingsPage = React.createClass({
   },
   handleChangeTrayIconTheme() {
     this.setState({
-      trayIconTheme: !this.refs.trayIconTheme.props.checked
+      trayIconTheme: ReactDOM.findDOMNode(this.refs.trayIconTheme).value
     });
   },
   handleChangeAutoStart() {
@@ -189,16 +190,19 @@ const SettingsPage = React.createClass({
     }
     if (process.platform === 'linux') {
       options.push(
-        <Checkbox
-          key='inputTrayIconTheme'
-          ref='trayIconTheme'
-          type='select'
-          value={this.state.trayIconTheme}
-          onChange={this.handleChangeTrayIconTheme}
-        >{'Icon theme (Need to restart the application)'}
-          <option value='light'>{'Light'}</option>
-          <option value='dark'>{'Dark'}</option>
-        </Checkbox>);
+        <FormGroup>
+          <ControlLabel>{'Icon theme (Need to restart the application)'}</ControlLabel>
+          <FormControl
+            componentClass='select'
+            key='inputTrayIconTheme'
+            ref='trayIconTheme'
+            value={this.state.trayIconTheme}
+            onChange={this.handleChangeTrayIconTheme}
+          >
+            <option value='light'>{'Light'}</option>
+            <option value='dark'>{'Dark'}</option>
+          </FormControl>
+        </FormGroup>);
     }
     options.push(
       <Checkbox

--- a/src/main.js
+++ b/src/main.js
@@ -153,12 +153,21 @@ const trayImages = (() => {
     }
   case 'linux':
     {
-      const theme = config.trayIconTheme || 'light';
-      return {
-        normal: nativeImage.createFromPath(path.resolve(assetsDir, 'linux', theme, 'MenuIconTemplate.png')),
-        unread: nativeImage.createFromPath(path.resolve(assetsDir, 'linux', theme, 'MenuIconUnreadTemplate.png')),
-        mention: nativeImage.createFromPath(path.resolve(assetsDir, 'linux', theme, 'MenuIconMentionTemplate.png'))
-      };
+      const theme = config.trayIconTheme;
+      try {
+        return {
+          normal: nativeImage.createFromPath(path.resolve(assetsDir, 'linux', theme, 'MenuIconTemplate.png')),
+          unread: nativeImage.createFromPath(path.resolve(assetsDir, 'linux', theme, 'MenuIconUnreadTemplate.png')),
+          mention: nativeImage.createFromPath(path.resolve(assetsDir, 'linux', theme, 'MenuIconMentionTemplate.png'))
+        };
+      } catch (e) {
+        //Fallback for invalid theme setting
+        return {
+          normal: nativeImage.createFromPath(path.resolve(assetsDir, 'linux', 'light', 'MenuIconTemplate.png')),
+          unread: nativeImage.createFromPath(path.resolve(assetsDir, 'linux', 'light', 'MenuIconUnreadTemplate.png')),
+          mention: nativeImage.createFromPath(path.resolve(assetsDir, 'linux', 'light', 'MenuIconMentionTemplate.png'))
+        };
+      }
     }
   default:
     return {};


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
This fixes a regression on the settings page that was introduced by upgrading react bootstrap (upgrading to the new form syntax).
On Linux the user can choose from a dark and a light theme for the tray icon. This setting was a select element which was transformed into a checkbox during react bootstrap upgrade.
The user was therefore not able to choose a different theme, when using the checkbox control a bool value was written to the config file which kept the app from opeining up on the next start.

This fix shows the dropdown again, allows to set sane values for the theme config and has a fallback when an invalid value has already been written to the config file - so that the application starts again.

**Test Cases**

**Additional Notes**
