### PR TITLE
Ignore did-fail-load event when trying to use U2F devices

### DIFF
--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -16,6 +16,9 @@ const ErrorView = require('./ErrorView.jsx');
 
 const preloadJS = `file://${remote.app.getAppPath()}/browser/webview/mattermost_bundle.js`;
 
+const ERR_NOT_IMPLEMENTED = -11;
+const U2F_EXTENSION_URL = 'chrome-extension://kmendfapggjehodndflmmgagdbamhnfd/u2f-comms.html';
+
 function extractFileURL(message) {
   const matched = message.match(/Not allowed to load local resource:\s*(.+)/);
   if (matched) {
@@ -70,6 +73,11 @@ const MattermostView = createReactClass({
     webview.addEventListener('did-fail-load', (e) => {
       console.log(self.props.name, 'webview did-fail-load', e);
       if (e.errorCode === -3) { // An operation was aborted (due to user action).
+        return;
+      }
+      if (e.errorCode === ERR_NOT_IMPLEMENTED && e.validatedURL === U2F_EXTENSION_URL) {
+        // U2F device is not supported, but the guest page should fall back to PIN code in 2FA.
+        // https://github.com/mattermost/desktop/issues/708
         return;
       }
 


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Ignore did-fail-load event when trying to use U2F devices.

The guest page should fall back to another option, so the app need to keep the screen even when the error occurred.

**Issue link**
#708 

**Test Cases**
1. Set up U2F devices for 2FA.
2. Add a URL as a server in order to login with U2F devices, such as https://gitlab.com.
3. Try to login.
4. The login form should fall back to PIN code in 2FA.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/680#artifacts