### PR TITLE
MM-12800 Remove partial ability to use file:// links

### DIFF
--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -22,25 +22,6 @@ const preloadJS = `file://${remote.app.getAppPath()}/browser/webview/mattermost_
 const ERR_NOT_IMPLEMENTED = -11;
 const U2F_EXTENSION_URL = 'chrome-extension://kmendfapggjehodndflmmgagdbamhnfd/u2f-comms.html';
 
-function extractFileURL(message) {
-  const matched = message.match(/Not allowed to load local resource:\s*(.+)/);
-  if (matched) {
-    return matched[1];
-  }
-  return '';
-}
-
-function isNetworkDrive(fileURL) {
-  const u = url.parse(fileURL);
-  if (u.protocol === 'file:' && u.host) {
-    // Disallow localhost, 127.0.0.1, ::1.
-    if (!u.host.match(/^localhost$|^127\.0\.0\.1$|^\[::1\]$/)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 export default class MattermostView extends React.Component {
   constructor(props) {
     super(props);
@@ -191,19 +172,9 @@ export default class MattermostView extends React.Component {
       case 1:
         console.warn(message);
         break;
-      case 2: {
-        const fileURL = extractFileURL(e.message);
-        if (isNetworkDrive(fileURL)) {
-          // Network drive: Should be allowed.
-          if (!shell.openExternal(decodeURI(fileURL))) {
-            console.log(`[${this.props.name}] shell.openExternal failed: ${fileURL}`);
-          }
-        } else {
-          // Local drive such as 'C:\Windows': Should not be allowed.
-          console.error(message);
-        }
+      case 2:
+        console.error(message);
         break;
-      }
       default:
         console.log(message);
         break;


### PR DESCRIPTION
We've decided to match the behaviour of most browsers by not allowing these links. They only worked sometimes anyway, so it's easier to not support them in all cases than inconsistently support them.

**Issue link**
https://mattermost.atlassian.net/browse/MM-12800
