### PR TITLE
Fix correct spellchecker locale is not selected for non en-US locales

### DIFF
--- a/src/common/config/defaultPreferences.js
+++ b/src/common/config/defaultPreferences.js
@@ -15,7 +15,6 @@ const defaultPreferences = {
   },
   showUnreadBadge: true,
   useSpellChecker: true,
-  spellCheckerLocale: 'en-US',
 };
 
 module.exports = defaultPreferences;

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -12,11 +12,8 @@ function merge(base, target) {
 const defaultPreferences = require('./config/defaultPreferences');
 const upgradePreferences = require('./config/upgradePreferences');
 
-function loadDefault(spellCheckerLocale) {
-  const config = JSON.parse(JSON.stringify(defaultPreferences));
-  return Object.assign({}, config, {
-    spellCheckerLocale: spellCheckerLocale || defaultPreferences.spellCheckerLocale || 'en-US',
-  });
+function loadDefault() {
+  return JSON.parse(JSON.stringify(defaultPreferences));
 }
 
 function hasBuildConfigDefaultTeams(config) {

--- a/src/main.js
+++ b/src/main.js
@@ -79,8 +79,7 @@ try {
     settings.writeFileSync(configFile, config);
   }
 } catch (e) {
-  const spellCheckerLocale = SpellChecker.getSpellCheckerLocale(app.getLocale());
-  config = settings.loadDefault(null, spellCheckerLocale);
+  config = settings.loadDefault();
   console.log('Failed to read or upgrade config.json', e);
   if (!config.teams.length && config.defaultTeam) {
     config.teams.push(config.defaultTeam);
@@ -384,6 +383,12 @@ app.on('will-finish-launching', () => {
 app.on('ready', () => {
   if (global.willAppQuit) {
     return;
+  }
+
+  if (!config.spellCheckerLocale) {
+    config.spellCheckerLocale = SpellChecker.getSpellCheckerLocale(app.getLocale());
+    const configFile = app.getPath('userData') + '/config.json';
+    settings.writeFileSync(configFile, config);
   }
 
   const appStateJson = path.join(app.getPath('userData'), 'app-state.json');

--- a/test/specs/spellchecker_test.js
+++ b/test/specs/spellchecker_test.js
@@ -3,6 +3,28 @@ const path = require('path');
 const SpellChecker = require('../../src/main/SpellChecker');
 
 describe('main/Spellchecker.js', function() {
+  describe('getSpellCheckerLocale()', () => {
+    it('should return recognized locale', () => {
+      SpellChecker.getSpellCheckerLocale('en').should.equal('en-US');
+      SpellChecker.getSpellCheckerLocale('en-US').should.equal('en-US');
+
+      SpellChecker.getSpellCheckerLocale('fr').should.equal('fr-FR');
+      SpellChecker.getSpellCheckerLocale('fr-FR').should.equal('fr-FR');
+
+      SpellChecker.getSpellCheckerLocale('de').should.equal('de-DE');
+      SpellChecker.getSpellCheckerLocale('de-DE').should.equal('de-DE');
+
+      SpellChecker.getSpellCheckerLocale('es').should.equal('es-ES');
+      SpellChecker.getSpellCheckerLocale('es-ES').should.equal('es-ES');
+
+      SpellChecker.getSpellCheckerLocale('nl').should.equal('nl-NL');
+      SpellChecker.getSpellCheckerLocale('nl-NL').should.equal('nl-NL');
+
+      SpellChecker.getSpellCheckerLocale('ja').should.equal('en-US');
+      SpellChecker.getSpellCheckerLocale('ja-JP').should.equal('en-US');
+    });
+  });
+
   describe('en-US', function() {
     let spellchecker = null;
 


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fix correct spellchecker locale is not selected for non en-US locales.

While launching the app, `app.getLocale()` can't return correct locale until `ready` event is emitted. So default `en-US` was chosen.
In this fix, `defaultPreferences.js` would lose `spellCheckerLocale` parameter because it should be determined by user's system locale.

Tested on macOS 10.12.

**Issue link**
#632

**Test Cases**
Before testing, change computer's locale to non en-US locale such as `de-DE` (Germany).
1. Make sure `config.json` is removed before launching the app.
2. Start the app.
3. The app should use correct locale for spellchecker.
4. `config.json` should have `spellCheckerLocale` parameter with correct locale.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/635#artifacts