### PR TITLE
BASH-19 Remove hardcoded product name references

### DIFF
--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -9,13 +9,12 @@ const AutoLaunch = require('auto-launch');
 const {debounce} = require('underscore');
 
 const settings = require('../../common/settings');
-const appName = require('../../package.json').productName;
 
 const TeamList = require('./TeamList.jsx');
 const AutoSaveIndicator = require('./AutoSaveIndicator.jsx');
 
 const appLauncher = new AutoLaunch({
-  name: appName,
+  name: remote.app.getName(),
   isHidden: true
 });
 

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -9,12 +9,13 @@ const AutoLaunch = require('auto-launch');
 const {debounce} = require('underscore');
 
 const settings = require('../../common/settings');
+const appName = require('../../package.json').productName;
 
 const TeamList = require('./TeamList.jsx');
 const AutoSaveIndicator = require('./AutoSaveIndicator.jsx');
 
 const appLauncher = new AutoLaunch({
-  name: 'Mattermost',
+  name: appName,
   isHidden: true
 });
 

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -1,7 +1,8 @@
 'use strict';
+const appName = require('../package.json').productName;
 
 window.eval = global.eval = () => {
-  throw new Error('Sorry, Mattermost does not support window.eval() for security reasons.');
+  throw new Error(`Sorry, ${appName} does not support window.eval() for security reasons.`);
 };
 
 const {remote} = require('electron');

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -1,11 +1,9 @@
 'use strict';
-const appName = require('../package.json').productName;
+const {remote} = require('electron');
 
 window.eval = global.eval = () => {
-  throw new Error(`Sorry, ${appName} does not support window.eval() for security reasons.`);
+  throw new Error(`Sorry, ${remote.app.getName()} does not support window.eval() for security reasons.`);
 };
-
-const {remote} = require('electron');
 
 const React = require('react');
 const ReactDOM = require('react-dom');

--- a/src/main/squirrelStartup.js
+++ b/src/main/squirrelStartup.js
@@ -1,4 +1,5 @@
 const AutoLaunch = require('auto-launch');
+const appName = require('../package.json').productName;
 
 function shouldQuitApp(cmd) {
   if (process.platform !== 'win32') {
@@ -9,7 +10,7 @@ function shouldQuitApp(cmd) {
 
 async function setupAutoLaunch(cmd) {
   const appLauncher = new AutoLaunch({
-    name: 'Mattermost',
+    name: appName, 
     isHidden: true
   });
   if (cmd === '--squirrel-uninstall') {

--- a/src/main/squirrelStartup.js
+++ b/src/main/squirrelStartup.js
@@ -10,7 +10,7 @@ function shouldQuitApp(cmd) {
 
 async function setupAutoLaunch(cmd) {
   const appLauncher = new AutoLaunch({
-    name: appName, 
+    name: appName,
     isHidden: true
   });
   if (cmd === '--squirrel-uninstall') {

--- a/src/main/squirrelStartup.js
+++ b/src/main/squirrelStartup.js
@@ -1,5 +1,5 @@
 const AutoLaunch = require('auto-launch');
-const {remote} = require('electron');
+const {app} = require('electron');
 
 function shouldQuitApp(cmd) {
   if (process.platform !== 'win32') {
@@ -10,7 +10,7 @@ function shouldQuitApp(cmd) {
 
 async function setupAutoLaunch(cmd) {
   const appLauncher = new AutoLaunch({
-    name: remote.app.getName(),
+    name: app.getName(),
     isHidden: true
   });
   if (cmd === '--squirrel-uninstall') {

--- a/src/main/squirrelStartup.js
+++ b/src/main/squirrelStartup.js
@@ -1,5 +1,5 @@
 const AutoLaunch = require('auto-launch');
-const appName = require('../package.json').productName;
+const {remote} = require('electron');
 
 function shouldQuitApp(cmd) {
   if (process.platform !== 'win32') {
@@ -10,7 +10,7 @@ function shouldQuitApp(cmd) {
 
 async function setupAutoLaunch(cmd) {
   const appLauncher = new AutoLaunch({
-    name: appName,
+    name: remote.app.getName(),
     isHidden: true
   });
   if (cmd === '--squirrel-uninstall') {


### PR DESCRIPTION
**Description**
This PR changes all hardcoded product name references to use the productName from the package.json file. 

- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting