### PR TITLE
Fix an issue where Windows installer crashed in some cases

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -30,7 +30,9 @@ process.on('uncaughtException', criticalErrorHandler.processUncaughtExceptionHan
 global.willAppQuit = false;
 
 app.setAppUserModelId('com.squirrel.mattermost.Mattermost'); // Use explicit AppUserModelID
-if (squirrelStartup()) {
+if (squirrelStartup(() => {
+  app.quit();
+})) {
   global.willAppQuit = true;
 }
 import settings from './common/settings';
@@ -279,7 +281,7 @@ app.on('activate', () => {
 
 app.on('before-quit', () => {
   // Make sure tray icon gets removed if the user exits via CTRL-Q
-  if (process.platform === 'win32') {
+  if (trayIcon && process.platform === 'win32') {
     trayIcon.destroy();
   }
   global.willAppQuit = true;


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fix an issue where Windows installer crashed in some cases.

Unfortunately the issue doesn't reproduce on my PC, so I'm not sure whether this PR can solve the problem.
Even though I found an issue in initial setup; a `null` object was being destroyed. So I fixed it and ensure that the initial setup correctly finishes.

**Issue link**
#728 

**Test Cases**
1. Install the desktop app with the installer exe.
2. The crash report dialog should not appear.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/798#artifacts