### PR TITLE
Update settings text for "Flash taskbar icon when..."

### DIFF
--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -311,7 +311,7 @@ const SettingsPage = React.createClass({
           onChange={this.handleFlashWindow}
         >{'Flash app window and taskbar icon when a new message is received'}
           <HelpBlock>
-            {'If enabled, app window and taskbar icon flashes for a few seconds when a new message is received.'}
+            {'If enabled, app window and taskbar icon flash for a few seconds when a new message is received.'}
           </HelpBlock>
         </Checkbox>);
     }

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -309,9 +309,9 @@ const SettingsPage = React.createClass({
           ref='flashWindow'
           checked={this.state.notifications.flashWindow === 2}
           onChange={this.handleFlashWindow}
-        >{'Flash taskbar icon when a new message is received'}
+        >{'Flash app window and taskbar icon when a new message is received'}
           <HelpBlock>
-            {'If enabled, taskbar icon flashes for a few seconds when a new message is received.'}
+            {'If enabled, app window and taskbar icon flashes for a few seconds when a new message is received.'}
           </HelpBlock>
         </Checkbox>);
     }

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -202,7 +202,7 @@ describe('browser/settings.html', function desc() {
       });
     });
 
-    describe('Flash taskbar icon when a new message is received', () => {
+    describe('Flash app window and taskbar icon when a new message is received', () => {
       it('should appear on win32 and linux', () => {
         const expected = (process.platform === 'win32' || process.platform === 'linux');
         env.addClientCommands(this.app.client);


### PR DESCRIPTION
Before submitting, please confirm you've
 - [X] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [X] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [X] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Update settings text for "Flash taskbar icon when..." to "Flash app window and taskbar icon when a new message is received", as the latter is the actual behaviour of the setting.

**Issue link**
https://github.com/mattermost/desktop/issues/447

**Test Cases**
1. Go to File > Settings
2. Confirm the settings text reads `Flash app window and taskbar icon when a new message is received`
3. Confirm the help text reads `If enabled, app window and taskbar icon flashes for a few seconds when a new message is received.`
