### PR TITLE
Update webpack-cli to fix error on npm run build

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "style-loader": "^0.21.0",
     "url-loader": "^1.0.1",
     "webpack": "^4.8.3",
-    "webpack-cli": "^2.1.4",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.4",
     "webpack-merge": "^4.1.2"
   }


### PR DESCRIPTION
Currently cloning and building the repo returns an error because of an outdated version of webpack-cli.
This PR updates the minimum required webpack version to 3.1.1 to enable building without errors again.