### PR TITLE
Use setTimeout instead of setInterval to get unread count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Release date: TBD
 
 ### Improvements
 
+#### All Platforms
+ - Possible improvement when the app is in background state.
+ [#563](https://github.com/mattermost/desktop/issues/563)
+
 #### Windows
  - [Windows 7/8] Added support to open the message when clicking desktop notification.
  [#67](https://github.com/mattermost/desktop/issues/67)

--- a/src/browser/webview/mattermost.js
+++ b/src/browser/webview/mattermost.js
@@ -5,6 +5,8 @@ const ipc = electron.ipcRenderer;
 const webFrame = electron.webFrame;
 const EnhancedNotification = require('../js/notification');
 
+const UNREAD_COUNT_INTERVAL = 1000;
+
 Notification = EnhancedNotification; // eslint-disable-line no-global-assign, no-native-reassign
 
 Reflect.deleteProperty(global.Buffer); // http://electron.atom.io/docs/tutorial/security/#buffer-global
@@ -17,7 +19,7 @@ function hasClass(element, className) {
   return false;
 }
 
-setInterval(function getUnreadCount() {
+function getUnreadCount() {
   if (!this.unreadCount) {
     this.unreadCount = 0;
   }
@@ -30,6 +32,7 @@ setInterval(function getUnreadCount() {
     ipc.sendToHost('onUnreadCountChange', 0, 0, false, false);
     this.unreadCount = 0;
     this.mentionCount = 0;
+    setTimeout(getUnreadCount, UNREAD_COUNT_INTERVAL);
     return;
   }
 
@@ -63,6 +66,7 @@ setInterval(function getUnreadCount() {
     // find active post-list.
     var postLists = document.querySelectorAll('div.post-list__content');
     if (postLists.length === 0) {
+      setTimeout(getUnreadCount, UNREAD_COUNT_INTERVAL);
       return;
     }
     var post = null;
@@ -72,6 +76,7 @@ setInterval(function getUnreadCount() {
       }
     }
     if (post === null) {
+      setTimeout(getUnreadCount, UNREAD_COUNT_INTERVAL);
       return;
     }
 
@@ -113,7 +118,9 @@ setInterval(function getUnreadCount() {
   }
   this.unreadCount = unreadCount;
   this.mentionCount = mentionCount;
-}, 1000);
+  setTimeout(getUnreadCount, UNREAD_COUNT_INTERVAL);
+}
+setTimeout(getUnreadCount, UNREAD_COUNT_INTERVAL);
 
 function isElementVisible(elem) {
   return elem.offsetHeight !== 0;


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Change the way to take intervals when counting unread channels/mention.

Possible fix for related issues. Unread counter is updated by the function invoked by `setInterval()`. But this function doesn't take care whether the invoked function finished. When the app is minimized, internal Chrome reduces performance by itself. So I think possibly the function might not be able to finish by the next interval.

Eventually we should also improve the function performance though, I use `setTimeout()` instead in order to take proper intervals first.

@jasonblais I haven't met the freezing issue. Would you try the artifact for a few days?

**Issue link**
#494 #520

**Test Cases**
1. Open desired servers.
2. Get messages in channels/DM.
3. Badge should be updated.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/295#artifacts