### PR TITLE
Fix an error where the main page gets blank when adding a server

### DIFF
--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -227,9 +227,10 @@ const MattermostView = createReactClass({
 
   focusOnWebView() {
     const webview = findDOMNode(this.refs.webview);
-    if (!webview.getWebContents().isFocused()) {
+    const webContents = webview.getWebContents(); // webContents might not be created yet.
+    if (webContents && webContents.isFocused()) {
       webview.focus();
-      webview.getWebContents().focus();
+      webContents.focus();
     }
   },
 


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fix an error where the main page gets blank when adding a server.

When adding a server on the main page, it tries to get focus to the new webview. However probably its webContents object is not created yet, so null reference error happened for me.

**Issue link**
N/A

Original report: https://pre-release.mattermost.com/core/pl/53y7wdj3wtye3pnewpfajzuatc

**Test Cases**
Add a server from `+` button of the main page or [File/Mattermost ->Sign in to Another Server] menu item.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/822#artifacts