### PR TITLE
Limit navigation to origins which is outside of servers

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -136,6 +136,40 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
+## electron-fetch
+
+This product contains a modified portion of 'electron-fetch', a light-weight module that brings window.fetch to Electron's background process,
+by Mehdi Kouhen.
+
+* HOMEPAGE:
+  * https://github.com/arantes555/electron-fetch
+
+* LICENSE:
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Mehdi Kouhen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Based on node-fetch, which has the following license:
+
+The MIT License (MIT)
+
+Copyright (c) 2016 David Frank
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
 ## electron-is-dev
 
 This product contains a modified portion of 'electron-is-dev', which checks if Electron is running in development, by Sindre Sorhus.

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -1,0 +1,10 @@
+const url = require('url');
+
+function getOrigin(URL) {
+  const obj = url.parse(URL);
+  return `${obj.protocol}//${obj.host}`;
+}
+
+module.exports = {
+  getOrigin
+};

--- a/src/main.js
+++ b/src/main.js
@@ -590,6 +590,7 @@ app.on('ready', () => {
   ipcMain.on('allow-origin', (event, origin) => {
     navigationManager.allowOrigin(origin);
   });
+  session.defaultSession.webRequest.onHeadersReceived(navigationManager.onHeadersReceived.bind(navigationManager));
 
   // Open the DevTools.
   // mainWindow.openDevTools();

--- a/src/main/NavigationManager.js
+++ b/src/main/NavigationManager.js
@@ -1,0 +1,44 @@
+const {app, dialog} = require('electron');
+const utils = require('../common/utils');
+
+class NavigationManager {
+  constructor() {
+    this.allowedOrigin = [];
+    this.parentWindow = null;
+  }
+
+  setWindowToPrompt(win) {
+    this.parentWindow = win;
+  }
+
+  allowOrigin(origin) {
+    if (this.allowedOrigin.indexOf(origin) === -1) {
+      this.allowedOrigin.push(origin);
+    }
+  }
+
+  onWillNavigate(event, url) {
+    const origin = utils.getOrigin(url);
+    if (this.allowedOrigin.indexOf(origin) > -1) {
+      return;
+    }
+    const Yes = 'Yes';
+    const No = 'No';
+    const buttons = [No, Yes];
+    const result = dialog.showMessageBox(this.parentWindow, {
+      type: 'warning',
+      title: `${app.getName()}`,
+      message: `The application is navigating to "${origin}". Do you want to continue?`,
+      buttons,
+      defaultId: buttons.indexOf(No),
+      cancelId: buttons.indexOf(No)
+    });
+    if (result === buttons.indexOf(Yes)) {
+      this.allowedOrigin.push(origin);
+    } else {
+      event.preventDefault();
+    }
+  }
+}
+
+module.exports = NavigationManager;

--- a/src/main/NavigationManager.js
+++ b/src/main/NavigationManager.js
@@ -39,6 +39,16 @@ function getTrustedOrigins(serverOrigin) {
   });
 }
 
+function getXVersionId(responseHeaders) {
+  const possibleKeys = ['X-Version-Id', 'x-version-id', 'X-VERSION-ID', 'X-Version-ID'];
+  for (const key of possibleKeys) {
+    if (responseHeaders[key]) {
+      return responseHeaders[key][0];
+    }
+  }
+  return null;
+}
+
 class NavigationManager {
   constructor() {
     this.allowedOrigin = [];
@@ -92,7 +102,7 @@ class NavigationManager {
   }
 
   onHeadersReceived(details, callback) {
-    const xVersionId = details.responseHeaders['X-Version-Id'] ? details.responseHeaders['X-Version-Id'][0] : null;
+    const xVersionId = getXVersionId(details.responseHeaders);
     if (xVersionId) {
       const origin = utils.getOrigin(details.url);
       if (!this.servers[origin]) {

--- a/src/package.json
+++ b/src/package.json
@@ -14,6 +14,7 @@
     "create-react-class": "^15.6.2",
     "electron-context-menu": "^0.9.0",
     "electron-devtools-installer": "^2.2.1",
+    "electron-fetch": "^1.1.0",
     "electron-is-dev": "^0.3.0",
     "electron-squirrel-startup": "^1.0.0",
     "prop-types": "^15.6.0",

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -169,6 +169,12 @@ electron-dl@^1.2.0:
     pupa "^1.0.0"
     unused-filename "^1.0.0"
 
+electron-fetch@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/electron-fetch/-/electron-fetch-1.1.0.tgz#74b0ea547fe149620d38596a84fb104d34218e31"
+  dependencies:
+    encoding "^0.1.12"
+
 electron-is-dev@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-0.1.2.tgz#8a1043e32b3a1da1c3f553dce28ce764246167e3"
@@ -183,7 +189,7 @@ electron-squirrel-startup@^1.0.0:
   dependencies:
     debug "^2.2.0"
 
-encoding@^0.1.11:
+encoding@^0.1.11, encoding@^0.1.12:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
   dependencies:


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Limit navigation flows to untrusted origins, which is outside of servers.

Once an origin is allowed, it's assumed as a trusted origin until the application finishes.

**Issue link**
https://mattermost.atlassian.net/browse/PLT-7457

**Test Cases**
1. Register a normal website as a server URL.
2. Click a link to another website in the tab.
3. A dialog should appear.
4. When clicking 'No', the page will not navigate.
5. When clicking 'Yes', the page will navigate to the URL.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/414#artifacts