### PR TITLE
GH-848 Add flag to enable MacOS dark mode title bar

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -56,6 +56,7 @@
       "zip",
       "dmg"
     ],
+    "darkModeSupport": true,
     "extraResources": [
       {
         "filter": [


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Enabled MacOS Mojave Dark Mode title bar.

**Issue link**
- https://github.com/mattermost/desktop/issues/848
- https://mattermost.uservoice.com/forums/306457-general/suggestions/36842986-desktop-mac-mojave-dark-titlebar


**Additional Notes**
Tested on MacOS 10.14.3.