### PR TITLE
Update create_desktop_file.sh with categories

### DIFF
--- a/resources/linux/create_desktop_file.sh
+++ b/resources/linux/create_desktop_file.sh
@@ -13,5 +13,6 @@ Exec="${FULL_PATH}/mattermost-desktop"
 Terminal=false
 Type=Application
 Icon=${FULL_PATH}/icon.png
+Categories=Network;InstantMessaging;
 EOS
 chmod +x Mattermost.desktop


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Add "Categories=Network;InstantMessaging;" to ensure that Mattermost is listed under the appropriate submenu of the application starter.

**Test Cases**
Tested with KDE/Plasma 5.46/5.12.5 and KMenu. With the change, Mattermost is listed under "Internet", without the change Mattermost is listed under "Lost & Found".
