### PR TITLE
Improve Ctrl+Q code on Windows

### DIFF
--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -59,9 +59,10 @@ function createTemplate(mainWindow, config, isDev) {
     }, separatorItem, {
       role: 'quit'
     }] : [separatorItem, {
-      role: 'quit',
+      label: 'Exit',
       accelerator: 'CmdOrCtrl+Q',
-      click() {
+      click: () => {
+        console.log('Ctrl+Q: The application finishes.');
         electron.app.quit();
       }
     }]


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Improve Ctrl+Q code.

Now `quit` role is supported on all platforms. https://electronjs.org/docs/api/menu-item#roles
So I removed `click` event handler from the item menu.

Currently this PR is submitted against to `release-4.0`.

**Issue link**
#692 (Possibly)

**Test Cases**
1. Open the app.
2. Click `File -> Exit` from menu bar.
3. The app should quit.
4. Open the app again.
5. Press `Ctrl+Q`.
6. The app should quit.
 
**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/559#artifacts