### PR TITLE
Open the corresponding tab when a server is clicked in settings page

### DIFF
--- a/src/browser/components/AutoSaveIndicator.jsx
+++ b/src/browser/components/AutoSaveIndicator.jsx
@@ -7,16 +7,16 @@ function AutoSaveIndicator(props) {
     <Alert
       className='AutoSaveIndicator'
       {...rest}
-      bsStyle={props.savingState === 'error' ? 'danger' : 'info'}
+      bsStyle={savingState === 'error' ? 'danger' : 'info'}
     >
       {(() => {
-        switch (props.savingState) {
+        switch (savingState) {
         case 'saving':
           return 'Saving...';
         case 'saved':
           return 'Saved!';
         case 'error':
-          return props.errorMessage;
+          return errorMessage;
         default:
           return '';
         }

--- a/src/browser/components/AutoSaveIndicator.jsx
+++ b/src/browser/components/AutoSaveIndicator.jsx
@@ -1,0 +1,33 @@
+const React = require('react');
+const {Alert} = require('react-bootstrap');
+
+function AutoSaveIndicator(props) {
+  const {savingState, errorMessage, ...rest} = props;
+  return (
+    <Alert
+      className='AutoSaveIndicator'
+      {...rest}
+      bsStyle={props.savingState === 'error' ? 'danger' : 'info'}
+    >
+      {(() => {
+        switch (props.savingState) {
+        case 'saving':
+          return 'Saving...';
+        case 'saved':
+          return 'Saved!';
+        case 'error':
+          return props.errorMessage;
+        default:
+          return '';
+        }
+      })()}
+    </Alert>
+  );
+}
+
+AutoSaveIndicator.propTypes = {
+  savingState: React.PropTypes.string.isRequired,
+  errorMessage: React.PropTypes.string
+};
+
+module.exports = AutoSaveIndicator;

--- a/src/browser/components/AutoSaveIndicator.jsx
+++ b/src/browser/components/AutoSaveIndicator.jsx
@@ -14,7 +14,7 @@ function AutoSaveIndicator(props) {
         case 'saving':
           return 'Saving...';
         case 'saved':
-          return 'Saved!';
+          return 'Saved';
         case 'error':
           return errorMessage;
         default:

--- a/src/browser/components/AutoSaveIndicator.jsx
+++ b/src/browser/components/AutoSaveIndicator.jsx
@@ -1,26 +1,34 @@
 const React = require('react');
 const {Alert} = require('react-bootstrap');
 
+const baseClassName = 'AutoSaveIndicator';
+const leaveClassName = `${baseClassName}-Leave`;
+
+function getClassNameAndMessage(savingState, errorMessage) {
+  switch (savingState) {
+  case 'saving':
+    return {className: baseClassName, message: 'Saving...'};
+  case 'saved':
+    return {className: baseClassName, message: 'Saved'};
+  case 'error':
+    return {className: `${baseClassName}`, message: errorMessage};
+  case 'done':
+    return {className: `${baseClassName} ${leaveClassName}`, message: 'Saved'};
+  default:
+    return {className: `${baseClassName} ${leaveClassName}`, message: ''};
+  }
+}
+
 function AutoSaveIndicator(props) {
   const {savingState, errorMessage, ...rest} = props;
+  const {className, message} = getClassNameAndMessage(savingState, errorMessage);
   return (
     <Alert
-      className='AutoSaveIndicator'
+      className={className}
       {...rest}
       bsStyle={savingState === 'error' ? 'danger' : 'info'}
     >
-      {(() => {
-        switch (savingState) {
-        case 'saving':
-          return 'Saving...';
-        case 'saved':
-          return 'Saved';
-        case 'error':
-          return errorMessage;
-        default:
-          return '';
-        }
-      })()}
+      {message}
     </Alert>
   );
 }

--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -39,12 +39,13 @@ const MainPage = React.createClass({
     disablewebsecurity: React.PropTypes.bool.isRequired,
     onUnreadCountChange: React.PropTypes.func.isRequired,
     teams: React.PropTypes.array.isRequired,
-    onTeamConfigChange: React.PropTypes.func.isRequired
+    onTeamConfigChange: React.PropTypes.func.isRequired,
+    initialIndex: React.PropTypes.number.isRequired
   },
 
   getInitialState() {
     return {
-      key: 0,
+      key: this.props.initialIndex,
       unreadCounts: new Array(this.props.teams.length),
       mentionCounts: new Array(this.props.teams.length),
       unreadAtActive: new Array(this.props.teams.length),

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -14,8 +14,9 @@ const appLauncher = new AutoLaunch({
   isHidden: true
 });
 
-function backToIndex() {
-  remote.getCurrentWindow().loadURL('file://' + __dirname + '/index.html');
+function backToIndex(index) {
+  const target = typeof index === 'undefined' ? 0 : index;
+  remote.getCurrentWindow().loadURL(`file://${__dirname}/index.html?index=${target}`);
 }
 
 const SettingsPage = React.createClass({
@@ -182,6 +183,7 @@ const SettingsPage = React.createClass({
             onTeamsChange={this.handleTeamsChange}
             updateTeam={this.updateTeam}
             addServer={this.addServer}
+            onTeamClick={backToIndex}
           />
         </Col>
       </Row>

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -414,6 +414,15 @@ const SettingsPage = React.createClass({
           className='navbar-fixed-top'
           style={settingsPage.navbar}
         >
+          <div className='IndicatorContainer'>
+            <ReactCSSTransitionGroup
+              transitionName='AutoSaveIndicator'
+              transitionEnterTimeout={500}
+              transitionLeaveTimeout={1000}
+            >
+              { this.state.savingState === 'done' ? null : <AutoSaveIndicator savingState={this.state.savingState}/> }
+            </ReactCSSTransitionGroup>
+          </div>
           <div style={{position: 'relative'}}>
             <h1 style={settingsPage.heading}>{'Settings'}</h1>
             <Button
@@ -456,15 +465,6 @@ const SettingsPage = React.createClass({
           <hr/>
           { optionsRow }
         </Grid>
-        <div className='IndicatorContainer'>
-          <ReactCSSTransitionGroup
-            transitionName='AutoSaveIndicator'
-            transitionEnterTimeout={500}
-            transitionLeaveTimeout={1000}
-          >
-            { this.state.savingState === 'done' ? null : <AutoSaveIndicator savingState={this.state.savingState}/> }
-          </ReactCSSTransitionGroup>
-        </div>
       </div>
     );
   }

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -173,13 +173,11 @@ const SettingsPage = React.createClass({
     this.setState({
       showAddTeamForm: !this.state.showAddTeamForm
     });
-    setImmediate(this.saveConfig);
   },
   setShowTeamFormVisibility(val) {
     this.setState({
       showAddTeamForm: val
     });
-    setImmediate(this.saveConfig);
   },
   handleFlashWindow() {
     this.setState({

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -1,6 +1,5 @@
 const React = require('react');
 const ReactDOM = require('react-dom');
-const ReactCSSTransitionGroup = require('react-addons-css-transition-group');
 const {Button, Checkbox, Col, FormGroup, Grid, HelpBlock, Navbar, Radio, Row} = require('react-bootstrap');
 
 const {ipcRenderer, remote} = require('electron');
@@ -432,16 +431,10 @@ const SettingsPage = React.createClass({
           style={settingsPage.navbar}
         >
           <div className='IndicatorContainer'>
-            <ReactCSSTransitionGroup
-              transitionName='AutoSaveIndicator'
-              transitionEnterTimeout={500}
-              transitionLeaveTimeout={1000}
-            >
-              { this.state.savingState === 'done' ? null : <AutoSaveIndicator
-                savingState={this.state.savingState}
-                errorMessage={'Can\'t save your changes. Please try again.'}
-                                                           /> }
-            </ReactCSSTransitionGroup>
+            <AutoSaveIndicator
+              savingState={this.state.savingState}
+              errorMessage={'Can\'t save your changes. Please try again.'}
+            />
           </div>
           <div style={{position: 'relative'}}>
             <h1 style={settingsPage.heading}>{'Settings'}</h1>

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -417,6 +417,7 @@ const SettingsPage = React.createClass({
           <div style={{position: 'relative'}}>
             <h1 style={settingsPage.heading}>{'Settings'}</h1>
             <Button
+              id='btnClose'
               bsStyle='link'
               style={settingsPage.close}
               onClick={this.handleCancel}

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -154,12 +154,6 @@ const SettingsPage = React.createClass({
     });
     setImmediate(this.startSaveConfig);
   },
-  handleChangeHideMenuBar() {
-    this.setState({
-      hideMenuBar: this.refs.hideMenuBar.props.checked
-    });
-    setImmediate(this.startSaveConfig);
-  },
   handleChangeShowTrayIcon() {
     var shouldShowTrayIcon = !this.refs.showTrayIcon.props.checked;
     this.setState({

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -65,7 +65,7 @@ const SettingsPage = React.createClass({
       this.setState({showAddTeamForm: true});
     }
   },
-  handleSave() {
+  handleSave(index) {
     var config = {
       teams: this.state.teams,
       showTrayIcon: this.state.showTrayIcon,
@@ -93,10 +93,13 @@ const SettingsPage = React.createClass({
     ipcRenderer.send('update-menu', config);
     ipcRenderer.send('update-config');
 
-    backToIndex();
+    backToIndex(index);
   },
   handleCancel() {
     backToIndex();
+  },
+  backToIndexWithSave(index) {
+    this.handleSave(index);
   },
   handleChangeDisableWebSecurity() {
     this.setState({
@@ -183,7 +186,7 @@ const SettingsPage = React.createClass({
             onTeamsChange={this.handleTeamsChange}
             updateTeam={this.updateTeam}
             addServer={this.addServer}
-            onTeamClick={backToIndex}
+            onTeamClick={this.backToIndexWithSave}
           />
         </Col>
       </Row>

--- a/src/browser/components/TeamList.jsx
+++ b/src/browser/components/TeamList.jsx
@@ -12,7 +12,8 @@ const TeamList = React.createClass({
     addServer: React.PropTypes.func,
     updateTeam: React.PropTypes.func,
     toggleAddTeamForm: React.PropTypes.func,
-    setAddTeamFormVisibility: React.PropTypes.func
+    setAddTeamFormVisibility: React.PropTypes.func,
+    onTeamClick: React.PropTypes.func
   },
 
   getInitialState() {
@@ -92,6 +93,7 @@ const TeamList = React.createClass({
           url={team.url}
           onTeamRemove={handleTeamRemove}
           onTeamEditing={handleTeamEditing}
+          onTeamClick={this.props.onTeamClick.bind(this, i)}
         />
       );
     });

--- a/src/browser/components/TeamList.jsx
+++ b/src/browser/components/TeamList.jsx
@@ -85,6 +85,10 @@ const TeamList = React.createClass({
         self.handleTeamEditing(team.name, team.url, i);
       }
 
+      function handleTeamClick() {
+        self.props.onTeamClick(i);
+      }
+
       return (
         <TeamListItem
           index={i}
@@ -93,7 +97,7 @@ const TeamList = React.createClass({
           url={team.url}
           onTeamRemove={handleTeamRemove}
           onTeamEditing={handleTeamEditing}
-          onTeamClick={this.props.onTeamClick.bind(this, i)}
+          onTeamClick={handleTeamClick}
         />
       );
     });

--- a/src/browser/components/TeamListItem.jsx
+++ b/src/browser/components/TeamListItem.jsx
@@ -17,6 +17,7 @@ class TeamListItem extends React.Component {
     var style = {
       left: {
         display: 'inline-block',
+        width: 'calc(100% - 100px)',
         cursor: 'pointer'
       }
     };

--- a/src/browser/components/TeamListItem.jsx
+++ b/src/browser/components/TeamListItem.jsx
@@ -16,12 +16,16 @@ class TeamListItem extends React.Component {
   render() {
     var style = {
       left: {
-        display: 'inline-block'
+        display: 'inline-block',
+        cursor: 'pointer'
       }
     };
     return (
       <div className='teamListItem list-group-item'>
-        <div style={style.left}>
+        <div
+          style={style.left}
+          onClick={this.props.onTeamClick}
+        >
           <h4 className='list-group-item-heading'>{ this.props.name }</h4>
           <p className='list-group-item-text'>
             { this.props.url }
@@ -47,6 +51,7 @@ TeamListItem.propTypes = {
   name: React.PropTypes.string,
   onTeamEditing: React.PropTypes.func,
   onTeamRemove: React.PropTypes.func,
+  onTeamClick: React.PropTypes.func,
   url: React.PropTypes.string
 };
 

--- a/src/browser/css/settings.css
+++ b/src/browser/css/settings.css
@@ -1,4 +1,8 @@
 
+.teamListItem:hover {
+  background: #eee;
+}
+
 .checkbox > label {
   width: 100%;
 }

--- a/src/browser/css/settings.css
+++ b/src/browser/css/settings.css
@@ -3,6 +3,39 @@
   background: #eee;
 }
 
+.IndicatorContainer {
+  pointer-events: none;
+  position: fixed;
+  top: 100px;
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-flow: row;
+  justify-content: center;
+}
+
+.IndicatorContainer * {
+  pointer-events: auto;
+}
+
+.AutoSaveIndicator-enter {
+  opacity: 0.01;
+}
+
+.AutoSaveIndicator-enter.AutoSaveIndicator-enter-active {
+  opacity: 1;
+  transition: opacity 0ms;
+}
+
+.AutoSaveIndicator-leave {
+  opacity: 1;
+}
+
+.AutoSaveIndicator-leave.AutoSaveIndicator-leave-active {
+  opacity: 0.01;
+  transition: opacity 1s cubic-bezier(0.19, 1, 0.22, 1);
+}
+
 .checkbox > label {
   width: 100%;
 }

--- a/src/browser/css/settings.css
+++ b/src/browser/css/settings.css
@@ -16,21 +16,8 @@
   margin: 0;
 }
 
-.AutoSaveIndicator-enter {
-  opacity: 0.01;
-}
-
-.AutoSaveIndicator-enter.AutoSaveIndicator-enter-active {
-  opacity: 1;
-  transition: opacity 0ms;
-}
-
-.AutoSaveIndicator-leave {
-  opacity: 1;
-}
-
-.AutoSaveIndicator-leave.AutoSaveIndicator-leave-active {
-  opacity: 0.01;
+.AutoSaveIndicator.AutoSaveIndicator-Leave {
+  opacity: 0;
   transition: opacity 1s cubic-bezier(0.19, 1, 0.22, 1);
 }
 

--- a/src/browser/css/settings.css
+++ b/src/browser/css/settings.css
@@ -4,18 +4,16 @@
 }
 
 .IndicatorContainer {
-  pointer-events: none;
-  position: fixed;
-  top: 100px;
-  left: 0;
-  right: 0;
+  position: absolute;
+  height: 100%;
   display: flex;
   flex-flow: row;
-  justify-content: center;
+  justify-content: flex-start;
+  align-items: center;
 }
 
-.IndicatorContainer * {
-  pointer-events: auto;
+.AutoSaveIndicator {
+  margin: 0;
 }
 
 .AutoSaveIndicator-enter {

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -10,6 +10,9 @@ const {remote, ipcRenderer} = require('electron');
 const MainPage = require('./components/MainPage.jsx');
 
 const AppConfig = require('./config/AppConfig.js');
+const url = require('url');
+
+const settings = require('../common/settings');
 const badge = require('./js/badge');
 
 remote.getCurrentWindow().removeAllListeners('focus');
@@ -86,10 +89,14 @@ function teamConfigChange(teams) {
   AppConfig.set('teams', teams);
 }
 
+const parsedURL = url.parse(window.location.href, true);
+const initialIndex = parsedURL.query.index ? parseInt(parsedURL.query.index, 10) : 0;
+
 ReactDOM.render(
   <MainPage
     disablewebsecurity={AppConfig.data.disablewebsecurity}
     teams={AppConfig.data.teams}
+    initialIndex={initialIndex}
     onUnreadCountChange={showUnreadBadge}
     onTeamConfigChange={teamConfigChange}
   />,

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -12,7 +12,6 @@ const MainPage = require('./components/MainPage.jsx');
 const AppConfig = require('./config/AppConfig.js');
 const url = require('url');
 
-const settings = require('../common/settings');
 const badge = require('./js/badge');
 
 remote.getCurrentWindow().removeAllListeners('focus');

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -67,6 +67,14 @@ module.exports = {
     return config;
   },
 
+  writeFile(configFile, config, callback) {
+    if (config.version !== settingsVersion) {
+      throw new Error('version ' + config.version + ' is not equal to ' + settingsVersion);
+    }
+    var data = JSON.stringify(config, null, '  ');
+    fs.writeFile(configFile, data, 'utf8', callback);
+  },
+
   writeFileSync(configFile, config) {
     if (config.version !== settingsVersion) {
       throw new Error('version ' + config.version + ' is not equal to ' + settingsVersion);

--- a/src/package.json
+++ b/src/package.json
@@ -24,6 +24,7 @@
     "react-addons-css-transition-group": "^15.4.1",
     "react-bootstrap": "~0.30.7",
     "react-dom": "^15.4.1",
+    "underscore": "^1.8.3",
     "yargs": "^3.32.0"
   }
 }

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -100,6 +100,7 @@ describe('browser/settings.html', function desc() {
               }
               return true;
             }).
+            pause(600).
             click('#btnClose').
             pause(1000).then(() => {
               const savedConfig = JSON.parse(fs.readFileSync(env.configFilePath, 'utf8'));
@@ -133,6 +134,7 @@ describe('browser/settings.html', function desc() {
               }
               return true;
             }).
+            pause(600).
             click('#btnClose').
             pause(1000).then(() => {
               const savedConfig = JSON.parse(fs.readFileSync(env.configFilePath, 'utf8'));

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -37,7 +37,7 @@ describe('browser/settings.html', function desc() {
       loadSettingsPage().
       click('#btnCancel').
       pause(1000).
-      getUrl().should.eventually.match(/\/index.html$/);
+      getUrl().should.eventually.match(/\/index.html(\?.+)?$/);
   });
 
   it('should show index.html when Save button is clicked', () => {
@@ -46,7 +46,7 @@ describe('browser/settings.html', function desc() {
       loadSettingsPage().
       click('#btnSave').
       pause(1000).
-      getUrl().should.eventually.match(/\/index.html$/);
+      getUrl().should.eventually.match(/\/index.html(\?.+)?$/);
   });
 
   it('should show NewServerModal after all servers are removed', () => {

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -65,6 +65,28 @@ describe('browser/settings.html', function desc() {
       isExisting('#newServerModal').should.eventually.equal(true);
   });
 
+  describe('Server list', () => {
+    it('should open the corresponding tab when a server list item is clicked', () => {
+      env.addClientCommands(this.app.client);
+      return this.app.client.
+      loadSettingsPage().
+      click('h4=example_1').
+      pause(100).
+      waitUntilWindowLoaded().
+      getUrl().should.eventually.match(/\/index.html(\?.+)?$/).
+      isVisible('#mattermostView0').should.eventually.be.true.
+      isVisible('#mattermostView1').should.eventually.be.false.
+
+      loadSettingsPage().
+      click('h4=example_2').
+      pause(100).
+      waitUntilWindowLoaded().
+      getUrl().should.eventually.match(/\/index.html(\?.+)?$/).
+      isVisible('#mattermostView0').should.eventually.be.false.
+      isVisible('#mattermostView1').should.eventually.be.true;
+    });
+  });
+
   describe('Options', () => {
     describe.skip('Hide Menu Bar', () => {
       it('should appear on win32 or linux', () => {

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -31,20 +31,11 @@ describe('browser/settings.html', function desc() {
     return true;
   });
 
-  it('should show index.html when Cancel button is clicked', () => {
+  it('should show index.html when Close button is clicked', () => {
     env.addClientCommands(this.app.client);
     return this.app.client.
       loadSettingsPage().
-      click('#btnCancel').
-      pause(1000).
-      getUrl().should.eventually.match(/\/index.html(\?.+)?$/);
-  });
-
-  it('should show index.html when Save button is clicked', () => {
-    env.addClientCommands(this.app.client);
-    return this.app.client.
-      loadSettingsPage().
-      click('#btnSave').
+      click('#btnClose').
       pause(1000).
       getUrl().should.eventually.match(/\/index.html(\?.+)?$/);
   });
@@ -109,7 +100,7 @@ describe('browser/settings.html', function desc() {
               }
               return true;
             }).
-            click('#btnSave').
+            click('#btnClose').
             pause(1000).then(() => {
               const savedConfig = JSON.parse(fs.readFileSync(env.configFilePath, 'utf8'));
               savedConfig.hideMenuBar.should.equal(v);
@@ -142,7 +133,7 @@ describe('browser/settings.html', function desc() {
               }
               return true;
             }).
-            click('#btnSave').
+            click('#btnClose').
             pause(1000).then(() => {
               const savedConfig = JSON.parse(fs.readFileSync(env.configFilePath, 'utf8'));
               savedConfig.disablewebsecurity.should.equal(!v);
@@ -248,7 +239,7 @@ describe('browser/settings.html', function desc() {
         element('.modal-dialog').click('.btn=Remove').
         pause(500).
         isExisting(modalTitleSelector).should.eventually.false.
-        click('#btnSave').
+        click('#btnClose').
         pause(500).then(() => {
           const savedConfig = JSON.parse(fs.readFileSync(env.configFilePath, 'utf8'));
           savedConfig.teams.should.deep.equal(config.teams.slice(1));
@@ -261,7 +252,7 @@ describe('browser/settings.html', function desc() {
         element('.modal-dialog').click('.btn=Cancel').
         pause(500).
         isExisting(modalTitleSelector).should.eventually.false.
-        click('#btnSave').
+        click('#btnClose').
         pause(500).then(() => {
           const savedConfig = JSON.parse(fs.readFileSync(env.configFilePath, 'utf8'));
           savedConfig.teams.should.deep.equal(config.teams);
@@ -374,7 +365,7 @@ describe('browser/settings.html', function desc() {
         this.app.client.
           click('#saveNewServerModal').
           pause(1000). // Animation
-          click('#btnSave').
+          click('#btnClose').
           pause(1000).then(() => {
             const savedConfig = JSON.parse(fs.readFileSync(env.configFilePath, 'utf8'));
             savedConfig.teams.should.contain({


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
The part 2 of #400.

Proposal:
To prevent unexpectedly clicking "Edit" or "Remove", a clickable area is limited to server name and URL. (Red squares in the screenshot)

<img width="464" alt="clickable_area" src="https://cloud.githubusercontent.com/assets/1412057/22467072/76f11f56-e806-11e6-9bb0-fc57f89ba246.png">


**Issue link**
#400

**Test Cases**
1. Open the settings page.
2. Click a server.
3. The page goes back to the main page and the corresponding tab is opened.

**Additional Notes**
Limitation: Currently the changes in settings page would be lost when this feature performs. There is no way to know whether the changes are already saved.