### PR TITLE
Show "Add Server" modal when no servers exist in SettingsPage

### DIFF
--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -34,6 +34,9 @@ const SettingsPage = React.createClass({
     initialState.showAddTeamForm = false;
     initialState.trayWasVisible = remote.getCurrentWindow().trayWasVisible;
     initialState.disableClose = initialState.teams.length === 0;
+    if (initialState.teams.length === 0) {
+      initialState.showAddTeamForm = true;
+    }
 
     return initialState;
   },
@@ -57,6 +60,9 @@ const SettingsPage = React.createClass({
       showAddTeamForm: false,
       teams
     });
+    if (teams.length === 0) {
+      this.setState({showAddTeamForm: true});
+    }
   },
   handleSave() {
     var config = {

--- a/test/specs/app_test.js
+++ b/test/specs/app_test.js
@@ -68,7 +68,8 @@ describe('application', function desc() {
     return this.app.start().then(() => {
       return this.app.client.
         waitUntilWindowLoaded().
-        getUrl().should.eventually.match(/\/settings.html$/);
+        getUrl().should.eventually.match(/\/settings.html$/).
+        isExisting('#newServerModal').should.eventually.equal(true);
     });
   });
 

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -49,6 +49,22 @@ describe('browser/settings.html', function desc() {
       getUrl().should.eventually.match(/\/index.html$/);
   });
 
+  it('should show NewServerModal after all servers are removed', () => {
+    const modalTitleSelector = '.modal-title=Remove Server';
+    env.addClientCommands(this.app.client);
+    return this.app.client.
+      loadSettingsPage().
+      click('=Remove').
+      waitForVisible(modalTitleSelector).
+      element('.modal-dialog').click('.btn=Remove').
+      pause(500).
+      click('=Remove').
+      waitForVisible(modalTitleSelector).
+      element('.modal-dialog').click('.btn=Remove').
+      pause(500).
+      isExisting('#newServerModal').should.eventually.equal(true);
+  });
+
   describe('Options', () => {
     describe('Hide Menu Bar', () => {
       it('should appear on win32 or linux', () => {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
The part 3 of #401.

Open "Add Server" modal...
- when openning the app without saved servers.
- when all servers are removed.

**Issue link**
#401 

**Test Cases**
a. Open the app when no servers are saved.
b. Remove all servers in settings page.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/160#artifacts