### PR TITLE
Fix the setting not saved when changing tray icon theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Release date: TBD
   [#430](https://github.com/mattermost/desktop/issues/430)
   [#431](https://github.com/mattermost/desktop/issues/431)
 
+#### Linux
+- Fixed an issue where the setting was not saved when changing tray icon theme.
+  [#456](https://github.com/mattermost/desktop/issues/456)
 
 ----
 

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -348,6 +348,7 @@ const SettingsPage = React.createClass({
             defaultChecked={this.state.trayIconTheme === 'light' || this.state.trayIconTheme === ''}
             onChange={() => {
               this.setState({trayIconTheme: 'light'});
+              setImmediate(this.startSaveConfig);
             }}
           >{'Light'}</Radio>
           {' '}
@@ -358,6 +359,7 @@ const SettingsPage = React.createClass({
             defaultChecked={this.state.trayIconTheme === 'dark'}
             onChange={() => {
               this.setState({trayIconTheme: 'dark'});
+              setImmediate(this.startSaveConfig);
             }}
           >{'Dark'}</Radio>
         </FormGroup>

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -180,6 +180,28 @@ describe('browser/settings.html', function desc() {
           loadSettingsPage().
           isExisting('#inputShowTrayIcon').should.eventually.equal(expected);
       });
+
+      describe('Save tray icon theme on linux', () => {
+        env.shouldTest(it, process.platform === 'linux')('should be saved when it\'s selected', () => {
+          env.addClientCommands(this.app.client);
+          return this.app.client.
+            loadSettingsPage().
+            click('#inputShowTrayIcon').
+            click('input[value="light"]').
+            pause(700). // wait auto-save
+            then(() => {
+              const config0 = JSON.parse(fs.readFileSync(env.configFilePath, 'utf-8'));
+              config0.trayIconTheme.should.equal('light');
+              return this.app.client;
+            }).
+            click('input[value="dark"]').
+            pause(700). // wait auto-save
+            then(() => {
+              const config1 = JSON.parse(fs.readFileSync(env.configFilePath, 'utf-8'));
+              config1.trayIconTheme.should.equal('dark');
+            });
+        });
+      });
     });
 
     describe('Leave app running in notification area when application window is closed', () => {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fix an issue where the setting was not saved when changing tray icon theme.

**Issue link**
#456 

**Test Cases**
The test is automated.

1. Start the application.
2. Open settings page.
3. Change tray icon theme.
4. "Saving..." indicator should appear and the selected theme should be written into `config.json`.

**Additional Notes**
Artifacts: https://circleci.com/gh/yuya-oc/desktop/190#artifacts