### PR TITLE
[MM-14176] Fix restart after quitting in full screen

### DIFF
--- a/src/main/mainWindow.js
+++ b/src/main/mainWindow.js
@@ -9,7 +9,6 @@ import {app, BrowserWindow} from 'electron';
 function saveWindowState(file, window) {
   const windowState = window.getBounds();
   windowState.maximized = window.isMaximized();
-  windowState.fullscreen = window.isFullScreen();
   try {
     fs.writeFileSync(file, JSON.stringify(windowState));
   } catch (e) {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Removes logic that saves fullscreen state when quitting, allowing the app to always open up in windowed mode.

**Issue link**
Github: #863
Jira: [MM-14176](https://mattermost.atlassian.net/browse/MM-14176)

**Additional Notes**
I was unable to replicate the exact issue described in the ticket in Mac OS Mojave, however, there was still some odd behaviour for me (App went fullscreen, but didn't get focus). This fix corrects that odd behaviour and should also correct the High Sierra issue.
