### PR TITLE
BASH-10 add local icon reference for squirrel

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -50,7 +50,7 @@
     ]
   },
   "squirrelWindows": {
-    "iconUrl": "https://raw.githubusercontent.com/mattermost/desktop/master/resources/icon.ico"
+    "iconUrl": "file://resources/icon.ico"
   },
   "win": {
     "target": [


### PR DESCRIPTION
To be able to customize icons, they can not be remote. Adding `file://` to the beginning of the relative path will make it work locally.
"iconUrl": "file://resources/icon.ico"

- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

**Test Cases**
Replace `resources/icon.ico` file
Run `npm run package:windows` and make sure it runs properly and generates the files with the correct icon.
