### PR TITLE
Count unread teams in team sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Release date: TBD
 
 #### All Platforms
 - Suppress white screen which is displayed for a moment on startup
+- Support unread indications in team sidebar of Mattermost server 3.6
 
 ### Bug Fixes
 

--- a/src/browser/webview/mattermost.js
+++ b/src/browser/webview/mattermost.js
@@ -36,6 +36,12 @@ setInterval(function getUnreadCount() {
   // Note: the active channel doesn't have '.unread-title'.
   var unreadCount = document.getElementsByClassName('unread-title').length;
 
+  // unreadCount in team sidebar
+  const teamSideBar = document.getElementsByClassName('team-sidebar'); // team-sidebar doesn't have id
+  if (teamSideBar.length === 1) {
+    unreadCount += teamSideBar[0].getElementsByClassName('unread').length;
+  }
+
   // mentionCount in sidebar
   var elem = document.getElementsByClassName('badge');
   var mentionCount = 0;


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Support unread indications in team sidebar of Mattermost server 3.6

<img width="226" alt="team unread" src="https://cloud.githubusercontent.com/assets/1412057/21982491/d6973d56-dc2f-11e6-8442-17b9fb1dc7de.png">


**Issue link**
#409 

**Test Cases**
1. Create multiple teams in the same server.
2. Get messages in a team where you don't see.

**Additional Notes**
Tested on Windows 10. This PR just changes a unread counting only, so the feature should work also on other platforms.

Currently teams are counted as "channels" on Windows.
This should be improved in future refactoring because internal parameters of the app would become very complicated.

<img width="105" alt="windows_tray" src="https://cloud.githubusercontent.com/assets/1412057/21982485/cacd7cec-dc2f-11e6-8886-906094476ce4.png">

