### PR TITLE
[MM-11896] Do not use minimize shortcut on win32

### DIFF
--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -191,6 +191,9 @@ function createTemplate(mainWindow, config, isDev) {
     label: '&Window',
     submenu: [{
       role: 'minimize',
+
+      // empty string removes shortcut on Windows; null will default by OS
+      accelerator: process.platform === 'win32' ? '' : null,
     }, {
       role: 'close',
     }, separatorItem, ...teams.slice(0, 9).map((team, i) => {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [X] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [X] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [X] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Adds condition to remove accelerator for Window -> Minimize when `process.platform === 'win32'`. 

By setting accelerator to `null` for other platform values, Minimize will use the default shortcut on those platforms.

**Issue link**
Fixes https://github.com/mattermost/mattermost-server/issues/9398

**Test Cases**
I was unable to come up with a good way to test this, and didn't see any comparable tests in the app.  I prefer to have a test here, and would appreciate any guidance to achieve that.
