### PR TITLE
Fix cache-purging not working

### DIFF
--- a/src/common/JsonFileManager.js
+++ b/src/common/JsonFileManager.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+
+class JsonFileManager {
+  constructor(file) {
+    this.jsonFile = file;
+    try {
+      this.json = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    } catch (err) {
+      this.json = {};
+    }
+  }
+
+  writeToFile() {
+    fs.writeFile(this.jsonFile, JSON.stringify(this.json, null, 2), (err) => {
+      if (err) {
+        console.error(err);
+      }
+    });
+  }
+
+  setJson(json) {
+    this.json = json;
+    this.writeToFile();
+  }
+
+  setValue(key, value) {
+    this.json[key] = value;
+    this.writeToFile();
+  }
+
+  getValue(key) {
+    return this.json[key];
+  }
+}
+
+module.exports = JsonFileManager;

--- a/src/main/AppStateManager.js
+++ b/src/main/AppStateManager.js
@@ -1,0 +1,13 @@
+const JsonFileManager = require('../common/JsonFileManager');
+
+class AppStateManager extends JsonFileManager {
+  set lastAppVersion(version) {
+    this.setValue('lastAppVersion', version);
+  }
+
+  get lastAppVersion() {
+    return this.getValue('lastAppVersion');
+  }
+}
+
+module.exports = AppStateManager;


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fix cache-purging not working.

I rewrote version detection with AppStateManager class which will be introduced by #582 
The temporary parameter, `lastAppVersion` is stored at `app-state.json` separately from `config.json`.

**Issue link**
N/A

**Test Cases**
1. Quit the app.
2. Create `AppData\Roaming\Mattermost\app-state.json` with following content.
    ```json
    {"lastAppVersion": "9.9.9"}
    ```
3. Open `AppData\Roaming\Mattermost\Cache` in Explorer.
4. Cache files should be temporarily removed when launching the app next time.
5. If `lastAppVersion` equals to the app version (3.7.1 in this PR), cache files should NOT be removed.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/538#artifacts