### PR TITLE
Add Ctrl(+Shift)+Tab as alternative to switch between servers

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -8,8 +8,7 @@ const {
   nativeImage,
   dialog,
   systemPreferences,
-  session,
-  globalShortcut
+  session
 } = require('electron');
 const isDev = require('electron-is-dev');
 const installExtension = require('electron-devtools-installer');
@@ -345,12 +344,15 @@ app.on('ready', () => {
 
   // Add Alt+Cmd+(Right|Left) as alternative to switch between servers
   if (process.platform === 'darwin') {
-    globalShortcut.register('Alt+Cmd+Right', () => {
-      mainWindow.webContents.send('select-next-tab');
-    });
-
-    globalShortcut.register('Alt+Cmd+Left', () => {
-      mainWindow.webContents.send('select-previous-tab');
+    mainWindow.webContents.on('before-input-event', (event, input) => {
+      if (input.alt && input.meta) {
+        if (input.key === 'ArrowRight') {
+          mainWindow.webContents.send('select-next-tab');
+        }
+        if (input.key === 'ArrowLeft') {
+          mainWindow.webContents.send('select-previous-tab');
+        }
+      }
     });
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -342,20 +342,6 @@ app.on('ready', () => {
     console.log('The application has crashed.');
   });
 
-  // Add Alt+Cmd+(Right|Left) as alternative to switch between servers
-  if (process.platform === 'darwin') {
-    mainWindow.webContents.on('before-input-event', (event, input) => {
-      if (input.alt && input.meta) {
-        if (input.key === 'ArrowRight') {
-          mainWindow.webContents.send('select-next-tab');
-        }
-        if (input.key === 'ArrowLeft') {
-          mainWindow.webContents.send('select-previous-tab');
-        }
-      }
-    });
-  }
-
   ipcMain.on('notified', () => {
     if (process.platform === 'win32' || process.platform === 'linux') {
       if (config.notifications.flashWindow === 2) {

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,8 @@ const {
   nativeImage,
   dialog,
   systemPreferences,
-  session
+  session,
+  globalShortcut
 } = require('electron');
 const isDev = require('electron-is-dev');
 const installExtension = require('electron-devtools-installer');
@@ -341,6 +342,17 @@ app.on('ready', () => {
   mainWindow.webContents.on('crashed', () => {
     console.log('The application has crashed.');
   });
+
+  // Add Alt+Cmd+(Right|Left) as alternative to switch between servers
+  if (process.platform === 'darwin') {
+    globalShortcut.register('Alt+Cmd+Right', () => {
+      mainWindow.webContents.send('select-next-tab');
+    });
+
+    globalShortcut.register('Alt+Cmd+Left', () => {
+      mainWindow.webContents.send('select-previous-tab');
+    });
+  }
 
   ipcMain.on('notified', () => {
     if (process.platform === 'win32' || process.platform === 'linux') {

--- a/src/main/mainWindow.js
+++ b/src/main/mainWindow.js
@@ -114,6 +114,21 @@ function createMainWindow(config, options) {
     mainWindow.webContents.send('focus-on-webview');
   });
 
+  // Register keyboard shortcuts
+  mainWindow.webContents.on('before-input-event', (event, input) => {
+    // Add Alt+Cmd+(Right|Left) as alternative to switch between servers
+    if (process.platform === 'darwin') {
+      if (input.alt && input.meta) {
+        if (input.key === 'ArrowRight') {
+          mainWindow.webContents.send('select-next-tab');
+        }
+        if (input.key === 'ArrowLeft') {
+          mainWindow.webContents.send('select-previous-tab');
+        }
+      }
+    }
+  });
+
   return mainWindow;
 }
 

--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -186,14 +186,14 @@ function createTemplate(mainWindow, config, isDev) {
       };
     }), separatorItem, {
       label: 'Select Next Server',
-      accelerator: (process.platform === 'darwin') ? 'Alt+Cmd+Right' : 'CmdOrCtrl+Tab',
+      accelerator: 'Ctrl+Tab',
       click() {
         mainWindow.webContents.send('select-next-tab');
       },
       enabled: (config.teams.length > 1)
     }, {
       label: 'Select Previous Server',
-      accelerator: (process.platform === 'darwin') ? 'Alt+Cmd+Left' : 'CmdOrCtrl+Shift+Tab',
+      accelerator: 'Ctrl+Shift+Tab',
       click() {
         mainWindow.webContents.send('select-previous-tab');
       },


### PR DESCRIPTION
Closes #512

Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
[Mac] Adds `Ctrl+Tab` and `Ctrl+Shift+Tab` keyboard shortcuts as an alternative to `Alt+Cmd+Right` and `Alt+Cmd+Left` to switch between servers.

**Issue link**
#512 