### PR TITLE
Fix an issue where the combination of deepmerge and webpack breaks tests

### DIFF
--- a/src/common/deepmerge.js
+++ b/src/common/deepmerge.js
@@ -1,0 +1,10 @@
+const deepmerge = require('deepmerge');
+
+function deepMergeProxy(x, y, options) {
+  if (process.env.TEST) {
+    return deepmerge(x, y, options);
+  }
+  return deepmerge.default(x, y, options); // due to webpack conversion
+}
+
+module.exports = deepMergeProxy;

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -3,10 +3,7 @@
 const fs = require('fs');
 
 const path = require('path');
-let deepmerge = require('deepmerge').default;
-if (process.env.TEST) {
-  deepmerge = require('deepmerge'); // eslint-disable-line
-}
+const deepmerge = require('./deepmerge');
 
 const settingsVersion = 1;
 const baseConfig = require('./config/base.json');

--- a/test/modules/environment.js
+++ b/test/modules/environment.js
@@ -1,5 +1,4 @@
 'use strict';
-process.env.TEST = 'test';
 
 const chai = require('chai');
 chai.should();

--- a/test/specs/settings_test.js
+++ b/test/specs/settings_test.js
@@ -2,6 +2,14 @@ const settings = require('../../src/common/settings');
 const deepmerge = require('deepmerge');
 
 describe('common/settings.js', () => {
+  before(() => {
+    process.env.TEST = 1;
+  });
+
+  after(() => {
+    delete process.env.TEST;
+  });
+
   it('should upgrade v0 config file', () => {
     const v0Config = {
       url: 'https://example.com/team'


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fix an issue where the combination of deepmerge and webpack breaks tests.

In #586, I had found that the combination of deepmerge and webpack makes a wrong state when requiring. Due to the problem, the application raised the error only in `npm test`. It's the reason why recently CircleCI is failing.

Unfortunately, I could not notice the behavior because #188 hides the error and doesn't quit the application. I will prepare another PR to quit the application when `uncaughtException` and other critical errors have been occurred.

**Issue link**
#586 #188

**Test Cases**
Execute `npm test` (done in CI)

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/429