### PR TITLE
Reduce tab bar height

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -217,7 +217,7 @@ const MainPage = React.createClass({
     var visibility = visible ? 'visible' : 'hidden';
     return {
       position: 'absolute',
-      top: (this.props.teams.length > 1) ? 42 : 0,
+      top: (this.props.teams.length > 1) ? 32 : 0,
       right: 0,
       bottom: 0,
       left: 0,

--- a/src/browser/components/TabBar.jsx
+++ b/src/browser/components/TabBar.jsx
@@ -16,7 +16,7 @@ class TabBar extends React.Component {
         lineHeight: '20px',
         height: '19px',
         marginLeft: '5px',
-        marginTop: '6px',
+        marginTop: '5px',
         borderRadius: '50%'
       };
 
@@ -85,7 +85,7 @@ class TabBar extends React.Component {
     var tabButton = {
       border: 'none',
       fontSize: '20px',
-      height: '35px',
+      height: '31px',
       padding: '2px 0 0 0',
       width: '40px',
       color: '#999',

--- a/src/browser/css/index.css
+++ b/src/browser/css/index.css
@@ -35,16 +35,17 @@
   border-radius: 2px 2px 0 0;
   border: 1px solid #ddd;
   color: #888;
-  height: 35px;
-  line-height: 32px;
+  height: 31px;
+  line-height: 29px;
   margin-right: -1px;
-  margin-top: 7px;
+  margin-top: 0px;
   padding: 0 15px;
 }
 
 .nav-tabs>li.buttonTab>a {
   border: none;
   background: transparent;
+  margin: 0px;
   margin-left: 1px; /*Has no border and would be placed above the last item's border due to it's margin-right: -1px */
   padding: 0;
   margin-bottom: 1px;


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Reduce tab bar height.

It seems that Chrome's tabs have about 28px of height at 100% of scaling.
But 28px looked a little narrow for me. So I used 32px. It always becomes an integer on monitor at all scaling.

- 100% -> 32 dots on monitor
- 125% -> 40 dots on monitor
- 150% -> 48 dots on monitor

![tab-height_100](https://cloud.githubusercontent.com/assets/1412057/24322699/dd59ef82-11ac-11e7-9cc7-4c4dd114de1d.png)
![tab-height_125](https://cloud.githubusercontent.com/assets/1412057/24322698/dd58fdde-11ac-11e7-9a5f-d600f9143ed7.png)
![tab-height_150](https://cloud.githubusercontent.com/assets/1412057/24322700/dd622422-11ac-11e7-9d6e-1b1941eac509.png)

**Issue link**
#462 

**Test Cases**
1. Add two servers at least to show the tab bar.
2. Get unread mention to show badges.

Please also check that webapp doesn't looks blurry.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/196#artifacts