### PR TITLE
Update NOTICE.txt

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -10,12 +10,14 @@ This document includes a list of open source components used in Mattermost Deskt
 
 ## auto-launch
 
-This product contains a modified portion of 'auto-launch', which allows one to launch any application or executable at startup, by Teamwork.com.
+This product contains 'auto-launch' by Donal Linehan.
+
+Launch node applications or executables at login (Mac, Windows, and Linux)
 
 * HOMEPAGE:
-  * https://github.com/Teamwork/node-auto-launch
+  * https://github.com/4ver/node-auto-launch
 
-* LICENSE:
+* LICENSE: MIT
 
 MIT License
 
@@ -43,18 +45,18 @@ SOFTWARE.
 
 ## bootstrap
 
-This product contains a modified portion of 'bootstrap', which is an HTML, CSS, and JavaScript framework for developing responsive, mobile first
-projects on the web, by Twitter, Inc. and Bootstrap Authors.
+This product contains 'bootstrap' by The Bootstrap Authors.
+
+The most popular front-end framework for developing responsive, mobile first projects on the web.
 
 * HOMEPAGE:
-  * https://github.com/twbs/bootstrap
+  * https://getbootstrap.com/
 
-* LICENSE:
+* LICENSE: MIT
 
 The MIT License (MIT)
 
-Copyright (c) 2011-2017 Twitter, Inc.
-Copyright (c) 2011-2017 The Bootstrap Authors
+Copyright (c) 2011-2016 Twitter, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -78,105 +80,82 @@ THE SOFTWARE.
 
 ## electron-context-menu
 
-This product contains a modified portion of 'electron-context-menu', which provides a context menu for Electron apps, by Sindre Sorhus.
+This product contains 'electron-context-menu' by Sindre Sorhus.
+
+Context menu for your Electron app
 
 * HOMEPAGE:
-  * https://github.com/sindresorhus/electron-context-menu
+  * https://github.com/sindresorhus/electron-context-menu#readme
 
-* LICENSE:
+* LICENSE: MIT
 
-The MIT License (MIT)
+MIT License
 
 Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
 ## electron-devtools-installer
 
-This product contains a modified portion of 'electron-devtools-installer', which allows an easy way to ensure Chrome DevTools extensions into Electron,
-by Samuel Attard.
+This product contains 'electron-devtools-installer' by Samuel Attard.
+
+An easy way to install Dev Tools extensions into Electron applications
 
 * HOMEPAGE:
-  * https://github.com/MarshallOfSound/electron-devtools-installer
+  * https://github.com/GPMDP/electron-devtools-installer#readme
 
