### PR TITLE
BASH-18 Add configs to show/hide server management and multiteam settings

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -24,7 +24,8 @@ const MainPage = createReactClass({
     initialIndex: PropTypes.number.isRequired,
     useSpellChecker: PropTypes.bool.isRequired,
     onSelectSpellCheckerLocale: PropTypes.func.isRequired,
-    deeplinkingUrl: PropTypes.string
+    deeplinkingUrl: PropTypes.string,
+    showAddServerButton: PropTypes.bool.isRequired
   },
 
   getInitialState() {
@@ -258,6 +259,7 @@ const MainPage = createReactClass({
             activeKey={this.state.key}
             onSelect={this.handleSelect}
             onAddServer={this.addServer}
+            showAddServerButton={this.props.showAddServerButton}
           />
         </Row>
       );

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -255,6 +255,41 @@ const SettingsPage = createReactClass({
   },
 
   render() {
+    const settingsPage = {
+      navbar: {
+        backgroundColor: '#fff'
+      },
+      close: {
+        textDecoration: 'none',
+        position: 'absolute',
+        right: '0',
+        top: '5px',
+        fontSize: '35px',
+        fontWeight: 'normal',
+        color: '#bbb'
+      },
+      heading: {
+        textAlign: 'center',
+        fontSize: '24px',
+        margin: '0',
+        padding: '1em 0'
+      },
+      sectionHeading: {
+        fontSize: '20px',
+        margin: '0',
+        padding: '1em 0',
+        float: 'left'
+      },
+      sectionHeadingLink: {
+        marginTop: '24px',
+        display: 'inline-block',
+        fontSize: '15px'
+      },
+      footer: {
+        padding: '0.4em 0'
+      }
+    };
+
     var teamsRow = (
       <Row>
         <Col md={12}>
@@ -267,10 +302,52 @@ const SettingsPage = createReactClass({
             updateTeam={this.updateTeam}
             addServer={this.addServer}
             onTeamClick={backToIndex}
+            allowTeamEdit={this.state.enableTeamModification}
           />
         </Col>
       </Row>
     );
+
+    var serversRow = (
+      <Row>
+        <Col
+          md={10}
+          xs={8}
+        >
+          <h2 style={settingsPage.sectionHeading}>{'Server Management'}</h2>
+          <div className='IndicatorContainer'>
+            <AutoSaveIndicator
+              savingState={this.state.savingState.servers}
+              errorMessage={'Can\'t save your changes. Please try again.'}
+            />
+          </div>
+        </Col>
+        <Col
+          md={2}
+          xs={4}
+        >
+          <p className='text-right'>
+            <a
+              style={settingsPage.sectionHeadingLink}
+              id='addNewServer'
+              href='#'
+              onClick={this.toggleShowTeamForm}
+            >{'⊞ Add new server'}</a>
+          </p>
+        </Col>
+      </Row>
+    );
+
+    var srvMgmt;
+    if (this.state.enableServerManagement || this.state.teams.length === 0) {
+      srvMgmt = (
+        <div>
+          {serversRow}
+          {teamsRow}
+          <hr/>
+        </div>
+      );
+    }
 
     var options = [];
 
@@ -404,41 +481,6 @@ const SettingsPage = createReactClass({
         </Checkbox>);
     }
 
-    const settingsPage = {
-      navbar: {
-        backgroundColor: '#fff'
-      },
-      close: {
-        textDecoration: 'none',
-        position: 'absolute',
-        right: '0',
-        top: '5px',
-        fontSize: '35px',
-        fontWeight: 'normal',
-        color: '#bbb'
-      },
-      heading: {
-        textAlign: 'center',
-        fontSize: '24px',
-        margin: '0',
-        padding: '1em 0'
-      },
-      sectionHeading: {
-        fontSize: '20px',
-        margin: '0',
-        padding: '1em 0',
-        float: 'left'
-      },
-      sectionHeadingLink: {
-        marginTop: '24px',
-        display: 'inline-block',
-        fontSize: '15px'
-      },
-      footer: {
-        padding: '0.4em 0'
-      }
-    };
-
     var optionsRow = (options.length > 0) ? (
       <Row>
         <Col md={12}>
@@ -482,35 +524,7 @@ const SettingsPage = createReactClass({
           className='settingsPage'
           style={{paddingTop: '100px'}}
         >
-          <Row>
-            <Col
-              md={10}
-              xs={8}
-            >
-              <h2 style={settingsPage.sectionHeading}>{'Server Management'}</h2>
-              <div className='IndicatorContainer'>
-                <AutoSaveIndicator
-                  savingState={this.state.savingState.servers}
-                  errorMessage={'Can\'t save your changes. Please try again.'}
-                />
-              </div>
-            </Col>
-            <Col
-              md={2}
-              xs={4}
-            >
-              <p className='text-right'>
-                <a
-                  style={settingsPage.sectionHeadingLink}
-                  id='addNewServer'
-                  href='#'
-                  onClick={this.toggleShowTeamForm}
-                >{'⊞ Add new server'}</a>
-              </p>
-            </Col>
-          </Row>
-          { teamsRow }
-          <hr/>
+          { srvMgmt }
           { optionsRow }
         </Grid>
       </div>

--- a/src/browser/components/TabBar.jsx
+++ b/src/browser/components/TabBar.jsx
@@ -53,17 +53,19 @@ function TabBar(props) {
         { badgeDiv }
       </NavItem>);
   });
-  tabs.push(
-    <NavItem
-      className='TabBar-addServerButton'
-      key='addServerButton'
-      id='addServerButton'
-      eventKey='addServerButton'
-      title='Add new server'
-    >
-      <Glyphicon glyph='plus'/>
-    </NavItem>
-  );
+  if (props.showAddServerButton === true) {
+    tabs.push(
+      <NavItem
+        className='TabBar-addServerButton'
+        key='addServerButton'
+        id='addServerButton'
+        eventKey='addServerButton'
+        title='Add new server'
+      >
+        <Glyphicon glyph='plus'/>
+      </NavItem>
+    );
+  }
   return (
     <Nav
       className='TabBar'
@@ -92,7 +94,8 @@ TabBar.propTypes = {
   unreadAtActive: PropTypes.array,
   mentionCounts: PropTypes.array,
   mentionAtActiveCounts: PropTypes.array,
-  onAddServer: PropTypes.func
+  onAddServer: PropTypes.func,
+  showAddServerButton: PropTypes.bool
 };
 
 module.exports = TabBar;

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -116,6 +116,7 @@ ReactDOM.render(
     useSpellChecker={AppConfig.data.useSpellChecker}
     onSelectSpellCheckerLocale={handleSelectSpellCheckerLocale}
     deeplinkingUrl={deeplinkingUrl}
+    showAddServerButton={AppConfig.data.enableServerManagement}
   />,
   document.getElementById('content')
 );

--- a/src/common/config/base.json
+++ b/src/common/config/base.json
@@ -11,7 +11,8 @@
     "showUnreadBadge": true,
     "useSpellChecker": true,
     "spellCheckerLocale": "en-US",
-    "helpLink": "https://docs.mattermost.com/help/apps/desktop-guide.html"
+    "helpLink": "https://docs.mattermost.com/help/apps/desktop-guide.html",
+    "enableServerManagement": true
   },
   "1": {
     "teams": [],
@@ -25,6 +26,7 @@
     "showUnreadBadge": true,
     "useSpellChecker": true,
     "spellCheckerLocale": "en-US",
-    "helpLink": "https://docs.mattermost.com/help/apps/desktop-guide.html"
+    "helpLink": "https://docs.mattermost.com/help/apps/desktop-guide.html",
+    "enableServerManagement": true
   }
 }

--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -15,7 +15,7 @@ function createTemplate(mainWindow, config, isDev) {
   var firstMenuName = (process.platform === 'darwin') ? appName : 'File';
   var template = [];
 
-  const platformAppMenu = process.platform === 'darwin' ? [{
+  var platformAppMenu = process.platform === 'darwin' ? [{
     label: 'About ' + appName,
     role: 'about',
     click() {
@@ -30,37 +30,40 @@ function createTemplate(mainWindow, config, isDev) {
     click() {
       mainWindow.loadURL(settingsURL);
     }
-  }, {
-    label: 'Sign in to Another Server',
-    click() {
-      mainWindow.webContents.send('add-server');
-    }
-  }, separatorItem, {
-    role: 'hide'
-  }, {
-    role: 'hideothers'
-  }, {
-    role: 'unhide'
-  }, separatorItem, {
-    role: 'quit'
   }] : [{
     label: 'Settings...',
     accelerator: 'CmdOrCtrl+,',
     click() {
       mainWindow.loadURL(settingsURL);
     }
-  }, {
-    label: 'Sign in to Another Server',
-    click() {
-      mainWindow.webContents.send('add-server');
-    }
-  }, separatorItem, {
-    role: 'quit',
-    accelerator: 'CmdOrCtrl+Q',
-    click() {
-      electron.app.quit();
-    }
   }];
+
+  if (config.enableServerManagement === true || config.teams.length === 0) {
+    platformAppMenu.push({
+      label: 'Sign in to Another Server',
+      click() {
+        mainWindow.webContents.send('add-server');
+      }
+    });
+  }
+
+  platformAppMenu = platformAppMenu.concat(process.platform === 'darwin' ? [
+    separatorItem, {
+      role: 'hide'
+    }, {
+      role: 'hideothers'
+    }, {
+      role: 'unhide'
+    }, separatorItem, {
+      role: 'quit'
+    }] : [separatorItem, {
+      role: 'quit',
+      accelerator: 'CmdOrCtrl+Q',
+      click() {
+        electron.app.quit();
+      }
+    }]
+  );
 
   template.push({
     label: '&' + firstMenuName,


### PR DESCRIPTION
**Description**
This PR add values `enableMultiTeams` and `enableServerManagement` to show/hide server management and multiteam settings.

- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

**Test Cases**
Add override values like this to override.json (src/common/config/override.json)
After entering the a fist server no others are accepted
```json 
//override.js
{
  "1": {
    "enableMultiTeams": false,
    "enableServerManagement": false
  }
}
```
![screen shot 2017-09-08 at 11 57 05 am](https://user-images.githubusercontent.com/9515253/30222749-c1815e50-947c-11e7-80fb-e1f017ab73ea.jpg)


**Notes**
Includes bash-20
