### PR TITLE
Update Electron to 1.6.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Release date: TBD
 
 ### Improvements
 
+#### Windows
+ - [Windows 7/8] Added support to open the message when clicking desktop notification.
+ [#67](https://github.com/mattermost/desktop/issues/67)
+ - Added support for different DPI across monitors.
+ [#357](https://github.com/mattermost/desktop/issues/357)
+
 ### Bug Fixes
 
 ---

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "cross-env": "^4.0.0",
     "css-loader": "^0.28.1",
     "devtron": "^1.4.0",
-    "electron": "1.6.6",
+    "electron": "1.6.10",
     "electron-builder": "17.4.0",
     "electron-builder-squirrel-windows": "17.4.0",
     "electron-connect": "^0.6.1",

--- a/src/main.js
+++ b/src/main.js
@@ -56,7 +56,6 @@ const os = require('os');
 const path = require('path');
 
 var settings = require('./common/settings');
-const osVersion = require('./common/osVersion');
 var certificateStore = require('./main/certificateStore').load(path.resolve(app.getPath('userData'), 'certificate.json'));
 const {createMainWindow} = require('./main/mainWindow');
 const appMenu = require('./main/menus/app');
@@ -427,19 +426,6 @@ app.on('ready', () => {
       }
 
       mainWindow.focus();
-    });
-    ipcMain.on('notified', (event, arg) => {
-      if (process.platform === 'win32') {
-        // On Windows 8.1 and Windows 8, a shortcut with a Application User Model ID must be installed to the Start screen.
-        // In current version, use tray balloon for notification
-        if (osVersion.isLowerThanOrEqualWindows8_1()) {
-          trayIcon.displayBalloon({
-            icon: path.resolve(assetsDir, 'appicon.png'),
-            title: arg.title,
-            content: arg.options.body
-          });
-        }
-      }
     });
 
     // Set overlay icon from dataURL


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Update Electron to v1.6.10. This is the prior work for #525.

Electron 1.6.7 supports following features for Windows. So this PR should test them.

- Desktop notification for Windows 7
- Per-monior DPI awareness

**Issue link**
#67, #357

**Test Cases**
Notification:
1. Prepare Windows 7, 8 or 8.1
2. Receive any message.
3. Notification should appear instead of a tray balloon.
4. Click the notification.
5. The message should appear in the main window as well as Windows 10.

Per-monitor DPI:
1. Prepare Windows 8.1 or 10
2. Connect two monitors and set different DPI scaling.
3. Move the window across monitors.
4. The window should be rendered in proper DPI.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/268#artifacts