### PR TITLE
Upgrade Electron to 2.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "cross-env": "^5.1.6",
     "css-loader": "^0.28.11",
     "devtron": "^1.4.0",
-    "electron": "2.0.8",
+    "electron": "2.0.12",
     "electron-builder": "20.14.7",
     "electron-builder-squirrel-windows": "~20.14.0",
     "electron-connect": "^0.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3726,9 +3726,9 @@ electron-to-chromium@^1.3.47:
   version "1.3.48"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz#d3b0d8593814044e092ece2108fc3ac9aea4b900"
 
-electron@2.0.8:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.8.tgz#6ec7113b356e09cc9899797e0d41ebff8163e962"
+electron@2.0.12:
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.12.tgz#04b11ef3246cd2a5839a8f16314051341dc5c449"
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Upgrade Electron to 2.0.12.

I believe there are no breaking changes from 2.0.8 to 2.0.12 as far as reading their release notes.

And I found Electron v3 and Spectron v5 break almost of our tests. I think it's hard to solve soon, so I used Electron v2.x.

**Issue link**
N/A

**Test Cases**
Automated tests. (`npm test`)

**Additional Notes**
https://circleci.com/gh/yuya-oc/desktop/1016#artifacts