### PR TITLE
Tweak setting help text for Dock icon bounce setting

### DIFF
--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -476,7 +476,7 @@ const SettingsPage = createReactClass({
           <HelpBlock
             style={{marginLeft: '20px'}}
           >
-            {'If enabled, the Dock icon bounces once or until the user opens the app when a new message is received.'}
+            {'If enabled, the Dock icon bounces once or until the user opens the app when a new notification is received.'}
           </HelpBlock>
         </FormGroup>
       );


### PR DESCRIPTION
Before submitting, please confirm you've
 - [X] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [X] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [X] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Tweak setting help text for Dock icon bounce setting

**Issue link**
https://github.com/mattermost/desktop/issues/677
