### PR TITLE
Add display-metrics-changed handler to place window on screen

### DIFF
--- a/src/main/mainWindow.js
+++ b/src/main/mainWindow.js
@@ -14,35 +14,6 @@ function saveWindowState(file, window) {
   }
 }
 
-function getValidWindowPosition(state) {
-  // Screen cannot be required before app is ready
-  const {screen} = require('electron'); // eslint-disable-line global-require
-
-  // Check if the previous position is out of the viewable area
-  // (e.g. because the screen has been plugged off)
-  const displays = screen.getAllDisplays();
-  let minX = 0;
-  let maxX = 0;
-  let minY = 0;
-  let maxY = 0;
-  for (let i = 0; i < displays.length; i++) {
-    const display = displays[i];
-    maxX = Math.max(maxX, display.bounds.x + display.bounds.width);
-    maxY = Math.max(maxY, display.bounds.y + display.bounds.height);
-    minX = Math.min(minX, display.bounds.x);
-    minY = Math.min(minY, display.bounds.y);
-  }
-
-  if (state.x > maxX || state.y > maxY || state.x < minX || state.y < minY) {
-    Reflect.deleteProperty(state, 'x');
-    Reflect.deleteProperty(state, 'y');
-    Reflect.deleteProperty(state, 'width');
-    Reflect.deleteProperty(state, 'height');
-  }
-
-  return state;
-}
-
 function createMainWindow(config, options) {
   const defaultWindowWidth = 1000;
   const defaultWindowHeight = 700;
@@ -53,11 +24,12 @@ function createMainWindow(config, options) {
   const boundsInfoPath = path.join(app.getPath('userData'), 'bounds-info.json');
   var windowOptions;
   try {
-    windowOptions = getValidWindowPosition(JSON.parse(fs.readFileSync(boundsInfoPath, 'utf-8')));
+    windowOptions = JSON.parse(fs.readFileSync(boundsInfoPath, 'utf-8'));
   } catch (e) {
     // Follow Electron's defaults, except for window dimensions which targets 1024x768 screen resolution.
     windowOptions = {width: defaultWindowWidth, height: defaultWindowHeight};
   }
+
   if (process.platform === 'linux') {
     windowOptions.icon = options.linuxAppIcon;
   }


### PR DESCRIPTION
Add display-metrics-changed handler to place window on screen when metrics change while the application is running.

Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
I added a listener for `display-metrics-changed` to handle changes while the app is running.
However the event doe snot fire on my OS so I'm not able to test this (+ I can't reproduce the bug on Linux so there is actually no bug to fix in my case).
However this might fix #471 if it works correctly...

**Test Cases**
See #471, place window on a dedicated monitor, remove that monitor. Hope the event fires and the window is moved to an existing screen.

**Additional Notes**
Not really tested, event does not fire on my OS. I hope it does on Window...