### PR TITLE
[WIP] Add team switch shortcut

### DIFF
--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -129,6 +129,24 @@ function createTemplate(mainWindow, config, isDev) {
     }, {
       role: 'togglefullscreen',
     }, separatorItem, {
+      label: 'Team',
+      submenu: [{
+        label: 'Team 1',
+        accelerator: 'CmdOrCtrl+1',
+        click(item, focusedWindow) {
+        },
+      }, {
+        label: 'Team 2',
+        accelerator: 'CmdOrCtrl+2',
+        click(item, focusedWindow) {
+        },
+      }, {
+        label: 'Team 3',
+        accelerator: 'CmdOrCtrl+3',
+        click(item, focusedWindow) {
+        },
+      }]
+    }, separatorItem, {
       role: 'resetzoom',
     }, {
       role: 'zoomin',


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [ ] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**

This is a rough work in progress aiming to add a shortcut for team switch

**Issue link**

https://github.com/mattermost/desktop/issues/850

**Test Cases**

1. Connect to a mattermost instance where you belong to two teams
1. Press Cmd/Ctrl+1 to switch to team 1
1. Press Cmd/Ctrl+2 to switch to team 2
1. Press Cmd/Ctrl+3 to switch to team 3

**Additional Notes**

As I said, this is very early in the development but pushing this PR will help me discussed with advanced electron developer (I'm just a newbie in this area).

Currently the teams are added statically (three team numbered from 1 to 3) but I would like it to be dynamic and correctly named.