### PR TITLE
Fix app crached after toggling tray icon settings on Mac and Linux

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -550,15 +550,17 @@ app.on('ready', () => {
     // set up context menu for tray icon
     if (shouldShowTrayIcon()) {
       const tMenu = trayMenu.createMenu(mainWindow, configData, global.isDev);
-      trayIcon.setContextMenu(tMenu);
       if (process.platform === 'darwin' || process.platform === 'linux') {
         // store the information, if the tray was initialized, for checking in the settings, if the application
         // was restarted after setting "Show icon on menu bar"
         if (trayIcon) {
+          trayIcon.setContextMenu(tMenu);
           mainWindow.trayWasVisible = true;
         } else {
           mainWindow.trayWasVisible = false;
         }
+      } else {
+        trayIcon.setContextMenu(tMenu);
       }
     }
   });

--- a/test/modules/environment.js
+++ b/test/modules/environment.js
@@ -70,6 +70,13 @@ module.exports = {
         return requireResult.value;
       });
     });
+    client.addCommand('waitForAppOptionsAutoSaved', function async() {
+      const ID_APP_OPTIONS_SAVE_INDICATOR = '#appOptionsSaveIndicator';
+      const TIMEOUT = 5000;
+      return this.
+        waitForVisible(ID_APP_OPTIONS_SAVE_INDICATOR, TIMEOUT).
+        waitForVisible(ID_APP_OPTIONS_SAVE_INDICATOR, TIMEOUT, true);
+    });
   },
 
   // execute the test only when `condition` is true

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -195,6 +195,27 @@ describe('browser/settings.html', function desc() {
           });
       });
 
+      describe('Save tray icon setting on mac', () => {
+        env.shouldTest(it, env.isOneOf(['darwin', 'linux']))('should be saved when it\'s selected', () => {
+          env.addClientCommands(this.app.client);
+          return this.app.client.
+            loadSettingsPage().
+            click('#inputShowTrayIcon').
+            waitForAppOptionsAutoSaved().
+            then(() => {
+              const config0 = JSON.parse(fs.readFileSync(env.configFilePath, 'utf-8'));
+              config0.showTrayIcon.should.true;
+              return this.app.client;
+            }).
+            click('#inputShowTrayIcon').
+            waitForAppOptionsAutoSaved().
+            then(() => {
+              const config0 = JSON.parse(fs.readFileSync(env.configFilePath, 'utf-8'));
+              config0.showTrayIcon.should.false;
+            });
+        });
+      });
+
       describe('Save tray icon theme on linux', () => {
         env.shouldTest(it, process.platform === 'linux')('should be saved when it\'s selected', () => {
           env.addClientCommands(this.app.client);


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fix app crashed after toggling tray icon setting.

**Issue link**
#706

**Test Cases**
See #706.

- Go to the Settings page via CMD+COMMA
- Enable "Show Mattermost icon in menu bar" setting. Then disable it.

On Linux, changing theme also made crashes.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/620#artifacts