### PR TITLE
Fix desktop notifications not working when the window is minimized from inactive state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Release date: TBD
  - Fixed mis-aligned `+` button of tab bar.
  [#541](https://github.com/mattermost/desktop/issues/541)
 
+#### Windows
+ - Fixed desktop notifications not working when the window has been minimized from inactive state.
+ [#522](https://github.com/mattermost/desktop/issues/522)
+
 ---
 
 ## Release v3.7.0

--- a/src/main/mainWindow.js
+++ b/src/main/mainWindow.js
@@ -77,6 +77,7 @@ function createMainWindow(config, options) {
   // Ideally, app should detect that OS is shutting down.
   mainWindow.on('blur', () => {
     saveWindowState(boundsInfoPath, mainWindow);
+    mainWindow.blurWebView();
   });
 
   mainWindow.on('close', (event) => {


### PR DESCRIPTION
Blur webview when the main window loses its focus.

Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fix desktop notifications not working when the window is minimized from inactive state.

Explicitly blur webview when the window loses focus. Tested on Windows 10 and server v3.8.

**Issue link**
#522 

**Test Cases**
1. Select any channel for this test (We call it "channel A" for simplicity)
2. Make the app window inactive (ex. by clicking on the other window)
3. Click on the "minimize" button on the title bar of Mattermost window.
4. Send a message to the channel A from the other account.
5. Desktop notifications should appear.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/271#artifacts