### PR TITLE
Make tabs undraggable

### DIFF
--- a/src/browser/components/TabBar.jsx
+++ b/src/browser/components/TabBar.jsx
@@ -49,6 +49,9 @@ class TabBar extends React.Component { // need "this"
           />
         </Overlay>
       );
+
+      // draggable=false is a workaround for https://github.com/mattermost/desktop/issues/667
+      // It would obstruct https://github.com/mattermost/desktop/issues/478
       return (
         <NavItem
           className='teamTabItem'
@@ -56,6 +59,7 @@ class TabBar extends React.Component { // need "this"
           id={id}
           eventKey={index}
           ref={id}
+          draggable={false}
         >
           <span className={unreadCount === 0 ? '' : 'teamTabItem-label'}>{team.name}</span>
           { ' ' }
@@ -71,6 +75,7 @@ class TabBar extends React.Component { // need "this"
           id='addServerButton'
           eventKey='addServerButton'
           title='Add new server'
+          draggable={false}
         >
           <Glyphicon glyph='plus'/>
         </NavItem>


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Make tabs undraggable.

This would block #478 in the future. But this is an easy workaround for now.

**Issue link**
#667

**Test Cases**
1. Add two servers at least.
2. Try to drag&drop a tab.
3. Anything should not happen.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/754#artifacts