### PR TITLE
Improve messages and options in "App Options" section

### DIFF
--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -61,13 +61,11 @@ const SettingsPage = React.createClass({
   handleSave() {
     var config = {
       teams: this.state.teams,
-      hideMenuBar: this.state.hideMenuBar,
       showTrayIcon: this.state.showTrayIcon,
       trayIconTheme: this.state.trayIconTheme,
       disablewebsecurity: this.state.disablewebsecurity,
       version: settings.version,
       minimizeToTray: this.state.minimizeToTray,
-      toggleWindowOnTrayIconClick: this.state.toggleWindowOnTrayIconClick,
       notifications: {
         flashWindow: this.state.notifications.flashWindow
       },
@@ -75,10 +73,6 @@ const SettingsPage = React.createClass({
     };
     settings.writeFileSync(this.props.configFile, config);
     if (process.platform === 'win32' || process.platform === 'linux') {
-      var currentWindow = remote.getCurrentWindow();
-      currentWindow.setAutoHideMenuBar(config.hideMenuBar);
-      currentWindow.setMenuBarVisibility(!config.hideMenuBar);
-
       var autostart = this.state.autostart;
       appLauncher.isEnabled().then((enabled) => {
         if (enabled && !autostart) {
@@ -100,11 +94,6 @@ const SettingsPage = React.createClass({
   handleChangeDisableWebSecurity() {
     this.setState({
       disablewebsecurity: this.refs.disablewebsecurity.props.checked
-    });
-  },
-  handleChangeHideMenuBar() {
-    this.setState({
-      hideMenuBar: !this.refs.hideMenuBar.props.checked
     });
   },
   handleChangeShowTrayIcon() {
@@ -134,11 +123,6 @@ const SettingsPage = React.createClass({
 
     this.setState({
       minimizeToTray: shouldMinimizeToTray
-    });
-  },
-  handleChangeToggleWindowOnTrayIconClick() {
-    this.setState({
-      toggleWindowOnTrayIconClick: !this.refs.toggleWindowOnTrayIconClick.props.checked
     });
   },
   toggleShowTeamForm() {

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -1,6 +1,6 @@
 const React = require('react');
 const ReactDOM = require('react-dom');
-const {Button, Checkbox, Col, FormGroup, FormControl, ControlLabel, Grid, HelpBlock, Navbar, Radio, Row} = require('react-bootstrap');
+const {Button, Checkbox, Col, FormGroup, Grid, HelpBlock, Navbar, Radio, Row} = require('react-bootstrap');
 
 const {ipcRenderer, remote} = require('electron');
 const AutoLaunch = require('auto-launch');

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -194,7 +194,7 @@ const SettingsPage = React.createClass({
           onChange={this.handleChangeAutoStart}
         >{'Start app on login'}
           <HelpBlock>
-            {'Enabling automatically starts the app when you log in to your machine.'}
+            {'If enabled, the app starts automatically when you log in to your machine.'}
             {' '}
             {'The app will initially start minimized and appear on the taskbar.'}
           </HelpBlock>
@@ -210,9 +210,9 @@ const SettingsPage = React.createClass({
         onChange={this.handleChangeDisableWebSecurity}
       >{'Display secure content only'}
         <HelpBlock>
-          {'Enabling allows only secure (HTTPS/SSL) content.'}
+          {'If enabled, the app only displays secure (HTTPS/SSL) content.'}
           {' '}
-          {'Disabling allows the app to display non-secure (HTTP) content such as images.'}
+          {'If disabled, the app displays secure and non-secure (HTTP) content such as images.'}
         </HelpBlock>
       </Checkbox>);
 
@@ -241,7 +241,7 @@ const SettingsPage = React.createClass({
           onChange={this.handleFlashWindow}
         >{'Flash taskbar icon when a new message is received'}
           <HelpBlock>
-            {'Taskbar icon flashes for a few seconds when a new message is received.'}
+            {'If enabled, taskbar icon flashes for a few seconds when a new message is received.'}
           </HelpBlock>
         </Checkbox>);
     }
@@ -304,7 +304,7 @@ const SettingsPage = React.createClass({
         >
           {'Leave app running in notification area when application window is closed'}
           <HelpBlock>
-            {'Enabling will leave the app running in the notification center when app window is closed.'}
+            {'If enabled, the app stays running in the notification area after app window is closed.'}
             {this.state.trayWasVisible || !this.state.showTrayIcon ? '' : ' Setting takes effect after restarting the app.'}
           </HelpBlock>
         </Checkbox>);

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -198,16 +198,6 @@ const SettingsPage = React.createClass({
     );
 
     var options = [];
-    if (process.platform === 'win32' || process.platform === 'linux') {
-      options.push(
-        <Checkbox
-          key='inputHideMenuBar'
-          id='inputHideMenuBar'
-          ref='hideMenuBar'
-          checked={this.state.hideMenuBar}
-          onChange={this.handleChangeHideMenuBar}
-        >{'Hide menu bar (Press Alt to show menu bar)'}</Checkbox>);
-    }
     if (process.platform === 'darwin' || process.platform === 'linux') {
       options.push(
         <Checkbox
@@ -257,7 +247,7 @@ const SettingsPage = React.createClass({
         >{'Start app on login.'}</Checkbox>);
     }
 
-    if (process.platform === 'darwin' || process.platform === 'linux') {
+    if (process.platform === 'linux') {
       options.push(
         <Checkbox
           key='inputMinimizeToTray'
@@ -267,17 +257,6 @@ const SettingsPage = React.createClass({
           checked={this.state.minimizeToTray}
           onChange={this.handleChangeMinimizeToTray}
         >{this.state.trayWasVisible || !this.state.showTrayIcon ? 'Leave app running in notification area when the window is closed' : 'Leave app running in notification area when the window is closed (available on next restart)'}</Checkbox>);
-    }
-
-    if (process.platform === 'win32') {
-      options.push(
-        <Checkbox
-          key='inputToggleWindowOnTrayIconClick'
-          id='inputToggleWindowOnTrayIconClick'
-          ref='toggleWindowOnTrayIconClick'
-          checked={this.state.toggleWindowOnTrayIconClick}
-          onChange={this.handleChangeToggleWindowOnTrayIconClick}
-        >{'Toggle window visibility when clicking on the tray icon.'}</Checkbox>);
     }
 
     if (process.platform === 'darwin' || process.platform === 'win32') {

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -363,7 +363,7 @@ const SettingsPage = React.createClass({
     var optionsRow = (options.length > 0) ? (
       <Row>
         <Col md={12}>
-          <h2 style={settingsPage.sectionHeading}>{'App options'}</h2>
+          <h2 style={settingsPage.sectionHeading}>{'App Options'}</h2>
           { options.map((opt, i) => (
             <FormGroup key={`fromGroup${i}`}>
               {opt}

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -1,6 +1,6 @@
 const React = require('react');
 const ReactDOM = require('react-dom');
-const {Button, Checkbox, Col, FormGroup, FormControl, ControlLabel, Grid, HelpBlock, Navbar, Row} = require('react-bootstrap');
+const {Button, Checkbox, Col, FormGroup, FormControl, ControlLabel, Grid, HelpBlock, Navbar, Radio, Row} = require('react-bootstrap');
 
 const {ipcRenderer, remote} = require('electron');
 const AutoLaunch = require('auto-launch');
@@ -280,19 +280,32 @@ const SettingsPage = React.createClass({
     }
     if (process.platform === 'linux') {
       options.push(
-        <FormGroup>
-          <ControlLabel>{'Icon theme (Need to restart the application)'}</ControlLabel>
-          <FormControl
-            componentClass='select'
-            key='inputTrayIconTheme'
-            ref='trayIconTheme'
-            value={this.state.trayIconTheme}
-            onChange={this.handleChangeTrayIconTheme}
-          >
-            <option value='light'>{'Light'}</option>
-            <option value='dark'>{'Dark'}</option>
-          </FormControl>
-        </FormGroup>);
+        <FormGroup
+          key='trayIconTheme'
+          style={{marginLeft: '20px'}}
+        >
+          {'Icon theme: '}
+          <Radio
+            inline={true}
+            name='trayIconTheme'
+            value='light'
+            defaultChecked={this.state.trayIconTheme === 'light' || this.state.trayIconTheme === ''}
+            onChange={() => {
+              this.setState({trayIconTheme: 'light'});
+            }}
+          >{'Light'}</Radio>
+          {' '}
+          <Radio
+            inline={true}
+            name='trayIconTheme'
+            value='dark'
+            defaultChecked={this.state.trayIconTheme === 'dark'}
+            onChange={() => {
+              this.setState({trayIconTheme: 'dark'});
+            }}
+          >{'Dark'}</Radio>
+        </FormGroup>
+      );
     }
 
     if (process.platform === 'linux') {

--- a/src/browser/css/settings.css
+++ b/src/browser/css/settings.css
@@ -1,0 +1,4 @@
+
+.checkbox > label {
+  width: 100%;
+}

--- a/src/browser/settings.html
+++ b/src/browser/settings.html
@@ -6,6 +6,7 @@
   <title>Settings</title>
   <link rel="stylesheet" href="modules/bootstrap/css/bootstrap.min.css">
   <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/settings.css">
 </head>
 
 <body>

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -16,12 +16,10 @@ function loadDefault(version) {
   case 1:
     return {
       teams: [],
-      hideMenuBar: false,
       showTrayIcon: false,
       trayIconTheme: 'light',
       disablewebsecurity: true,
       minimizeToTray: false,
-      toggleWindowOnTrayIconClick: false,
       version: 1,
       notifications: {
         flashWindow: 0 // 0 = flash never, 1 = only when idle (after 10 seconds), 2 = always

--- a/src/main.js
+++ b/src/main.js
@@ -254,16 +254,6 @@ app.on('window-all-closed', () => {
   }
 });
 
-// For win32, auto-hide menu bar.
-app.on('browser-window-created', (event, window) => {
-  if (process.platform === 'win32' || process.platform === 'linux') {
-    if (config.hideMenuBar) {
-      window.setAutoHideMenuBar(true);
-      window.setMenuBarVisibility(false);
-    }
-  }
-});
-
 // For OSX, show hidden mainWindow when clicking dock icon.
 app.on('activate', () => {
   mainWindow.show();
@@ -366,8 +356,6 @@ app.on('ready', () => {
         if (process.platform === 'darwin') {
           app.dock.show();
         }
-      } else if ((process.platform === 'win32') && config.toggleWindowOnTrayIconClick) {
-        mainWindow.minimize();
       } else {
         mainWindow.focus();
       }
@@ -561,9 +549,6 @@ app.on('ready', () => {
         break;
       case 'darwin':
         hideWindow(mainWindow);
-        if (config.minimizeToTray) {
-          app.dock.hide();
-        }
         break;
       default:
       }

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -50,7 +50,7 @@ describe('browser/settings.html', function desc() {
   });
 
   describe('Options', () => {
-    describe('Hide Menu Bar', () => {
+    describe.skip('Hide Menu Bar', () => {
       it('should appear on win32 or linux', () => {
         const expected = (process.platform === 'win32' || process.platform === 'linux');
         env.addClientCommands(this.app.client);
@@ -152,8 +152,8 @@ describe('browser/settings.html', function desc() {
     });
 
     describe('Minimize to tray', () => {
-      it('should appear on darwin or linux', () => {
-        const expected = (process.platform === 'darwin' || process.platform === 'linux');
+      it('should appear on linux', () => {
+        const expected = (process.platform === 'linux');
         env.addClientCommands(this.app.client);
         return this.app.client.
           loadSettingsPage().
@@ -161,7 +161,7 @@ describe('browser/settings.html', function desc() {
       });
     });
 
-    describe('Toggle window visibility when clicking on the tray icon', () => {
+    describe.skip('Toggle window visibility when clicking on the tray icon', () => {
       it('should appear on win32', () => {
         const expected = (process.platform === 'win32');
         env.addClientCommands(this.app.client);

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -89,10 +89,10 @@ describe('browser/settings.html', function desc() {
       });
     });
 
-    describe('Allow mixed content', () => {
+    describe('Display secure content only', () => {
       [true, false].forEach((v) => {
         it(`should be saved and loaded: ${v}`, () => {
-          const webPreferences = v ? 'allowDisplayingInsecureContent' : '';
+          const webPreferences = v ? '' : 'allowDisplayingInsecureContent';
           env.addClientCommands(this.app.client);
 
           return this.app.client.
@@ -107,7 +107,7 @@ describe('browser/settings.html', function desc() {
             click('#btnSave').
             pause(1000).then(() => {
               const savedConfig = JSON.parse(fs.readFileSync(env.configFilePath, 'utf8'));
-              savedConfig.disablewebsecurity.should.equal(v);
+              savedConfig.disablewebsecurity.should.equal(!v);
             }).
             getAttribute('.mattermostView', 'webpreferences').then((disablewebsecurity) => { // confirm actual behavior
               // disablewebsecurity is an array of String
@@ -141,7 +141,7 @@ describe('browser/settings.html', function desc() {
       });
     });
 
-    describe('Show tray icon', () => {
+    describe('Show icon in menu bar / notification area', () => {
       it('should appear on darwin or linux', () => {
         const expected = (process.platform === 'darwin' || process.platform === 'linux');
         env.addClientCommands(this.app.client);
@@ -151,7 +151,7 @@ describe('browser/settings.html', function desc() {
       });
     });
 
-    describe('Minimize to tray', () => {
+    describe('Leave app running in notification area when application window is closed', () => {
       it('should appear on linux', () => {
         const expected = (process.platform === 'linux');
         env.addClientCommands(this.app.client);
@@ -171,7 +171,7 @@ describe('browser/settings.html', function desc() {
       });
     });
 
-    describe('Flash taskbar icon on new messages', () => {
+    describe('Flash taskbar icon when a new message is received', () => {
       it('should appear on win32 and linux', () => {
         const expected = (process.platform === 'win32' || process.platform === 'linux');
         env.addClientCommands(this.app.client);
@@ -181,7 +181,7 @@ describe('browser/settings.html', function desc() {
       });
     });
 
-    describe('Show red icon for unread', () => {
+    describe('Show red badge on taskbar icon to indicate unread messages', () => {
       it('should appear on darwin or win32', () => {
         const expected = (process.platform === 'darwin' || process.platform === 'win32');
         env.addClientCommands(this.app.client);


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Improve messages and options in "App Options" section.

Difference from #398 
- Display secure content only
   - Help Text: Enabling allows only secure (HTTPS/SSL) content. Disabling allows the app to display non-secure (HTTP) content such as images.
- Icon theme
   - Changed to radio buttons in order to make a little more consistent.

**Issue link**
#398 

**Test Cases**
1. Open the settings page.
2. Change desired options.

**Additional Notes**
N/A