### PR TITLE
Fix package.json to use correct package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "npm-run-all test:* lint:*",
     "test:app": "npm run build && mocha -r babel-register --reporter mocha-circleci-reporter --recursive test/specs",
     "package:all": "cross-env NODE_ENV=production npm-run-all check-build-config package:windows package:mac package:linux",
-    "package:windows": "cross-env NODE_ENV=production npm-run-all check-build-config build && build --win --x64 --ia32 --publish=never && npm run manipulate-windows-zip",
+    "package:windows": "cross-env NODE_ENV=production npm-run-all check-build-config build && build --win --x64 --ia32 --config.extraMetadata.name=mattermost --publish=never && npm run manipulate-windows-zip",
     "package:mac": "cross-env NODE_ENV=production npm-run-all check-build-config build && build --mac --publish=never",
     "package:linux": "cross-env NODE_ENV=production npm-run-all check-build-config build && build --linux --x64 --ia32 --config.extraMetadata.name=mattermost-desktop --publish=never",
     "manipulate-windows-zip": "node scripts/manipulate_windows_zip.js",


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fix package.json to use correct package name.

Probably it's regression of #749. The app was installed under `AppData\Local\mattermost-desktop`. It may causes an issue when upgrading the desktop app.

**Issue link**
N/A

**Test Cases**
1. Uninstall all `Mattermost` from the Control Panel.
2. Install the artifact.
3. The app should be installed under `AppData\Local\mattermost`.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/797#artifacts