### PR TITLE
Don't show an extra window when clicking public file link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Release date: TBD
 
 #### All Platforms
 - Fixed an issue where an unexpected row appeared after switching channels with `CTRL+K` shortcut. [#426](https://github.com/mattermost/desktop/issues/426)
+- Fixed an issue where an unexpected extra window opened when clicking the public link for an uploaded file.
+  [#390](https://github.com/mattermost/desktop/issues/390)
 
 #### Windows
 - Fixed an issue where the main window still has focus and exists

--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -64,9 +64,14 @@ const MattermostView = React.createClass({
         ipcRenderer.send('confirm-protocol', destURL.protocol, e.url);
         return;
       }
+
       if (currentURL.host === destURL.host) {
-        // New window should disable nodeIntergration.
-        window.open(e.url, 'Mattermost', 'nodeIntegration=no, show=yes');
+        if (destURL.path.match(/^\/api\/v[3-4]\/public\/files\//)) {
+          ipcRenderer.send('download-url', e.url);
+        } else {
+          // New window should disable nodeIntergration.
+          window.open(e.url, 'Mattermost', 'nodeIntegration=no, show=yes');
+        }
       } else {
         // if the link is external, use default browser.
         shell.openExternal(e.url);

--- a/src/main.js
+++ b/src/main.js
@@ -327,6 +327,10 @@ allowProtocolDialog.init(mainWindow);
 ipcMain.on('download-url', (event, URL) => {
   downloadURL(mainWindow, URL, (err) => {
     if (err) {
+      dialog.showMessageBox(mainWindow, {
+        type: 'error',
+        message: err.toString()
+      });
       console.log(err);
     }
   });

--- a/src/main.js
+++ b/src/main.js
@@ -61,6 +61,7 @@ var certificateStore = require('./main/certificateStore').load(path.resolve(app.
 const {createMainWindow} = require('./main/mainWindow');
 const appMenu = require('./main/menus/app');
 const trayMenu = require('./main/menus/tray');
+const downloadURL = require('./main/downloadURL');
 const allowProtocolDialog = require('./main/allowProtocolDialog');
 
 const assetsDir = path.resolve(app.getAppPath(), 'assets');
@@ -322,6 +323,14 @@ app.on('login', (event, webContents, request, authInfo, callback) => {
 });
 
 allowProtocolDialog.init(mainWindow);
+
+ipcMain.on('download-url', (event, URL) => {
+  downloadURL(mainWindow, URL, (err) => {
+    if (err) {
+      console.log(err);
+    }
+  });
+});
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.

--- a/src/main/downloadURL.js
+++ b/src/main/downloadURL.js
@@ -35,7 +35,7 @@ function getAttachmentName(headers) {
 
 function saveResponseBody(response, filename, callback) {
   const output = fs.createWriteStream(filename);
-  output.on('close', callback).on('error', callback);
+  output.on('close', callback);
   switch (response.headers['content-encoding']) {
   case 'gzip':
     response.pipe(zlib.createGunzip()).pipe(output).on('error', callback);

--- a/src/main/downloadURL.js
+++ b/src/main/downloadURL.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+const zlib = require('zlib');
+const electron = require('electron');
+const {app, dialog} = electron;
+
+function downloadURL(browserWindow, URL, callback) {
+  const {net} = electron;
+  const request = net.request(URL);
+  request.setHeader('Accept-Encoding', 'gzip,deflate');
+  request.on('response', (response) => {
+    const file = getAttachmentName(response.headers);
+    const dialogOptions = {
+      defaultPath: path.join(app.getPath('downloads'), file)
+    };
+    dialog.showSaveDialog(browserWindow, dialogOptions, (filename) => {
+      if (filename) {
+        saveResponseBody(response, filename, callback);
+      }
+    });
+  }).on('error', callback);
+  request.end();
+}
+
+function getAttachmentName(headers) {
+  if (headers['content-disposition']) {
+    const contentDisposition = headers['content-disposition'][0];
+    const matched = contentDisposition.match(/filename="(.*)"/);
+    if (matched) {
+      return path.basename(matched[1]);
+    }
+  }
+  return '';
+}
+
+function saveResponseBody(response, filename, callback) {
+  const output = fs.createWriteStream(filename);
+  output.on('close', callback).on('error', callback);
+  switch (response.headers['content-encoding']) {
+  case 'gzip':
+    response.pipe(zlib.createGunzip()).pipe(output).on('error', callback);
+    break;
+  case 'deflate':
+    response.pipe(zlib.createInflate()).pipe(output).on('error', callback);
+    break;
+  default:
+    response.pipe(output).on('error', callback);
+    break;
+  }
+}
+
+module.exports = downloadURL;


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Don't show an extra window when clicking a public link for uploaded files.

When clicked link is a public link (`/api/v[34]/public/files`), open a save file dialog.

**Issue link**
#390

**Test Cases**
1. Post a public link for an uploaded file.
2. Click the link.
3. Only save file dialog should appear.
4. The file should be saved correcty.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/234#artifacts