### PR TITLE
Use sheet-end event to handle focus when closing macOS file upload dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Release date: TBD
  - Fixed mis-aligned `+` button of tab bar.
  [#541](https://github.com/mattermost/desktop/issues/541)
 
+#### Mac
+ - Fixed an issue where the text box didn't keep focus after uploading a file.
+ [#341](https://github.com/mattermost/desktop/issues/341)
+
 ---
 
 ## Release v3.7.0

--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -104,6 +104,10 @@ const MainPage = createReactClass({
     ipcRenderer.on('add-server', () => {
       this.addServer();
     });
+
+    ipcRenderer.on('focus-on-webview', () => {
+      this.focusOnWebView();
+    });
   },
   componentDidUpdate(prevProps, prevState) {
     if (prevState.key !== this.state.key) { // i.e. When tab has been changed
@@ -207,6 +211,11 @@ const MainPage = createReactClass({
       showNewTeamModal: true
     });
   },
+
+  focusOnWebView() {
+    this.refs[`mattermostView${this.state.key}`].focusOnWebView();
+  },
+
   render() {
     var self = this;
 

--- a/src/main/mainWindow.js
+++ b/src/main/mainWindow.js
@@ -107,6 +107,10 @@ function createMainWindow(config, options) {
     }
   });
 
+  mainWindow.on('sheet-end', () => {
+    mainWindow.webContents.send('focus-on-webview');
+  });
+
   return mainWindow;
 }
 


### PR DESCRIPTION

Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Keep focus when closing file upload dialog on macOS.

This requires Electron 1.6.8 which is still beta.

**Issue link**
#341 

**Test Cases**
On Mac:

1. Upload file using CMD or CTRL + U
2. Choose file with keyboard + hit enter to select
3. Hit enter to send the message

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/240#artifacts
