### PR TITLE
Hide the main window on Mac auto-start

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -50,6 +50,7 @@ import PermissionManager from './main/PermissionManager';
 import permissionRequestHandler from './main/permissionRequestHandler';
 import AppStateManager from './main/AppStateManager';
 import initCookieManager from './main/cookieManager';
+import {shouldBeHiddenOnStartup} from './main/utils';
 
 import SpellChecker from './main/SpellChecker';
 
@@ -65,11 +66,7 @@ let appState = null;
 let permissionManager = null;
 
 const argv = parseArgv(process.argv.slice(1));
-
-var hideOnStartup;
-if (argv.hidden) {
-  hideOnStartup = true;
-}
+const hideOnStartup = shouldBeHiddenOnStartup(argv);
 
 if (argv['data-dir']) {
   app.setPath('userData', path.resolve(argv['data-dir']));

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -1,0 +1,17 @@
+// Copyright (c) 2015-2016 Yuya Ochiai
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {app} from 'electron';
+
+export function shouldBeHiddenOnStartup(parsedArgv) {
+  if (parsedArgv.hidden) {
+    return true;
+  }
+  if (process.platform === 'darwin') {
+    if (app.getLoginItemSettings().wasOpenedAsHidden) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Hide the main window on Mac auto-start

**Issue link**
#583

**Test Cases**
1. Configure auto-start on Mac: https://support.apple.com/kb/PH25590?viewlocale=en_US
2. Select the "Hide" checkbox next to Mattermost.
3. Logout from Mac.
4. Login to Mac.
5. The app should launch automatically, but the window should not appear.

**Additional Notes**
Artifacts: https://circleci.com/gh/yuya-oc/desktop/966#artifacts