### PR TITLE
Fix --hidden not working on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ Release date: TBD
  - Fixed an issue where the text box didn't keep focus after uploading a file.
  [#341](https://github.com/mattermost/desktop/issues/341)
 
+#### Linux
+ - Fixed the main window not minimized when the app is launched via "Start app on Login" option.
+ [#570](https://github.com/mattermost/desktop/issues/570)
 ---
 
 ## Release v3.7.0

--- a/src/main/mainWindow.js
+++ b/src/main/mainWindow.js
@@ -42,6 +42,11 @@ function createMainWindow(config, options) {
   });
 
   const mainWindow = new BrowserWindow(windowOptions);
+
+  const indexURL = global.isDev ? 'http://localhost:8080/browser/index.html' : `file://${app.getAppPath()}/browser/index.html`;
+  mainWindow.loadURL(indexURL);
+
+  // This section should be called after loadURL() #570
   if (options.hideOnStartup) {
     if (windowOptions.maximized) {
       mainWindow.maximize();
@@ -58,9 +63,6 @@ function createMainWindow(config, options) {
   mainWindow.webContents.on('will-attach-webview', (event, webPreferences) => {
     webPreferences.nodeIntegration = false;
   });
-
-  const indexURL = global.isDev ? 'http://localhost:8080/browser/index.html' : `file://${app.getAppPath()}/browser/index.html`;
-  mainWindow.loadURL(indexURL);
 
   mainWindow.once('ready-to-show', () => {
     if (process.platform !== 'darwin') {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fix --hidden not working on Linux.

I'm not sure why the problem happens though, it seems that the problem happens by calling `BrowserWindow.loadURL()` after `BrowserWindow.minimize()`. So I changed the order of functions.

Tested on Ubuntu 16.04. To make sure, we need to check about Windows as well.

**Issue link**
#570 

**Test Cases**
1. Enable "Start app on login".
2. Logout from the computer, then login again.
3. Started app should be minimized.

**Additional Notes**
https://circleci.com/gh/mattermost/desktop/985#artifacts