### PR TITLE
Fix for being unable to type in the form fields on the add server dialog when launched from the tab bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ Release date: TBD
 [#708](https://github.com/mattermost/desktop/issues/708)
 - Fixed an issue where the main screen opens a blank page when a tab is dropped into the screen.
 [#667](https://github.com/mattermost/desktop/issues/667)
+- Fixed an issue that prevented typing in the form fields on the add server dialog when launched from the tab bar.
+[#780](https://github.com/mattermost/desktop/issues/780)
 
 #### Windows
 - Fixed `file://` protocol not working. But localhost URL will not continue to work.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mattermost-desktop",
   "productName": "Mattermost",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Mattermost",
   "main": "main.js",
   "author": "Mattermost, Inc. <feedback@mattermost.com>",

--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -148,6 +148,9 @@ export default class NewTeamModal extends React.Component {
                 value={this.state.teamName}
                 placeholder='Server Name'
                 onChange={this.handleTeamNameChange.bind(this)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                }}
               />
               <FormControl.Feedback/>
               <HelpBlock>{'The name of the server displayed on your desktop app tab bar.'}</HelpBlock>
@@ -163,6 +166,9 @@ export default class NewTeamModal extends React.Component {
                 value={this.state.teamUrl}
                 placeholder='https://example.com'
                 onChange={this.handleTeamUrlChange.bind(this)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                }}
               />
               <FormControl.Feedback/>
               <HelpBlock className='NewTeamModal-noBottomSpace'>{'The URL of your Mattermost server. Must start with http:// or https://.'}</HelpBlock>

--- a/src/package.json
+++ b/src/package.json
@@ -2,7 +2,7 @@
   "name": "mattermost-desktop",
   "productName": "Mattermost",
   "desktopName": "Mattermost.desktop",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Mattermost",
   "main": "main_bundle.js",
   "author": "Mattermost, Inc. <feedback@mattermost.com>",


### PR DESCRIPTION

Closes #780

Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting