### PR TITLE
Fix an issue where server select menu was not working in settings page

### DIFF
--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -58,6 +58,9 @@ const SettingsPage = React.createClass({
         showAddTeamForm: true
       });
     });
+    ipcRenderer.on('switch-tab', (event, key) => {
+      backToIndex(key);
+    });
   },
 
   setSavingState(state) {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fix an issue where server select menu was not working in settings page.

In v3.5.0, the behavior of #443 is expected because the config is not saved yet in the settings page.
Now the config is auto-saved, so I added an event listener for menu items.

**Issue link**
#443 

**Test Cases**
1. Open the settings page.
2. Select a server from the tray icon menu or "Window" menu items.
3. The selected server' tab should be shown in the main window.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/167#artifacts