### PR TITLE
BASH-3 Remember user’s last url

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -32,11 +32,14 @@ const MainPage = createReactClass({
       unreadAtActive: new Array(this.props.teams.length),
       mentionAtActiveCounts: new Array(this.props.teams.length),
       loginQueue: [],
-      targetURL: ''
+      targetURL: '',
+      lastUrl: ''
     };
   },
   componentDidMount() {
     var self = this;
+    self.setState({lastUrl: localStorage.getItem('lastUrl')});
+
     ipcRenderer.on('login-request', (event, request, authInfo) => {
       self.setState({
         loginRequired: true
@@ -247,6 +250,14 @@ const MainPage = createReactClass({
       }
       var id = 'mattermostView' + index;
       var isActive = self.state.key === index;
+
+      var lastUrl;
+      if (this.state.lastUrl !== '' && this.state.lastUrl !== null) {
+        lastUrl = this.state.lastUrl;
+      } else {
+        lastUrl = team.url;
+      }
+
       return (
         <MattermostView
           key={id}
@@ -254,7 +265,7 @@ const MainPage = createReactClass({
           withTab={this.props.teams.length > 1}
           useSpellChecker={this.props.useSpellChecker}
           onSelectSpellCheckerLocale={this.props.onSelectSpellCheckerLocale}
-          src={team.url}
+          src={lastUrl}
           name={team.name}
           onTargetURLChange={self.handleTargetURLChange}
           onUnreadCountChange={handleUnreadCountChange}

--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -251,10 +251,8 @@ const MainPage = createReactClass({
       var id = 'mattermostView' + index;
       var isActive = self.state.key === index;
 
-      var lastUrl;
-      if (this.state.lastUrl !== '' && this.state.lastUrl !== null) {
-        lastUrl = this.state.lastUrl;
-      } else {
+      var lastUrl = this.state.lastUrl;
+      if (this.state.lastUrl === null || this.state.lastUrl === '' || !this.state.lastUrl.includes(team.url)) {
         lastUrl = team.url;
       }
 

--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -66,6 +66,11 @@ const MattermostView = createReactClass({
       }
     });
 
+    //storing on localStorage last channel visited, so when the user comes back, the app loads that channel
+    webview.addEventListener('did-navigate-in-page', () => {
+      localStorage.setItem('lastUrl', webview.getURL());
+    });
+
     // Open link in browserWindow. for exmaple, attached files.
     webview.addEventListener('new-window', (e) => {
       var currentURL = url.parse(webview.getURL());


### PR DESCRIPTION
BASH-3 Remember user’s last url

**Description**
This PR stores the last navigated url to local storage, so that restarting the app returns the user to their last visited channel

- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting


**Test Cases**
Start app, login and navigate to any channel besides town hall. Shut down app and start up app and it should load your last visited channel, not town hall.
