### PR TITLE
check the system activity and send activity messages to webapp

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -27,6 +27,7 @@ import {protocols} from '../electron-builder.json';
 
 import AutoLauncher from './main/AutoLauncher';
 import CriticalErrorHandler from './main/CriticalErrorHandler';
+import SystemActivityMonitor from './main/SystemActivityMonitor';
 import upgradeAutoLaunch from './main/autoLaunch';
 import autoUpdater from './main/autoUpdater';
 import buildConfig from './common/config/buildConfig';
@@ -417,6 +418,9 @@ app.on('ready', () => {
   if (global.willAppQuit) {
     return;
   }
+
+  const systemActivityMonitor = new SystemActivityMonitor();
+  systemActivityMonitor.start();
 
   if (!config.spellCheckerLocale) {
     config.spellCheckerLocale = SpellChecker.getSpellCheckerLocale(app.getLocale());

--- a/src/main/SystemActivityMonitor.js
+++ b/src/main/SystemActivityMonitor.js
@@ -1,0 +1,65 @@
+// Copyright (c) 2015-2016 Yuya Ochiai
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {ipcMain, powerMonitor} from 'electron';
+
+const ACTIVITY_CHECK_INTERVAL = 1000;
+const IDLE_THRESHOLD = 30;
+
+export default class SystemActivityMonitor {
+  constructor() {
+    this.sendActiveInterval = '';
+    this.stateCheckIinterval = '';
+    this.isIdle = false;
+
+    powerMonitor.on('suspend', () => {
+      this.
+        stop().
+        updateIdleState(true);
+    });
+
+    powerMonitor.on('lock-screen', () => {
+      this.
+        stop().
+        updateIdleState(true);
+    });
+
+    powerMonitor.on('resume', () => {
+      this.
+        start().
+        updateIdleState(false);
+    });
+
+    powerMonitor.on('unlock-screen', () => {
+      this.
+        start().
+        updateIdleState(false);
+    });
+
+    ipcMain.on('check-idle', (event) => {
+      event.returnValue = this.isIdle;
+    });
+  }
+
+  start() {
+    clearInterval(this.stateCheckIinterval);
+
+    this.stateCheckIinterval = setInterval(() => {
+      powerMonitor.querySystemIdleTime((idleTime) => {
+        this.updateIdleState(idleTime > IDLE_THRESHOLD);
+      });
+    }, ACTIVITY_CHECK_INTERVAL);
+    return this;
+  }
+
+  stop() {
+    clearInterval(this.stateCheckIinterval);
+    return this;
+  }
+
+  updateIdleState(isIdle) {
+    this.isIdle = isIdle;
+    return this;
+  }
+}


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Monitor system activity and keep user online 

**Issue link**
https://github.com/mattermost/mattermost-server/issues/7721

**Test Cases**

**Additional Notes**
required wabapp support (https://github.com/mattermost/mattermost-webapp/pull/2512) and server fix (https://github.com/mattermost/mattermost-server/pull/10458)