### PR TITLE
Ignore "gpu-process-crashed" event then output the log to console

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -305,8 +305,8 @@ app.on('certificate-error', (event, webContents, url, error, certificate, callba
   }
 });
 
-app.on('gpu-process-crashed', () => {
-  throw new Error('The GPU process has crached');
+app.on('gpu-process-crashed', (event, killed) => {
+  console.log(`The GPU process has crached (killed = ${killed})`);
 });
 
 const loginCallbackMap = new Map();


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Ignore "gpu-process-crashed" event then output the log to console.

This PR changes `throw new Error()` to `console.log`. So the user will not see the event.
As investigated in #646, it doesn't affect the app.

**Issue link**
#646

**Test Cases**
a. Use the app. The app should not crash with the error of GPU process.
b. Kill the GPU process with Process Explorer.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/494#artifacts