### PR TITLE
Clear webFrame cache at a certain interval

### DIFF
--- a/src/browser/webview/mattermost.js
+++ b/src/browser/webview/mattermost.js
@@ -7,7 +7,8 @@ const webFrame = electron.webFrame;
 const EnhancedNotification = require('../js/notification');
 
 const UNREAD_COUNT_INTERVAL = 1000;
-const CLEAR_CACHE_INTERVAL = 60 * 60 * 1000; // 1 hour
+//eslint-disable-next-line no-magic-numbers
+const CLEAR_CACHE_INTERVAL = 6 * 60 * 60 * 1000; // 6 hours
 
 Notification = EnhancedNotification; // eslint-disable-line no-global-assign, no-native-reassign
 

--- a/src/browser/webview/mattermost.js
+++ b/src/browser/webview/mattermost.js
@@ -7,6 +7,7 @@ const webFrame = electron.webFrame;
 const EnhancedNotification = require('../js/notification');
 
 const UNREAD_COUNT_INTERVAL = 1000;
+const CLEAR_CACHE_INTERVAL = 60 * 60 * 1000; // 1 hour
 
 Notification = EnhancedNotification; // eslint-disable-line no-global-assign, no-native-reassign
 
@@ -185,3 +186,10 @@ function setSpellChecker() {
 }
 setSpellChecker();
 ipc.on('set-spellcheker', setSpellChecker);
+
+// mattermost-webapp is SPA. So cache is not cleared due to no navigation.
+// We needed to manually clear cache to free memory in long-term-use.
+// http://seenaburns.com/debugging-electron-memory-usage/
+setInterval(() => {
+  webFrame.clearCache();
+}, CLEAR_CACHE_INTERVAL);


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Clear webFrame cache at a certain interval.

mattermost-webapp is SPA. So cache is not cleared due to no navigation by assuming this article.
http://seenaburns.com/debugging-electron-memory-usage/

We need to manually clear cache to free memory in long-term-use. Just for now, the interval is set to 1 hour.

**Issue link**
#710

**Test Cases**
Use an artifact for longer than the interval. After that, memory usage should not be highly increased.
For testing purpose, switching channels is a way to temporarily increase memory usage.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/712#artifacts