### PR TITLE
[MM-15389] Prevent installing 32bit on 64bit and vise versa

### DIFF
--- a/resources/windows/msi_i18n/en_US.wxl
+++ b/resources/windows/msi_i18n/en_US.wxl
@@ -3,6 +3,9 @@
   <String Id="LANG" Overridable="yes">1033</String>
   
   <String Id="OsRequirements" Overridable="yes">Windows 7 or higher is required to run [ProductName].</String>
+
+  <String Id="Requires64Bit" Overridable="yes">This install package only supports 64-bit operating systems</String>
+  <String Id="Requires32Bit" Overridable="yes">This install package only supports 32-bit operating systems</String>
   
   <String Id="WelcomeDlgInstructions" Overridable="yes">Welcome to the [ProductName] [Wizard]!
 

--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -77,14 +77,8 @@
       <![CDATA[Installed OR (VersionNT >= 601)]]>
     </Condition>
 
-    <?if $(var.Platform) = x64 ?>
-      <Condition Message="!(loc.Requires64Bit)">
-        <![CDATA[VersionNT64]]>
-      </Condition>
-    <?else ?>
-      <Condition Message="!(loc.Requires32Bit)">
-        <![CDATA[NOT VersionNT64]]>
-      </Condition>
+    <?if $(var.Platform) != x64 ?>
+      <Condition Message="!(loc.Requires32Bit)"><![CDATA[NOT VersionNT64]]></Condition>
     <?endif ?>
     
     <!--<MajorUpgrade

--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -76,6 +76,16 @@
     <Condition Message="!(loc.OsRequirements)">
       <![CDATA[Installed OR (VersionNT >= 601)]]>
     </Condition>
+
+    <?if $(var.Platform) = x64 ?>
+      <Condition Message="!(loc.Requires64Bit)">
+        <![CDATA[VersionNT64]]>
+      </Condition>
+    <?else ?>
+      <Condition Message="!(loc.Requires32Bit)">
+        <![CDATA[NOT VersionNT64]]>
+      </Condition>
+    <?endif ?>
     
     <!--<MajorUpgrade
       DowngradeErrorMessage="A later version of [ProductName] is already installed. Setup will now exit." />-->


### PR DESCRIPTION
This PR configures the Desktop app MSI installers to prevent installation on non-matching-bit systems, i.e. the 32-bit installer won’t install on 64-bit systems.