### PR TITLE
Fix close button not working when the number of servers is not zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Release date: TBD
 #### All Platforms
  - Fixed mis-aligned `+` button of tab bar.
  [#541](https://github.com/mattermost/desktop/issues/541)
+ - Fixed the close button of the Settings page not working on first installation.
+ [#552](https://github.com/mattermost/desktop/issues/552)
 
 #### Windows
  - Fixed desktop notifications not working when the window has been minimized from inactive state.

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -39,7 +39,6 @@ const SettingsPage = createReactClass({
 
     initialState.showAddTeamForm = false;
     initialState.trayWasVisible = remote.getCurrentWindow().trayWasVisible;
-    initialState.disableClose = initialState.teams.length === 0;
     if (initialState.teams.length === 0) {
       initialState.showAddTeamForm = true;
     }
@@ -454,7 +453,7 @@ const SettingsPage = createReactClass({
               bsStyle='link'
               style={settingsPage.close}
               onClick={this.handleCancel}
-              disabled={this.state.disableClose}
+              disabled={this.state.teams.length === 0}
             >
               <span>{'×'}</span>
             </Button>

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -31,13 +31,41 @@ describe('browser/settings.html', function desc() {
     return true;
   });
 
-  it('should show index.html when Close button is clicked', () => {
-    env.addClientCommands(this.app.client);
-    return this.app.client.
-      loadSettingsPage().
-      click('#btnClose').
-      pause(1000).
-      getUrl().then((url) => url.should.match(/\/index.html(\?.+)?$/));
+  describe('Close button', () => {
+    it('should show index.html when it\'s clicked', () => {
+      env.addClientCommands(this.app.client);
+      return this.app.client.
+        loadSettingsPage().
+        click('#btnClose').
+        pause(1000).
+        getUrl().then((url) => url.should.match(/\/index.html(\?.+)?$/));
+    });
+
+    it('should be disabled when the number of servers is zero', () => {
+      return this.app.stop().then(() => {
+        env.cleanTestConfig();
+        return this.app.start();
+      }).then(() => {
+        return this.app.client.waitUntilWindowLoaded().
+          waitForVisible('#newServerModal').
+          click('#cancelNewServerModal').
+          isEnabled('#btnClose').then((enabled) => {
+            enabled.should.equal(false);
+          }).
+          waitForVisible('#newServerModal', true).
+          pause(250).
+          click('#addNewServer').
+          waitForVisible('#newServerModal').
+          setValue('#teamNameInput', 'TestTeam').
+          setValue('#teamUrlInput', 'http://example.org').
+          click('#saveNewServerModal').
+          waitForVisible('#newServerModal', true).
+          waitForVisible('.AutoSaveIndicator', true).
+          isEnabled('#btnClose').then((enabled) => {
+            enabled.should.equal(true);
+          });
+      });
+    });
   });
 
   it('should show NewServerModal after all servers are removed', () => {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fix close button not working when the number of servers is not zero when it's started from initial config.

**Issue link**
#552 

**Test Cases**
Tested on macOS.

1. Remove `config.json` (please make backup before testing)
2. Launch the app.
3. Add a server to the list in Settings page.
4. Confirm that "X" in top right corner works.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/276#artifacts