### PR TITLE
MM-9922 Don't show hovered URL for internal links

### DIFF
--- a/src/browser/components/HoveringURL.jsx
+++ b/src/browser/components/HoveringURL.jsx
@@ -2,10 +2,6 @@ const React = require('react');
 const PropTypes = require('prop-types');
 
 function HoveringURL(props) {
-  if (props.targetURL.startsWith(props.currentTeamURL)) {
-    return <div/>;
-  }
-
   return (
     <div className='HoveringURL HoveringURL-left'>
       {props.targetURL}
@@ -14,7 +10,6 @@ function HoveringURL(props) {
 }
 
 HoveringURL.propTypes = {
-  currentTeamURL: PropTypes.string,
   targetURL: PropTypes.string,
 };
 

--- a/src/browser/components/HoveringURL.jsx
+++ b/src/browser/components/HoveringURL.jsx
@@ -2,6 +2,10 @@ const React = require('react');
 const PropTypes = require('prop-types');
 
 function HoveringURL(props) {
+  if (props.targetURL.startsWith(props.currentTeamURL)) {
+    return <div/>;
+  }
+
   return (
     <div className='HoveringURL HoveringURL-left'>
       {props.targetURL}
@@ -10,6 +14,7 @@ function HoveringURL(props) {
 }
 
 HoveringURL.propTypes = {
+  currentTeamURL: PropTypes.string,
   targetURL: PropTypes.string,
 };
 

--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -372,6 +372,7 @@ const MainPage = createReactClass({
             >
               <HoveringURL
                 key='hoveringURL'
+                currentTeamURL={this.props.teams[this.state.key].url}
                 targetURL={this.state.targetURL}
               />
             </CSSTransition>

--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -317,6 +317,7 @@ const MainPage = createReactClass({
       authServerURL = `${tmpURL.protocol}//${tmpURL.host}`;
       authInfo = this.state.loginQueue[0].authInfo;
     }
+    var currentTeamURL = this.props.teams[this.state.key].url;
     var modal = (
       <NewTeamModal
         show={this.state.showNewTeamModal}
@@ -364,7 +365,7 @@ const MainPage = createReactClass({
           { viewsRow }
         </Grid>
         <TransitionGroup>
-          { (this.state.targetURL === '') ?
+          { (this.state.targetURL === '' || this.state.targetURL.startsWith(currentTeamURL)) ?
             null :
             <CSSTransition
               classNames='hovering'
@@ -372,7 +373,6 @@ const MainPage = createReactClass({
             >
               <HoveringURL
                 key='hoveringURL'
-                currentTeamURL={this.props.teams[this.state.key].url}
                 targetURL={this.state.targetURL}
               />
             </CSSTransition>


### PR DESCRIPTION
**Summary**
We keep getting tickets to hide different links throughout the app, but the root problem seems to be that these are links within the app, so they're not considered important. We still want the full URL to appear on hover for external links so the user can avoid malicious ones, but this should solve it without us making additional changes to the web app.

**Issue link**
https://mattermost.atlassian.net/browse/MM-9922

**Test Cases**
Tested locally using `yarn run watch`. Let me know if there's anywhere else that I should be adding tests