### PR TITLE
Set focus to the next top-level window when close the main window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ Release date: TBD
 #### All Platforms
 - Fixed an issue where an unexpected row appeared after switching channels with `CTRL+K` shortcut. [#426](https://github.com/mattermost/desktop/issues/426)
 
+#### Windows
+- Fixed an issue where the main window still has focus and exists
+  in the classic Alt+Tab switcher after it's closed.
+  [#430](https://github.com/mattermost/desktop/issues/430)
+  [#431](https://github.com/mattermost/desktop/issues/431)
+
+
 ----
 
 ## Release v3.6.0

--- a/src/main.js
+++ b/src/main.js
@@ -529,8 +529,8 @@ app.on('ready', () => {
     } else { // Minimize or hide the window for close button.
       event.preventDefault();
       function hideWindow(window) {
-        window.hide();
         window.blur(); // To move focus to the next top-level window in Windows
+        window.hide();
       }
       switch (process.platform) {
       case 'win32':


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Set focus to the next top-level window when the main window has been closed.

**Issue link**
#430, #431 

**Test Cases**

#430 
1. Open Mattermost and another application window.
2. Activate Mattermost window.
3. Close Mattermost window.
4. Another window should get focus.

#431 
1. Open Mattermost and another application window.
2. Activate Mattermost window.
3. Close Mattermost.
4. Show the classic Alt+Tab switcher. (See #431)
5. Mattermost should not appear on the switcher.

**Additional Notes**
Testable apps: https://circleci.com/gh/yuya-oc/desktop/187#artifacts