### PR TITLE
BASH-23 Add npm clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build:main": "cross-env NODE_ENV=production webpack --bail --config webpack.config.main.js",
     "build:renderer": "cross-env NODE_ENV=production webpack --bail --config webpack.config.renderer.js",
     "start": "electron src --disable-dev-mode",
+    "clean": "rm -rf release/ node_modules/ src/node_modules/ && find src -name '*_bundle.js' | xargs rm",
     "watch": "run-p watch:*",
     "watch:main": "node scripts/watch_main_and_preload.js",
     "watch:renderer": "webpack-dev-server --config webpack.config.renderer.js",


### PR DESCRIPTION
**Description**
Adds a simple rm command to npm to remove all dynamically generated files to make it easy to reset between builds/branches

- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

**Test Cases**
Run `npm run clean`
