### PR TITLE
Revert "Merge pull request #745 from mattermost/mm9922"

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -317,7 +317,6 @@ const MainPage = createReactClass({
       authServerURL = `${tmpURL.protocol}//${tmpURL.host}`;
       authInfo = this.state.loginQueue[0].authInfo;
     }
-    var currentTeamURL = this.props.teams[this.state.key].url;
     var modal = (
       <NewTeamModal
         show={this.state.showNewTeamModal}
@@ -365,7 +364,7 @@ const MainPage = createReactClass({
           { viewsRow }
         </Grid>
         <TransitionGroup>
-          { (this.state.targetURL === '' || this.state.targetURL.startsWith(currentTeamURL)) ?
+          { (this.state.targetURL === '') ?
             null :
             <CSSTransition
               classNames='hovering'


### PR DESCRIPTION
**Summary**
Unfortunately, the actual behaviour that we want where hovered links in posts always show the URL isn't possible with this behaviour since I haven't found a way to identify what in the WebView has been hovered from these events, so this will have to be handled from the web app.

**Issue link**
https://mattermost.atlassian.net/browse/MM-9922