### PR TITLE
Improve error messages on add new server dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ Release date: TBD
 [#707](https://github.com/mattermost/desktop/issues/707)
 - Fixed an issue that prevented typing in the form fields on the add server dialog when launched from the tab bar.
 [#780](https://github.com/mattermost/desktop/issues/780)
+- Fixed an issue that could cause an error message on the add new server dialog to be misleading.
+[#438](https://github.com/mattermost/desktop/issues/438)
 
 #### Windows
 - Fixed `file://` protocol not working. But localhost URL will not continue to work.

--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -68,7 +68,17 @@ export default class NewTeamModal extends React.Component {
   }
 
   getError() {
-    return this.getTeamNameValidationError() || this.getTeamUrlValidationError();
+    const nameError = this.getTeamNameValidationError();
+    const urlError = this.getTeamUrlValidationError();
+
+    if (nameError && urlError) {
+      return 'Name and URL are required.';
+    } else if (nameError) {
+      return nameError;
+    } else if (urlError) {
+      return urlError;
+    }
+    return null;
   }
 
   validateForm() {


### PR DESCRIPTION
Closes #438

This solution is different than what @jasonblais suggested. @jasonblais suggested not highlighting the field that hasn't been filled out yet, but I think it's a better UX to continue to highlight them all as it currently does, but to clarify the error messages. Also notably, as far as I can tell, the react-bootstrap [forms API](https://react-bootstrap.github.io/components/forms/) does not appear to support selectively highlighting some fields in the form but not others anyway.

Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting