### PR TITLE
Fix alignment for 'Add new server' button

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -111,9 +111,6 @@ const MainPage = createReactClass({
     }
   },
   handleSelect(key) {
-    if (key === 'addServerButton') {
-      return;
-    }
     const newKey = (this.props.teams.length + key) % this.props.teams.length;
     this.setState({
       key: newKey

--- a/src/browser/components/TabBar.jsx
+++ b/src/browser/components/TabBar.jsx
@@ -1,29 +1,6 @@
 const React = require('react');
 const PropTypes = require('prop-types');
-const {Nav, NavItem, Button} = require('react-bootstrap');
-
-function AddServerButton(props) {
-  return (
-    <NavItem
-      className='AddServerButton'
-      key='addServerButton'
-      eventKey='addServerButton'
-    >
-      <Button
-        id='tabBarAddNewTeam'
-        onClick={props.onClick}
-        className='AddServerButton-button'
-        title='Add new server'
-      >
-        {'+'}
-      </Button>
-    </NavItem>
-  );
-}
-
-AddServerButton.propTypes = {
-  onClick: PropTypes.func
-};
+const {Glyphicon, Nav, NavItem} = require('react-bootstrap');
 
 function TabBar(props) {
   const tabs = props.teams.map((team, index) => {
@@ -76,16 +53,32 @@ function TabBar(props) {
         { badgeDiv }
       </NavItem>);
   });
+  tabs.push(
+    <NavItem
+      className='TabBar-addServerButton'
+      key='addServerButton'
+      id='addServerButton'
+      eventKey='addServerButton'
+      title='Add new server'
+    >
+      <Glyphicon glyph='plus'/>
+    </NavItem>
+  );
   return (
     <Nav
       className='TabBar'
       id={props.id}
       bsStyle='tabs'
       activeKey={props.activeKey}
-      onSelect={props.onSelect}
+      onSelect={(eventKey) => {
+        if (eventKey === 'addServerButton') {
+          props.onAddServer();
+        } else {
+          props.onSelect(eventKey);
+        }
+      }}
     >
       { tabs }
-      <AddServerButton onClick={props.onAddServer}/>
     </Nav>
   );
 }

--- a/src/browser/css/components/TabBar.css
+++ b/src/browser/css/components/TabBar.css
@@ -10,13 +10,18 @@
   padding: 0 15px;
 }
 
-.TabBar .AddServerButton>a {
+.TabBar .TabBar-addServerButton>a {
   border: none;
   background: transparent;
-  margin: 0px;
-  margin-left: 1px; /*Has no border and would be placed above the last item's border due to it's margin-right: -1px */
-  padding: 0;
-  margin-bottom: 1px;
+  color: #999;
+  font-size: 10px;
+  line-height: 31px;
+}
+
+.TabBar .TabBar-addServerButton>a:hover {
+  color: #333;
+  background-color: #e6e6e6;
+  border-color: #adadad;
 }
 
 .TabBar .TabBar-badge {
@@ -32,30 +37,3 @@
   margin-top: 5px;
   border-radius: 50%;
 };
-
-
-.TabBar .AddServerButton-button {
-  background-color: #fff;
-  border-color: #ccc;
-  color: #333;
-  margin-top: 3px;
-}
-
-.TabBar .AddServerButton-button {
-  border: none;
-  font-size: 20px;
-  height: 31px;
-  padding: 2px 0 0 0;
-  width: 40px;
-  color: #999;
-  font-weight: bold;
-  margin: 0;
-  border-radius: 2px 2px 0 0;
-  outline: none;
-}
-
-.TabBar .AddServerButton-button:hover {
-  color: #333;
-  background-color: #e6e6e6;
-  border-color: #adadad;
-}

--- a/test/specs/browser/index_test.js
+++ b/test/specs/browser/index_test.js
@@ -185,7 +185,7 @@ describe('browser/index.html', function desc() {
   it('should open the new server prompt after clicking the add button', () => {
     // See settings_test for specs that cover the actual prompt
     return this.app.client.waitUntilWindowLoaded().
-      click('#tabBarAddNewTeam').
+      click('#addServerButton').
       pause(500).
       isExisting('#newServerModal').then((existing) => existing.should.be.true);
   });


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fix alignment for 'Add new server' button. (+)

v3.7.0 on Mac:
![v3 7 0](https://cloud.githubusercontent.com/assets/1412057/26585612/972db4bc-4587-11e7-8ba7-58c79aebbb2d.png)

PR on Mac:
![proposal](https://cloud.githubusercontent.com/assets/1412057/26585615/993a9ebe-4587-11e7-8697-5a70efa5e07d.png)



It looks `Button` component makes the alignment difficult. So I stopped using `Button`. And '+' is a plain text font, so I think it's difficult to layout at "complete center".
Please see the actual alignment.

**Issue link**
https://github.com/mattermost/desktop/pull/540#issuecomment-303734982

**Test Cases**
1. Add two servers at least.
2. Open the main page.
3. See tab bar.
4. The '+' button should work as expected.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/264#artifacts