### PR TITLE
open certain internal paths in default browser

### DIFF
--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -99,6 +99,9 @@ export default class MattermostView extends React.Component {
       if (Utils.isInternalURL(destURL, currentURL, this.state.basename)) {
         if (destURL.path.match(/^\/api\/v[3-4]\/public\/files\//)) {
           ipcRenderer.send('download-url', e.url);
+        } else if (destURL.path.match(/^\/help\//)) {
+          // continue to open special case internal urls in default browser
+          shell.openExternal(e.url);
         } else {
           // New window should disable nodeIntegration.
           window.open(e.url, remote.app.getName(), 'nodeIntegration=no, show=yes');


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
This PR opens the help link below the textbox in the default system browser instead of in the desktop app.

**Issue link**
[MM-14349](https://mattermost.atlassian.net/browse/MM-14349)

**Test Cases**
See issue link.