### PR TITLE
Add eslint-plugin-eslint-comments

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,8 @@
 {
-    "extends": "./.eslintrc-webapp.json",
+    "extends": [
+      "./.eslintrc-webapp.json",
+      "plugin:eslint-comments/recommended"
+    ],
     "parserOptions": {
         "ecmaVersion": 2017
     },
@@ -7,6 +10,7 @@
         "import/resolver": "node"
     },
     "rules": {
+        "eslint-comments/no-unused-disable": "error",
         "header/header": [2, "line", [
             " Copyright (c) 2015-2016 Yuya Ochiai",
             " Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4898,6 +4898,24 @@
         "globals": "^11.0.1"
       }
     },
+    "eslint-plugin-eslint-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.1.1.tgz",
+      "integrity": "sha512-GZDKhOFqJLKlaABX+kdoLskcTINMrVOWxGca54KcFb1QCPd0CLmqgAMRxkkUfGSmN+5NJUMGh7NGccIMcWPSfQ==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "ignore": "^5.0.5"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.5.tgz",
+          "integrity": "sha512-kOC8IUb8HSDMVcYrDVezCxpJkzSQWTAzf3olpKM6o9rM5zpojx23O0Fl8Wr4+qJ6ZbPEHqf1fdwev/DS7v7pmA==",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-header": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eslint": "^5.9.0",
     "eslint-config-mattermost": "github:mattermost/eslint-config-mattermost",
     "eslint-plugin-cypress": "^2.1.2",
+    "eslint-plugin-eslint-comments": "^3.1.1",
     "eslint-plugin-header": "^2.0.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-react": "^7.11.1",

--- a/scripts/extract_dict.js
+++ b/scripts/extract_dict.js
@@ -2,6 +2,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+// This file uses process.exit().
 /* eslint-disable no-process-exit */
 
 const {spawn} = require('child_process');
@@ -19,3 +20,5 @@ spawn(path7za, ['e', '-y', '*.zip'], {
 }).on('close', (code) => {
   process.exit(code);
 });
+
+/* eslint-enable no-process-exit */

--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -2,6 +2,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+// This files uses setState().
 /* eslint-disable react/no-set-state */
 
 import url from 'url';
@@ -459,3 +460,5 @@ MainPage.propTypes = {
   requestingPermission: TabBar.propTypes.requestingPermission,
   onClickPermissionDialog: PropTypes.func,
 };
+
+/* eslint-enable react/no-set-state */

--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -2,8 +2,8 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+// This file uses setState().
 /* eslint-disable react/no-set-state */
-// setState() is necessary for this component
 
 import url from 'url';
 
@@ -303,3 +303,5 @@ MattermostView.propTypes = {
   useSpellChecker: PropTypes.bool,
   onSelectSpellCheckerLocale: PropTypes.func,
 };
+
+/* eslint-enable react/no-set-state */

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -2,6 +2,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+// This file uses setState().
 /* eslint-disable react/no-set-state */
 
 import React from 'react';
@@ -628,3 +629,5 @@ SettingsPage.propTypes = {
   configFile: PropTypes.string,
   enableServerManagement: PropTypes.bool,
 };
+
+/* eslint-enable react/no-set-state */

--- a/src/main.js
+++ b/src/main.js
@@ -284,7 +284,7 @@ function handleScreenResize(screen, browserWindow) {
 
 app.on('browser-window-created', (e, newWindow) => {
   // Screen cannot be required before app is ready
-  const {screen} = electron; // eslint-disable-line global-require
+  const {screen} = electron;
   handleScreenResize(screen, newWindow);
 });
 

--- a/test/specs/settings_test.js
+++ b/test/specs/settings_test.js
@@ -39,7 +39,7 @@ describe('common/settings.js', () => {
 describe('common/config/', () => {
   it('pastDefaultPreferences should have each past version of defaultPreferences', () => {
     for (let version = 0; version <= defaultPreferences.version; version++) {
-      pastDefaultPreferences[`${version}`].should.exist; // eslint-disable-line no-unused-expressions
+      pastDefaultPreferences[`${version}`].should.exist;
     }
   });
 

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -2,6 +2,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+// This file uses CommonJS.
 /* eslint-disable import/no-commonjs */
 'use strict';
 
@@ -19,3 +20,5 @@ module.exports = {
   ] : [],
   devtool: isProduction ? false : '#inline-source-map',
 };
+
+/* eslint-enable import/no-commonjs */

--- a/webpack.config.main.js
+++ b/webpack.config.main.js
@@ -2,6 +2,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+// This files uses CommonJS.
 /* eslint-disable import/no-commonjs */
 'use strict';
 
@@ -23,3 +24,5 @@ module.exports = merge(base, {
   },
   target: 'electron-main',
 });
+
+/* eslint-enable import/no-commonjs */

--- a/webpack.config.renderer.js
+++ b/webpack.config.renderer.js
@@ -2,6 +2,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+// This file uses CommonJS.
 /* eslint-disable import/no-commonjs */
 'use strict';
 
@@ -53,3 +54,5 @@ module.exports = merge(base, {
     publicPath: '/browser/',
   },
 });
+
+/* eslint-enable import/no-commonjs */


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Add eslint-plugin-eslint-comments. It prevents abuse of `eslint-disable` directive.

See https://mysticatea.github.io/eslint-plugin-eslint-comments/ for detail.

**Issue link**
N/A

**Test Cases**
Add unwanted `/* eslint-disable */` comments, then execute `npm run lint:js`. It should report errors.

**Additional Notes**
N/A