### PR TITLE
Reset misspelled state after changing spelling language

### DIFF
--- a/src/browser/webview/mattermost.js
+++ b/src/browser/webview/mattermost.js
@@ -148,6 +148,17 @@ notification.override({
   }
 });
 
+function resetMisspelledState() {
+  ipc.once('spellchecker-is-ready', () => {
+    const element = document.activeElement;
+    if (element) {
+      element.blur();
+      element.focus();
+    }
+  });
+  ipc.send('reply-on-spellchecker-is-ready');
+}
+
 function setSpellChecker() {
   const spellCheckerLocale = ipc.sendSync('get-spellchecker-locale');
   webFrame.setSpellCheckProvider(spellCheckerLocale, false, {
@@ -156,6 +167,7 @@ function setSpellChecker() {
       return res === null ? true : res;
     }
   });
+  resetMisspelledState();
 }
 setSpellChecker();
 ipc.on('set-spellcheker', setSpellChecker);

--- a/src/main.js
+++ b/src/main.js
@@ -542,6 +542,15 @@ app.on('ready', () => {
   ipcMain.on('get-spellchecker-locale', (event) => {
     event.returnValue = config.spellCheckerLocale;
   });
+  ipcMain.on('reply-on-spellchecker-is-ready', (event) => {
+    if (spellChecker.isReady()) {
+      event.sender.send('spellchecker-is-ready');
+      return;
+    }
+    spellChecker.once('ready', () => {
+      event.sender.send('spellchecker-is-ready');
+    });
+  });
   ipcMain.emit('update-dict');
 
   // Open the DevTools.

--- a/src/main/SpellChecker.js
+++ b/src/main/SpellChecker.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const EventEmitter = require('events');
 const simpleSpellChecker = require('simple-spellchecker');
 
 /// Following approach for contractions is derived from electron-spellchecker.
@@ -26,17 +27,20 @@ const contractionMap = contractions.reduce((acc, word) => {
 
 /// End: derived from electron-spellchecker.
 
-class SpellChecker {
+class SpellChecker extends EventEmitter {
   constructor(locale, dictDir, callback) {
+    super();
     this.dict = null;
     this.locale = locale;
     simpleSpellChecker.getDictionary(locale, dictDir, (err, dict) => {
       if (err) {
+        this.emit('error', err);
         if (callback) {
           callback(err);
         }
       } else {
         this.dict = dict;
+        this.emit('ready');
         if (callback) {
           callback(null, this);
         }


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Reset misspelled state after changing spelling language.

**Issue link**
#524 

**Test Cases**
See #524. After the step 7, the highlight should be updated a moment later.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/241#artifacts