### PR TITLE
Whitelabel: Downloads link opens in Mattermost branded window.

### DIFF
--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -104,7 +104,7 @@ const MattermostView = createReactClass({
           ipcRenderer.send('download-url', e.url);
         } else {
           // New window should disable nodeIntergration.
-          window.open(e.url, 'Mattermost', 'nodeIntegration=no, show=yes');
+          window.open(e.url, remote.app.getName(), 'nodeIntegration=no, show=yes');
         }
       } else {
         // if the link is external, use default browser.


### PR DESCRIPTION
**Summary**
Modal window title is not white-labeled based on app name. It displays when clicking the `Download apps` or `help` links.