### PR TITLE
Startup via config json

### DIFF
--- a/src/common/config/defaultPreferences.js
+++ b/src/common/config/defaultPreferences.js
@@ -20,6 +20,7 @@ const defaultPreferences = {
   showUnreadBadge: true,
   useSpellChecker: true,
   enableHardwareAcceleration: true,
+  autostart: false,
 };
 
 export default defaultPreferences;

--- a/src/common/config/defaultPreferences.js
+++ b/src/common/config/defaultPreferences.js
@@ -20,7 +20,7 @@ const defaultPreferences = {
   showUnreadBadge: true,
   useSpellChecker: true,
   enableHardwareAcceleration: true,
-  autostart: false,
+  autostart: true,
 };
 
 export default defaultPreferences;

--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,7 @@ import {parse as parseArgv} from 'yargs';
 import {protocols} from '../electron-builder.json';
 
 import squirrelStartup from './main/squirrelStartup';
+import AutoLauncher from './main/AutoLauncher';
 import CriticalErrorHandler from './main/CriticalErrorHandler';
 
 const criticalErrorHandler = new CriticalErrorHandler();
@@ -102,6 +103,15 @@ if (config.enableHardwareAcceleration === false) {
 ipcMain.on('update-config', () => {
   const configFile = app.getPath('userData') + '/config.json';
   config = settings.readFileSync(configFile);
+  if (process.platform === 'win32' || process.platform === 'linux') {
+    const appLauncher = new AutoLauncher();
+    const autoStartTask = config.autostart ? appLauncher.enable() : appLauncher.disable();
+    autoStartTask.then(() => {
+      console.log('config.autostart has been configured:', config.autostart);
+    }).catch((err) => {
+      console.log('error:', err);
+    });
+  }
   const trustedURLs = settings.mergeDefaultTeams(config.teams).map((team) => team.url);
   permissionManager.setTrustedURLs(trustedURLs);
   ipcMain.emit('update-dict', true, config.spellCheckerLocale);

--- a/src/main/AutoLauncher.js
+++ b/src/main/AutoLauncher.js
@@ -1,0 +1,48 @@
+// Copyright (c) 2015-2016 Yuya Ochiai
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import AutoLaunch from 'auto-launch';
+import {app} from 'electron';
+import isDev from 'electron-is-dev';
+
+export default class AutoLauncher {
+  constructor() {
+    this.appLauncher = new AutoLaunch({
+      name: app.getName(),
+      isHidden: true,
+    });
+  }
+
+  isEnabled() {
+    return this.appLauncher.isEnabled();
+  }
+
+  async blankPromise() {
+    return null;
+  }
+
+  async enable() {
+    if (isDev) {
+      console.log('In development mode, autostart config never effects');
+      return this.blankPromise();
+    }
+    const enabled = await this.isEnabled();
+    if (!enabled) {
+      return this.appLauncher.enable();
+    }
+    return this.blankPromise();
+  }
+
+  async disable() {
+    if (isDev) {
+      console.log('In development mode, autostart config never effects');
+      return this.blankPromise();
+    }
+    const enabled = await this.isEnabled();
+    if (enabled) {
+      return this.appLauncher.disable();
+    }
+    return this.blankPromise();
+  }
+}


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
<!--
Write a short (one line) summary that describes the changes in this pull request for inclusion in the changelog
-->

**Issue link**
https://mattermost.atlassian.net/browse/MM-11474

**Test Cases**

Case A: Confirm "app start on login" is on by default.
1. Install then launch the app.
2. Quit the app.
3. Log out then log in.
4. Confirm that the app launches on login

Case B: Edit config.json.
1. Quit the app.
2. Edit config.json to set `autostart: false`.
3. Launch the app.
4. Confirm that "app start on login" is disabled.

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/957#artifacts