-* LICENSE:
+* LICENSE: MIT
 
 The MIT License (MIT)
 Copyright (c) 2016 Samuel Attard
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files
-(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
-FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
 ## electron-is-dev
 
-This product contains a modified portion of 'electron-is-dev', which checks if Electron is running in development, by Sindre Sorhus.
+This product contains 'electron-is-dev' by Sindre Sorhus.
+
+Check if Electron is running in development
 
 * HOMEPAGE:
-  * https://github.com/sindresorhus/electron-is-dev
+  * https://github.com/sindresorhus/electron-is-dev#readme
 
-* LICENSE:
+* LICENSE: MIT
 
-The MIT License (MIT)
+MIT License
 
 Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
 ## electron-squirrel-startup
 
-This product contains a modified portion of 'electron-squirrel-startup', a default Squirrel.Windows event handler for Electron apps, by mongodb-js.
+This product contains 'electron-squirrel-startup' by Lucas Hrabovsky.
+
+Default Squirrel.Windows event handler for your Electron apps.
 
 * HOMEPAGE:
-  * https://github.com/mongodb-js/electron-squirrel-startup
+  * http://github.com/mongodb-js/electron-squirrel-startup
 
-* LICENSE:
+* LICENSE: Apache-2.0
 
 Apache License
 Version 2.0, January 2004
@@ -384,57 +363,14 @@ limitations under the License.
 
 ## prop-types
 
-This product contains a modified portion of 'prop-types', runtime type checking for React props and similar objects, by Facebook, Inc.
+This product contains 'prop-types' by Facebook.
+
+Runtime type checking for React props and similar objects.
 
 * HOMEPAGE:
-  * https://github.com/facebook/prop-types
+  * https://facebook.github.io/react/
 
-* LICENSE:
-
-BSD License
-
-For React software
-
-Copyright (c) 2013-present, Facebook, Inc.
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
- * Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
- * Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
- * Neither the name Facebook nor the names of its contributors may be used to
-   endorse or promote products derived from this software without specific
-   prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
----
-
-## react
-
-This product contains a modified portion of 'react', a declarative, efficient, and flexible JavaScript library for building user interfaces,
-and 'react-dom', the entry point of the DOM-related
-rendering paths, by Facebook, Inc.
-
-* HOMEPAGE:
-  * https://github.com/facebook/react
-
-* LICENSE:
+* LICENSE: MIT
 
 MIT License
 
@@ -460,15 +396,51 @@ SOFTWARE.
 
 ---
 
-## react-bootstrap
+## react
 
-This product contains a modified portion of 'react-bootstrap', Bootstrap 3 components for front-end framework built with React, by Stephen J. Collings,
-Matthew Honnibal, Pieter Vanderwerff and react-bootstrap.
+This product contains 'react' by Facebook.
+
+React is a JavaScript library for building user interfaces.
 
 * HOMEPAGE:
-  * https://github.com/react-bootstrap/react-bootstrap
+  * https://reactjs.org/
 
-* LICENSE:
+* LICENSE: MIT
+
+MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+## react-bootstrap
+
+This product contains 'react-bootstrap' by Stephen J. Collings.
+
+Bootstrap 3 components built with React
+
+* HOMEPAGE:
+  * https://react-bootstrap.github.io/
+
+* LICENSE: MIT
 
 The MIT License (MIT)
 
@@ -494,14 +466,51 @@ THE SOFTWARE.
 
 ---
 
-## react-transition-group
+## react-dom
 
-This product contains a modified portion of 'react-transition-group', a fork, and "drop in" replacement for the original React TransitionGroup addons, by React Community.
+This product contains 'react-dom' by Facebook.
+
+React package for working with the DOM.
 
 * HOMEPAGE:
-  * https://github.com/reactjs/react-transition-group
+  * https://reactjs.org/
 
-* LICENSE:
+* LICENSE: MIT
+
+MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+## react-transition-group
+
+This product contains 'react-transition-group' by React Community.
+
+A react component toolset for managing animations
+
+* HOMEPAGE:
+  * https://github.com/reactjs/react-transition-group#readme
+
+* LICENSE: BSD-3-Clause
 
 BSD 3-Clause License
 
@@ -538,16 +547,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ## simple-spellchecker
 
-This product contains a modified portion of 'simple-spellchecker', a simple and fast spellchecker with spelling suggestions and Electron's integration, by jfmdev.
+This product contains 'simple-spellchecker' by JFMDev.
 
-Access to the source code of Simple Spellchecker ©jfmdev can be found at https://github.com/jfmdev/simple-spellchecker.
+A simple spellchecker compatible with Electron
 
 * HOMEPAGE:
-  * https://github.com/jfmdev/simple-spellchecker
+  * https://github.com/jfmdev/simple-spellchecker#readme
 
-* LICENSE:
+* LICENSE: MPL-2.0
 
-Mozilla Public License Version 2.0
+﻿Mozilla Public License Version 2.0
 ==================================
 
 1. Definitions
@@ -584,7 +593,7 @@ Mozilla Public License Version 2.0
     means any form of the work other than Source Code Form.
 
 1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in
+    means a work that combines Covered Software with other material, in 
     a separate file or files, that is not Covered Software.
 
 1.8. "License"
@@ -925,16 +934,16 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 
 ## underscore
 
-This product contains a modified portion of 'underscore', a utility-belt library for JavaScript that provides support for usual functional suspects
-without extending any core JavaScript objects, by Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors.
+This product contains 'underscore' by Jeremy Ashkenas.
+
+JavaScript's functional programming helper library.
 
 * HOMEPAGE:
-  * https://github.com/jashkenas/underscore
+  * http://underscorejs.org
 
-* LICENSE:
+* LICENSE: MIT
 
-The MIT License (MIT)
-Copyright (c) 2009-2017 Jeremy Ashkenas, DocumentCloud and Investigative
+Copyright (c) 2009-2018 Jeremy Ashkenas, DocumentCloud and Investigative
 Reporters & Editors
 
 Permission is hereby granted, free of charge, to any person
@@ -962,12 +971,14 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ## yargs
 
-This product contains a modified portion of 'yargs', a modern successor to optimist, by James Halliday and Yargs.
+This product contains 'yargs' by GitHub user "yargs".
+
+yargs the modern, pirate-themed, successor to optimist.
 
 * HOMEPAGE:
-  * https://github.com/yargs/yargs
+  * http://yargs.js.org/
 
-* LICENSE:
+* LICENSE: MIT
 
 Copyright 2010 James Halliday (mail@substack.net)
 Modified work Copyright 2014 Contributors (ben@npmjs.com)


### PR DESCRIPTION
**Summary**
Update NOTICE.txt with latest open-source license info

**Additional Notes**
This follows the recent NOTICE.txt update to `mattermost-server`, PR here: https://github.com/mattermost/mattermost-server/pull/9433

The only difference is that this is an NPM-based project, so the dependency manifest is created by listing the "dependencies" section of all `package.json` files.

- Add new dependencies (react-dom)
- Update homepage and project owner info for all dependencies
- Add SPDX open-source license IDs

Linebreak/whitespace changes in this PR are to match the original LICENSE files supplied with each dependency. This is a one-time change that will make future automated updates smaller.

