### PR TITLE
Add workaround for permissionRequestHandler error on deep linking

### DIFF
--- a/src/main/permissionRequestHandler.js
+++ b/src/main/permissionRequestHandler.js
@@ -37,7 +37,14 @@ export default function permissionRequestHandler(mainWindow, permissionManager) 
     dequeueRequests(requestQueue, permissionManager, origin, permission, status);
   });
   return (webContents, permission, callback) => {
-    const targetURL = new URL(webContents.getURL());
+    let targetURL;
+    try {
+      targetURL = new URL(webContents.getURL());
+    } catch (err) {
+      console.log(err);
+      callback(false);
+      return;
+    }
     if (permissionManager.isDenied(targetURL.origin, permission)) {
       callback(false);
       return;


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Add workaround for permissionRequestHandler error on deep linking.

The original problem doesn't happen on my PC. However the call stack indicates the error happened at permissionRequestHandler apart from deep linking.
So it seems there is a timing that the handler failed to get URL. I added try-catch statement for workaround. 

**Issue link**
#771

**Test Cases**
See #771. Quit the desktop app, then click mattermost:// link in web browser.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/816#artifacts