### PR TITLE
Make sure that cookies are saved to disk when closing the app

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -46,6 +46,7 @@ import allowProtocolDialog from './main/allowProtocolDialog';
 import PermissionManager from './main/PermissionManager';
 import permissionRequestHandler from './main/permissionRequestHandler';
 import AppStateManager from './main/AppStateManager';
+import initCookieManager from './main/cookieManager';
 
 import SpellChecker from './main/SpellChecker';
 
@@ -422,6 +423,8 @@ app.on('ready', () => {
       setDeeplinkingUrl(tmpArgs[0]);
     }
   }
+
+  initCookieManager(session.defaultSession);
 
   mainWindow = createMainWindow(config, {
     hideOnStartup,

--- a/src/main/cookieManager.js
+++ b/src/main/cookieManager.js
@@ -1,0 +1,22 @@
+import {app} from 'electron';
+
+function flushCookiesStore(session) {
+  session.cookies.flushStore((err) => {
+    if (err) {
+      console.log(err);
+    }
+  });
+}
+
+export default function initCookieManager(session) {
+  // Somehow cookies are not immediately saved to disk.
+  // So manually flush cookie store to disk on closing the app.
+  // https://github.com/electron/electron/issues/8416
+  app.on('before-quit', () => {
+    flushCookiesStore(session);
+  });
+
+  app.on('browser-window-blur', () => {
+    flushCookiesStore(session);
+  });
+}


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Make sure that cookies are saved to disk when closing the app.

Somehow cookies are not immediately saved to disk. Possibly https://github.com/electron/electron/issues/8416 is related.
So I manually called [`cookies.flushStore()`](https://electronjs.org/docs/api/cookies#cookiesflushstorecallback) when the app is quitting or the window loses focus. This would cover almost use cases even if application crashed.


**Issue link**
Original report: https://pre-release.mattermost.com/core/pl/m4s6qfjb5f815x4co388pscrfe

**Test Cases**
1. Quit the app.
2. Remove the application data folder
    - Windows: `AppData\Roaming\Mattermost`
    - Mac: `~/Library/Application Support/Mattermost`
    - Linux: `~/.config/Mattermost`
3. Open the app.
4. Login to webapp then quit the app soon (`Ctrl/Cmd+Q` shortcut).
5. Reopen the app.
6. You should not be logged out from webapp.

**Additional Notes**
