### PR TITLE
Disable Certificate Transparency verification

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,7 @@ const os = require('os');
 const path = require('path');
 const isDev = require('electron-is-dev');
 const installExtension = require('electron-devtools-installer');
+const semver = require('semver');
 const squirrelStartup = require('./main/squirrelStartup');
 const CriticalErrorHandler = require('./main/CriticalErrorHandler');
 
@@ -609,6 +610,20 @@ app.on('ready', () => {
   const trustedURLs = settings.mergeDefaultTeams(config.teams).map((team) => team.url);
   permissionManager = new PermissionManager(permissionFile, trustedURLs);
   session.defaultSession.setPermissionRequestHandler(permissionRequestHandler(mainWindow, permissionManager));
+
+  // Disable Certificate Transparency until Electron 1.8.3
+  // due to https://github.com/electron/electron/issues/11997
+  if (semver.lt(process.versions.electron, '1.8.3')) {
+    const SUCCESS_AND_DISABLE_CERTIFICATE_TRANSPARENCY = 0;
+    const USE_VERIFICATION_RESULT_FROM_CHROMIUM = -3;
+    session.defaultSession.setCertificateVerifyProc((request, callback) => {
+      if (request.verificationResult === 'net::OK') {
+        callback(SUCCESS_AND_DISABLE_CERTIFICATE_TRANSPARENCY);
+      } else {
+        callback(USE_VERIFICATION_RESULT_FROM_CHROMIUM);
+      }
+    });
+  }
 
   // Open the DevTools.
   // mainWindow.openDevTools();


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Disable Certificate Transparency verification.

It seems that there is problem in Electron's Certificate Transparency verification.
https://github.com/electron/electron/issues/11997

Some error cases reported at #742 would be solved by disabling the verification. This is issued against to release-4.0. And we need to know whether Electron v1.8.3 actually fixes the issue.
https://github.com/mattermost/desktop/issues/742#issuecomment-376165341

**Issue link**
#742

**Test Cases**
- Case A: Certificate Transparency error
    1. Add the URL as a server which have the error appears.
    2. The error should not appear.

- Case B: Actually invalid
    1. Add the URL as a server which is actually insecure. e.g. https://expired.sca1a.amazontrust.com/
    2. HTTPS error should appear.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/709#artifacts