### PR TITLE
Show uncaughtException as an internal error and quit the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Release date: TBD
 #### All Platforms
  - Now "Saved" indicators appear for each preferences section.
  [#500](https://github.com/mattermost/desktop/issues/500)
+ - Added the dialog to reopen the application when it quits unexpectedly.
+ [#626](https://github.com/mattermost/desktop/pull/626)
 
 #### Windows
  - Added the feature to open the application via `mattermost://` link.

--- a/src/main.js
+++ b/src/main.js
@@ -471,7 +471,7 @@ app.on('ready', () => {
         }
       }
 
-      if (trayIcon) {
+      if (trayIcon && !trayIcon.isDestroyed()) {
         if (arg.mentionCount > 0) {
           trayIcon.setImage(trayImages.mention);
           if (process.platform === 'darwin') {

--- a/src/main.js
+++ b/src/main.js
@@ -10,15 +10,18 @@ const {
   systemPreferences,
   session
 } = require('electron');
+const os = require('os');
+const path = require('path');
 const isDev = require('electron-is-dev');
 const installExtension = require('electron-devtools-installer');
 const squirrelStartup = require('./main/squirrelStartup');
+const CriticalErrorHandler = require('./main/CriticalErrorHandler');
 
 const protocols = require('../electron-builder.json').protocols;
 
-process.on('uncaughtException', (error) => {
-  console.error(error);
-});
+const criticalErrorHandler = new CriticalErrorHandler();
+
+process.on('uncaughtException', criticalErrorHandler.processUncaughtExceptionHandler.bind(criticalErrorHandler));
 
 global.willAppQuit = false;
 
@@ -26,9 +29,6 @@ app.setAppUserModelId('com.squirrel.mattermost.Mattermost'); // Use explicit App
 if (squirrelStartup()) {
   global.willAppQuit = true;
 }
-
-const os = require('os');
-const path = require('path');
 
 var settings = require('./common/settings');
 var certificateStore = require('./main/certificateStore').load(path.resolve(app.getPath('userData'), 'certificate.json'));
@@ -304,6 +304,10 @@ app.on('certificate-error', (event, webContents, url, error, certificate, callba
   }
 });
 
+app.on('gpu-process-crashed', () => {
+  throw new Error('The GPU process has crached');
+});
+
 const loginCallbackMap = new Map();
 
 ipcMain.on('login-credentials', (event, request, user, password) => {
@@ -392,11 +396,10 @@ app.on('ready', () => {
     // when you should delete the corresponding element.
     mainWindow = null;
   });
-  mainWindow.on('unresponsive', () => {
-    console.log('The application has become unresponsive.');
-  });
+  criticalErrorHandler.setMainWindow(mainWindow);
+  mainWindow.on('unresponsive', criticalErrorHandler.windowUnresponsiveHandler.bind(criticalErrorHandler));
   mainWindow.webContents.on('crashed', () => {
-    console.log('The application has crashed.');
+    throw new Error('webContents \'crashed\' event has been emitted');
   });
 
   ipcMain.on('notified', () => {

--- a/src/main.js
+++ b/src/main.js
@@ -172,7 +172,7 @@ if (app.makeSingleInstance((commandLine/*, workingDirectory*/) => {
     }
   }
 })) {
-  app.quit();
+  app.exit();
 }
 
 function shouldShowTrayIcon() {

--- a/src/main/CriticalErrorHandler.js
+++ b/src/main/CriticalErrorHandler.js
@@ -1,0 +1,64 @@
+const {app, dialog, shell} = require('electron');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function createErrorReport(err) {
+  return `Application: ${app.getName()} ${app.getVersion()}\n` +
+         `Platform: ${os.type()} ${os.release()} ${os.arch()}\n` +
+         `${err.stack}`;
+}
+
+function bindWindowToShowMessageBox(win) {
+  if (win && win.isVisible()) {
+    return dialog.showMessageBox.bind(null, win);
+  }
+  return dialog.showMessageBox;
+}
+
+class CriticalErrorHandler {
+  constructor() {
+    this.mainWindow = null;
+  }
+
+  setMainWindow(mainWindow) {
+    this.mainWindow = mainWindow;
+  }
+
+  windowUnresponsiveHandler() {
+    const result = dialog.showMessageBox(this.mainWindow, {
+      type: 'warning',
+      title: `Unresponsive - ${app.getName()}`,
+      message: 'The window is no longer responsive.\nDo you wait until the window becomes responsive again?',
+      buttons: ['No', 'Yes'],
+      defaultId: 0
+    });
+    if (result === 0) {
+      throw new Error('BrowserWindow \'unresponsive\' event has been emitted');
+    }
+  }
+
+  processUncaughtExceptionHandler(err) {
+    const file = path.join(app.getPath('userData'), `uncaughtException-${Date.now()}.txt`);
+    const report = createErrorReport(err);
+    fs.writeFileSync(file, report.replace(new RegExp('\\n', 'g'), os.EOL));
+    fs.writeSync(2, `See "${file}" to report the problem.\n`);
+
+    if (app.isReady()) {
+      const showMessageBox = bindWindowToShowMessageBox(this.mainWindow);
+      const result = showMessageBox({
+        type: 'error',
+        title: `Error - ${app.getName()}`,
+        message: `An internal error has occurred: ${err.message}\nThe application will quit.`,
+        buttons: ['OK', 'Show detail'],
+        defaultId: 0
+      });
+      if (result === 1) {
+        shell.openExternal(file);
+      }
+    }
+    throw err;
+  }
+}
+
+module.exports = CriticalErrorHandler;

--- a/src/main/CriticalErrorHandler.js
+++ b/src/main/CriticalErrorHandler.js
@@ -43,7 +43,7 @@ class CriticalErrorHandler {
   windowUnresponsiveHandler() {
     const result = dialog.showMessageBox(this.mainWindow, {
       type: 'warning',
-      title: `Unresponsive - ${app.getName()}`,
+      title: app.getName(),
       message: 'The window is no longer responsive.\nDo you wait until the window becomes responsive again?',
       buttons: ['No', 'Yes'],
       defaultId: 0
@@ -63,12 +63,13 @@ class CriticalErrorHandler {
       const showMessageBox = bindWindowToShowMessageBox(this.mainWindow);
       const result = showMessageBox({
         type: 'error',
-        title: `Error - ${app.getName()}`,
-        message: `An internal error has occurred: ${err.message}\nThe application will quit.`,
-        buttons: ['OK', 'Show detail'],
-        defaultId: 0
+        title: app.getName(),
+        message: `The ${app.getName()} app quit unexpectedly. Click "Show Details" to learn more.\n\n Internal error: ${err.message}`,
+        buttons: ['Show details', 'OK'],
+        defaultId: 1,
+        noLink: true
       });
-      if (result === 1) {
+      if (result === 0) {
         const child = openDetachedExternal(file);
         if (child) {
           child.on('error', (spawnError) => {

--- a/src/main/CriticalErrorHandler.js
+++ b/src/main/CriticalErrorHandler.js
@@ -57,7 +57,6 @@ class CriticalErrorHandler {
     const file = path.join(app.getPath('userData'), `uncaughtException-${Date.now()}.txt`);
     const report = createErrorReport(err);
     fs.writeFileSync(file, report.replace(new RegExp('\\n', 'g'), os.EOL));
-    fs.writeSync(2, `See "${file}" to report the problem.\n`);
 
     if (app.isReady()) {
       const showMessageBox = bindWindowToShowMessageBox(this.mainWindow);


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
When an uncaught error occurred, the error log is saved to `AppData\Roaming\Mattermost\uncaughtException-*.txt`. Then a dialog would pop up to notice it.

<img width="273" alt="error_dialog" src="https://user-images.githubusercontent.com/1412057/31672883-acea5740-b398-11e7-84ba-fe53bf9ffae6.png">

When the user click "Show detail", the file is opened in the default text editor.

```sample.txt
Application: Mattermost 3.7.1
Platform: Windows_NT 10.0.15063 x64
Error: test error
    at Timeout.setTimeout [as _onTimeout] (C:\Users\yuya-oc\git\mattermost-desktop\src\main_bundle.js:7781:11)
    at ontimeout (timers.js:386:14)
    at tryOnTimeout (timers.js:250:5)
    at Timer.listOnTimeout (timers.js:214:5)
```

Usually the error is unrecoverable, so the application should finish soon.
https://nodejs.org/api/process.html#process_warning_using_uncaughtexception_correctly

**Issue link**
#625 

**Test Cases**
- General use cases. The error should NOT appear.
- Check text messages.

**Additional Notes**
CircleCI is delaying...