### PR TITLE
Fix Windows uninstaller not removing files correctly

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,9 @@
 {
     "extends": "./.eslintrc-platform.json",
+    "parserOptions": {
+        "ecmaVersion": 2017
+    },
     "rules": {
-        "global-require": 1,
         "indent": [2, 2, {"SwitchCase": 0}],
         "no-console": 0,
         "no-eval": 1,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Release date: TBD
 #### Windows
  - Fixed desktop notifications not working when the window has been minimized from inactive state.
  [#522](https://github.com/mattermost/desktop/issues/522)
+ - Fixed the uninstaller not removing files correctly.
+ [#551](https://github.com/mattermost/desktop/issues/551)
 
 #### Mac
  - Fixed an issue where the text box didn't keep focus after uploading a file.

--- a/src/main.js
+++ b/src/main.js
@@ -12,8 +12,7 @@ const {
 } = require('electron');
 const isDev = require('electron-is-dev');
 const installExtension = require('electron-devtools-installer');
-
-const AutoLaunch = require('auto-launch');
+const squirrelStartup = require('./main/squirrelStartup');
 
 process.on('uncaughtException', (error) => {
   console.error(error);
@@ -21,34 +20,8 @@ process.on('uncaughtException', (error) => {
 
 global.willAppQuit = false;
 
-if (process.platform === 'win32') {
-  var cmd = process.argv[1];
-  var appLauncher = new AutoLaunch({
-    name: 'Mattermost',
-    isHidden: true
-  });
-  if (cmd === '--squirrel-uninstall') {
-    // If we're uninstalling, make sure we also delete our auto launch registry key
-    appLauncher.isEnabled().then((enabled) => {
-      if (enabled) {
-        appLauncher.disable();
-      }
-    });
-  } else if (cmd === '--squirrel-install' || cmd === '--squirrel-updated') {
-    // If we're updating and already have an registry entry for auto launch, make sure to update the path
-    appLauncher.isEnabled().then((enabled) => {
-      if (enabled) {
-        return appLauncher.disable().then(() => {
-          return appLauncher.enable();
-        });
-      }
-      return true;
-    });
-  }
-}
-
 app.setAppUserModelId('com.squirrel.mattermost.Mattermost'); // Use explicit AppUserModelID
-if (require('electron-squirrel-startup')) {
+if (squirrelStartup()) {
   global.willAppQuit = true;
 }
 

--- a/src/main/squirrelStartup.js
+++ b/src/main/squirrelStartup.js
@@ -1,0 +1,39 @@
+const AutoLaunch = require('auto-launch');
+
+function shouldQuitApp(cmd) {
+  if (process.platform !== 'win32') {
+    return false;
+  }
+  return ['--squirrel-install', '--squirrel-updated', '--squirrel-uninstall', '--squirrel-obsolete'].includes(cmd);
+}
+
+async function setupAutoLaunch(cmd) {
+  const appLauncher = new AutoLaunch({
+    name: 'Mattermost',
+    isHidden: true
+  });
+  if (cmd === '--squirrel-uninstall') {
+      // If we're uninstalling, make sure we also delete our auto launch registry key
+    return appLauncher.disable();
+  } else if (cmd === '--squirrel-install' || cmd === '--squirrel-updated') {
+      // If we're updating and already have an registry entry for auto launch, make sure to update the path
+    const enabled = await appLauncher.isEnabled();
+    if (enabled) {
+      return appLauncher.enable();
+    }
+  }
+  return async () => true;
+}
+
+function squirrelStartup() {
+  if (process.platform === 'win32') {
+    const cmd = process.argv[1];
+    setupAutoLaunch(cmd).then(() => {
+      require('electron-squirrel-startup'); // eslint-disable-line global-require
+    });
+    return shouldQuitApp(cmd);
+  }
+  return false;
+}
+
+module.exports = squirrelStartup;


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fix Windows uninstaller not removing files correctly

Multiple async tasks were not performed completely when running uninstaller.
So rearranged tasks with sequential order.
i.e. take care startup registry, finally call electron-squirrel-startup.

**Issue link**
#551 

**Test Cases**
1. Install the app with the installer.
2. Enable "Start app on login" option.
3. Uninstall the app.
4. Files under `C:\Users\%USERNAME%\AppData\Local\mattermost` should be removed excepting `.dead` and `Update.exe`.
5. Registry key `\HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run\Mattermost` should be removed.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/280#artifacts/containers