### PR TITLE
[MM-15391] Turn auto-launch after installation off

### DIFF
--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -157,7 +157,7 @@
     <Property Id="ComponentDownload"><![CDATA[https://releases.mattermost.com/desktop/4.1.2/mattermost-setup-4.1.2-win64.msi]]></Property>
     <Property Id="ADDDESKTOPSHORTCUT">true</Property>
     <Property Id="ADDSTARTMENUSHORTCUT">true</Property>
-    <Property Id="LAUNCHAPPAFTERINSTALL">true</Property>
+    <Property Id="LAUNCHAPPAFTERINSTALL"></Property>
 
     <UI>
       <Publish Dialog="SuccessDlg" Control="Finish" Order="1" Event="DoAction" Value="LaunchApp">LAUNCHAPPAFTERINSTALL</Publish>


### PR DESCRIPTION
PR to set auto-launch of the desktop app after MSI installation completes to off by default.