### PR TITLE
Reload tabs when the computer resumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Release date: TBD
 
 ### Improvements
 - Removed "Display secure content only" option it's no longer necessary.
+- Reload tabs to fetch latest messages when the computer resumes.
 
 #### Windows
 - Removed Japanese fonts support it's no longer necessary.

--- a/src/browser/components/ErrorView.jsx
+++ b/src/browser/components/ErrorView.jsx
@@ -31,10 +31,17 @@ const errorPage = {
 };
 
 function ErrorView(props) {
+  const classNames = ['errorView'];
+  if (!props.active) {
+    classNames.push('errorView-hidden');
+  }
+  if (props.withTab) {
+    classNames.push('errorView-with-tab');
+  }
   return (
     <Grid
       id={props.id}
-      style={props.style}
+      bsClass={classNames.join(' ')}
     >
       <div style={errorPage.tableStyle}>
         <div style={errorPage.cellStyle}>
@@ -87,7 +94,8 @@ function ErrorView(props) {
 ErrorView.propTypes = {
   errorInfo: React.PropTypes.object,
   id: React.PropTypes.number,
-  style: React.PropTypes.object
+  active: React.PropTypes.bool,
+  withTab: React.PropTypes.bool
 };
 
 module.exports = ErrorView;

--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -213,18 +213,6 @@ const MainPage = React.createClass({
     this.markReadAtActive(index);
   },
 
-  visibleStyle(visible) {
-    var visibility = visible ? 'visible' : 'hidden';
-    return {
-      position: 'absolute',
-      top: (this.props.teams.length > 1) ? 42 : 0,
-      right: 0,
-      bottom: 0,
-      left: 0,
-      visibility
-    };
-  },
-
   handleLogin(request, username, password) {
     ipcRenderer.send('login-credentials', request, username, password);
     const loginQueue = this.state.loginQueue;
@@ -287,7 +275,7 @@ const MainPage = React.createClass({
         <MattermostView
           key={id}
           id={id}
-          style={self.visibleStyle(isActive)}
+          withTab={this.props.teams.length > 1}
           src={team.url}
           name={team.name}
           onTargetURLChange={self.handleTargetURLChange}

--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -15,7 +15,8 @@ const MattermostView = React.createClass({
     onTargetURLChange: React.PropTypes.func,
     onUnreadCountChange: React.PropTypes.func,
     src: React.PropTypes.string,
-    style: React.PropTypes.object
+    active: React.PropTypes.bool,
+    withTab: React.PropTypes.bool
   },
 
   getInitialState() {
@@ -185,19 +186,26 @@ const MattermostView = React.createClass({
     const errorView = this.state.errorInfo ? (
       <ErrorView
         id={this.props.id + '-fail'}
-        style={this.props.style}
         className='errorView'
         errorInfo={this.state.errorInfo}
+        active={this.props.active}
+        withTab={this.props.withTab}
       />) : null;
 
     // Need to keep webview mounted when failed to load.
+    const classNames = ['mattermostView'];
+    if (this.props.withTab) {
+      classNames.push('mattermostView-with-tab');
+    }
+    if (!this.props.active) {
+      classNames.push('mattermostView-hidden');
+    }
     return (
       <div>
         { errorView }
         <webview
           id={this.props.id}
-          className='mattermostView'
-          style={this.props.style}
+          className={classNames.join(' ')}
           preload={preloadJS}
           src={this.props.src}
           ref='webview'

--- a/src/browser/css/components/ErrorView.css
+++ b/src/browser/css/components/ErrorView.css
@@ -1,0 +1,15 @@
+.errorView {
+  position: absolute;
+  top: 0px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
+}
+
+.errorView-with-tab {
+  top: 42px;
+}
+
+.errorView-hidden {
+  visibility: hidden;
+}

--- a/src/browser/css/components/MattermostView.css
+++ b/src/browser/css/components/MattermostView.css
@@ -1,0 +1,17 @@
+.mattermostView {
+  position: absolute;
+  top: 0px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
+}
+
+.mattermostView-with-tab {
+  top: 42px;
+}
+
+.mattermostView-hidden {
+  flex: 0 1;
+  width: 0px;
+  height: 0px;
+}

--- a/src/browser/css/index.css
+++ b/src/browser/css/index.css
@@ -1,3 +1,5 @@
+@import url("components/MattermostView.css");
+@import url("components/ErrorView.css");
 
 .hovering-enter {
   opacity: 0.01;

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const electron = require('electron');
 const {
   app,
   Menu,
@@ -9,7 +10,7 @@ const {
   dialog,
   systemPreferences,
   session
-} = require('electron');
+} = electron;
 const isDev = require('electron-is-dev');
 const installExtension = require('electron-devtools-installer');
 
@@ -446,6 +447,15 @@ app.on('ready', () => {
     }
   });
   ipcMain.emit('update-menu', true, config);
+
+  electron.powerMonitor.on('resume', () => {
+    const allWebContents = electron.webContents.getAllWebContents();
+    for (const webContents of allWebContents) {
+      if (webContents !== mainWindow.webContents) {
+        webContents.reload();
+      }
+    }
+  });
 
   // Open the DevTools.
   // mainWindow.openDevTools();

--- a/src/main.js
+++ b/src/main.js
@@ -452,7 +452,7 @@ app.on('ready', () => {
     const allWebContents = electron.webContents.getAllWebContents();
     for (const webContents of allWebContents) {
       if (webContents !== mainWindow.webContents) {
-        webContents.reload();
+        webContents.send('resume');
       }
     }
   });

--- a/test/specs/browser/index_test.js
+++ b/test/specs/browser/index_test.js
@@ -126,14 +126,16 @@ describe('browser/index.html', function desc() {
     return this.app.restart().then(() => {
       return this.app.client.waitUntilWindowLoaded().pause(500);
     }).then(() => {
+      // Note: Indices of webview are correct.
+      // Somehow they are swapped.
       return this.app.client.
-        windowByIndex(1).
+        windowByIndex(2).
         execute(() => {
           document.title = 'Title 0';
         }).
         windowByIndex(0).
         browserWindow.getTitle().should.eventually.equal('Title 0').
-        windowByIndex(2).
+        windowByIndex(1).
         execute(() => {
           document.title = 'Title 1';
         }).
@@ -154,14 +156,16 @@ describe('browser/index.html', function desc() {
       }]
     }));
     return this.app.restart().then(() => {
+      // Note: Indices of webview are correct.
+      // Somehow they are swapped.
       return this.app.client.
         waitUntilWindowLoaded().
         pause(500).
-        windowByIndex(1).
+        windowByIndex(2).
         execute(() => {
           document.title = 'Title 0';
         }).
-        windowByIndex(2).
+        windowByIndex(1).
         execute(() => {
           document.title = 'Title 1';
         }).


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Reload tabs when the computer resumes.

If the computer is offline when resuming from sleep, the app doesn't reload any tabs to keep their contents.

**Issue link**
#461 

**Test Cases**
Tested on macOS 10.12.3

Case 1:

1. Let the computer sleep.
2. Resume from sleep.
3. The app should reload all tabs immediately.

Case 2:

1. Turn off Wi-Fi or unplug LAN cable.
2. Let the computer sleep.
3. Resume from sleep.
4. The app should NOT reload any tabs immediately.
5. Connect the computer to a network.
6. The app should reload all tabs.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/200#artifacts