### PR TITLE
Locate NOTICE.txt and LICENSE.txt under Content/Resources on Mac

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -12,14 +12,6 @@
     "node_modules/bootstrap/dist/**",
     "node_modules/simple-spellchecker/dict/*.dic"
   ],
-  "extraFiles": [
-    {
-      "filter": [
-        "LICENSE.txt",
-        "NOTICE.txt"
-      ]
-    }
-  ],
   "protocols": [
     {
       "name": "Mattermost",
@@ -37,6 +29,12 @@
     ],
     "extraFiles": [
       {
+        "filter": [
+          "LICENSE.txt",
+          "NOTICE.txt"
+        ]
+      },
+      {
         "from": "resources",
         "filter": "icon.png"
       },
@@ -53,6 +51,14 @@
     "category": "public.app-category.productivity",
     "target": [
       "tar.gz"
+    ],
+    "extraResources": [
+      {
+        "filter": [
+          "LICENSE.txt",
+          "NOTICE.txt"
+        ]
+      }
     ]
   },
   "squirrelWindows": {
@@ -62,6 +68,14 @@
     "target": [
       "squirrel",
       "zip"
+    ],
+    "extraFiles": [
+      {
+        "filter": [
+          "LICENSE.txt",
+          "NOTICE.txt"
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Locate NOTICE.txt and LICENSE.txt under Content/Resources on Mac.

Please see https://github.com/mattermost/desktop/issues/681#issuecomment-358647921 for detail.

**Issue link**
#681 

**Test Cases**
1. Download .zip or .tar.gz package.
2. NOTICE.txt and LICENSE.txt should be located under:
    - Windows, Linux: Top level directory of extracted directory. (Same as before)
    - Mac: `Mattermost.app/Content/Resources`

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/540#artifacts