### PR TITLE
Fix deep linking not working when the app is not already opened

### DIFF
--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -8,6 +8,8 @@ const {findDOMNode} = require('react-dom');
 const {ipcRenderer, remote, shell} = require('electron');
 const url = require('url');
 const contextMenu = require('../js/contextMenu');
+const {protocols} = require('../../../electron-builder.json');
+const scheme = protocols[0].schemes[0];
 
 const ErrorView = require('./ErrorView.jsx');
 
@@ -72,7 +74,7 @@ const MattermostView = createReactClass({
     webview.addEventListener('new-window', (e) => {
       var currentURL = url.parse(webview.getURL());
       var destURL = url.parse(e.url);
-      if (destURL.protocol !== 'http:' && destURL.protocol !== 'https:') {
+      if (destURL.protocol !== 'http:' && destURL.protocol !== 'https:' && destURL.protocol !== `${scheme}:`) {
         ipcRenderer.send('confirm-protocol', destURL.protocol, e.url);
         return;
       }

--- a/src/main.js
+++ b/src/main.js
@@ -361,9 +361,16 @@ app.on('will-finish-launching', () => {
   app.on('open-url', (event, url) => {
     event.preventDefault();
     setDeeplinkingUrl(url);
-    if (mainWindow) { // 'open-url' is emitted before 'ready' when the app is launched by URL scheme.
-      mainWindow.webContents.send('protocol-deeplink', deeplinkingUrl);
-      mainWindow.show();
+    if (app.isReady()) {
+      function openDeepLink() {
+        try {
+          mainWindow.webContents.send('protocol-deeplink', deeplinkingUrl);
+          mainWindow.show();
+        } catch (err) {
+          setTimeout(openDeepLink, 1000);
+        }
+      }
+      openDeepLink();
     }
   });
 });

--- a/src/main.js
+++ b/src/main.js
@@ -356,14 +356,16 @@ function setDeeplinkingUrl(url) {
   }
 }
 
-// Protocol handler for osx
-app.on('open-url', (event, url) => {
-  event.preventDefault();
-  setDeeplinkingUrl(url);
-  if (mainWindow) { // 'open-url' is emitted before 'ready' when the app is launched by URL scheme.
-    mainWindow.webContents.send('protocol-deeplink', deeplinkingUrl);
-    mainWindow.show();
-  }
+app.on('will-finish-launching', () => {
+  // Protocol handler for osx
+  app.on('open-url', (event, url) => {
+    event.preventDefault();
+    setDeeplinkingUrl(url);
+    if (mainWindow) { // 'open-url' is emitted before 'ready' when the app is launched by URL scheme.
+      mainWindow.webContents.send('protocol-deeplink', deeplinkingUrl);
+      mainWindow.show();
+    }
+  });
 });
 
 // This method will be called when Electron has finished

--- a/src/main.js
+++ b/src/main.js
@@ -360,8 +360,10 @@ function setDeeplinkingUrl(url) {
 app.on('open-url', (event, url) => {
   event.preventDefault();
   setDeeplinkingUrl(url);
-  mainWindow.webContents.send('protocol-deeplink', deeplinkingUrl);
-  mainWindow.show();
+  if (mainWindow) { // 'open-url' is emitted before 'ready' when the app is launched by URL scheme.
+    mainWindow.webContents.send('protocol-deeplink', deeplinkingUrl);
+    mainWindow.show();
+  }
 });
 
 // This method will be called when Electron has finished


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fix deep linking not working when the app is not already opened.

On macOS, deep linking is implemented with `open-url` event. When the app is launched by URL scheme, the event is emitted before `ready` event. In this case, the main windows is not created yet. So there was null reference error and the app was not able to start correctly.

**Issue link**
#678 

**Test Cases**
1. Register 2 servers to the app. https://pre-release.mattermost.com must be the second server.
2. Quit the app.
3. Open mattermost://pre-release.mattermost.com/core/channels/developers in your web browser.
4. App should be launched then the Developers channel of pre-release should be opened.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/534#artifacts