### PR TITLE
Ux manage servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ from the final changelog of the release.
 Release date: TBD
 
 ### Improvements
+- Added a new team button next to the team tabs
 
 #### All Platforms
 - Suppress white screen which is displayed for a moment on startup

--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -10,6 +10,8 @@ const MattermostView = require('./MattermostView.jsx');
 const TabBar = require('./TabBar.jsx');
 const HoveringURL = require('./HoveringURL.jsx');
 
+const NewTeamModal = require('./NewTeamModal.jsx');
+
 // Todo: Need to consider better way to apply styles
 const styles = {
   hoveringURL: {
@@ -237,6 +239,11 @@ const MainPage = React.createClass({
       this.setState({targetURL});
     }
   },
+  addTeam() {
+    this.setState({
+      showNewTeamModal: true
+    });
+  },
   render() {
     var self = this;
 
@@ -253,6 +260,7 @@ const MainPage = React.createClass({
             mentionAtActiveCounts={this.state.mentionAtActiveCounts}
             activeKey={this.state.key}
             onSelect={this.handleSelect}
+            onAddTeam={this.addTeam}
           />
         </Row>
       );
@@ -296,6 +304,25 @@ const MainPage = React.createClass({
       authServerURL = `${tmpURL.protocol}//${tmpURL.host}`;
       authInfo = this.state.loginQueue[0].authInfo;
     }
+    var modal;
+    if (this.state.showNewTeamModal) {
+      modal = (
+        <NewTeamModal
+          onClose={() => {
+            this.setState({
+              showNewTeamModal: false
+            });
+          }}
+          onSave={(newTeam) => {
+            this.setState({
+              showNewTeamModal: false
+            });
+            this.props.teams.push(newTeam);
+            this.render();
+          }}
+        />
+      );
+    }
     return (
       <div>
         <LoginModal
@@ -323,6 +350,9 @@ const MainPage = React.createClass({
               targetURL={this.state.targetURL}
             /> }
         </ReactCSSTransitionGroup>
+        <div>
+          { modal }
+        </div>
       </div>
     );
   }

--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -130,6 +130,10 @@ const MainPage = React.createClass({
         mattermost.goForward();
       }
     });
+
+    ipcRenderer.on('add-server', () => {
+      this.addServer();
+    });
   },
   componentDidUpdate(prevProps, prevState) {
     if (prevState.key !== this.state.key) { // i.e. When tab has been changed
@@ -240,7 +244,7 @@ const MainPage = React.createClass({
       this.setState({targetURL});
     }
   },
-  addTeam() {
+  addServer() {
     this.setState({
       showNewTeamModal: true
     });
@@ -261,7 +265,7 @@ const MainPage = React.createClass({
             mentionAtActiveCounts={this.state.mentionAtActiveCounts}
             activeKey={this.state.key}
             onSelect={this.handleSelect}
-            onAddTeam={this.addTeam}
+            onAddServer={this.addServer}
           />
         </Row>
       );

--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -315,10 +315,11 @@ const MainPage = React.createClass({
             });
           }}
           onSave={(newTeam) => {
-            this.setState({
-              showNewTeamModal: false
-            });
             this.props.teams.push(newTeam);
+            this.setState({
+              showNewTeamModal: false,
+              key: this.props.teams.length - 1
+            });
             this.render();
             this.props.onTeamConfigChange(this.props.teams);
           }}

--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -38,7 +38,8 @@ const MainPage = React.createClass({
   propTypes: {
     disablewebsecurity: React.PropTypes.bool.isRequired,
     onUnreadCountChange: React.PropTypes.func.isRequired,
-    teams: React.PropTypes.array.isRequired
+    teams: React.PropTypes.array.isRequired,
+    onTeamConfigChange: React.PropTypes.func.isRequired
   },
 
   getInitialState() {
@@ -319,6 +320,7 @@ const MainPage = React.createClass({
             });
             this.props.teams.push(newTeam);
             this.render();
+            this.props.onTeamConfigChange(this.props.teams);
           }}
         />
       );

--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -309,27 +309,25 @@ const MainPage = React.createClass({
       authServerURL = `${tmpURL.protocol}//${tmpURL.host}`;
       authInfo = this.state.loginQueue[0].authInfo;
     }
-    var modal;
-    if (this.state.showNewTeamModal) {
-      modal = (
-        <NewTeamModal
-          onClose={() => {
-            this.setState({
-              showNewTeamModal: false
-            });
-          }}
-          onSave={(newTeam) => {
-            this.props.teams.push(newTeam);
-            this.setState({
-              showNewTeamModal: false,
-              key: this.props.teams.length - 1
-            });
-            this.render();
-            this.props.onTeamConfigChange(this.props.teams);
-          }}
-        />
-      );
-    }
+    var modal = (
+      <NewTeamModal
+        show={this.state.showNewTeamModal}
+        onClose={() => {
+          this.setState({
+            showNewTeamModal: false
+          });
+        }}
+        onSave={(newTeam) => {
+          this.props.teams.push(newTeam);
+          this.setState({
+            showNewTeamModal: false,
+            key: this.props.teams.length - 1
+          });
+          this.render();
+          this.props.onTeamConfigChange(this.props.teams);
+        }}
+      />
+    );
     return (
       <div>
         <LoginModal

--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -55,20 +55,20 @@ class NewTeamModal extends React.Component {
         </Modal.Header>
 
         <Modal.Body>
-          {'Please specify a team name and a valid Mattermost URL'}
+          {'Please specify a server name and a valid Mattermost URL'}
           <form>
             <FormGroup
               validationState={this.getTeamNameValidationState()}
             >
-              <ControlLabel>{'Team Display Name'}</ControlLabel>
+              <ControlLabel>{'Server Display Name'}</ControlLabel>
               <FormControl
                 type='text'
                 value={this.state.teamName}
-                placeholder='Team Name'
+                placeholder='Server Name'
                 onChange={this.handleTeamNameChange.bind(this)}
               />
               <FormControl.Feedback/>
-              <HelpBlock>{'Team Name must not be empty'}</HelpBlock>
+              <HelpBlock>{'The name of the server displayed on your desktop app tab bar.'}</HelpBlock>
             </FormGroup>
             <FormGroup
               validationState={this.getTeamUrlValidationState()}
@@ -81,7 +81,7 @@ class NewTeamModal extends React.Component {
                 onChange={this.handleTeamUrlChange.bind(this)}
               />
               <FormControl.Feedback/>
-              <HelpBlock>{'Must be a valid URL'}</HelpBlock>
+              <HelpBlock>{'The URL of your Mattermost server. Must start with http:// or https://.'}</HelpBlock>
             </FormGroup>
           </form>
         </Modal.Body>

--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -13,6 +13,15 @@ class NewTeamModal extends React.Component {
     };
   }
 
+  componentWillMount() {
+    this.state = {
+      teamName: this.props.team ? this.props.team.name : '',
+      teamUrl: this.props.team ? this.props.team.url : '',
+      teamIndex: this.props.team ? this.props.team.index : false,
+      saveStarted: false
+    };
+  }
+
   getTeamNameValidationError() {
     if (!this.state.saveStarted) {
       return null;
@@ -69,7 +78,8 @@ class NewTeamModal extends React.Component {
       if (this.validateForm()) {
         this.props.onSave({
           url: this.state.teamUrl,
-          name: this.state.teamName
+          name: this.state.teamName,
+          index: this.state.teamIndex
         });
       }
     });
@@ -159,7 +169,8 @@ class NewTeamModal extends React.Component {
 
 NewTeamModal.propTypes = {
   onClose: React.PropTypes.func,
-  onSave: React.PropTypes.func
+  onSave: React.PropTypes.func,
+  team: React.PropTypes.object
 };
 
 module.exports = NewTeamModal;

--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -1,6 +1,5 @@
 const React = require('react');
 const {Modal, Button, FormGroup, FormControl, ControlLabel, HelpBlock} = require('react-bootstrap');
-const validUrl = require('valid-url');
 
 class NewTeamModal extends React.Component {
   constructor() {
@@ -51,7 +50,7 @@ class NewTeamModal extends React.Component {
     if (this.state.teamUrl.length === 0) {
       return 'URL is required.';
     }
-    if (!validUrl.isUri(this.state.teamUrl)) {
+    if (!(/^https?:\/\/.*/).test(this.state.teamUrl.trim())) {
       return 'URL should start with http:// or https://.';
     }
     return null;

--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -53,11 +53,10 @@ class NewTeamModal extends React.Component {
         id='newServerModal'
       >
         <Modal.Header>
-          <Modal.Title>{'Add a new Team'}</Modal.Title>
+          <Modal.Title>{'Add Server'}</Modal.Title>
         </Modal.Header>
 
         <Modal.Body>
-          {'Please specify a server name and a valid Mattermost URL'}
           <form>
             <FormGroup
               validationState={this.getTeamNameValidationState()}
@@ -81,7 +80,7 @@ class NewTeamModal extends React.Component {
                 id='teamUrlInput'
                 type='text'
                 value={this.state.teamUrl}
-                placeholder='https://example.org'
+                placeholder='https://example.com'
                 onChange={this.handleTeamUrlChange.bind(this)}
               />
               <FormControl.Feedback/>

--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -13,11 +13,15 @@ class NewTeamModal extends React.Component {
     };
   }
 
-  getTeamNameValidationState() {
+  getTeamNameValidationError() {
     if (!this.state.saveStarted) {
-      return '';
+      return null;
     }
-    return this.state.teamName.length > 0 ? '' : 'error';
+    return this.state.teamName.length > 0 ? null : 'Name is required.';
+  }
+
+  getTeamNameValidationState() {
+    return this.getTeamNameValidationError() === null ? null : 'error';
   }
 
   handleTeamNameChange(e) {
@@ -26,17 +30,21 @@ class NewTeamModal extends React.Component {
     });
   }
 
-  getTeamUrlValidationState() {
+  getTeamUrlValidationError() {
     if (!this.state.saveStarted) {
-      return '';
+      return null;
     }
     if (this.state.teamUrl.length === 0) {
-      return 'error';
+      return 'URL is required.';
     }
     if (!validUrl.isUri(this.state.teamUrl)) {
-      return 'error';
+      return 'URL should start with http:// or https://.';
     }
-    return '';
+    return null;
+  }
+
+  getTeamUrlValidationState() {
+    return this.getTeamUrlValidationError() === null ? null : 'error';
   }
 
   handleTeamUrlChange(e) {
@@ -45,9 +53,13 @@ class NewTeamModal extends React.Component {
     });
   }
 
+  getError() {
+    return this.getTeamNameValidationError() || this.getTeamUrlValidationError();
+  }
+
   validateForm() {
-    return this.getTeamNameValidationState() === '' &&
-           this.getTeamUrlValidationState() === '';
+    return this.getTeamNameValidationState() === null &&
+           this.getTeamUrlValidationState() === null;
   }
 
   save() {
@@ -122,6 +134,12 @@ class NewTeamModal extends React.Component {
         </Modal.Body>
 
         <Modal.Footer>
+          <div
+            className='pull-left'
+          >
+            {this.getError()}
+          </div>
+
           <Button
             id='cancelNewServerModal'
             onClick={this.props.onClose}

--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -135,7 +135,7 @@ class NewTeamModal extends React.Component {
 
         <Modal.Footer>
           <div
-            className='pull-left'
+            className='pull-left modal-error'
           >
             {this.getError()}
           </div>

--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -1,0 +1,115 @@
+const React = require('react');
+const {Modal, Button, FormGroup, FormControl, ControlLabel, HelpBlock} = require('react-bootstrap');
+const validUrl = require('valid-url');
+
+class NewTeamModal extends React.Component {
+
+  constructor() {
+    super();
+    this.state = {
+      teamName: '',
+      teamUrl: ''
+    };
+  }
+
+  shouldComponentUpdate() {
+    return true;
+  }
+
+  getTeamNameValidationState() {
+    return this.state.teamName.length > 0 ? '' : 'error';
+  }
+
+  handleTeamNameChange(e) {
+    this.setState({
+      teamName: e.target.value
+    });
+  }
+
+  getTeamUrlValidationState() {
+    if (this.state.teamUrl.length === 0) {
+      return 'error';
+    }
+    if (!validUrl.isUri(this.state.teamUrl)) {
+      return 'error';
+    }
+    return '';
+  }
+
+  handleTeamUrlChange(e) {
+    this.setState({
+      teamUrl: e.target.value
+    });
+  }
+
+  validateForm() {
+    return this.getTeamNameValidationState() === '' &&
+           this.getTeamUrlValidationState() === '';
+  }
+
+  render() {
+    return (
+      <Modal.Dialog>
+        <Modal.Header>
+          <Modal.Title>{'Add a new Team'}</Modal.Title>
+        </Modal.Header>
+
+        <Modal.Body>
+          {'Please specify a team name and a valid Mattermost URL'}
+          <form>
+            <FormGroup
+              validationState={this.getTeamNameValidationState()}
+            >
+              <ControlLabel>{'Team Display Name'}</ControlLabel>
+              <FormControl
+                type='text'
+                value={this.state.teamName}
+                placeholder='Team Name'
+                onChange={this.handleTeamNameChange.bind(this)}
+              />
+              <FormControl.Feedback/>
+              <HelpBlock>{'Team Name must not be empty'}</HelpBlock>
+            </FormGroup>
+            <FormGroup
+              validationState={this.getTeamUrlValidationState()}
+            >
+              <ControlLabel>{'Team URL'}</ControlLabel>
+              <FormControl
+                type='text'
+                value={this.state.teamUrl}
+                placeholder='https://example.org'
+                onChange={this.handleTeamUrlChange.bind(this)}
+              />
+              <FormControl.Feedback/>
+              <HelpBlock>{'Must be a valid URL'}</HelpBlock>
+            </FormGroup>
+          </form>
+        </Modal.Body>
+
+        <Modal.Footer>
+          <Button
+            onClick={this.props.onClose}
+          >{'Cancel'}</Button>
+          <Button
+            onClick={() => {
+              this.props.onSave({
+                url: this.state.teamUrl,
+                name: this.state.teamName
+              });
+            }}
+            disabled={!this.validateForm()}
+            bsStyle='primary'
+          >{'Add'}</Button>
+        </Modal.Footer>
+
+      </Modal.Dialog>
+    );
+  }
+}
+
+NewTeamModal.propTypes = {
+  onClose: React.PropTypes.func,
+  onSave: React.PropTypes.func
+};
+
+module.exports = NewTeamModal;

--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -143,7 +143,7 @@ class NewTeamModal extends React.Component {
             <FormGroup
               validationState={this.getTeamUrlValidationState()}
             >
-              <ControlLabel>{'Team URL'}</ControlLabel>
+              <ControlLabel>{'Server URL'}</ControlLabel>
               <FormControl
                 id='teamUrlInput'
                 type='text'

--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -49,7 +49,9 @@ class NewTeamModal extends React.Component {
 
   render() {
     return (
-      <Modal.Dialog>
+      <Modal.Dialog
+        id='newServerModal'
+      >
         <Modal.Header>
           <Modal.Title>{'Add a new Team'}</Modal.Title>
         </Modal.Header>
@@ -62,6 +64,7 @@ class NewTeamModal extends React.Component {
             >
               <ControlLabel>{'Server Display Name'}</ControlLabel>
               <FormControl
+                id='teamNameInput'
                 type='text'
                 value={this.state.teamName}
                 placeholder='Server Name'
@@ -75,6 +78,7 @@ class NewTeamModal extends React.Component {
             >
               <ControlLabel>{'Team URL'}</ControlLabel>
               <FormControl
+                id='teamUrlInput'
                 type='text'
                 value={this.state.teamUrl}
                 placeholder='https://example.org'
@@ -88,9 +92,11 @@ class NewTeamModal extends React.Component {
 
         <Modal.Footer>
           <Button
+            id='cancelNewServerModal'
             onClick={this.props.onClose}
           >{'Cancel'}</Button>
           <Button
+            id='saveNewServerModal'
             onClick={() => {
               this.props.onSave({
                 url: this.state.teamUrl,

--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -8,11 +8,15 @@ class NewTeamModal extends React.Component {
     super();
     this.state = {
       teamName: '',
-      teamUrl: ''
+      teamUrl: '',
+      saveStarted: false
     };
   }
 
   getTeamNameValidationState() {
+    if (!this.state.saveStarted) {
+      return '';
+    }
     return this.state.teamName.length > 0 ? '' : 'error';
   }
 
@@ -23,6 +27,9 @@ class NewTeamModal extends React.Component {
   }
 
   getTeamUrlValidationState() {
+    if (!this.state.saveStarted) {
+      return '';
+    }
     if (this.state.teamUrl.length === 0) {
       return 'error';
     }
@@ -44,12 +51,16 @@ class NewTeamModal extends React.Component {
   }
 
   save() {
-    if (this.validateForm()) {
-      this.props.onSave({
-        url: this.state.teamUrl,
-        name: this.state.teamName
-      });
-    }
+    this.setState({
+      saveStarted: true
+    }, () => {
+      if (this.validateForm()) {
+        this.props.onSave({
+          url: this.state.teamUrl,
+          name: this.state.teamName
+        });
+      }
+    });
   }
 
   render() {

--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -85,6 +85,20 @@ class NewTeamModal extends React.Component {
     });
   }
 
+  getSaveButtonLabel() {
+    if (this.props.editMode) {
+      return 'Save';
+    }
+    return 'Add';
+  }
+
+  getModalTitle() {
+    if (this.props.editMode) {
+      return 'Edit Server';
+    }
+    return 'Add Server';
+  }
+
   render() {
     return (
       <Modal
@@ -107,7 +121,7 @@ class NewTeamModal extends React.Component {
         }}
       >
         <Modal.Header>
-          <Modal.Title>{'Add Server'}</Modal.Title>
+          <Modal.Title>{this.getModalTitle()}</Modal.Title>
         </Modal.Header>
 
         <Modal.Body>
@@ -159,7 +173,7 @@ class NewTeamModal extends React.Component {
             onClick={this.save.bind(this)}
             disabled={!this.validateForm()}
             bsStyle='primary'
-          >{'Add'}</Button>
+          >{this.getSaveButtonLabel()}</Button>
         </Modal.Footer>
 
       </Modal>
@@ -170,7 +184,8 @@ class NewTeamModal extends React.Component {
 NewTeamModal.propTypes = {
   onClose: React.PropTypes.func,
   onSave: React.PropTypes.func,
-  team: React.PropTypes.object
+  team: React.PropTypes.object,
+  editMode: React.PropTypes.boolean
 };
 
 module.exports = NewTeamModal;

--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -3,9 +3,10 @@ const {Modal, Button, FormGroup, FormControl, ControlLabel, HelpBlock} = require
 const validUrl = require('valid-url');
 
 class NewTeamModal extends React.Component {
-
   constructor() {
     super();
+
+    this.wasShown = false;
     this.state = {
       teamName: '',
       teamUrl: '',
@@ -14,6 +15,10 @@ class NewTeamModal extends React.Component {
   }
 
   componentWillMount() {
+    this.initializeOnShow();
+  }
+
+  initializeOnShow() {
     this.state = {
       teamName: this.props.team ? this.props.team.name : '',
       teamUrl: this.props.team ? this.props.team.url : '',
@@ -105,9 +110,14 @@ class NewTeamModal extends React.Component {
       'margin-bottom': 0
     };
 
+    if (this.wasShown !== this.props.show && this.props.show) {
+      this.initializeOnShow();
+    }
+    this.wasShown = this.props.show;
+
     return (
       <Modal
-        show={true}
+        show={this.props.show}
         id='newServerModal'
         onHide={this.props.onClose}
         onKeyDown={(e) => {
@@ -193,7 +203,8 @@ NewTeamModal.propTypes = {
   onClose: React.PropTypes.func,
   onSave: React.PropTypes.func,
   team: React.PropTypes.object,
-  editMode: React.PropTypes.boolean
+  editMode: React.PropTypes.boolean,
+  show: React.PropTypes.boolean
 };
 
 module.exports = NewTeamModal;

--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -12,10 +12,6 @@ class NewTeamModal extends React.Component {
     };
   }
 
-  shouldComponentUpdate() {
-    return true;
-  }
-
   getTeamNameValidationState() {
     return this.state.teamName.length > 0 ? '' : 'error';
   }
@@ -47,10 +43,35 @@ class NewTeamModal extends React.Component {
            this.getTeamUrlValidationState() === '';
   }
 
+  save() {
+    if (this.validateForm()) {
+      this.props.onSave({
+        url: this.state.teamUrl,
+        name: this.state.teamName
+      });
+    }
+  }
+
   render() {
     return (
-      <Modal.Dialog
+      <Modal
+        show={true}
         id='newServerModal'
+        onHide={this.props.onClose}
+        onKeyDown={(e) => {
+          switch (e.key) {
+          case 'Enter':
+            this.save();
+
+            // The add button from behind this might still be focused
+            e.preventDefault();
+            e.stopPropagation();
+            break;
+          case 'Escape':
+            this.props.onClose();
+            break;
+          }
+        }}
       >
         <Modal.Header>
           <Modal.Title>{'Add Server'}</Modal.Title>
@@ -96,18 +117,13 @@ class NewTeamModal extends React.Component {
           >{'Cancel'}</Button>
           <Button
             id='saveNewServerModal'
-            onClick={() => {
-              this.props.onSave({
-                url: this.state.teamUrl,
-                name: this.state.teamName
-              });
-            }}
+            onClick={this.save.bind(this)}
             disabled={!this.validateForm()}
             bsStyle='primary'
           >{'Add'}</Button>
         </Modal.Footer>
 
-      </Modal.Dialog>
+      </Modal>
     );
   }
 }

--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -100,6 +100,11 @@ class NewTeamModal extends React.Component {
   }
 
   render() {
+    const noBottomSpaceing = {
+      'padding-bottom': 0,
+      'margin-bottom': 0
+    };
+
     return (
       <Modal
         show={true}
@@ -142,6 +147,7 @@ class NewTeamModal extends React.Component {
             </FormGroup>
             <FormGroup
               validationState={this.getTeamUrlValidationState()}
+              style={noBottomSpaceing}
             >
               <ControlLabel>{'Server URL'}</ControlLabel>
               <FormControl
@@ -152,7 +158,9 @@ class NewTeamModal extends React.Component {
                 onChange={this.handleTeamUrlChange.bind(this)}
               />
               <FormControl.Feedback/>
-              <HelpBlock>{'The URL of your Mattermost server. Must start with http:// or https://.'}</HelpBlock>
+              <HelpBlock
+                style={noBottomSpaceing}
+              >{'The URL of your Mattermost server. Must start with http:// or https://.'}</HelpBlock>
             </FormGroup>
           </form>
         </Modal.Body>

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -159,6 +159,7 @@ const SettingsPage = React.createClass({
           <TeamList
             teams={this.state.teams}
             showAddTeamForm={this.state.showAddTeamForm}
+            toggleAddTeamForm={this.toggleShowTeamForm}
             onTeamsChange={this.handleTeamsChange}
           />
         </Col>
@@ -351,6 +352,7 @@ const SettingsPage = React.createClass({
               <p className='text-right'>
                 <a
                   style={settingsPage.sectionHeadingLink}
+                  id='addNewServer'
                   href='#'
                   onClick={this.toggleShowTeamForm}
                 >{'⊞ Add new team'}</a>

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -45,6 +45,11 @@ const SettingsPage = React.createClass({
         });
       });
     }
+    ipcRenderer.on('add-server', () => {
+      this.setState({
+        showAddTeamForm: true
+      });
+    });
   },
   handleTeamsChange(teams) {
     this.setState({
@@ -161,7 +166,7 @@ const SettingsPage = React.createClass({
     });
   },
 
-  addTeam(team) {
+  addServer(team) {
     var teams = this.state.teams;
     teams.push(team);
     this.setState({
@@ -179,7 +184,7 @@ const SettingsPage = React.createClass({
             toggleAddTeamForm={this.toggleShowTeamForm}
             onTeamsChange={this.handleTeamsChange}
             updateTeam={this.updateTeam}
-            addTeam={this.addTeam}
+            addServer={this.addServer}
           />
         </Col>
       </Row>

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -152,6 +152,23 @@ const SettingsPage = React.createClass({
       showUnreadBadge: !this.refs.showUnreadBadge.props.checked
     });
   },
+
+  updateTeam(index, newData) {
+    var teams = this.state.teams;
+    teams[index] = newData;
+    this.setState({
+      teams
+    });
+  },
+
+  addTeam(team) {
+    var teams = this.state.teams;
+    teams.push(team);
+    this.setState({
+      teams
+    });
+  },
+
   render() {
     var teamsRow = (
       <Row>
@@ -161,6 +178,8 @@ const SettingsPage = React.createClass({
             showAddTeamForm={this.state.showAddTeamForm}
             toggleAddTeamForm={this.toggleShowTeamForm}
             onTeamsChange={this.handleTeamsChange}
+            updateTeam={this.updateTeam}
+            addTeam={this.addTeam}
           />
         </Col>
       </Row>

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -145,6 +145,11 @@ const SettingsPage = React.createClass({
       showAddTeamForm: !this.state.showAddTeamForm
     });
   },
+  setShowTeamFormVisibility(val) {
+    this.setState({
+      showAddTeamForm: val
+    });
+  },
   handleFlashWindow() {
     this.setState({
       notifications: {
@@ -182,6 +187,7 @@ const SettingsPage = React.createClass({
             teams={this.state.teams}
             showAddTeamForm={this.state.showAddTeamForm}
             toggleAddTeamForm={this.toggleShowTeamForm}
+            setAddTeamFormVisibility={this.setShowTeamFormVisibility}
             onTeamsChange={this.handleTeamsChange}
             updateTeam={this.updateTeam}
             addServer={this.addServer}

--- a/src/browser/components/TabBar.jsx
+++ b/src/browser/components/TabBar.jsx
@@ -1,5 +1,5 @@
 const React = require('react');
-const {Nav, NavItem} = require('react-bootstrap');
+const {Nav, NavItem, Button} = require('react-bootstrap');
 
 class TabBar extends React.Component {
   render() {
@@ -75,7 +75,19 @@ class TabBar extends React.Component {
         onSelect={this.props.onSelect}
       >
         { tabs }
+        { this.renderAddTeamButton() }
       </Nav>
+    );
+  }
+
+  renderAddTeamButton() {
+    return (
+      <Button
+        onClick={this.props.onAddTeam}
+        bsStyle='tabButton'
+      >
+        {'+'}
+      </Button>
     );
   }
 }
@@ -84,7 +96,8 @@ TabBar.propTypes = {
   activeKey: React.PropTypes.number,
   id: React.PropTypes.string,
   onSelect: React.PropTypes.func,
-  teams: React.PropTypes.array
+  teams: React.PropTypes.array,
+  onAddTeam: React.PropTypes.func
 };
 
 module.exports = TabBar;

--- a/src/browser/components/TabBar.jsx
+++ b/src/browser/components/TabBar.jsx
@@ -84,7 +84,7 @@ class TabBar extends React.Component {
     return (
       <Button
         id='tabBarAddNewTeam'
-        onClick={this.props.onAddTeam}
+        onClick={this.props.onAddServer}
         bsStyle='tabButton'
       >
         {'+'}
@@ -98,7 +98,7 @@ TabBar.propTypes = {
   id: React.PropTypes.string,
   onSelect: React.PropTypes.func,
   teams: React.PropTypes.array,
-  onAddTeam: React.PropTypes.func
+  onAddServer: React.PropTypes.func
 };
 
 module.exports = TabBar;

--- a/src/browser/components/TabBar.jsx
+++ b/src/browser/components/TabBar.jsx
@@ -83,6 +83,7 @@ class TabBar extends React.Component {
   renderAddTeamButton() {
     return (
       <Button
+        id='tabBarAddNewTeam'
         onClick={this.props.onAddTeam}
         bsStyle='tabButton'
       >

--- a/src/browser/components/TeamList.jsx
+++ b/src/browser/components/TeamList.jsx
@@ -9,8 +9,9 @@ const TeamList = React.createClass({
     onTeamsChange: React.PropTypes.func,
     showAddTeamForm: React.PropTypes.bool,
     teams: React.PropTypes.array,
-    addTeam: React.PropTypes.func,
-    updateTeam: React.PropTypes.func
+    addServer: React.PropTypes.func,
+    updateTeam: React.PropTypes.func,
+    toggleAddTeamForm: React.PropTypes.func
   },
 
   getInitialState() {
@@ -94,24 +95,24 @@ const TeamList = React.createClass({
       );
     });
 
-    var addTeamForm;
+    var addServerForm;
     if (this.props.showAddTeamForm || this.state.showEditTeamForm) {
-      addTeamForm = (
+      addServerForm = (
         <NewTeamModal
           onClose={() => {
             this.setState({
               showNewTeamModal: false,
-              showEditTeamForm: false,
               team: {
                 name: '',
                 url: '',
                 index: false
               }
             });
+            this.props.toggleAddTeamForm();
           }}
           onSave={(newTeam) => {
             if (this.props.showAddTeamForm) {
-              this.props.addTeam(newTeam);
+              this.props.addServer(newTeam);
             } else {
               this.props.updateTeam(newTeam.index, newTeam);
             }
@@ -131,7 +132,7 @@ const TeamList = React.createClass({
           team={this.state.team}
         />);
     } else {
-      addTeamForm = '';
+      addServerForm = '';
     }
 
     const removeServer = this.props.teams[this.state.indexToRemoveServer];
@@ -151,7 +152,7 @@ const TeamList = React.createClass({
     return (
       <ListGroup className='teamList'>
         { teamNodes }
-        { addTeamForm }
+        { addServerForm }
         { removeServerModal}
       </ListGroup>
     );

--- a/src/browser/components/TeamList.jsx
+++ b/src/browser/components/TeamList.jsx
@@ -111,10 +111,14 @@ const TeamList = React.createClass({
             this.props.toggleAddTeamForm();
           }}
           onSave={(newTeam) => {
+            var teamData = {
+              name: newTeam.name,
+              url: newTeam.url
+            };
             if (this.props.showAddTeamForm) {
-              this.props.addServer(newTeam);
+              this.props.addServer(teamData);
             } else {
-              this.props.updateTeam(newTeam.index, newTeam);
+              this.props.updateTeam(newTeam.index, teamData);
             }
             this.setState({
               showNewTeamModal: false,

--- a/src/browser/components/TeamList.jsx
+++ b/src/browser/components/TeamList.jsx
@@ -9,7 +9,8 @@ const TeamList = React.createClass({
     onTeamsChange: React.PropTypes.func,
     showAddTeamForm: React.PropTypes.bool,
     teams: React.PropTypes.array,
-    toggleAddTeamForm: React.PropTypes.func
+    addTeam: React.PropTypes.func,
+    updateTeam: React.PropTypes.func
   },
 
   getInitialState() {
@@ -110,9 +111,9 @@ const TeamList = React.createClass({
           }}
           onSave={(newTeam) => {
             if (this.props.showAddTeamForm) {
-              this.props.teams.push(newTeam);
+              this.props.addTeam(newTeam);
             } else {
-              this.props.teams[newTeam.index] = newTeam;
+              this.props.updateTeam(newTeam.index, newTeam);
             }
             this.setState({
               showNewTeamModal: false,

--- a/src/browser/components/TeamList.jsx
+++ b/src/browser/components/TeamList.jsx
@@ -14,7 +14,7 @@ const TeamList = React.createClass({
 
   getInitialState() {
     return {
-      showTeamListItemNew: false,
+      showEditTeamForm: false,
       indexToRemoveServer: -1,
       team: {
         url: '',
@@ -41,7 +41,7 @@ const TeamList = React.createClass({
     }
 
     this.setState({
-      showTeamListItemNew: false,
+      showEditTeamForm: false,
       team: {
         url: '',
         name: '',
@@ -53,7 +53,7 @@ const TeamList = React.createClass({
   },
   handleTeamEditing(teamName, teamUrl, teamIndex) {
     this.setState({
-      showTeamListItemNew: true,
+      showEditTeamForm: true,
       team: {
         url: teamUrl,
         name: teamName,
@@ -94,19 +94,40 @@ const TeamList = React.createClass({
     });
 
     var addTeamForm;
-    if (this.props.showAddTeamForm || this.state.showTeamListItemNew) {
+    if (this.props.showAddTeamForm || this.state.showEditTeamForm) {
       addTeamForm = (
         <NewTeamModal
-          onClose={this.props.toggleAddTeamForm}
-          onSave={(newTeam) => {
+          onClose={() => {
             this.setState({
-              showNewTeamModal: false
+              showNewTeamModal: false,
+              showEditTeamForm: false,
+              team: {
+                name: '',
+                url: '',
+                index: false
+              }
             });
-            this.props.teams.push(newTeam);
+          }}
+          onSave={(newTeam) => {
+            if (this.props.showAddTeamForm) {
+              this.props.teams.push(newTeam);
+            } else {
+              this.props.teams[newTeam.index] = newTeam;
+            }
+            this.setState({
+              showNewTeamModal: false,
+              showEditTeamForm: false,
+              team: {
+                name: '',
+                url: '',
+                index: false
+              }
+            });
             this.render();
 
             this.props.onTeamsChange(this.props.teams);
           }}
+          team={this.state.team}
         />);
     } else {
       addTeamForm = '';

--- a/src/browser/components/TeamList.jsx
+++ b/src/browser/components/TeamList.jsx
@@ -1,14 +1,15 @@
 const React = require('react');
 const {ListGroup} = require('react-bootstrap');
 const TeamListItem = require('./TeamListItem.jsx');
-const TeamListItemNew = require('./TeamListItemNew.jsx');
+const NewTeamModal = require('./NewTeamModal.jsx');
 const RemoveServerModal = require('./RemoveServerModal.jsx');
 
 const TeamList = React.createClass({
   propTypes: {
     onTeamsChange: React.PropTypes.func,
     showAddTeamForm: React.PropTypes.bool,
-    teams: React.PropTypes.array
+    teams: React.PropTypes.array,
+    toggleAddTeamForm: React.PropTypes.func
   },
 
   getInitialState() {
@@ -95,12 +96,17 @@ const TeamList = React.createClass({
     var addTeamForm;
     if (this.props.showAddTeamForm || this.state.showTeamListItemNew) {
       addTeamForm = (
-        <TeamListItemNew
-          key={this.state.team.index}
-          onTeamAdd={this.handleTeamAdd}
-          teamIndex={this.state.team.index}
-          teamName={this.state.team.name}
-          teamUrl={this.state.team.url}
+        <NewTeamModal
+          onClose={this.props.toggleAddTeamForm}
+          onSave={(newTeam) => {
+            this.setState({
+              showNewTeamModal: false
+            });
+            this.props.teams.push(newTeam);
+            this.render();
+
+            this.props.onTeamsChange(this.props.teams);
+          }}
         />);
     } else {
       addTeamForm = '';

--- a/src/browser/components/TeamList.jsx
+++ b/src/browser/components/TeamList.jsx
@@ -11,7 +11,8 @@ const TeamList = React.createClass({
     teams: React.PropTypes.array,
     addServer: React.PropTypes.func,
     updateTeam: React.PropTypes.func,
-    toggleAddTeamForm: React.PropTypes.func
+    toggleAddTeamForm: React.PropTypes.func,
+    setAddTeamFormVisibility: React.PropTypes.func
   },
 
   getInitialState() {
@@ -99,16 +100,17 @@ const TeamList = React.createClass({
     if (this.props.showAddTeamForm || this.state.showEditTeamForm) {
       addServerForm = (
         <NewTeamModal
+          editMode={this.state.showEditTeamForm}
           onClose={() => {
             this.setState({
-              showNewTeamModal: false,
+              showEditTeamForm: false,
               team: {
                 name: '',
                 url: '',
                 index: false
               }
             });
-            this.props.toggleAddTeamForm();
+            this.props.setAddTeamFormVisibility(false);
           }}
           onSave={(newTeam) => {
             var teamData = {
@@ -130,8 +132,7 @@ const TeamList = React.createClass({
               }
             });
             this.render();
-
-            this.props.onTeamsChange(this.props.teams);
+            this.props.setAddTeamFormVisibility(false);
           }}
           team={this.state.team}
         />);

--- a/src/browser/components/TeamList.jsx
+++ b/src/browser/components/TeamList.jsx
@@ -96,49 +96,45 @@ const TeamList = React.createClass({
       );
     });
 
-    var addServerForm;
-    if (this.props.showAddTeamForm || this.state.showEditTeamForm) {
-      addServerForm = (
-        <NewTeamModal
-          editMode={this.state.showEditTeamForm}
-          onClose={() => {
-            this.setState({
-              showEditTeamForm: false,
-              team: {
-                name: '',
-                url: '',
-                index: false
-              }
-            });
-            this.props.setAddTeamFormVisibility(false);
-          }}
-          onSave={(newTeam) => {
-            var teamData = {
-              name: newTeam.name,
-              url: newTeam.url
-            };
-            if (this.props.showAddTeamForm) {
-              this.props.addServer(teamData);
-            } else {
-              this.props.updateTeam(newTeam.index, teamData);
+    var addServerForm = (
+      <NewTeamModal
+        show={this.props.showAddTeamForm || this.state.showEditTeamForm}
+        editMode={this.state.showEditTeamForm}
+        onClose={() => {
+          this.setState({
+            showEditTeamForm: false,
+            team: {
+              name: '',
+              url: '',
+              index: false
             }
-            this.setState({
-              showNewTeamModal: false,
-              showEditTeamForm: false,
-              team: {
-                name: '',
-                url: '',
-                index: false
-              }
-            });
-            this.render();
-            this.props.setAddTeamFormVisibility(false);
-          }}
-          team={this.state.team}
-        />);
-    } else {
-      addServerForm = '';
-    }
+          });
+          this.props.setAddTeamFormVisibility(false);
+        }}
+        onSave={(newTeam) => {
+          var teamData = {
+            name: newTeam.name,
+            url: newTeam.url
+          };
+          if (this.props.showAddTeamForm) {
+            this.props.addServer(teamData);
+          } else {
+            this.props.updateTeam(newTeam.index, teamData);
+          }
+          this.setState({
+            showNewTeamModal: false,
+            showEditTeamForm: false,
+            team: {
+              name: '',
+              url: '',
+              index: false
+            }
+          });
+          this.render();
+          this.props.setAddTeamFormVisibility(false);
+        }}
+        team={this.state.team}
+      />);
 
     const removeServer = this.props.teams[this.state.indexToRemoveServer];
     const removeServerModal = (

--- a/src/browser/config/AppConfig.js
+++ b/src/browser/config/AppConfig.js
@@ -1,12 +1,22 @@
 const settings = require('../../common/settings');
 const {remote} = require('electron');
 
-var config;
-try {
-  const configFile = remote.app.getPath('userData') + '/config.json';
-  config = settings.readFileSync(configFile);
-} catch (e) {
-  config = {};
+class AppConfig {
+  constructor(file) {
+    this.fileName = file;
+    try {
+      this.data = settings.readFileSync(file);
+    } catch (e) {
+      this.data = {
+        teams: []
+      };
+    }
+  }
+
+  set(key, value) {
+    this.data[key] = value;
+    settings.writeFileSync(this.fileName, this.data);
+  }
 }
 
-module.exports = config;
+module.exports = new AppConfig(remote.app.getPath('userData') + '/config.json');

--- a/src/browser/config/AppConfig.js
+++ b/src/browser/config/AppConfig.js
@@ -1,0 +1,12 @@
+const settings = require('../../common/settings');
+const {remote} = require('electron');
+
+var config;
+try {
+  const configFile = remote.app.getPath('userData') + '/config.json';
+  config = settings.readFileSync(configFile);
+} catch (e) {
+  config = {};
+}
+
+module.exports = config;

--- a/src/browser/css/index.css
+++ b/src/browser/css/index.css
@@ -16,3 +16,16 @@
   opacity: 0.01;
   transition: opacity 500ms ease-in-out;
 }
+
+.btn-tabButton {
+  margin-top: 3px;
+  color: #333;
+  background-color: #fff;
+  border-color: #ccc;
+}
+
+.btn-tabButton:hover {
+  color: #333;
+  background-color: #e6e6e6;
+  border-color: #adadad;
+}

--- a/src/browser/css/index.css
+++ b/src/browser/css/index.css
@@ -29,3 +29,12 @@
   background-color: #e6e6e6;
   border-color: #adadad;
 }
+
+.has-error .control-label,
+.has-error .help-block {
+  color: #333;
+}
+
+.modal-error {
+  color: #a94442;
+}

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -14,7 +14,7 @@ const badge = require('./js/badge');
 
 remote.getCurrentWindow().removeAllListeners('focus');
 
-if (AppConfig.teams.length === 0) {
+if (AppConfig.data.teams.length === 0) {
   window.location = 'settings.html';
 }
 
@@ -33,7 +33,7 @@ function showUnreadBadgeWindows(unreadCount, mentionCount) {
   if (mentionCount > 0) {
     const dataURL = badge.createDataURL(mentionCount.toString());
     sendBadge(dataURL, 'You have unread mentions (' + mentionCount + ')');
-  } else if (unreadCount > 0 && config.showUnreadBadge) {
+  } else if (unreadCount > 0 && AppConfig.data.showUnreadBadge) {
     const dataURL = badge.createDataURL('•');
     sendBadge(dataURL, 'You have unread channels (' + unreadCount + ')');
   } else {
@@ -44,7 +44,7 @@ function showUnreadBadgeWindows(unreadCount, mentionCount) {
 function showUnreadBadgeOSX(unreadCount, mentionCount) {
   if (mentionCount > 0) {
     remote.app.dock.setBadge(mentionCount.toString());
-  } else if (unreadCount > 0 && config.showUnreadBadge) {
+  } else if (unreadCount > 0 && AppConfig.data.showUnreadBadge) {
     remote.app.dock.setBadge('•');
   } else {
     remote.app.dock.setBadge('');
@@ -82,11 +82,16 @@ function showUnreadBadge(unreadCount, mentionCount) {
   }
 }
 
+function teamConfigChange(teams) {
+  AppConfig.set('teams', teams);
+}
+
 ReactDOM.render(
   <MainPage
-    disablewebsecurity={config.disablewebsecurity}
-    teams={config.teams}
+    disablewebsecurity={AppConfig.data.disablewebsecurity}
+    teams={AppConfig.data.teams}
     onUnreadCountChange={showUnreadBadge}
+    onTeamConfigChange={teamConfigChange}
   />,
   document.getElementById('content')
 );

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -9,19 +9,12 @@ const ReactDOM = require('react-dom');
 const {remote, ipcRenderer} = require('electron');
 const MainPage = require('./components/MainPage.jsx');
 
-const settings = require('../common/settings');
+const AppConfig = require('./config/AppConfig.js');
 const badge = require('./js/badge');
 
 remote.getCurrentWindow().removeAllListeners('focus');
 
-var config;
-try {
-  const configFile = remote.app.getPath('userData') + '/config.json';
-  config = settings.readFileSync(configFile);
-} catch (e) {
-  window.location = 'settings.html';
-}
-if (config.teams.length === 0) {
+if (AppConfig.teams.length === 0) {
   window.location = 'settings.html';
 }
 

--- a/src/browser/settings.html
+++ b/src/browser/settings.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8">
   <title>Settings</title>
   <link rel="stylesheet" href="modules/bootstrap/css/bootstrap.min.css">
+  <link rel="stylesheet" href="css/index.css">
 </head>
 
 <body>

--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -27,6 +27,11 @@ function createTemplate(mainWindow, config) {
     click() {
       mainWindow.loadURL('file://' + __dirname + '/browser/settings.html');
     }
+  }, {
+    label: 'Sign in to Another Server',
+    click() {
+      mainWindow.webContents.send('add-server');
+    }
   }, separatorItem, {
     role: 'hide'
   }, {
@@ -40,6 +45,11 @@ function createTemplate(mainWindow, config) {
     accelerator: 'CmdOrCtrl+,',
     click() {
       mainWindow.loadURL('file://' + __dirname + '/browser/settings.html');
+    }
+  }, {
+    label: 'Sign in to Another Server',
+    click() {
+      mainWindow.webContents.send('add-server');
     }
   }, separatorItem, {
     role: 'quit',

--- a/src/package.json
+++ b/src/package.json
@@ -24,7 +24,6 @@
     "react-addons-css-transition-group": "^15.4.1",
     "react-bootstrap": "~0.30.7",
     "react-dom": "^15.4.1",
-    "valid-url": "^1.0.9",
     "yargs": "^3.32.0"
   }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -24,6 +24,7 @@
     "react-addons-css-transition-group": "^15.4.1",
     "react-bootstrap": "~0.30.7",
     "react-dom": "^15.4.1",
+    "valid-url": "^1.0.9",
     "yargs": "^3.32.0"
   }
 }

--- a/test/specs/browser/index_test.js
+++ b/test/specs/browser/index_test.js
@@ -171,4 +171,11 @@ describe('browser/index.html', function desc() {
         browserWindow.getTitle().should.eventually.equal('Title 1');
     });
   });
+
+  it('should open the new server prompt after clicking the add button', () => {
+    // See settings_test for specs that cover the actual prompt
+    return this.app.client.waitUntilWindowLoaded().
+      click('#tabBarAddNewTeam').
+      isExisting('#newServerModal').should.eventually.be.true;
+  });
 });

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -261,6 +261,7 @@ describe('browser/settings.html', function desc() {
     it('should close the window after clicking cancel', () => {
       return this.app.client.
         click('#cancelNewServerModal').
+        pause(1000). // Animation
         isExisting('#newServerModal').should.eventually.equal(false);
     });
 
@@ -334,15 +335,16 @@ describe('browser/settings.html', function desc() {
       it('should add the team to the config file', (done) => {
         this.app.client.
           click('#saveNewServerModal').
-          click('#btnSave');
-        this.app.client.pause(1000).then(() => {
-          const savedConfig = JSON.parse(fs.readFileSync(env.configFilePath, 'utf8'));
-          savedConfig.teams.should.contain({
-            name: 'TestTeam',
-            url: 'http://example.org'
+          pause(1000). // Animation
+          click('#btnSave').
+          pause(1000).then(() => {
+            const savedConfig = JSON.parse(fs.readFileSync(env.configFilePath, 'utf8'));
+            savedConfig.teams.should.contain({
+              name: 'TestTeam',
+              url: 'http://example.org'
+            });
+            return done();
           });
-          return done();
-        });
       });
     });
   });

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -266,18 +266,21 @@ describe('browser/settings.html', function desc() {
 
     it('should not be valid if no team name has been set', () => {
       return this.app.client.
+        click('#saveNewServerModal').
         isExisting('.has-error #teamNameInput').should.eventually.equal(true);
     });
 
     it('should not be valid if no server address has been set', () => {
       return this.app.client.
+        click('#saveNewServerModal').
         isExisting('.has-error #teamUrlInput').should.eventually.equal(true);
     });
 
     describe('Valid server name', () => {
       beforeEach(() => {
         return this.app.client.
-            setValue('#teamNameInput', 'TestTeam');
+            setValue('#teamNameInput', 'TestTeam').
+            click('#saveNewServerModal');
       });
 
       it('should not be marked invalid', () => {
@@ -294,7 +297,8 @@ describe('browser/settings.html', function desc() {
     describe('Valid server url', () => {
       beforeEach(() => {
         return this.app.client.
-            setValue('#teamUrlInput', 'http://example.org');
+            setValue('#teamUrlInput', 'http://example.org').
+            click('#saveNewServerModal');
       });
 
       it('should be valid', () => {
@@ -311,6 +315,7 @@ describe('browser/settings.html', function desc() {
     it('should not be valid if an invalid server address has been set', () => {
       return this.app.client.
         setValue('#teamUrlInput', 'superInvalid url').
+        click('#saveNewServerModal').
         isExisting('.has-error #teamUrlInput').should.eventually.equal(true);
     });
 


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Adds a button to the Tab Header which allows the user to add a new team without opening the settings page. Use the new Modal in the settings view as well.

**Issue link**
#400, #401 

**Test Cases**
Add a new server from the tab header and the settings page.

I added multiple specs that test if newly added teams are being persisted and if the modal behaves as expected in general.

I'm not sure if the way I do error handling is a good idea, I just saw that #400 defines an area where the error message should be displayed - I think that it's best to have the message next to the input that is incorrect but I could change it (might be a good idea to discuss). 