### PR TITLE
Fix permission dialog lag

### DIFF
--- a/src/browser/components/PermissionRequestDialog.jsx
+++ b/src/browser/components/PermissionRequestDialog.jsx
@@ -79,8 +79,8 @@ function PermissionRequestDialog(props) {
 }
 
 PermissionRequestDialog.propTypes = {
-  origin: PropTypes.string.isRequired,
-  permission: PropTypes.oneOf(['media', 'geolocation', 'notifications', 'midiSysex', 'pointerLock', 'fullscreen', 'openExternal']).isRequired,
+  origin: PropTypes.string,
+  permission: PropTypes.oneOf(['media', 'geolocation', 'notifications', 'midiSysex', 'pointerLock', 'fullscreen', 'openExternal']),
   onClickAllow: PropTypes.func,
   onClickBlock: PropTypes.func,
   onClickClose: PropTypes.func

--- a/src/browser/components/TabBar.jsx
+++ b/src/browser/components/TabBar.jsx
@@ -31,48 +31,36 @@ class TabBar extends React.Component { // need "this"
           </div>);
       }
       const id = 'teamTabItem' + index;
-      const permissionOverlay = this.props.requestingPermission[index] ? (
+      const requestingPermission = this.props.requestingPermission[index];
+      const permissionOverlay = (
         <Overlay
           className='TabBar-permissionOverlay'
           placement='bottom'
-          show={this.props.activeKey === index}
+          show={requestingPermission && this.props.activeKey === index}
           target={() => findDOMNode(this.refs[id])}
         >
           <PermissionRequestDialog
             id={`${id}-permissionDialog`}
-            origin={this.props.requestingPermission[index].origin}
-            permission={this.props.requestingPermission[index].permission}
+            origin={requestingPermission ? requestingPermission.origin : null}
+            permission={requestingPermission ? requestingPermission.permission : null}
             onClickAllow={this.props.onClickPermissionDialog.bind(null, index, 'allow')}
             onClickBlock={this.props.onClickPermissionDialog.bind(null, index, 'block')}
             onClickClose={this.props.onClickPermissionDialog.bind(null, index, 'close')}
           />
         </Overlay>
-      ) : null;
-      if (unreadCount === 0) {
-        return (
-          <NavItem
-            className='teamTabItem'
-            key={id}
-            id={id}
-            eventKey={index}
-            ref={id}
-          >
-            { team.name }
-            { ' ' }
-            { badgeDiv }
-            {permissionOverlay}
-          </NavItem>);
-      }
+      );
       return (
         <NavItem
           className='teamTabItem'
           key={id}
           id={id}
           eventKey={index}
+          ref={id}
         >
-          <b>{ team.name }</b>
+          <span className={unreadCount === 0 ? '' : 'teamTabItem-label'}>{team.name}</span>
           { ' ' }
           { badgeDiv }
+          {permissionOverlay}
         </NavItem>);
     });
     if (this.props.showAddServerButton === true) {

--- a/src/browser/components/TabBar.jsx
+++ b/src/browser/components/TabBar.jsx
@@ -37,7 +37,7 @@ class TabBar extends React.Component { // need "this"
           className='TabBar-permissionOverlay'
           placement='bottom'
           show={requestingPermission && this.props.activeKey === index}
-          target={() => findDOMNode(this.refs[id])}
+          target={() => this.refs[id]}
         >
           <PermissionRequestDialog
             id={`${id}-permissionDialog`}

--- a/src/browser/css/components/TabBar.css
+++ b/src/browser/css/components/TabBar.css
@@ -37,3 +37,7 @@
   margin-top: 5px;
   border-radius: 50%;
 }
+
+.TabBar .teamTabItem-label {
+  font-weight: bold;
+}


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fix lag to show/hide permission dialog.

If the LHS has unread channels, the dialog doesn't correctly appear/hide due to complicated rendering function of TabBar.jsx. Now some `if` statements are removed, so the TabBar correctly render the dialog in any cases.

By the way, I feel `notifications` should be allowed as default. Users might not notice the dialog until they open the tab.

**Issue link**
#643

**Test Cases**
1. Remove `AppData\Roaming\Mattermost\permisson.json`
2. Start the app.
3. Receive new messages or WebRTC concall

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/499#artifacts