### PR TITLE
build a portable Windows target

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -77,6 +77,7 @@
   "win": {
     "target": [
       "nsis",
+      "portable",
       "zip"
     ],
     "extraFiles": [
@@ -90,5 +91,8 @@
   },
   "nsis": {
     "artifactName": "${name}-setup-${version}-win.${ext}"
+  },
+  "portable": {
+    "artifactName": "${name}-portable-${version}-win.${ext}"
   }
 }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -26,6 +26,11 @@
         "regenerator-runtime": "^0.12.0"
       }
     },
+    "@warren-bank/electron-portable-paths": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@warren-bank/electron-portable-paths/-/electron-portable-paths-3.0.8.tgz",
+      "integrity": "sha512-RavDQfvE15fv20BB4WELMTpaD5Sh6Nhi57QdjD/Gp3cTLIJENpyOfiWNyZ2NUxlzIv+LN+198rblwHl4082neA=="
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",

--- a/src/package.json
+++ b/src/package.json
@@ -9,6 +9,7 @@
   "homepage": "https://about.mattermost.com",
   "license": "Apache-2.0",
   "dependencies": {
+    "@warren-bank/electron-portable-paths": "^3.0.8",
     "auto-launch": "^5.0.5",
     "bootstrap": "^3.3.7",
     "electron-context-menu": "^0.10.1",


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**

* adds the windows build target: "portable"
* adds the dependency: [electron-portable-paths](https://github.com/warren-bank/electron-portable-paths)
* in [`src/main.js`](https://github.com/warren-bank/electron-mattermost-desktop/blob/PR-01-win-portable/src/main.js#L73-L79):
  * uses the new dependency around the code that checks `argv['data-dir']`
  * the purpose of the imported [function](https://github.com/warren-bank/electron-portable-paths/blob/master/src/index.js) is to:
    * detect whether the electron app is a windows portable build
    * if so: call `app.setPath()` such that the paths to all special directories are relative to the `.exe`

**Issue link**

_N/A_

although:
* it should be noted that the resulting portable .exe is effected by [this issue](https://github.com/electron/electron/issues/11858#issuecomment-366050737)
  * erroneously creates the empty directory: `%APPDATA%\Mattermost\logs`

**Test Cases**

* [release w/ binary builds](https://github.com/warren-bank/electron-mattermost-desktop/releases/tag/v4.2.0.05-win-portable)

**Additional Notes**
