### PR TITLE
Keep MainWindow's zoom level to zero excepting webview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Release date: TBD
  [#497](https://github.com/mattermost/desktop/issues/497)
  - Fixed an issue where unnecessary focus remains after closing dialogs on the settings page.
  [#446](https://github.com/mattermost/desktop/issues/446)
+ - Fixed an issue where there is a case of that modified font size causes wrong rendering.
+ [#334](https://github.com/mattermost/desktop/issues/334)
 
 #### Windows
  - Fixed desktop notifications not working when the window has been minimized from inactive state.

--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -329,7 +329,10 @@ const MainPage = createReactClass({
       />
     );
     return (
-      <div className='MainPage'>
+      <div
+        className='MainPage'
+        onClick={this.focusOnWebView}
+      >
         <LoginModal
           show={this.state.loginQueue.length !== 0}
           request={request}

--- a/src/main/mainWindow.js
+++ b/src/main/mainWindow.js
@@ -66,6 +66,7 @@ function createMainWindow(config, options) {
   });
 
   mainWindow.once('ready-to-show', () => {
+    mainWindow.webContents.setZoomLevel(0);
     if (process.platform !== 'darwin') {
       mainWindow.show();
     } else if (options.hideOnStartup !== true) {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Keep MainWindow's zoom level to zero excepting webview.

This PR makes a workaround for #334. The problem is that the main window and webview tags have zoom level on their own. The issue happens the main window has modified zoom level. A workaround is below.

- Always reset zoom level when launching the app.
- Keep focus on webview tags when clicking tab bar area.

**Issue link**
#334 

**Test Cases**
1. Click the tab bar area where there are no buttons.
2. Use `Ctrl+Plus` or `Ctrl+Minus` to change zoom level.
3. Make sure that #334 doesn't happen.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/454#artifacts