### PR TITLE
Use "Dock" instead of "taskbar" on macOS

### DIFF
--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -287,6 +287,7 @@ const SettingsPage = React.createClass({
       </Checkbox>);
 
     if (process.platform === 'darwin' || process.platform === 'win32') {
+      const TASKBAR = process.platform === 'win32' ? 'taskbar' : 'Dock';
       options.push(
         <Checkbox
           key='inputShowUnreadBadge'
@@ -294,9 +295,9 @@ const SettingsPage = React.createClass({
           ref='showUnreadBadge'
           checked={this.state.showUnreadBadge}
           onChange={this.handleShowUnreadBadge}
-        >{'Show red badge on taskbar icon to indicate unread messages'}
+        >{`Show red badge on ${TASKBAR} icon to indicate unread messages`}
           <HelpBlock>
-            {'Regardless of this setting, mentions are always indicated with a red badge and item count on the taskbar icon.'}
+            {`Regardless of this setting, mentions are always indicated with a red badge and item count on the ${TASKBAR} icon.`}
           </HelpBlock>
         </Checkbox>);
     }


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
On macOS, "Dock" is the correct word.

![dock_icon](https://cloud.githubusercontent.com/assets/1412057/23307376/a1419802-faea-11e6-8e4c-1b589836a35b.png)


**Issue link**
N/A

**Test Cases**
1. Open settings page.
2. Check sentences.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/170#artifacts