### PR TITLE
Add flag for AppImage packaging

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -26,7 +26,8 @@
     "category": "Network;InstantMessaging",
     "target": [
       "deb",
-      "tar.gz"
+      "tar.gz",
+      "appimage"
     ],
     "extraFiles": [
       {


### PR DESCRIPTION
**Summary**
Sets a flag in the electron builder that enables AppImage packaging.

**Additional Notes**
This would enable most linux users to simply run the application from the downloaded image and if wanted sets the necessary path variables to launch it from the preferred desktop environment. 
IMO it is better than distributing with a .deb or .rpm package, because it's distribution independent and comes with all needed dependencies, if any. Also it is just a minor change in packaging that enables a lot more users to comfortably install and use the app on their system.