### PR TITLE
Add it-IT as spellchecker

### DIFF
--- a/src/browser/js/contextMenu.js
+++ b/src/browser/js/contextMenu.js
@@ -26,7 +26,7 @@ function getSpellCheckerLocaleMenus(onSelectSpellCheckerLocale) {
     {language: 'English (US)', locale: 'en-US'},
     {language: 'French', locale: 'fr-FR'},
     {language: 'German', locale: 'de-DE'},
-    {language: 'Italien', locale: 'it-IT'},
+    {language: 'Italian', locale: 'it-IT'},
     {language: 'Portuguese (BR)', locale: 'pt-BR'},
     {language: 'Spanish (ES)', locale: 'es-ES'},
     {language: 'Spanish (MX)', locale: 'es-MX'},

--- a/src/browser/js/contextMenu.js
+++ b/src/browser/js/contextMenu.js
@@ -26,6 +26,7 @@ function getSpellCheckerLocaleMenus(onSelectSpellCheckerLocale) {
     {language: 'English (US)', locale: 'en-US'},
     {language: 'French', locale: 'fr-FR'},
     {language: 'German', locale: 'de-DE'},
+    {language: 'Italien', locale: 'it-IT'},
     {language: 'Portuguese (BR)', locale: 'pt-BR'},
     {language: 'Spanish (ES)', locale: 'es-ES'},
     {language: 'Spanish (MX)', locale: 'es-MX'},

--- a/src/main/SpellChecker.js
+++ b/src/main/SpellChecker.js
@@ -104,6 +104,9 @@ SpellChecker.getSpellCheckerLocale = (electronLocale) => {
   if (electronLocale.match(/^es-?/)) {
     return 'es-ES';
   }
+  if (electronLocale.match(/^it-?/)) {
+    return 'it-IT';
+  }
   if (electronLocale.match(/^nl-?/)) {
     return 'nl-NL';
   }

--- a/test/specs/spellchecker_test.js
+++ b/test/specs/spellchecker_test.js
@@ -19,6 +19,9 @@ describe('main/Spellchecker.js', function() {
 
       SpellChecker.getSpellCheckerLocale('es').should.equal('es-ES');
       SpellChecker.getSpellCheckerLocale('es-ES').should.equal('es-ES');
+      
+      SpellChecker.getSpellCheckerLocale('it').should.equal('it-IT');
+      SpellChecker.getSpellCheckerLocale('it-IT').should.equal('it-IT');
 
       SpellChecker.getSpellCheckerLocale('nl').should.equal('nl-NL');
       SpellChecker.getSpellCheckerLocale('nl-NL').should.equal('nl-NL');


### PR DESCRIPTION
This pull request adds it-IT as available spellchecker within the DesktopApp.

Needs prior #938 to merge.