### PR TITLE
Add PermissionRequestDialog for when the app doesn't show the TabBar

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -11,6 +11,7 @@ const LoginModal = require('./LoginModal.jsx');
 const MattermostView = require('./MattermostView.jsx');
 const TabBar = require('./TabBar.jsx');
 const HoveringURL = require('./HoveringURL.jsx');
+const PermissionRequestDialog = require('./PermissionRequestDialog.jsx');
 
 const NewTeamModal = require('./NewTeamModal.jsx');
 
@@ -347,6 +348,16 @@ const MainPage = createReactClass({
           onLogin={this.handleLogin}
           onCancel={this.handleLoginCancel}
         />
+        {this.props.teams.length === 1 && this.props.requestingPermission[0] ? // eslint-disable-line multiline-ternary
+          <PermissionRequestDialog
+            id='MainPage-permissionDialog'
+            placement='bottom'
+            {...this.props.requestingPermission[0]}
+            onClickAllow={this.props.onClickPermissionDialog.bind(null, 0, 'allow')}
+            onClickBlock={this.props.onClickPermissionDialog.bind(null, 0, 'block')}
+            onClickClose={this.props.onClickPermissionDialog.bind(null, 0, 'close')}
+          /> : null
+        }
         <Grid fluid={true}>
           { tabsRow }
           { viewsRow }

--- a/src/browser/css/components/MainPage.css
+++ b/src/browser/css/components/MainPage.css
@@ -7,3 +7,7 @@
   position: absolute;
   bottom: 0px;
 }
+
+div[id*="-permissionDialog"] {
+  max-width: 350px;
+}

--- a/src/browser/css/components/TabBar.css
+++ b/src/browser/css/components/TabBar.css
@@ -37,7 +37,3 @@
   margin-top: 5px;
   border-radius: 50%;
 }
-
-div[id*="-permissionDialog"] {
-  max-width: 350px;
-}


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Add PermissionRequestDialog for when the app doesn't show the TabBar.
This is quick fix for #644.

<img width="653" alt="permission-request-dialog" src="https://user-images.githubusercontent.com/1412057/32506134-2429d198-c427-11e7-9bee-8917649fc1f5.png">

**Issue link**
#644 

**Test Cases**
See #644. The dialog should appear even when the app shows one server.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/493#artifacts