### PR TITLE
Use setTimeout instead of setInterval to get unread count

### DIFF
--- a/src/browser/webview/mattermost.js
+++ b/src/browser/webview/mattermost.js
@@ -5,6 +5,8 @@ const ipc = electron.ipcRenderer;
 const webFrame = electron.webFrame;
 const notification = require('../js/notification');
 
+const UNREAD_COUNT_INTERVAL = 1000;
+
 Reflect.deleteProperty(global.Buffer); // http://electron.atom.io/docs/tutorial/security/#buffer-global
 
 function hasClass(element, className) {
@@ -15,7 +17,7 @@ function hasClass(element, className) {
   return false;
 }
 
-setInterval(function getUnreadCount() {
+function getUnreadCount() {
   if (!this.unreadCount) {
     this.unreadCount = 0;
   }
@@ -28,6 +30,7 @@ setInterval(function getUnreadCount() {
     ipc.sendToHost('onUnreadCountChange', 0, 0, false, false);
     this.unreadCount = 0;
     this.mentionCount = 0;
+    setTimeout(getUnreadCount, UNREAD_COUNT_INTERVAL);
     return;
   }
 
@@ -61,6 +64,7 @@ setInterval(function getUnreadCount() {
     // find active post-list.
     var postLists = document.querySelectorAll('div.post-list__content');
     if (postLists.length === 0) {
+      setTimeout(getUnreadCount, UNREAD_COUNT_INTERVAL);
       return;
     }
     var post = null;
@@ -70,6 +74,7 @@ setInterval(function getUnreadCount() {
       }
     }
     if (post === null) {
+      setTimeout(getUnreadCount, UNREAD_COUNT_INTERVAL);
       return;
     }
 
@@ -111,7 +116,9 @@ setInterval(function getUnreadCount() {
   }
   this.unreadCount = unreadCount;
   this.mentionCount = mentionCount;
-}, 1000);
+  setTimeout(getUnreadCount, UNREAD_COUNT_INTERVAL);
+}
+setTimeout(getUnreadCount, UNREAD_COUNT_INTERVAL);
 
 function isElementVisible(elem) {
   return elem.offsetHeight !== 0;


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Change the way to take intervals when counting unread channels/mention.

This was cherry-picked from de29dfab46391e7b09b00e1a989567c2560c2c8a (#563).

**Issue link**
#494 #520 #563

**Test Cases**
1. Open desired servers.
2. Get messages in channels/DM.
3. Badge should be updated.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/330#artifacts