### PR TITLE
Show permissions dialog only for untrusted origins

### DIFF
--- a/src/main/PermissionManager.js
+++ b/src/main/PermissionManager.js
@@ -1,0 +1,73 @@
+const fs = require('fs');
+const utils = require('../utils/util');
+
+const PERMISSION_GRANTED = 'granted';
+const PERMISSION_DENIED = 'denied';
+
+class PermissionManager {
+  constructor(file, trustedURLs = []) {
+    this.file = file;
+    this.setTrustedURLs(trustedURLs);
+    if (fs.existsSync(file)) {
+      try {
+        this.permissions = JSON.parse(fs.readFileSync(this.file, 'utf-8'));
+      } catch (err) {
+        console.error(err);
+        this.permissions = {};
+      }
+    } else {
+      this.permissions = {};
+    }
+  }
+
+  writeFileSync() {
+    fs.writeFileSync(this.file, JSON.stringify(this.permissions, null, '  '));
+  }
+
+  grant(origin, permission) {
+    if (!this.permissions[origin]) {
+      this.permissions[origin] = {};
+    }
+    this.permissions[origin][permission] = PERMISSION_GRANTED;
+    this.writeFileSync();
+  }
+
+  deny(origin, permission) {
+    if (!this.permissions[origin]) {
+      this.permissions[origin] = {};
+    }
+    this.permissions[origin][permission] = PERMISSION_DENIED;
+    this.writeFileSync();
+  }
+
+  clear(origin, permission) {
+    delete this.permissions[origin][permission];
+  }
+
+  isGranted(origin, permission) {
+    if (this.trustedOrigins[origin] === true) {
+      return true;
+    }
+    if (this.permissions[origin]) {
+      return this.permissions[origin][permission] === PERMISSION_GRANTED;
+    }
+    return false;
+  }
+
+  isDenied(origin, permission) {
+    if (this.permissions[origin]) {
+      return this.permissions[origin][permission] === PERMISSION_DENIED;
+    }
+    return false;
+  }
+
+  setTrustedURLs(trustedURLs) {
+    this.trustedOrigins = {};
+    for (const url of trustedURLs) {
+      const origin = utils.getDomain(url);
+      this.trustedOrigins[origin] = true;
+    }
+  }
+}
+
+module.exports = PermissionManager;

--- a/src/main/permissionRequestHandler.js
+++ b/src/main/permissionRequestHandler.js
@@ -1,63 +1,5 @@
 const {ipcMain} = require('electron');
 const {URL} = require('url');
-const fs = require('fs');
-
-const PERMISSION_GRANTED = 'granted';
-const PERMISSION_DENIED = 'denied';
-
-class PermissionManager {
-  constructor(file) {
-    this.file = file;
-    if (fs.existsSync(file)) {
-      try {
-        this.permissions = JSON.parse(fs.readFileSync(this.file, 'utf-8'));
-      } catch (err) {
-        console.error(err);
-        this.permissions = {};
-      }
-    } else {
-      this.permissions = {};
-    }
-  }
-
-  writeFileSync() {
-    fs.writeFileSync(this.file, JSON.stringify(this.permissions, null, '  '));
-  }
-
-  grant(origin, permission) {
-    if (!this.permissions[origin]) {
-      this.permissions[origin] = {};
-    }
-    this.permissions[origin][permission] = PERMISSION_GRANTED;
-    this.writeFileSync();
-  }
-
-  deny(origin, permission) {
-    if (!this.permissions[origin]) {
-      this.permissions[origin] = {};
-    }
-    this.permissions[origin][permission] = PERMISSION_DENIED;
-    this.writeFileSync();
-  }
-
-  clear(origin, permission) {
-    delete this.permissions[origin][permission];
-  }
-
-  isGranted(origin, permission) {
-    if (this.permissions[origin]) {
-      return this.permissions[origin][permission] === PERMISSION_GRANTED;
-    }
-    return false;
-  }
-
-  isDenied(origin, permission) {
-    if (this.permissions[origin]) {
-      return this.permissions[origin][permission] === PERMISSION_DENIED;
-    }
-    return false;
-  }
-}
 
 function dequeueRequests(requestQueue, permissionManager, origin, permission, status) {
   switch (status) {
@@ -88,8 +30,7 @@ function dequeueRequests(requestQueue, permissionManager, origin, permission, st
   }
 }
 
-function permissionRequestHandler(mainWindow, permissionFile) {
-  const permissionManager = new PermissionManager(permissionFile);
+function permissionRequestHandler(mainWindow, permissionManager) {
   const requestQueue = [];
   ipcMain.on('update-permission', (event, origin, permission, status) => {
     dequeueRequests(requestQueue, permissionManager, origin, permission, status);
@@ -113,7 +54,5 @@ function permissionRequestHandler(mainWindow, permissionFile) {
     mainWindow.webContents.send('request-permission', targetURL.origin, permission);
   };
 }
-
-permissionRequestHandler.PermissionManager = PermissionManager;
 
 module.exports = permissionRequestHandler;

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -1,10 +1,8 @@
-const {URL} = require('url');
+const url = require('url');
 
-export function getDomain(url) {
-  try {
-    const objectUrl = new URL(url);
-    return objectUrl.origin;
-  } catch (e) {
-    return null;
-  }
+function getDomain(inputURL) {
+  const parsedURL = url.parse(inputURL);
+  return `${parsedURL.protocol}//${parsedURL.host}`;
 }
+
+module.exports = {getDomain};

--- a/test/specs/permisson_test.js
+++ b/test/specs/permisson_test.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const env = require('../modules/environment');
-const {PermissionManager} = require('../../src/main/permissionRequestHandler');
+const PermissionManager = require('../../src/main/PermissionManager');
 
 const permissionFile = path.join(env.userDataDir, 'permission.json');
 
@@ -76,5 +76,12 @@ describe('PermissionManager', function() {
     const manager = new PermissionManager(permissionFile);
     manager.isDenied('origin', 'permission').should.be.true;
     manager.isGranted('origin_another', 'permission_another').should.be.true;
+  });
+
+  it('should allow permissions for trusted URLs', function() {
+    fs.writeFileSync(permissionFile, JSON.stringify({}));
+    const manager = new PermissionManager(permissionFile, ['https://example.com', 'https://example2.com/2']);
+    manager.isGranted('https://example.com', 'notifications').should.be.true;
+    manager.isGranted('https://example2.com', 'test').should.be.true;
   });
 });


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Show permissions dialog only for untrusted origins.

"Trusted" means that a origin is one of URLs which are saved at `config.json` or `buildConfig.js`.

**Issue link**
#659 

**Test Cases**
1. Remove `AppData\Roaming\Mattermost\permissions.json`.
2. Start the app.
3. The dialog should not appear when receiving new messages or webrtc concall.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/522#artifacts