### PR TITLE
Fix MattermostView.focusOnWebview() if statement

### DIFF
--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -228,7 +228,7 @@ const MattermostView = createReactClass({
   focusOnWebView() {
     const webview = findDOMNode(this.refs.webview);
     const webContents = webview.getWebContents(); // webContents might not be created yet.
-    if (webContents && webContents.isFocused()) {
+    if (webContents && !webContents.isFocused()) {
       webview.focus();
       webContents.focus();
     }


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Fix `MattermostView.focusOnWebview()` if statement.

It's my mistake when fixing #787. Necessary `!` was missing.

**Issue link**
#790 

**Test Cases**
1. Click the dock/taskbar icon to focus on the desktop app
2. Press CMD/CTRL+K to open channel switcher

And test cases of #787

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/826#artifacts