### PR TITLE
Remove focus after cancelling modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Release date: TBD
  [#573](https://github.com/mattermost/desktop/issues/573)
  - Fixed file upload dialogs did not allow any file to be selected.
  [#497](https://github.com/mattermost/desktop/issues/497)
+ - Fixed an issue where unnecessary focus remains after closing dialogs on the settings page.
+ [#446](https://github.com/mattermost/desktop/issues/446)
 
 #### Windows
  - Fixed desktop notifications not working when the window has been minimized from inactive state.

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -191,6 +191,7 @@ const SettingsPage = createReactClass({
     this.setState({
       showAddTeamForm: !this.state.showAddTeamForm
     });
+    document.activeElement.blur();
   },
   setShowTeamFormVisibility(val) {
     this.setState({

--- a/src/browser/components/TeamList.jsx
+++ b/src/browser/components/TeamList.jsx
@@ -80,10 +80,12 @@ const TeamList = createReactClass({
     var self = this;
     var teamNodes = this.props.teams.map((team, i) => {
       function handleTeamRemove() {
+        document.activeElement.blur();
         self.openServerRemoveModal(i);
       }
 
       function handleTeamEditing() {
+        document.activeElement.blur();
         self.handleTeamEditing(team.name, team.url, i);
       }
 

--- a/src/browser/components/TeamListItem.jsx
+++ b/src/browser/components/TeamListItem.jsx
@@ -9,11 +9,9 @@ class TeamListItem extends React.Component {
   }
 
   handleTeamRemove() {
-    document.activeElement.blur();
     this.props.onTeamRemove();
   }
   handleTeamEditing() {
-    document.activeElement.blur();
     this.props.onTeamEditing();
   }
   render() {

--- a/src/browser/components/TeamListItem.jsx
+++ b/src/browser/components/TeamListItem.jsx
@@ -9,9 +9,11 @@ class TeamListItem extends React.Component {
   }
 
   handleTeamRemove() {
+    document.activeElement.blur();
     this.props.onTeamRemove();
   }
   handleTeamEditing() {
+    document.activeElement.blur();
     this.props.onTeamEditing();
   }
   render() {


### PR DESCRIPTION
Closes #446 

Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
After closing the modal the focus of the clicked link will be removed

**Issue link**
#446 