### PR TITLE
BASH-21 Add build files and npm files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@ node_modules/
 release/
 npm-debug.log*
 
+build/
+dist/
+package-lock.json
+src/package-lock.json
+
 test-results.xml
 test_config.json
 .idea


### PR DESCRIPTION
**Description**
This PR adds the following folders and files to gitignore:

build/
dist/
package-lock.json
src/package-lock.json

- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

