### PR TITLE
Upgrade Electron dependancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "chai": "^3.5.0",
     "cross-env": "^3.1.4",
     "devtron": "^1.4.0",
-    "electron": "1.6.2",
+    "electron": "1.6.10",
     "electron-builder": "^14.5.3",
     "electron-builder-squirrel-windows": "^15.0.0",
     "electron-connect": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "chai": "^3.5.0",
     "cross-env": "^3.1.4",
     "devtron": "^1.4.0",
-    "electron": "1.6.10",
+    "electron": "1.6.11",
     "electron-builder": "^14.5.3",
     "electron-builder-squirrel-windows": "^15.0.0",
     "electron-connect": "^0.6.1",

--- a/src/main.js
+++ b/src/main.js
@@ -56,7 +56,6 @@ const os = require('os');
 const path = require('path');
 
 var settings = require('./common/settings');
-const osVersion = require('./common/osVersion');
 var certificateStore = require('./main/certificateStore').load(path.resolve(app.getPath('userData'), 'certificate.json'));
 const {createMainWindow} = require('./main/mainWindow');
 const appMenu = require('./main/menus/app');
@@ -427,19 +426,6 @@ app.on('ready', () => {
       }
 
       mainWindow.focus();
-    });
-    ipcMain.on('notified', (event, arg) => {
-      if (process.platform === 'win32') {
-        // On Windows 8.1 and Windows 8, a shortcut with a Application User Model ID must be installed to the Start screen.
-        // In current version, use tray balloon for notification
-        if (osVersion.isLowerThanOrEqualWindows8_1()) {
-          trayIcon.displayBalloon({
-            icon: path.resolve(assetsDir, 'appicon.png'),
-            title: arg.title,
-            content: arg.options.body
-          });
-        }
-      }
     });
 
     // Set overlay icon from dataURL


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Upgrade Electron for security fix of HTTPS.
https://github.com/electron/electron/releases/tag/v1.6.11

This should include #543 to upgrade Electron from 1.6.2 to 1.6.11.

- Desktop notification for Windows 7/8
- Per-monior DPI awareness

**Issue link**
#543

**Test Cases**
Notification:
1. Prepare Windows 7, 8 or 8.1
2. Receive any message.
3. Notification should appear instead of a tray balloon.
4. Click the notification.
5. The message should appear in the main window as well as Windows 10.

Per-monitor DPI:
- Not necessary because already tested at #543.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/332#artifacts