### PR TITLE
Tweak for part 1 of #400

### DIFF
--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -33,6 +33,7 @@ const SettingsPage = React.createClass({
 
     initialState.showAddTeamForm = false;
     initialState.trayWasVisible = remote.getCurrentWindow().trayWasVisible;
+    initialState.disableClose = initialState.teams.length === 0;
 
     return initialState;
   },
@@ -91,21 +92,6 @@ const SettingsPage = React.createClass({
   handleCancel() {
     backToIndex();
   },
-
-  handleClose(e) {
-    let savedConfig;
-    try {
-      savedConfig = settings.readFileSync(this.props.configFile);
-    } catch (err) {
-      savedConfig = settings.loadDefault();
-    }
-    if (savedConfig.teams.length === 0) {
-      e.preventDefault();
-    } else {
-      backToIndex();
-    }
-  },
-
   handleChangeDisableWebSecurity() {
     this.setState({
       disablewebsecurity: !this.refs.disablewebsecurity.props.checked
@@ -290,13 +276,13 @@ const SettingsPage = React.createClass({
         backgroundColor: '#fff'
       },
       close: {
+        textDecoration: 'none',
         position: 'absolute',
         right: '0',
-        top: '10px',
+        top: '5px',
         fontSize: '35px',
         fontWeight: 'normal',
-        color: '#bbb',
-        cursor: 'pointer'
+        color: '#bbb'
       },
       heading: {
         textAlign: 'center',
@@ -340,12 +326,14 @@ const SettingsPage = React.createClass({
         >
           <div style={{position: 'relative'}}>
             <h1 style={settingsPage.heading}>{'Settings'}</h1>
-            <div
+            <Button
+              bsStyle='link'
               style={settingsPage.close}
-              onClick={this.handleClose}
+              onClick={this.handleCancel}
+              disabled={this.state.disableClose}
             >
               <span>{'×'}</span>
-            </div>
+            </Button>
           </div>
         </Navbar>
         <Grid

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -342,7 +342,7 @@ const SettingsPage = React.createClass({
               md={10}
               xs={8}
             >
-              <h2 style={settingsPage.sectionHeading}>{'Team Management'}</h2>
+              <h2 style={settingsPage.sectionHeading}>{'Server Management'}</h2>
             </Col>
             <Col
               md={2}
@@ -353,7 +353,7 @@ const SettingsPage = React.createClass({
                   style={settingsPage.sectionHeadingLink}
                   href='#'
                   onClick={this.toggleShowTeamForm}
-                >{'⊞ Add new team'}</a>
+                >{'⊞ Add new server'}</a>
               </p>
             </Col>
           </Row>

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -91,6 +91,21 @@ const SettingsPage = React.createClass({
   handleCancel() {
     backToIndex();
   },
+
+  handleClose(e) {
+    let savedConfig;
+    try {
+      savedConfig = settings.readFileSync(this.props.configFile);
+    } catch (err) {
+      savedConfig = settings.loadDefault();
+    }
+    if (savedConfig.teams.length === 0) {
+      e.preventDefault();
+    } else {
+      backToIndex();
+    }
+  },
+
   handleChangeDisableWebSecurity() {
     this.setState({
       disablewebsecurity: !this.refs.disablewebsecurity.props.checked
@@ -327,7 +342,7 @@ const SettingsPage = React.createClass({
             <h1 style={settingsPage.heading}>{'Settings'}</h1>
             <div
               style={settingsPage.close}
-              onClick={this.handleCancel}
+              onClick={this.handleClose}
             >
               <span>{'×'}</span>
             </div>


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
The part 1 of #400. 

- Some tweak of labels
- Remain settings page on clicking "x" button when there are no servers in config.

**Issue link**
#400 

**Test Cases**
1. Open settings page.
2. Click "x" on top right of UI.
3. If no servers are saved yet, the settings page remain open.

**Additional Notes**
artifacts: https://circleci.com/gh/yuya-oc/desktop/142#artifacts