### PR TITLE
Fixed an issue where clicking on a file:// protocol path does not open windows explorer since version 3.5.0. #579

### DIFF
--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -15,6 +15,25 @@ const ErrorView = require('./ErrorView.jsx');
 
 const preloadJS = `file://${remote.app.getAppPath()}/browser/webview/mattermost_bundle.js`;
 
+function extractFileURL(message) {
+  const matched = message.match(/Not allowed to load local resource:\s*(.+)/);
+  if (matched) {
+    return matched[1];
+  }
+  return '';
+}
+
+function isNetworkDrive(fileURL) {
+  const u = url.parse(fileURL);
+  if (u.protocol === 'file:' && u.host) {
+    // Disallow localhost, 127.0.0.1, ::1.
+    if (!u.host.match(/^localhost$|^127\.0\.0\.1$|^\[::1\]$/)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 const MattermostView = createReactClass({
   propTypes: {
     name: PropTypes.string,
@@ -156,9 +175,9 @@ const MattermostView = createReactClass({
       case 1:
         console.warn(message);
         break;
-      case 2:
-        const fileURL = this.extractFileURL(e.message);
-        if (this.isNetworkDrive(fileURL)) {
+      case 2: {
+        const fileURL = extractFileURL(e.message);
+        if (isNetworkDrive(fileURL)) {
           // Network drive: Should be allowed.
           if (!shell.openExternal(decodeURI(fileURL))) {
             console.log(`[${this.props.name}] shell.openExternal failed: ${fileURL}`);
@@ -168,6 +187,7 @@ const MattermostView = createReactClass({
           console.error(message);
         }
         break;
+      }
       default:
         console.log(message);
         break;
@@ -237,22 +257,6 @@ const MattermostView = createReactClass({
     webview.executeJavaScript(
       'dispatchEvent(new PopStateEvent("popstate", null));'
     );
-  },
-
-  extractFileURL(message) {
-    const matched = message.match(/Not allowed to load local resource:\s*(.+)/);
-    if (matched) {
-      return matched[1];
-    }
-    return '';
-  },
-
-  isNetworkDrive(fileURL) {
-    const u = url.parse(fileURL);
-    if (u.protocol === 'file:' && u.host) {
-      return true;
-    }
-    return false;
   },
 
   render() {

--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -157,7 +157,33 @@ const MattermostView = createReactClass({
         console.warn(message);
         break;
       case 2:
-        console.error(message);
+        let match = e.message.match(/Not allowed to load local resource:\s*(.+)/);
+        let resURL = "";
+        let isNetworkDrive = false;
+
+        if (match != null) {
+          if (match.length == 2) {
+            resURL = match[1];
+
+            let u = url.parse(resURL);
+
+            // Is it on a network drive?
+            if (u.protocol === 'file:' && u.host) {
+              isNetworkDrive = true;
+            }
+          }
+        }
+
+        // Network drive: Should be allowed.
+        if (isNetworkDrive) {
+          if (!shell.openExternal(decodeURI(resURL))) {
+            console.log(`[${this.props.name}] shell.openExternal failed: ${resURL}`);
+          }
+        }
+        // Local drive such as 'C:\Windows': Should not be allowed.
+        else {
+          console.error(message);
+        }
         break;
       default:
         console.log(message);


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fixed an issue where clicking on a file:// protocol path does not open windows explorer since version 3.5.0.

**Issue link**
https://github.com/mattermost/desktop/issues/579

**Test Cases**
1. Post a "file://..." path to a channel. (e.g. file://\\\\ComputerName\ShaedFolder)
2. Click on that link.
-> Windows explorer opens.

Tested only on Windows 7 and 10.

**Additional Notes**
Not tested on Linux and Mac. I am not familiar with folder sharing on those operating systems.
