### PR TITLE
 Add "Enable GPU hardware acceleration" option

### DIFF
--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -136,6 +136,7 @@ const SettingsPage = createReactClass({
       showUnreadBadge: this.state.showUnreadBadge,
       useSpellChecker: this.state.useSpellChecker,
       spellCheckerLocale: this.state.spellCheckerLocale,
+      enableHardwareAcceleration: this.state.enableHardwareAcceleration,
     };
 
     settings.writeFile(this.props.configFile, config, (err) => {
@@ -255,6 +256,13 @@ const SettingsPage = createReactClass({
   handleChangeUseSpellChecker() {
     this.setState({
       useSpellChecker: !this.refs.useSpellChecker.props.checked,
+    });
+    setImmediate(this.startSaveConfig, CONFIG_TYPE_APP_OPTIONS);
+  },
+
+  handleChangeEnableHardwareAcceleration() {
+    this.setState({
+      enableHardwareAcceleration: !this.refs.enableHardwareAcceleration.props.checked,
     });
     setImmediate(this.startSaveConfig, CONFIG_TYPE_APP_OPTIONS);
   },
@@ -548,6 +556,23 @@ const SettingsPage = createReactClass({
           </HelpBlock>
         </Checkbox>);
     }
+
+    options.push(
+      <Checkbox
+        key='inputEnableHardwareAcceleration'
+        id='inputEnableHardwareAcceleration'
+        ref='enableHardwareAcceleration'
+        checked={this.state.enableHardwareAcceleration}
+        onChange={this.handleChangeEnableHardwareAcceleration}
+      >
+        {'Use GPU hardware acceleration'}
+        <HelpBlock>
+          {'Disable this setting if you see a blank page after logging in to Mattermost.'}
+          {' If enabled, the Mattermost UI is rendered more efficiently but can cause stability issues for some systems.'}
+          {' Setting takes affect after restarting the app.'}
+        </HelpBlock>
+      </Checkbox>
+    );
 
     var optionsRow = (options.length > 0) ? (
       <Row>

--- a/src/common/config/defaultPreferences.js
+++ b/src/common/config/defaultPreferences.js
@@ -15,6 +15,7 @@ const defaultPreferences = {
   },
   showUnreadBadge: true,
   useSpellChecker: true,
+  enableHardwareAcceleration: true,
 };
 
 module.exports = defaultPreferences;

--- a/src/main.js
+++ b/src/main.js
@@ -88,6 +88,10 @@ try {
     settings.writeFileSync(configFile, config);
   }
 }
+if (config.enableHardwareAcceleration === false) {
+  app.disableHardwareAcceleration();
+}
+
 ipcMain.on('update-config', () => {
   const configFile = app.getPath('userData') + '/config.json';
   config = settings.readFileSync(configFile);

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -272,7 +272,6 @@ describe('browser/settings.html', function desc() {
         const existing = await this.app.client.isExisting('#inputSpellChecker');
         existing.should.equal(true);
 
-        await this.app.client.scroll('#inputSpellChecker');
         const selected = await this.app.client.isSelected('#inputSpellChecker');
         selected.should.equal(true);
 

--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -281,6 +281,30 @@ describe('browser/settings.html', function desc() {
         config1.useSpellChecker.should.equal(false);
       });
     });
+
+    describe('Enable GPU hardware acceleration', () => {
+      it('should save selected option', async () => {
+        const ID_INPUT_ENABLE_HARDWARE_ACCELERATION = '#inputEnableHardwareAcceleration';
+        env.addClientCommands(this.app.client);
+        await this.app.client.
+          loadSettingsPage().
+          waitForExist(ID_INPUT_ENABLE_HARDWARE_ACCELERATION, 5000);
+        const selected = await this.app.client.isSelected(ID_INPUT_ENABLE_HARDWARE_ACCELERATION);
+        selected.should.equal(true);
+
+        await this.app.client.click(ID_INPUT_ENABLE_HARDWARE_ACCELERATION).
+          waitForVisible('#appOptionsSaveIndicator', 5000).
+          waitForVisible('#appOptionsSaveIndicator', 5000, true); // at least 2500 ms to disappear
+        const config0 = JSON.parse(fs.readFileSync(env.configFilePath, 'utf-8'));
+        config0.enableHardwareAcceleration.should.equal(false);
+
+        await this.app.client.click(ID_INPUT_ENABLE_HARDWARE_ACCELERATION).
+          waitForVisible('#appOptionsSaveIndicator', 5000).
+          waitForVisible('#appOptionsSaveIndicator', 5000, true); // at least 2500 ms to disappear
+        const config1 = JSON.parse(fs.readFileSync(env.configFilePath, 'utf-8'));
+        config1.enableHardwareAcceleration.should.equal(true);
+      });
+    });
   });
 
   describe('RemoveServerModal', () => {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Add "Enable GPU hardware acceleration" option.

It's enabled by default.

**Issue link**
#713

**Test Cases**
- `config.json` (covered by CI)
    -  `enableHardwareAcceleration` key is saved when clicking the option in the settings page.

- Actual process
    1. Set `Enable GPU hardware acceleration` to disabled.
    2. Restart the app.
    3. Check running mattermost-desktop processes.
    4. Processes which have an argument `--type=gpu-process` should not exist.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/696#artifacts