### PR TITLE
[MM-15385] Make license button always visible

### DIFF
--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -367,10 +367,8 @@
           <Text>!(loc.WelcomeDlgAcceptLicenseCheckBox)</Text>
         </Control>        
         
-        <Control Id="License" Type="PushButton" X="10" Y="243" Width="56" Height="17" TabSkip="yes" Hidden="yes" Property="AdvancedInstallation" Text="[ButtonText_License]">
+        <Control Id="License" Type="PushButton" X="10" Y="243" Width="56" Height="17" Property="AdvancedInstallation" Text="[ButtonText_License]">
           <Publish Event="NewDialog" Value="LicenseAgreementDlg"><![CDATA[1]]></Publish>
-          <Condition Action="hide"><![CDATA[AdvancedLicenseAccepted <> "true"]]></Condition>
-          <Condition Action="show"><![CDATA[AdvancedLicenseAccepted = "true"]]></Condition>
         </Control>
         <Control Id="Reset" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Reset]">
           <Publish Event="Reset" Value="0"><![CDATA[1]]></Publish>

--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -699,10 +699,8 @@
           </Control>
 
           <!-- TabSkip is needed in order to hack the zindex and make the button appear above the background image -->
-          <Control Id="License" Type="PushButton" X="10" Y="243" Width="56" Height="17" TabSkip="yes" Hidden="yes" Text="[ButtonText_License]">
+          <Control Id="License" Type="PushButton" X="10" Y="243" Width="56" Height="17" Text="[ButtonText_License]">
             <Publish Event="NewDialog" Value="LicenseAgreementDlg"><![CDATA[1]]></Publish>
-            <Condition Action="hide"><![CDATA[LicenseAccepted <> "true"]]></Condition>
-            <Condition Action="show"><![CDATA[LicenseAccepted = "true"]]></Condition>
           </Control>
           <Control Id="Advanced" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_AdvancedInstall]">
             <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[1]]></Publish>


### PR DESCRIPTION
Updates MSI installer definition file to leave license button as always visible.