### PR TITLE
GPO: Configure server addresses and prevent adding new servers

### DIFF
--- a/resources/windows/gpo/en-US/mattermost.adml
+++ b/resources/windows/gpo/en-US/mattermost.adml
@@ -11,6 +11,24 @@
 
 If this policy is disabled or not configured, the Mattermost Desktop Application receives updates.
 </string>
+      <string id="PreventAddNewServer">Prevent adding new Mattermost server</string>
+      <string id="PreventAddNewServer_Explain">If this policy is enabled, it is not possible to add new servers.
+
+If this policy is disabled or not configured, it is possible to add new servers.
+</string>
+      <string id="ServerURL">Server addresses</string>
+      <string id="ServerURL_Explain">If this policy is enabled, you can set one or more Mattermost server addresses. Use the syntax Servername,https://server.com|Servername2,https://server2.com
+
+If this policy is disabled or not configured, no servers are preconfigured.</string>
+    </stringTable>
+    <presentationTable>
+	<presentation id="ServerURL">
+        <text>URL:</text>
+        <textBox refId="ServerURL">
+          <label/>
+        </textBox>
+      </presentation>
+	  </presentationTable>
     </stringTable>
   </resources>
 </policyDefinitionResources>

--- a/resources/windows/gpo/mattermost.admx
+++ b/resources/windows/gpo/mattermost.admx
@@ -24,5 +24,22 @@
         <decimal value="0"/>
       </disabledValue>
     </policy>
-   </policies>
+    <policy name="PreventAddNewServer" class="Both" displayName="$(string.PreventAddNewServer)" explainText="$(string.PreventAddNewServer_Explain)" key="Software\Policies\Mattermost" valueName="PreventAddNewServer">
+      <parentCategory ref="mattermost"/>
+      <supportedOn ref="SUPPORTED_MMD43"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy name="ServerURL" class="Both" displayName="$(string.ServerURL)" explainText="$(string.ServerURL_Explain)" key="Software\Policies\Mattermost" presentation="$(presentation.ServerURL)" >
+      <parentCategory ref="mattermost"/>
+      <supportedOn ref="SUPPORTED_MMD43"/>
+      <elements >
+        <text id="ServerURL" valueName="URL" required="true" />
+      </elements>
+    </policy>
+  </policies>
 </policyDefinitions>


### PR DESCRIPTION
This pull request add the GPO functionality to

- configure the server addresses
- control if the + for adding more server is available or not

Target for 4.3, if not we need to change slightly this policy before merge. 