### PR TITLE
Support React 16 of webapp for loading icon

### DIFF
--- a/src/browser/webview/mattermost.js
+++ b/src/browser/webview/mattermost.js
@@ -12,7 +12,10 @@ Notification = EnhancedNotification; // eslint-disable-line no-global-assign, no
 Reflect.deleteProperty(global.Buffer); // http://electron.atom.io/docs/tutorial/security/#buffer-global
 
 function isReactAppInitialized() {
-  const initializedRoot = document.querySelector('div[data-reactroot]') || document.querySelector('#root.channel-view');
+  const initializedRoot =
+    document.querySelector('#root.channel-view') || // React 16 webapp
+    document.querySelector('#root .signup-team__container') || // React 16 login
+    document.querySelector('div[data-reactroot]'); // Older React apps
   if (initializedRoot === null) {
     return false;
   }

--- a/src/browser/webview/mattermost.js
+++ b/src/browser/webview/mattermost.js
@@ -12,11 +12,11 @@ Notification = EnhancedNotification; // eslint-disable-line no-global-assign, no
 Reflect.deleteProperty(global.Buffer); // http://electron.atom.io/docs/tutorial/security/#buffer-global
 
 function isReactAppInitialized() {
-  const reactRoot = document.querySelector('div[data-reactroot]');
-  if (reactRoot === null) {
+  const initializedRoot = document.querySelector('div[data-reactroot]') || document.querySelector('#root.channel-view');
+  if (initializedRoot === null) {
     return false;
   }
-  return reactRoot.children.length !== 0;
+  return initializedRoot.children.length !== 0;
 }
 
 function watchReactAppUntilInitialized(callback) {


### PR DESCRIPTION
https://stackoverflow.com/questions/47203183/missing-data-reactroot-attirbute-in-react-16

Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
In React 16, `data-reactroot` attribute is no longer used. So the desktop app can't know whether a webapp is initialized.
So I added a query selector to detect React app from DOM.

**Issue link**
N/A

**Test Cases**
1. Start the app to show the latest mattermost server (https://pre-release.mattermost.com).
2. The loading icon should disappear within 30 seconds.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/508#artifacts