### PR TITLE
Pin electron-context-menu to version 0.9.0 (Fix for save image context item)

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -12,7 +12,7 @@
     "auto-launch": "^5.0.5",
     "bootstrap": "^3.3.7",
     "create-react-class": "^15.6.3",
-    "electron-context-menu": "^0.9.0",
+    "electron-context-menu": "0.9.0",
     "electron-devtools-installer": "^2.2.3",
     "electron-is-dev": "^0.3.0",
     "electron-squirrel-startup": "^1.0.0",

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -137,9 +137,9 @@ dom-helpers@^3.2.0, dom-helpers@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
 
-electron-context-menu@^0.9.0:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/electron-context-menu/-/electron-context-menu-0.9.1.tgz#ed4df20c080491c3c996abfcb363159946a38058"
+electron-context-menu@0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/electron-context-menu/-/electron-context-menu-0.9.0.tgz#8a66bef502f0524255a1350a2b4704dbaacfd503"
   dependencies:
     electron-dl "^1.2.0"
     electron-is-dev "^0.1.1"


### PR DESCRIPTION
This is a resolution to #707 

The root cause to this loss of functionality was this pull request merged into electron-context-menu about 1 year ago: https://github.com/sindresorhus/electron-context-menu/pull/40/files#diff-168726dbe96b3ce427e7fedce31bb0bcL48

By eliminating the arguments in the click event important context was lost in its downstream dependency [electron-dl](https://github.com/sindresorhus/electron-dl/blob/master/index.js#L129) which handled the target for the image download.

For now this issue can be solved by pinning version 0.9.0 which doesn't include that change, and in the mean time I've also opened a pull request to electron-context-menu itself that restores these parameters: https://github.com/sindresorhus/electron-context-menu/pull/54