### PR TITLE
add a menu to open dev tools for current webview

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -112,6 +112,10 @@ export default class MainPage extends React.Component {
       focusListener();
     });
 
+    ipcRenderer.on('open-devtool', () => {
+      document.getElementById(`mattermostView${self.state.key}`).openDevTools();
+    });
+
     //goBack and goForward
     ipcRenderer.on('go-back', () => {
       const mattermost = self.refs[`mattermostView${self.state.key}`];

--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -145,7 +145,7 @@ function createTemplate(mainWindow, config, isDev) {
       visible: false,
       role: 'zoomout',
     }, separatorItem, {
-      label: 'Toggle Developer Tools',
+      label: 'Developer Tools for Application Wrapper',
       accelerator: (() => {
         if (process.platform === 'darwin') {
           return 'Alt+Command+I';
@@ -156,6 +156,11 @@ function createTemplate(mainWindow, config, isDev) {
         if (focusedWindow) {
           focusedWindow.toggleDevTools();
         }
+      },
+    }, {
+      label: 'Developer Tools for Current Server',
+      click() {
+        mainWindow.webContents.send('open-devtool');
       },
     }],
   });


### PR DESCRIPTION
Before submitting, please confirm you've
 - [X] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [X] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [X] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**

Add a menu to open dev tools for current webview 

**Issue link**

https://github.com/mattermost/mattermost-server/issues/10131

**Test Cases**

**Additional Notes**

![mattermost-desktop-console](https://user-images.githubusercontent.com/1492516/52380527-6a516880-2a6e-11e9-8b07-ecaf9169bca4.gif)
