### PR TITLE
Change the app publisher to Mattermost, Inc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Release date: TBD
  [#541](https://github.com/mattermost/desktop/issues/541)
  - Fixed the close button of the Settings page not working on first installation.
  [#552](https://github.com/mattermost/desktop/issues/552)
+ - Fixed the app publisher was not changed to Mattermost, Inc.
+ [#542](https://github.com/mattermost/desktop/issues/542)
 
 #### Windows
  - Fixed desktop notifications not working when the window has been minimized from inactive state.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,5 @@
-Copyright (c) 2015-present Yuya Ochiai
+Copyright (c) 2015-2016 Yuya Ochiai
+Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 
                                  Apache License
                            Version 2.0, January 2004

--- a/package.json
+++ b/package.json
@@ -4,10 +4,7 @@
   "version": "3.7.0",
   "description": "Mattermost",
   "main": "main.js",
-  "author": {
-    "name": "Yuya Ochiai",
-    "email": "yuya0321@gmail.com"
-  },
+  "author": "Mattermost, Inc. <feedback@mattermost.com>",
   "license": "Apache-2.0",
   "engines": {
     "node": ">=4.2.0"

--- a/src/package.json
+++ b/src/package.json
@@ -5,10 +5,7 @@
   "version": "3.7.0",
   "description": "Mattermost",
   "main": "main_bundle.js",
-  "author": {
-    "name": "Yuya Ochiai",
-    "email": "yuya0321@gmail.com"
-  },
+  "author": "Mattermost, Inc. <feedback@mattermost.com>",
   "homepage": "https://about.mattermost.com",
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fix the app publisher was not changed to Mattermost, Inc.

**Issue link**
#542 

**Test Cases**
- Windows:
After installation, open "Apps and Features".
<img width="565" alt="apps_and_features" src="https://user-images.githubusercontent.com/1412057/28021831-2c55e062-65c4-11e7-83d7-e2b6614ad112.png">

- Mac:
Open "About Mattermost" in the menu bar.
![about_dialog](https://user-images.githubusercontent.com/1412057/28021677-abc7203c-65c3-11e7-8a02-4999078b7f2b.png)

- Linux:
Open deb packages with GDebi Package Installer.
<img width="330" alt="deb_maintainer" src="https://user-images.githubusercontent.com/1412057/28021858-4181bf24-65c4-11e7-9e67-c0b9242c69f5.png">


**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/278#artifacts