### PR TITLE
BASH-14 Set default server/team in settings

### DIFF
--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const fs = require('fs');
+
+const path = require('path');
 let deepmerge = require('deepmerge').default;
 if (process.env.TEST) {
   deepmerge = require('deepmerge'); // eslint-disable-line
@@ -14,7 +16,7 @@ function merge(base, target) {
   return Object.assign({}, base, target);
 }
 
-function deepMergeArray(dest) {
+function deepMergeArray(source, dest) {
   return dest;
 }
 
@@ -27,7 +29,7 @@ function loadDefault(version, spellCheckerLocale) {
   const base = baseConfig[ver] || baseConfig.default;
   const override = overrideConfig[ver] || {};
 
-  const defaults = deepmerge(base, override, {clone: true, arrayMerge: deepMergeArray});
+  const defaults = deepmerge(base, override, {arrayMerge: deepMergeArray});
 
   return Object.assign(defaults, {
     spellCheckerLocale: spellCheckerLocale || defaults.spellCheckerLocale || 'en-US'
@@ -87,6 +89,12 @@ module.exports = {
     if (config.version != settingsVersion) { // eslint-disable-line
       throw new Error('version ' + config.version + ' is not equal to ' + settingsVersion);
     }
+
+    const dir = path.dirname(configFile);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir);
+    }
+
     var data = JSON.stringify(config, null, '  ');
     fs.writeFileSync(configFile, data, 'utf8');
   },

--- a/src/main.js
+++ b/src/main.js
@@ -71,6 +71,12 @@ try {
   const spellCheckerLocale = SpellChecker.getSpellCheckerLocale(app.getLocale());
   config = settings.loadDefault(null, spellCheckerLocale);
   console.log('Failed to read or upgrade config.json', e);
+  if (!config.teams.length && config.defaultTeam) {
+    config.teams.push(config.defaultTeam);
+
+    const configFile = app.getPath('userData') + '/config.json';
+    settings.writeFileSync(configFile, config);
+  }
 }
 
 ipcMain.on('update-config', () => {


### PR DESCRIPTION
**Description**
This PR allows for a defaultTeam to be defined in the override.json file (src/common/config/override.json). When this value is defined and the config file does not contain any teams in the team’s array, the team defined in the defaultTeam property will be added to the team's array in the config.

- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

**Test Cases**
Add override values like this:
```json 
// Exampleoverride.js
{
  "1": {
    "defaultTeam": {
       “name”: “Test Team”,
       “url”: “https://test.team.com” 
    }
  }
}
```
Remove the application support folder by running rm -rf /Users/{yourusername}/Library/Application Support/Mattermost

When the application starts the login for the defaultTeam will be shown.

**notes**
includes bash-20
