### PR TITLE
BASH-7 make dynamic zip scripts

### DIFF
--- a/scripts/manipulate_windows_zip.js
+++ b/scripts/manipulate_windows_zip.js
@@ -2,7 +2,9 @@
 
 const spawnSync = require('child_process').spawnSync;
 const path7za = require('7zip-bin').path7za;
-const appVersion = require('../package.json').version;
+const pkg = require('../src/package.json');
+const appVersion = pkg.version;
+const productName = pkg.productName;
 
 function renameInZip(zipPath, oldName, newName) {
   const result = spawnSync(path7za, ['rn', zipPath, oldName, newName]);
@@ -10,11 +12,11 @@ function renameInZip(zipPath, oldName, newName) {
 }
 
 console.log('Manipulating 64-bit zip...');
-if (!renameInZip(`release/Mattermost-${appVersion}-win.zip`, 'win-unpacked', `Mattermost-${appVersion}-win64`)) {
+if (!renameInZip(`release/${productName}-${appVersion}-win.zip`, 'win-unpacked', `${productName}-${appVersion}-win64`)) {
   throw new Error('7za returned non-zero exit code for 64-bit zip');
 }
 
 console.log('Manipulating 32-bit zip...');
-if (!renameInZip(`release/Mattermost-${appVersion}-ia32-win.zip`, 'win-ia32-unpacked', `Mattermost-${appVersion}-win32`)) {
+if (!renameInZip(`release/${productName}-${appVersion}-ia32-win.zip`, 'win-ia32-unpacked', `${productName}-${appVersion}-win32`)) {
   throw new Error('7za returned non-zero exit code for 32-bit zip');
 }


### PR DESCRIPTION
Use value for `productName` from `package.json` inside of the `scripts/manipulate_windows_zip.js` script not to have the hardcoded `mattermost` value.

- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

**Test Cases**
Change `productName` in `package.json`
Run `npm run package:windows` and make sure it runs properly and generates the files with the proper name.
