### PR TITLE
Move LoginModal username and password into instance properties, remove refs

### DIFF
--- a/src/browser/components/LoginModal.jsx
+++ b/src/browser/components/LoginModal.jsx
@@ -9,17 +9,23 @@ export default class LoginModal extends React.Component {
   constructor(props) {
     super(props);
     this.handleSubmit = this.handleSubmit.bind(this);
-    this.usernameRef = React.createRef();
-    this.passwordRef = React.createRef();
+    this.username = '';
+    this.password = '';
   }
 
   handleSubmit(event) {
     event.preventDefault();
-    const usernameNode = this.usernameRef.current;
-    const passwordNode = this.passwordRef.current;
-    this.props.onLogin(this.props.request, usernameNode.value, passwordNode.value);
-    usernameNode.value = '';
-    passwordNode.value = '';
+    this.props.onLogin(this.props.request, this.username, this.password);
+    this.username = '';
+    this.password = '';
+  }
+
+  setUsername = (e) => {
+    this.username = e.target.value;
+  }
+
+  setPassword = (e) => {
+    this.password = e.target.value;
   }
 
   render() {
@@ -54,7 +60,7 @@ export default class LoginModal extends React.Component {
                 <FormControl
                   type='text'
                   placeholder='User Name'
-                  ref={this.usernameRef}
+                  onChange={this.setUsername}
                   onClick={(e) => {
                     e.stopPropagation();
                   }}
@@ -70,7 +76,7 @@ export default class LoginModal extends React.Component {
                 <FormControl
                   type='password'
                   placeholder='Password'
-                  ref={this.passwordRef}
+                  onChange={this.setPassword}
                   onClick={(e) => {
                     e.stopPropagation();
                   }}


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Resolves an issue where username and password were not being passed for HTTP basic authentication.

**Issue link**
Fixes #965

**Test Cases**

**Additional Notes**
