### PR TITLE
Enable spellchecker as default setting

### DIFF
--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -24,7 +24,7 @@ function loadDefault(version, spellCheckerLocale) {
         flashWindow: 0 // 0 = flash never, 1 = only when idle (after 10 seconds), 2 = always
       },
       showUnreadBadge: true,
-      useSpellChecker: false,
+      useSpellChecker: true,
       spellCheckerLocale: spellCheckerLocale || 'en-US'
     };
   default:

--- a/src/main.js
+++ b/src/main.js
@@ -96,7 +96,8 @@ try {
     settings.writeFileSync(configFile, config);
   }
 } catch (e) {
-  config = settings.loadDefault();
+  const spellCheckerLocale = SpellChecker.getSpellCheckerLocale(app.getLocale());
+  config = settings.loadDefault(null, spellCheckerLocale);
   console.log('Failed to read or upgrade config.json', e);
 }
 

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -208,11 +208,12 @@ describe('browser/settings.html', function desc() {
           loadSettingsPage().
           isExisting('#inputSpellChecker').then((existing) => existing.should.equal(true)).
           scroll('#inputSpellChecker').
+          isSelected('#inputSpellChecker').then((selected) => selected.should.equal(true)).
           click('#inputSpellChecker').
           pause(700).
           then(() => {
             const config1 = JSON.parse(fs.readFileSync(env.configFilePath, 'utf-8'));
-            config1.useSpellChecker.should.equal(true);
+            config1.useSpellChecker.should.equal(false);
           });
       });
     });


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Enable spellchecker as default setting.

The language should be determined by user's locale. If it's not available in spellchecker, English is used.

**Issue link**
#527 

**Test Cases**
A. First installation.

1. Exit from the app.
2. Rename `config.json` to backup.
3. Start the app.
4. Spellchecker should be enabled as default setting.

B. Upgrading
1. Exit from the app.
2. Remove `useSpellChecker` and `spellCheckerLocale` entries from `config.json`.
3. Start the app.
4. Spellchecker should be enabled.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/244#artifacts