### PR TITLE
Fix an extra reloading when an error page is manually reloaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Release date: TBD
  [#552](https://github.com/mattermost/desktop/issues/552)
  - Fixed the app publisher was not changed to Mattermost, Inc.
  [#542](https://github.com/mattermost/desktop/issues/542)
+ - Fixed an extra reloading when an error page is manually reloaded.
+ [#573](https://github.com/mattermost/desktop/issues/573)
 
 #### Windows
  - Fixed desktop notifications not working when the window has been minimized from inactive state.

--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -1,3 +1,6 @@
+// eslint-disable react/no-set-state
+// setState() is necessary for this component
+
 const React = require('react');
 const PropTypes = require('prop-types');
 const createReactClass = require('create-react-class');
@@ -26,7 +29,8 @@ const MattermostView = createReactClass({
   getInitialState() {
     return {
       errorInfo: null,
-      isContextMenuAdded: false
+      isContextMenuAdded: false,
+      reloadTimeoutID: null
     };
   },
 
@@ -54,7 +58,9 @@ const MattermostView = createReactClass({
         self.reload();
       }
       if (navigator.onLine) {
-        setTimeout(reload, 30000);
+        self.setState({
+          reloadTimeoutID: setTimeout(reload, 30000)
+        });
       } else {
         window.addEventListener('online', reload);
       }
@@ -152,8 +158,10 @@ const MattermostView = createReactClass({
   },
 
   reload() {
+    clearTimeout(this.state.reloadTimeoutID);
     this.setState({
-      errorInfo: null
+      errorInfo: null,
+      reloadTimeoutID: null
     });
     var webview = findDOMNode(this.refs.webview);
     webview.reload();


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fix an extra reloading when an error page is manually reloaded.

This PR cancels the automated reloading when an error page is manually reloaded by `Ctrl+R`.

**Issue link**
#573 

**Test Cases**
1. Unplug ethernet cable or disable Wi-Fi to get error page.
2. Start the application.
3. Make sure that the error is NOT `ERR_INTERNET_DISCONNECTED (-106)`.
4. Repair internet connection then press `Ctrl+R`.
5. Extra reloading should not happen within 30 seconds.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/327#artifacts