### PR TITLE
[MM-14172] Fix black screen when closing window in fullscreen on a Mac

### DIFF
--- a/src/main/mainWindow.js
+++ b/src/main/mainWindow.js
@@ -110,7 +110,15 @@ function createMainWindow(config, options) {
         }
         break;
       case 'darwin':
-        hideWindow(mainWindow);
+        // need to leave fullscreen first, then hide the window
+        if (mainWindow.isFullScreen()) {
+          mainWindow.once('leave-full-screen', () => {
+            hideWindow(mainWindow);
+          });
+          mainWindow.setFullScreen(false);
+        } else {
+          hideWindow(mainWindow);
+        }
         break;
       default:
       }


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
On Mac, when the window is closed in fullscreen, this PR first exits fullscreen and then closes the window to prevent a black screen when trying to close the window in fullscreen.

**Issue link**
[MM-14172](https://mattermost.atlassian.net/browse/MM-14172)
