### PR TITLE
MM-11910: Add a '[US]' to the word 'English' in the dictionary, and add Portuguese to settings helps text list 

### DIFF
--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -417,7 +417,7 @@ const SettingsPage = createReactClass({
         {'Check spelling'}
         <HelpBlock>
           {'Highlight misspelled words in your messages.'}
-          {' Available for English, French, German, Spanish, and Dutch.'}
+          {' Available for English, French, German, Portuguese, Spanish, and Dutch.'}
         </HelpBlock>
       </Checkbox>);
 

--- a/src/browser/js/contextMenu.js
+++ b/src/browser/js/contextMenu.js
@@ -22,7 +22,7 @@ function getSuggestionsMenus(win, suggestions) {
 function getSpellCheckerLocaleMenus(onSelectSpellCheckerLocale) {
   const currentLocale = ipcRenderer.sendSync('get-spellchecker-locale');
   const locales = [
-    {language: 'English', locale: 'en-US'},
+    {language: 'English (US)', locale: 'en-US'},
     {language: 'French', locale: 'fr-FR'},
     {language: 'German', locale: 'de-DE'},
     {language: 'Spanish', locale: 'es-ES'},


### PR DESCRIPTION
Before submitting, please confirm you've
 - [X] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [X] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [-] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Add a '[US]' to the word 'English' in the dictionary, and add Portuguese to settings helps text list 

**Issue link**
https://mattermost.atlassian.net/browse/MM-11910

**Test Cases**

**Additional Notes**
