### PR TITLE
Preserve case of first letter in spell check, fixes #562

### DIFF
--- a/src/main/SpellChecker.js
+++ b/src/main/SpellChecker.js
@@ -70,7 +70,24 @@ export default class SpellChecker extends EventEmitter {
   }
 
   getSuggestions(word, maxSuggestions) {
-    return this.dict.getSuggestions(word, maxSuggestions);
+    const suggestions = this.dict.getSuggestions(word, maxSuggestions);
+
+    const firstCharWord = word.charAt(0);
+    let i;
+    for (i = 0; i < suggestions.length; i++) {
+      if (suggestions[i].charAt(0).toUpperCase() === firstCharWord.toUpperCase()) {
+        suggestions[i] = firstCharWord + suggestions[i].slice(1);
+      }
+    }
+
+    const uniqueSuggestions = suggestions.reduce((a, b) => {
+      if (a.indexOf(b) < 0) {
+        a.push(b);
+      }
+      return a;
+    }, []);
+
+    return uniqueSuggestions;
   }
 }
 

--- a/test/specs/spellchecker_test.js
+++ b/test/specs/spellchecker_test.js
@@ -67,6 +67,27 @@ describe('main/Spellchecker.js', function() {
       spellchecker.spellCheck('Mattermost').should.equal(true);
       spellchecker.spellCheck('mattermost').should.equal(true);
     });
+
+    it('should give at most the requested number of suggestions', function() {
+      // helllo known to give at least 4 suggestions
+      spellchecker.getSuggestions('helllo', 4).length.should.be.equal(4);
+      spellchecker.getSuggestions('helllo', 1).length.should.be.equal(1);
+    });
+
+    it('should give suggestions which preserve case of first letter', function() {
+      let suggestions = spellchecker.getSuggestions('carr', 4);
+      suggestions.length.should.not.be.equal(0);
+      let i;
+      for (i = 0; i < suggestions.length; i++) {
+        suggestions[i].charAt(0).should.be.equal('c');
+      }
+
+      suggestions = spellchecker.getSuggestions('Carr', 4);
+      suggestions.length.should.not.be.equal(0);
+      for (i = 0; i < suggestions.length; i++) {
+        suggestions[i].charAt(0).should.be.equal('C');
+      }
+    });
   });
 
   describe('en-GB', function() {
@@ -106,6 +127,21 @@ describe('main/Spellchecker.js', function() {
       spellchecker.spellCheck('1').should.equal(true);
       spellchecker.spellCheck('-100').should.equal(true);
       spellchecker.spellCheck('3.14').should.equal(true);
+    });
+
+    it('should give suggestions which preserve case of first letter', function() {
+      let suggestions = spellchecker.getSuggestions('gutenn', 4);
+      suggestions.length.should.not.be.equal(0);
+      let i;
+      for (i = 0; i < suggestions.length; i++) {
+        suggestions[i].charAt(0).should.be.equal('g');
+      }
+
+      suggestions = spellchecker.getSuggestions('Gutenn', 4);
+      suggestions.length.should.not.be.equal(0);
+      for (i = 0; i < suggestions.length; i++) {
+        suggestions[i].charAt(0).should.be.equal('G');
+      }
     });
   });
 });


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Preserve case of first letter in spell check, fixes #562

**Issue link**
https://github.com/mattermost/desktop/issues/562

**Test Cases**

**Additional Notes**
Implemented as described in yuya-oc's proposal from Jul 12, 2017