### PR TITLE
Remove "Display secure content only" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ from the final changelog of the release.
 Release date: TBD
 
 ### Improvements
+- Removed "Display secure content only" option it's no longer necessary.
 
 ### Bug Fixes
 

--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -36,7 +36,6 @@ const styles = {
 
 const MainPage = React.createClass({
   propTypes: {
-    disablewebsecurity: React.PropTypes.bool.isRequired,
     onUnreadCountChange: React.PropTypes.func.isRequired,
     teams: React.PropTypes.array.isRequired,
     onTeamConfigChange: React.PropTypes.func.isRequired,
@@ -291,7 +290,6 @@ const MainPage = React.createClass({
           style={self.visibleStyle(isActive)}
           src={team.url}
           name={team.name}
-          disablewebsecurity={this.props.disablewebsecurity}
           onTargetURLChange={self.handleTargetURLChange}
           onUnreadCountChange={handleUnreadCountChange}
           onNotificationClick={handleNotificationClick}

--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -12,7 +12,6 @@ const preloadJS = `file://${remote.app.getAppPath()}/browser/webview/mattermost_
 
 const MattermostView = React.createClass({
   propTypes: {
-    disablewebsecurity: React.PropTypes.bool,
     name: React.PropTypes.string,
     id: React.PropTypes.string,
     onTargetURLChange: React.PropTypes.func,
@@ -37,12 +36,6 @@ const MattermostView = React.createClass({
   componentDidMount() {
     var self = this;
     var webview = findDOMNode(this.refs.webview);
-
-    // This option allows insecure content, when set to true it is possible to
-    // load content via HTTP while the mattermost server serves HTTPS
-    if (this.props.disablewebsecurity === true) {
-      webview.setAttribute('webpreferences', 'allowDisplayingInsecureContent');
-    }
 
     webview.addEventListener('did-fail-load', (e) => {
       console.log(self.props.name, 'webview did-fail-load', e);
@@ -217,10 +210,6 @@ const MattermostView = React.createClass({
         className='errorView'
         errorInfo={this.state.errorInfo}
       />) : null;
-
-    // 'disablewebsecurity' is necessary to display external images.
-    // However, it allows also CSS/JavaScript.
-    // So webview should use 'allowDisplayingInsecureContent' as same as BrowserWindow.
 
     // Need to keep webview mounted when failed to load.
     return (

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -107,7 +107,6 @@ const SettingsPage = React.createClass({
       teams: this.state.teams,
       showTrayIcon: this.state.showTrayIcon,
       trayIconTheme: this.state.trayIconTheme,
-      disablewebsecurity: this.state.disablewebsecurity,
       version: settings.version,
       minimizeToTray: this.state.minimizeToTray,
       notifications: {
@@ -150,12 +149,6 @@ const SettingsPage = React.createClass({
 
   handleCancel() {
     backToIndex();
-  },
-  handleChangeDisableWebSecurity() {
-    this.setState({
-      disablewebsecurity: this.refs.disablewebsecurity.props.checked
-    });
-    setImmediate(this.startSaveConfig);
   },
   handleChangeShowTrayIcon() {
     var shouldShowTrayIcon = !this.refs.showTrayIcon.props.checked;
@@ -271,21 +264,6 @@ const SettingsPage = React.createClass({
           </HelpBlock>
         </Checkbox>);
     }
-
-    options.push(
-      <Checkbox
-        key='inputDisableWebSecurity'
-        id='inputDisableWebSecurity'
-        ref='disablewebsecurity'
-        checked={!this.state.disablewebsecurity}
-        onChange={this.handleChangeDisableWebSecurity}
-      >{'Display secure content only'}
-        <HelpBlock>
-          {'If enabled, the app only displays secure (HTTPS/SSL) content.'}
-          {' '}
-          {'If disabled, the app displays secure and non-secure (HTTP) content such as images.'}
-        </HelpBlock>
-      </Checkbox>);
 
     if (process.platform === 'darwin' || process.platform === 'win32') {
       const TASKBAR = process.platform === 'win32' ? 'taskbar' : 'Dock';

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -95,7 +95,6 @@ const initialIndex = parsedURL.query.index ? parseInt(parsedURL.query.index, 10)
 
 ReactDOM.render(
   <MainPage
-    disablewebsecurity={AppConfig.data.disablewebsecurity}
     teams={AppConfig.data.teams}
     initialIndex={initialIndex}
     onUnreadCountChange={showUnreadBadge}

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -18,7 +18,6 @@ function loadDefault(version) {
       teams: [],
       showTrayIcon: false,
       trayIconTheme: 'light',
-      disablewebsecurity: true,
       minimizeToTray: false,
       version: 1,
       notifications: {

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -119,49 +119,6 @@ describe('browser/settings.html', function desc() {
       });
     });
 
-    describe('Display secure content only', () => {
-      [true, false].forEach((v) => {
-        it(`should be saved and loaded: ${v}`, () => {
-          const webPreferences = v ? '' : 'allowDisplayingInsecureContent';
-          env.addClientCommands(this.app.client);
-
-          return this.app.client.
-            loadSettingsPage().
-            scroll('#inputDisableWebSecurity').
-            isSelected('#inputDisableWebSecurity').then((isSelected) => {
-              if (isSelected !== v) {
-                return this.app.client.click('#inputDisableWebSecurity');
-              }
-              return true;
-            }).
-            pause(600).
-            click('#btnClose').
-            pause(1000).then(() => {
-              const savedConfig = JSON.parse(fs.readFileSync(env.configFilePath, 'utf8'));
-              savedConfig.disablewebsecurity.should.equal(!v);
-            }).
-            getAttribute('.mattermostView', 'webpreferences').then((disablewebsecurity) => { // confirm actual behavior
-              // disablewebsecurity is an array of String
-              disablewebsecurity.forEach((d) => {
-                d.should.equal(webPreferences);
-              });
-            }).then(() => {
-              return this.app.restart();
-            }).then(() => {
-              env.addClientCommands(this.app.client);
-              return this.app.client. // confirm actual behavior
-                getAttribute('.mattermostView', 'webpreferences').then((disablewebsecurity) => { // disablewebsecurity is an array of String
-                  disablewebsecurity.forEach((d) => {
-                    d.should.equal(webPreferences);
-                  });
-                }).
-                loadSettingsPage().
-                isSelected('#inputDisableWebSecurity').should.eventually.equal(v);
-            });
-        });
-      });
-    });
-
     describe('Start app on login', () => {
       it('should appear on win32 or linux', () => {
         const expected = (process.platform === 'win32' || process.platform === 'linux');


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Remove "Display secure content only" option.

allowDisplayingInsecureContent is removed in Electron 1.6 https://github.com/electron/electron/commit/2e0780308c7ef2258422efd34c968091d7cd5b65. 
And it's no longer necessary to show http contents in https server.


**Issue link**
N/A

**Test Cases**
1. Post a HTTP link or an embedded image (`![image](URL)`) in a channel provided by HTTPS.
2. The image should appear.

Tested on Windows 10 and macOS 10.12.3.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/192#artifacts