### PR TITLE
Fix Quick Look not closing in file upload dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,18 @@ Release date: TBD
 #### Mac
 - Fixed an issue where the application was not avaliable on the Dock after a reboot.
   [#411](https://github.com/mattermost/desktop/issues/411)
+- Fixed an issue where Quick Look doesn't close in file upload dialog.
+  [#498](https://github.com/mattermost/desktop/issues/498)
 
 #### Linux
 - Fixed an issue where the setting was not saved when changing tray icon theme.
   [#456](https://github.com/mattermost/desktop/issues/456)
+
+### New known issues
+
+#### Mac
+- The application crashes when a file upload dialog is canceled without closing Quick Look.
+
 
 ----
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "chai": "^3.5.0",
     "cross-env": "^3.1.4",
     "devtron": "^1.4.0",
-    "electron": "1.6.1",
+    "electron": "1.6.2",
     "electron-builder": "^14.5.3",
     "electron-builder-squirrel-windows": "^15.0.0",
     "electron-connect": "^0.6.1",


### PR DESCRIPTION

Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fix Quick Look not closing in file upload dialog.

https://github.com/electron/electron/releases/tag/v1.6.2

But still there is a problem where the app craches when the dialog is canceled without closing Quick Look.

**Issue link**
#498 

**Test Cases**
1. Open file upload dialog
2. Use Quick Look to preview a file.
3. Quick Look can be closed via close button or space bar.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/213#artifacts