### PR TITLE
BASH-11 Open help link from config

### DIFF
--- a/src/common/config/base.json
+++ b/src/common/config/base.json
@@ -10,7 +10,8 @@
     },
     "showUnreadBadge": true,
     "useSpellChecker": true,
-    "spellCheckerLocale": "en-US"
+    "spellCheckerLocale": "en-US",
+    "helpLink": "https://docs.mattermost.com/help/apps/desktop-guide.html"
   },
   "1": {
     "teams": [],
@@ -23,6 +24,7 @@
     },
     "showUnreadBadge": true,
     "useSpellChecker": true,
-    "spellCheckerLocale": "en-US"
+    "spellCheckerLocale": "en-US",
+    "helpLink": "https://docs.mattermost.com/help/apps/desktop-guide.html"
   }
 }

--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -202,21 +202,21 @@ function createTemplate(mainWindow, config, isDev) {
     }]
   };
   template.push(windowMenu);
-
-  template.push({
-    label: '&Help',
-    submenu: [{
+  var submenu = [];
+  if (config.helpLink) {
+    submenu.push({
       label: 'Learn More...',
       click() {
         electron.shell.openExternal(config.helpLink);
       }
-    }, {
-      type: 'separator'
-    }, {
-      label: `Version ${electron.app.getVersion()}`,
-      enabled: false
-    }]
+    });
+    submenu.push(separatorItem);
+  }
+  submenu.push({
+    label: `Version ${electron.app.getVersion()}`,
+    enabled: false
   });
+  template.push({label: '&Help', submenu});
   return template;
 }
 

--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const electron = require('electron');
+
 const Menu = electron.Menu;
 
 function createTemplate(mainWindow, config, isDev) {
@@ -207,7 +208,7 @@ function createTemplate(mainWindow, config, isDev) {
     submenu: [{
       label: 'Learn More...',
       click() {
-        electron.shell.openExternal('https://docs.mattermost.com/help/apps/desktop-guide.html');
+        electron.shell.openExternal(config.helpLink);
       }
     }, {
       type: 'separator'


### PR DESCRIPTION
**Description**
This PR changes the behavior of the Help menu Learn More item to open the link that is defined for the helpLink property in the base.json file (src/common/config/base.json). This property can be overridden by defining the helpLink property in the override.json file (src/common/config/override.json). 

- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

**Test Cases**
Add override values like this:

```json 
// Exampleoverride.js
{
  "1": {
    "helpLink": “http://test.helplink.com”
  }
}
```

**Notes**
includes BASH-20
