### PR TITLE
Consolidated updates to MSI installer

### DIFF
--- a/resources/windows/license.rtf
+++ b/resources/windows/license.rtf
@@ -1,73 +1,56 @@
 {\rtf1\ansi\deff0\nouicompat{\fonttbl{\f0\fnil\fcharset0 Courier New;}}\pard\qj\f0\fs18
-Copyright (c) 2015-2016 Yuya Ochiai\par
-Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.\par
-\par
-Apache License\par
-Version 2.0, January 2004\par
-http://www.apache.org/licenses/\par
-\par
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\par
-\par
-\par
-1. Definitions.\par
-\par
-"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.\par
-\par
-"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.\par
-\par
-"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.\par
-\par
-"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.\par
-\par
-"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.\par
-\par
-"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.\par
-\par
-"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).\par
-\par
-"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.\par
-\par
-"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."\par
-\par
-"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.\par
-\par
-2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.\par
-\par
-3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.\par
-\par
-4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:\par
-\par
-(a) You must give any other recipients of the Work or Derivative Works a copy of this License; and\par
-\par
-(b) You must cause any modified files to carry prominent notices stating that You changed the files; and\par
-\par
-(c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and\par
-\par
-(d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.\par
-\par
-You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.\par
-\par
-5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.\par
-\par
-6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.\par
-\par
-7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.\par
-\par
-8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.\par
-\par
-9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.\par
-\par
-END OF TERMS AND CONDITIONS\par
-\par
-APPENDIX: How to apply the Apache License to your work.\par
-\par
-To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "\{\}" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.\par
-\par
-Copyright \{yyyy\} \{name of copyright owner\}\par
-\par
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at\par
-\par
-http://www.apache.org/licenses/LICENSE-2.0\par
-
-\par
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.\par
+\b Terms of Service\b0 
+\par\par
+The below are the Conditions of Use (End Users) for Mattermost, the software that powers the online service you are using, not for the service itself.
+\par\par
+\b Mattermost Conditions of Use (End Users)\b0 
+\par\par
+This instance of the Mattermost platform is provided to you for your use by a third party entity who is not Mattermost, Inc. Mattermost, Inc. owns some of the intellectual property required for use of the Mattermost platform, and as such, the third party has agreed that your use of our IP is allowed only if you agree and comply with the following terms and conditions.
+\par\par
+Your promise to comply with these conditions in exchange for access to the Mattermost IP via the Mattermost platform provided by a third party entity are an Agreement by and between you and Mattermost, Inc. (the “Agreement”).
+\par\par
+If you do not agree to these conditions, you may not use the Mattermost platform.
+\par\par
+1. Your Mattermost Account
+\par\par
+You may not use your Account in violation of any law or policies instituted by the entity providing you access to this Service.
+\par\par
+2. Responsibility of Contributors
+\par\par
+If you choose to make content available on the Mattermost platform (“Content”), you must ensure that the following is true:
+\par\par
+– the downloading, copying and use of the Content will not infringe the proprietary rights, including but not limited to the copyright, patent, trademark or trade secret rights, of any third party;
+\par\par
+– if your employer has rights to intellectual property you create, you have either (i) received permission from your employer to post or make available the Content, including but not limited to any software, or (ii) secured from your employer a waiver as to all rights in or to the Content;
+\par\par
+– you have fully complied with any third-party licenses relating to the Content, and have done all things necessary to successfully pass through to end users any required terms;
+\par\par
+– the Content does not contain or install any viruses, worms, malware, Trojan horses or other harmful or destructive content;
+\par\par
+– the Content is not spam, is not machine- or randomly-generated, and does not contain unethical or unwanted commercial content designed to drive traffic to third party sites or boost the search engine rankings of third party sites, or to further unlawful acts (such as phishing) or mislead recipients as to the source of the material (such as spoofing);
+\par\par
+– the Content is not pornographic, does not contain threats or incite violence, and does not violate the privacy or publicity rights of any third party;
+\par\par
+– your content is not getting advertised via unwanted electronic messages such as spam links on newsgroups, email lists, blogs and web sites, and similar unsolicited promotional methods;
+\par\par
+– your content is not named in a manner that misleads your readers into thinking that you are another person or company; and
+\par\par
+– you have, in the case of Content that includes computer code, accurately categorized and/or described the type, nature, uses and effects of the materials, whether requested to do so by Mattermost or otherwise.
+\par\par
+3. Intellectual Property
+\par\par
+Your use of the Mattermost platform does not transfer from Mattermost to you any Mattermost or third party intellectual property, and all right, title and interest in and to such property will remain (as between the parties) solely with Mattermost. Mattermost, mattermost.com, the mattermost.com logo, and all other trademarks, service marks, graphics and logos used in connection with mattermost.com, or the Mattermost platform are trademarks or registered trademarks of Mattermost or Mattermost’s licensors. Other trademarks, service marks, graphics and logos used in connection with the Platform may be the trademarks of other third parties.
+\par\par
+4. Disclaimer of Warranties
+\par\par
+THE MATTERMOST PLATFORM IS PROVIDED “AS IS.” MATTERMOST AND ITS SUPPLIERS AND LICENSORS HEREBY DISCLAIM ALL WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING, WITHOUT LIMITATION, THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. NEITHER MATTERMOST NOR ITS SUPPLIERS AND LICENSORS, MAKES ANY WARRANTY THAT THE MATTERMOST PLATFORM WILL BE ERROR FREE OR THAT SERVICES USING IT WILL BE CONTINUOUS OR UNINTERRUPTED.
+\par\par
+5. Limitation of Liability
+\par\par
+IN NO EVENT WILL MATTERMOST, OR ITS SUPPLIERS OR LICENSORS, BE LIABLE TO YOU UNDER ANY THEORY OF CONTRACT, NEGLIGENCE, STRICT LIABILITY OR OTHER LEGAL OR EQUITABLE THEORY FOR: (I) ANY SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES; (II) THE COST OF PROCUREMENT FOR SUBSTITUTE PRODUCTS OR SERVICES; (III) INTERRUPTION OF USE OR LOSS OR CORRUPTION OF DATA; OR (IV) ANY AMOUNTS IN EXCESS OF $50 USD.
+\par\par
+6. Indemnification
+\par\par
+You agree to indemnify and hold harmless Mattermost, its contractors, and its licensors, and their respective directors, officers, employees and agents from and against any and all claims and expenses, including attorneys’ fees, arising out of your use of the Mattermost platform, including but not limited to your violation of this Agreement.
+\par\par
+7. This Agreement constitutes the entire agreement between Mattermost and you concerning you use of the Mattermost platform provided by a third party. Except to the extent applicable law, if any, provides otherwise, this Agreement will be governed by the laws of the state of California, U.S.A., excluding its conflict of law provisions, and the proper venue for any disputes arising out of or relating to any of the same will be the state and federal courts located in San Francisco County, California. Except for claims for injunctive or equitable relief or claims regarding intellectual property rights (which may be brought in any competent court without the posting of a bond), any dispute arising under this Agreement shall be finally settled in accordance with the Comprehensive Arbitration Rules of the Judicial Arbitration and Mediation Service, Inc. (“JAMS”) by one arbitrator appointed in accordance with such Rules. The arbitration shall take place in San Francisco, California, in the English language and the arbitral decision may be enforced in any court. The prevailing party in any action or proceeding to enforce this Agreement shall be entitled to costs and attorneys’ fees. If any part of this Agreement is held invalid or unenforceable, that part will be construed to reflect the parties’ original intent, and the remaining portions will remain in full force and effect. A waiver by either party of any term or condition of this Agreement or any breach thereof, in any one instance, will not waive such term or condition or any subsequent breach thereof.

--- a/resources/windows/msi_i18n/en_US.wxl
+++ b/resources/windows/msi_i18n/en_US.wxl
@@ -3,6 +3,9 @@
   <String Id="LANG" Overridable="yes">1033</String>
   
   <String Id="OsRequirements" Overridable="yes">Windows 7 or higher is required to run [ProductName].</String>
+
+  <String Id="Requires64Bit" Overridable="yes">This install package only supports 64-bit operating systems</String>
+  <String Id="Requires32Bit" Overridable="yes">This install package only supports 32-bit operating systems</String>
   
   <String Id="WelcomeDlgInstructions" Overridable="yes">Welcome to the [ProductName] [Wizard]!
 

--- a/resources/windows/msi_i18n/en_US.wxl
+++ b/resources/windows/msi_i18n/en_US.wxl
@@ -7,21 +7,22 @@
   <String Id="Requires64Bit" Overridable="yes">This install package only supports 64-bit operating systems</String>
   <String Id="Requires32Bit" Overridable="yes">This install package only supports 32-bit operating systems</String>
   
-  <String Id="WelcomeDlgInstructions" Overridable="yes">Welcome to the [ProductName] [Wizard]!
+  <String Id="WelcomeDlgInstructions" Overridable="yes">Welcome to the [ProductName] [Installer]!
 
-Click Install to immediately proceed to the installation of [ProductName] or click Advanced if you want to customize the install process.</String>
-  <String Id="WelcomeDlgAcceptLicenseCheckBox" Overridable="yes">Accept the license agreement</String>
-  <String Id="AdvancedDlgInstructions" Overridable="yes">Welcome to the [ProductName] advanced [Wizard]!
+Click Install to proceed with a standard installation, or click Advanced to change the installation directory and access other customizations.</String>
 
-Change the installation directory to your likings, choose whether you want shortcuts and if you want to launch Mattermost after the installation process.</String>
-  <String Id="AdvancedDlgTitle" Overridable="yes">Mattermost Desktop Advanced install</String>
+  <String Id="MaintenanceWelcomeDlgInstructions" Overridable="yes">[ProductName] [Installer]!
+
+This wizard will help you install, modify, repair or uninstall the [ProductName] application on this computer.</String>
+  <String Id="WelcomeDlgAcceptLicenseCheckBox" Overridable="yes">I accept the terms in the License Agreement</String>
+  <String Id="AdvancedDlgInstructions" Overridable="yes">Change the installation directory, create application shortcuts and choose whether to launch the application after installation. Click Cancel to exit the installer.</String>
   <String Id="AdvancedDlgLocationLabel" Overridable="yes">Location:</String>
   <String Id="AdvancedDlgBrowse" Overridable="yes">Browse</String>
   <String Id="AdvancedDlgAddDesktopShortcut" Overridable="yes">Add a shortcut to the desktop</String>
-  <String Id="AdvancedDlgAddStartMenuShortcut" Overridable="yes">Add a shortcut to the start menu</String>
-  <String Id="AdvancedDlgLaunchAppAfterInstall" Overridable="yes">Launch [ProductName] just after the installation process</String>
+  <String Id="AdvancedDlgAddStartMenuShortcut" Overridable="yes">Add a shortcut to the Start menu</String>
+  <String Id="AdvancedDlgLaunchAppAfterInstall" Overridable="yes">Launch [ProductName] after installation</String>
   
-  <String Id="BrowseDlgInstructions" Overridable="yes">Select the directory you want Mattermost Desktop be installed to.</String>
+  <String Id="BrowseDlgInstructions" Overridable="yes">Select the directory you want [ProductName] be installed to.</String>
   <String Id="BrowseDlgNewFolder" Overridable="yes">Create a new folder</String>
   <String Id="BrowseDlgUp" Overridable="yes">Go thte parent folder</String>
   
@@ -29,24 +30,14 @@ Change the installation directory to your likings, choose whether you want short
   
   <String Id="CancelDlgText" Overridable="yes">Are you sure you want to cancel [ProductName] installation?</String>
   
-  <String Id="UserExitDlgInstructions" Overridable="yes">We are sad to see you go :-(
+  <String Id="UserExitDlgInstructions" Overridable="yes">[ProductName] installation was interrupted and your system has not been modified.
   
-[ProductName] setup was interrupted. Your system has not been modified.
-
-To install Mattermost Desktop at a later time, please run the installation again.
-
-Click the Finish button to exit the [Wizard].</String>
+  To install [ProductName] in the future, please run the installer again.</String>
   
-  <String Id="ProgressDlgInstructions" Overridable="yes">The [Wizard] [Progress2] [ProductName]. This may take several minutes.</String>
+  <String Id="ProgressDlgInstructions" Overridable="yes">[Progress1] [ProductName]. This may take several minutes.</String>
   <String Id="ProgressDlgStatusLabel" Overridable="yes">Status:</String>
   
-  <String Id="SuccessDlgInstructions" Overridable="yes">The installation process of Mattermost Desktop has been completed with succesful.
-
-You can now enjoy your corporate chat features.
-
-For any questions, we are always willing to help.
-
-Click the Finish button to exit the [Wizard].</String>
+  <String Id="SuccessDlgInstructions" Overridable="yes">[Progress2] successful. Click Finish to exit the installer.</String>
 
 
 </WixLocalization>

--- a/scripts/make_build.ps1
+++ b/scripts/make_build.ps1
@@ -139,55 +139,6 @@ Write-Host "Cleaning build dir..."
 Remove-Item .\release\win-ia32-unpacked\resources\app.asar.unpacked\ -Force -Recurse
 Remove-Item .\release\win-unpacked\resources\app.asar.unpacked\ -Force -Recurse
 
-# Convert license to RTF
-$licenseTxtFile = "$(Get-Location)/LICENSE.txt";
-$licenseRtfFile = "$(Get-Location)/resources/windows/license.rtf";
-$licenseNewParagraph = "\par" + [Environment]::NewLine;
-$sw = [System.IO.File]::CreateText($licenseRtfFile);
-$sw.WriteLine("{\rtf1\ansi\deff0\nouicompat{\fonttbl{\f0\fnil\fcharset0 Courier New;}}\pard\qj\f0\fs18");
-$lineToAdd = "";
-$gapDetected = 0;
-# We are relying on introspected C#/.NET rather than the buggy Get-Content
-# cmdlet because Get-Content considers by default a `-Delimiter` to '\n'
-# and thus breaks the purpose of the parser.
-foreach($line in [System.IO.File]::ReadLines($licenseTxtFile)) {
-    # trim() is equivalent to .replace("\ \s+", "")
-    # We replace one backslash by two. Since the first arg is a regex,
-    # we need to escape it.
-    # src.: https://stackoverflow.com/a/31324570/3514658
-    $sanitizedLine = $line.trim().replace("\\", "\\").replace("{", "\{").replace("}", "\}");
-    # Print previous string gathered if gap detected.
-    if ([string]::IsNullOrEmpty($sanitizedLine)) {
-        $gapDetected++;
-        # For first line keep paragraph definition from document head.
-        if ($gapDetected -eq 1) {
-            $sw.Write($lineToAdd);
-        } elseif ($gapDetected -eq 2) {
-            $sw.Write($licenseNewParagraph + $lineToAdd);
-        } else {
-            $sw.Write($licenseNewParagraph + $lineToAdd + $licenseNewParagraph);
-        }
-        $lineToAdd = "";
-        continue;
-    }
-    # Keep carriage return for first two blocks comprising Copyright and
-    # license name statements.
-    if ($gapDetected -lt 3) {
-        $lineToAdd += $sanitizedLine + $licenseNewParagraph;
-        continue;
-    }
-    # Do not add heading space if the line begins a new paragraph.
-    if ($lineToAdd -eq "") {
-        $lineToAdd += $sanitizedLine;
-        continue;
-    }
-    $lineToAdd += " " + $sanitizedLine;
-}
-if ($lineToAdd -ne "") {
-    $sw.Write([Environment]::NewLine + $licenseNewParagraph + $lineToAdd + "\par");
-}
-$sw.Close();
-
 heat dir .\release\win-ia32-unpacked\ -o .\scripts\msi_installer_files.wxs -scom -frag -srd -sreg -gg -cg MattermostDesktopFiles -t .\scripts\msi_installer_files_replace_id.xslt -dr INSTALLDIR
 candle.exe -dPlatform=x86 .\scripts\msi_installer.wxs .\scripts\msi_installer_files.wxs -o .\scripts\
 light.exe .\scripts\msi_installer.wixobj .\scripts\msi_installer_files.wixobj -loc .\resources\windows\msi_i18n\en_US.wxl -o .\release\mattermost-desktop-$($env:MATTERMOST_BUILD_ID)-x86.msi -b ./release/win-ia32-unpacked/

--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -367,10 +367,8 @@
           <Text>!(loc.WelcomeDlgAcceptLicenseCheckBox)</Text>
         </Control>        
         
-        <Control Id="License" Type="PushButton" X="10" Y="243" Width="56" Height="17" TabSkip="yes" Hidden="yes" Property="AdvancedInstallation" Text="[ButtonText_License]">
+        <Control Id="License" Type="PushButton" X="10" Y="243" Width="56" Height="17" Property="AdvancedInstallation" Text="[ButtonText_License]">
           <Publish Event="NewDialog" Value="LicenseAgreementDlg"><![CDATA[1]]></Publish>
-          <Condition Action="hide"><![CDATA[AdvancedLicenseAccepted <> "true"]]></Condition>
-          <Condition Action="show"><![CDATA[AdvancedLicenseAccepted = "true"]]></Condition>
         </Control>
         <Control Id="Reset" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Reset]">
           <Publish Event="Reset" Value="0"><![CDATA[1]]></Publish>

--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -173,7 +173,6 @@
     <Property Id="ComponentDownload"><![CDATA[https://releases.mattermost.com/desktop/4.1.2/mattermost-setup-4.1.2-win64.msi]]></Property>
     <Property Id="ADDDESKTOPSHORTCUT">true</Property>
     <Property Id="ADDSTARTMENUSHORTCUT">true</Property>
-    <Property Id="LAUNCHAPPAFTERINSTALL"></Property>
 
     <UI>
       <Publish Dialog="SuccessDlg" Control="Finish" Order="1" Event="DoAction" Value="LaunchApp">LAUNCHAPPAFTERINSTALL</Publish>

--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -378,11 +378,11 @@
           <Text>!(loc.AdvancedDlgLaunchAppAfterInstall)</Text>
         </Control>
 
-        <Control Id="AcceptLicenseCheckBox" Type="CheckBox" X="10" Y="220" Width="350" Height="20" Property="AdvancedLicenseAccepted" CheckBoxValue="true">
+        <Control Id="AcceptLicenseCheckBox" Type="CheckBox" X="10" Y="220" Width="350" Height="20" CheckBoxPropertyRef="LicenseAccepted" CheckBoxValue="true">
           <Text>!(loc.WelcomeDlgAcceptLicenseCheckBox)</Text>
         </Control>        
         
-        <Control Id="License" Type="PushButton" X="10" Y="243" Width="56" Height="17" Property="AdvancedInstallation" Text="[ButtonText_License]">
+        <Control Id="License" Type="PushButton" X="10" Y="243" Width="56" Height="17" Text="[ButtonText_License]">
           <Publish Event="NewDialog" Value="LicenseAgreementDlg"><![CDATA[1]]></Publish>
         </Control>
         <Control Id="Reset" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Reset]">
@@ -390,8 +390,8 @@
         </Control>
         
         <Control Id="Install" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Install]" ElevationShield="yes">
-          <Condition Action="disable"><![CDATA[AdvancedLicenseAccepted <> "true"]]></Condition>
-          <Condition Action="enable"><![CDATA[AdvancedLicenseAccepted = "true"]]></Condition>
+          <Condition Action="disable"><![CDATA[LicenseAccepted <> "true"]]></Condition>
+          <Condition Action="enable"><![CDATA[LicenseAccepted = "true"]]></Condition>
           <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
           <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
           <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
@@ -476,7 +476,7 @@
         
         <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Back]">
           <Publish Event="NewDialog" Value="WelcomeDlg"><![CDATA[1]]></Publish>
-          <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[AdvancedLicenseAccepted = "true"]]></Publish>
+          <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[LicenseAccepted = "true"]]></Publish>
         </Control>
         <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
           <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>

--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -699,10 +699,8 @@
           </Control>
 
           <!-- TabSkip is needed in order to hack the zindex and make the button appear above the background image -->
-          <Control Id="License" Type="PushButton" X="10" Y="243" Width="56" Height="17" TabSkip="yes" Hidden="yes" Text="[ButtonText_License]">
+          <Control Id="License" Type="PushButton" X="10" Y="243" Width="56" Height="17" Text="[ButtonText_License]">
             <Publish Event="NewDialog" Value="LicenseAgreementDlg"><![CDATA[1]]></Publish>
-            <Condition Action="hide"><![CDATA[LicenseAccepted <> "true"]]></Condition>
-            <Condition Action="show"><![CDATA[LicenseAccepted = "true"]]></Condition>
           </Control>
           <Control Id="Advanced" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_AdvancedInstall]">
             <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[1]]></Publish>

--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -77,14 +77,8 @@
       <![CDATA[Installed OR (VersionNT >= 601)]]>
     </Condition>
 
-    <?if $(var.Platform) = x64 ?>
-      <Condition Message="!(loc.Requires64Bit)">
-        <![CDATA[VersionNT64]]>
-      </Condition>
-    <?else ?>
-      <Condition Message="!(loc.Requires32Bit)">
-        <![CDATA[NOT VersionNT64]]>
-      </Condition>
+    <?if $(var.Platform) != x64 ?>
+      <Condition Message="!(loc.Requires32Bit)"><![CDATA[NOT VersionNT64]]></Condition>
     <?endif ?>
     
     <!--<MajorUpgrade

--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -102,6 +102,16 @@
               <Shortcut Id="MattermostDesktopShortcutStartMenu" Directory="ProgramMenuDir" Name="Mattermost Desktop"
                 WorkingDirectory='INSTALLDIR' Icon="Mattermost.ico" IconIndex="0" Advertise="no" Target="[INSTALLDIR]Mattermost.exe" />
             </Component>
+            <Directory Id='GPOFiles' Name='gpo'>
+              <Component Id='GPODefinitionFile' Guid='BE30D350-8727-41CB-9F8D-9E0B7B9572A9' Win64='$(var.Win64)'>
+                <File Id="MattermostAdmxFile" Name="mattermost.admx" Source="../resources/windows/gpo/mattermost.admx" KeyPath="yes" />
+              </Component>
+              <Directory Id='GPOUSEnglishFiles' Name="en-US">
+                <Component Id='GPOUSEnglishFiles' Guid='1D49A24E-769C-4AF0-863E-0648628A4554' Win64='$(var.Win64)'>
+                  <File Id="MattermostAdmlFile" Name="mattermost.adml" Source="../resources/windows/gpo/en-US/mattermost.adml" KeyPath="yes" />
+                </Component>
+              </Directory>
+            </Directory>
           </Directory>
         </Directory>
       </Directory>
@@ -141,6 +151,8 @@
       <ComponentRef Id='MainExecutableShortcutStartMenu' />
       <ComponentRef Id='ProgramMenuDir' />
       <ComponentRef Id='RegInstallLocation' />
+      <ComponentRef Id='GPODefinitionFile' />
+      <ComponentRef Id='GPOUSEnglishFiles' />
     </Feature>   
     
     <InstallExecuteSequence>

--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -173,7 +173,7 @@
     <Property Id="ComponentDownload"><![CDATA[https://releases.mattermost.com/desktop/4.1.2/mattermost-setup-4.1.2-win64.msi]]></Property>
     <Property Id="ADDDESKTOPSHORTCUT">true</Property>
     <Property Id="ADDSTARTMENUSHORTCUT">true</Property>
-    <Property Id="LAUNCHAPPAFTERINSTALL">true</Property>
+    <Property Id="LAUNCHAPPAFTERINSTALL"></Property>
 
     <UI>
       <Publish Dialog="SuccessDlg" Control="Finish" Order="1" Event="DoAction" Value="LaunchApp">LAUNCHAPPAFTERINSTALL</Publish>

--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -1,11 +1,10 @@
-<?xml version='1.0' encoding='utf-8'?>
-<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
-  <!--
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <!--
   Copyright (c) 2018-present William Gathoye
   See LICENSE.txt
   -->
-
-  <!--
+    <!--
   Determine wich bitness version of the msi to build depending on the
   variables passed as argument to candle.
   src.: http://wixtoolset.org/documentation/manual/v3/overview/preprocessor.html
@@ -18,17 +17,16 @@
     nodes have ProcessorArchitecture attribute set to x64.
   src.: https://msdn.microsoft.com/en-us/library/gg513929.aspx
   -->
-  <?if $(var.Platform) = x64 ?>
+    <?if $(var.Platform) = x64 ?>
     <?define Win64 = "yes" ?>
     <?define ProgramFilesVersion = "ProgramFiles64Folder" ?>
-    <?define ReleaseDir = "../release/win-unpacked" ?>    
-  <?else ?>
+    <?define ReleaseDir = "../release/win-unpacked" ?>
+    <?else ?>
     <?define Win64 = "no" ?>
     <?define ProgramFilesVersion = "ProgramFilesFolder" ?>
     <?define ReleaseDir = "../release/win-ia32-unpacked" ?>
-  <?endif ?>
-
-  <!-- 
+    <?endif ?>
+    <!-- 
   The product GUID must not be changed except when:
   - the old and new versions have to coexist on the user's computer
   - the .msi filename change for any reason
@@ -37,101 +35,67 @@
   - there are any changes in the feature hierarchy (child
     feature moving out of a parent, or a parent feature getting a new child).
   -->
-  <Product
-    Id='*'
-    UpgradeCode='8523DAF0-699D-4CC7-9A65-C5E696A9DE6D'
-    Name='Mattermost Desktop'
-    Manufacturer='Mattermost, Inc.'    
-    Language='1033'
-    Codepage='1252'
-    Version='4.1.2'
-    >
-
-    <!--
+    <Product Id="*" UpgradeCode="8523DAF0-699D-4CC7-9A65-C5E696A9DE6D" Name="Mattermost Desktop" Manufacturer="Mattermost, Inc." Language="1033" Codepage="1252" Version="4.1.2">
+        <!--
     perMachine installs the app system wide (ALLUSERS is set to 1)
     src.: https://www.joyofsetup.com/2008/04/01/new-wix-feature-setting-package-installation-scope/
     -->
-    <Package
-      Id='*'
-      Keywords='Installer'
-      Description="Mattermost Desktop Installer"
-      Manufacturer='Mattermost, Inc.'
-      InstallerVersion='400'
-      Languages='1033'
-      Compressed='yes'
-      SummaryCodepage='1252'
-      Platform="$(var.Platform)"
-      InstallScope='perMachine'
-    />
-      
-    <MediaTemplate EmbedCab="yes" CompressionLevel="high"/>
-    
-    <!--
+        <Package Id="*" Keywords="Installer" Description="Mattermost Desktop Installer" Manufacturer="Mattermost, Inc." InstallerVersion="400" Languages="1033" Compressed="yes" SummaryCodepage="1252" Platform="$(var.Platform)" InstallScope="perMachine" />
+        <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
+        <!--
     Perform OS check requirements only if we are installing (not on repair/
     uninstall) the package. The state "installing" is meant by the
     Installed keyword. Even if the OR seems weird, this is what must be
     used according to the doc.
     src.: http://wixtoolset.org/documentation/manual/v3/howtos/redistributables_and_install_checks/block_install_on_os.html
     -->
-    <Condition Message="!(loc.OsRequirements)">
-      <![CDATA[Installed OR (VersionNT >= 601)]]>
-    </Condition>
-
-    <?if $(var.Platform) != x64 ?>
-      <Condition Message="!(loc.Requires32Bit)"><![CDATA[NOT VersionNT64]]></Condition>
-    <?endif ?>
-    
-    <!--<MajorUpgrade
+        <Condition Message="!(loc.OsRequirements)"><![CDATA[Installed OR (VersionNT >= 601)]]></Condition>
+        <?if $(var.Platform) != x64 ?>
+        <Condition Message="!(loc.Requires32Bit)"><![CDATA[NOT VersionNT64]]></Condition>
+        <?endif ?>
+        <!--<MajorUpgrade
       DowngradeErrorMessage="A later version of [ProductName] is already installed. Setup will now exit." />-->
-
-    <!-- Retrieve previous installation path -->
-    <Property Id="INSTALLDIR">
-      <RegistrySearch Id="DetermineInstallLocation" Type="raw" Root="HKLM" Key="Software\Mattermost\Desktop" Name="InstallLocation" Win64="$(var.Win64)" />
-    </Property>
-
-    <Directory Id='TARGETDIR' Name='SourceDir'>
-    
-      <Directory Id='$(var.ProgramFilesVersion)' Name='PFiles'>
-        <Directory Id='MattermostFolder' Name='Mattermost'>
-          <Directory Id='INSTALLDIR' Name='Desktop'>
-            <Component Id='MainExecutableShortcutDesktop' Guid='9C71385D-C892-48BA-A35D-D89A661D2952' Win64="$(var.Win64)">
-              <Condition><![CDATA[ADDDESKTOPSHORTCUT = "true"]]></Condition>
-              <RegistryValue Id="RegShortcutDesktop" Root="HKCU" Key="SOFTWARE\Mattermost\Desktop\settings" Name="MattermostDesktopShortcutDesktop" Value="1" Type="integer" KeyPath="yes" />
-              <Shortcut Id="MattermostDesktopShortcutDesktop" Directory="DesktopFolder" Name="Mattermost Desktop"
-                WorkingDirectory='INSTALLDIR' Icon="Mattermost.ico" IconIndex="0" Advertise="no" Target="[INSTALLDIR]Mattermost.exe" />
-            </Component>
-            <Component Id='MainExecutableShortcutStartMenu' Guid='DF2028FF-7E03-407B-A46A-726E1B67DF83' Win64="$(var.Win64)">
-              <Condition><![CDATA[ADDSTARTMENUSHORTCUT = "true"]]></Condition>
-              <RegistryValue Id="RegShortcutStartMenu" Root="HKCU" Key="SOFTWARE\Mattermost\Desktop\settings" Name="MattermostDesktopShortcutStartMenu" Value="1" Type="integer" KeyPath="yes" />
-              <Shortcut Id="MattermostDesktopShortcutStartMenu" Directory="ProgramMenuDir" Name="Mattermost Desktop"
-                WorkingDirectory='INSTALLDIR' Icon="Mattermost.ico" IconIndex="0" Advertise="no" Target="[INSTALLDIR]Mattermost.exe" />
-            </Component>
-            <Directory Id='GPOFiles' Name='gpo'>
-              <Component Id='GPODefinitionFile' Guid='BE30D350-8727-41CB-9F8D-9E0B7B9572A9' Win64='$(var.Win64)'>
-                <File Id="MattermostAdmxFile" Name="mattermost.admx" Source="../resources/windows/gpo/mattermost.admx" KeyPath="yes" />
-              </Component>
-              <Directory Id='GPOUSEnglishFiles' Name="en-US">
-                <Component Id='GPOUSEnglishFiles' Guid='1D49A24E-769C-4AF0-863E-0648628A4554' Win64='$(var.Win64)'>
-                  <File Id="MattermostAdmlFile" Name="mattermost.adml" Source="../resources/windows/gpo/en-US/mattermost.adml" KeyPath="yes" />
-                </Component>
-              </Directory>
+        <!-- Retrieve previous installation path -->
+        <Property Id="INSTALLDIR">
+            <RegistrySearch Id="DetermineInstallLocation" Type="raw" Root="HKLM" Key="Software\Mattermost\Desktop" Name="InstallLocation" Win64="$(var.Win64)" />
+        </Property>
+        <Directory Id="TARGETDIR" Name="SourceDir">
+            <Directory Id="$(var.ProgramFilesVersion)" Name="PFiles">
+                <Directory Id="MattermostFolder" Name="Mattermost">
+                    <Directory Id="INSTALLDIR" Name="Desktop">
+                        <Component Id="MainExecutableShortcutDesktop" Guid="9C71385D-C892-48BA-A35D-D89A661D2952" Win64="$(var.Win64)">
+                            <Condition><![CDATA[ADDDESKTOPSHORTCUT = "true"]]></Condition>
+                            <RegistryValue Id="RegShortcutDesktop" Root="HKCU" Key="SOFTWARE\Mattermost\Desktop\settings" Name="MattermostDesktopShortcutDesktop" Value="1" Type="integer" KeyPath="yes" />
+                            <Shortcut Id="MattermostDesktopShortcutDesktop" Directory="DesktopFolder" Name="Mattermost Desktop" WorkingDirectory="INSTALLDIR" Icon="Mattermost.ico" IconIndex="0" Advertise="no" Target="[INSTALLDIR]Mattermost.exe" />
+                        </Component>
+                        <Component Id="MainExecutableShortcutStartMenu" Guid="DF2028FF-7E03-407B-A46A-726E1B67DF83" Win64="$(var.Win64)">
+                            <Condition><![CDATA[ADDSTARTMENUSHORTCUT = "true"]]></Condition>
+                            <RegistryValue Id="RegShortcutStartMenu" Root="HKCU" Key="SOFTWARE\Mattermost\Desktop\settings" Name="MattermostDesktopShortcutStartMenu" Value="1" Type="integer" KeyPath="yes" />
+                            <Shortcut Id="MattermostDesktopShortcutStartMenu" Directory="ProgramMenuDir" Name="Mattermost Desktop" WorkingDirectory="INSTALLDIR" Icon="Mattermost.ico" IconIndex="0" Advertise="no" Target="[INSTALLDIR]Mattermost.exe" />
+                        </Component>
+                        <Directory Id="GPOFiles" Name="gpo">
+                            <Component Id="GPODefinitionFile" Guid="BE30D350-8727-41CB-9F8D-9E0B7B9572A9" Win64="$(var.Win64)">
+                                <File Id="MattermostAdmxFile" Name="mattermost.admx" Source="../resources/windows/gpo/mattermost.admx" KeyPath="yes" />
+                            </Component>
+                            <Directory Id="GPOUSEnglishFiles" Name="en-US">
+                                <Component Id="GPOUSEnglishFiles" Guid="1D49A24E-769C-4AF0-863E-0648628A4554" Win64="$(var.Win64)">
+                                    <File Id="MattermostAdmlFile" Name="mattermost.adml" Source="../resources/windows/gpo/en-US/mattermost.adml" KeyPath="yes" />
+                                </Component>
+                            </Directory>
+                        </Directory>
+                    </Directory>
+                </Directory>
             </Directory>
-          </Directory>
-        </Directory>
-      </Directory>
-
-      <Directory Id="ProgramMenuFolder" Name="Programs">
-        <Directory Id="ProgramMenuDir" Name="Mattermost Desktop">
-          <Component Id="ProgramMenuDir" Guid="CA5C6FAF-C004-4909-AF1C-AA0A5F53C245">
-            <RemoveFolder Id='ProgramMenuDir' On='uninstall' />
-            <RegistryValue Root='HKCU' Key='Software\Mattermost\Desktop' Type='string' Value='' KeyPath='yes' />
-          </Component>
-        </Directory>
-      </Directory>
-
-      <Directory Id="DesktopFolder" Name="Desktop" />
-      
-    <!--
+            <Directory Id="ProgramMenuFolder" Name="Programs">
+                <Directory Id="ProgramMenuDir" Name="Mattermost Desktop">
+                    <Component Id="ProgramMenuDir" Guid="CA5C6FAF-C004-4909-AF1C-AA0A5F53C245">
+                        <RemoveFolder Id="ProgramMenuDir" On="uninstall" />
+                        <RegistryValue Root="HKCU" Key="Software\Mattermost\Desktop" Type="string" Value="" KeyPath="yes" />
+                    </Component>
+                </Directory>
+            </Directory>
+            <Directory Id="DesktopFolder" Name="Desktop" />
+            <!--
     We are creating a registry out of tree (i.e. that won't be removed at
     desinstallation) because the purpose here is to remember the install
     location across updates (important when installing a newer version,
@@ -139,952 +103,897 @@
     src.: https://web.archive.org/web/20180322000314/http://robmensching.com/blog/posts/2010/5/2/the-wix-toolsets-remember-property-pattern/
     src.: https://web.archive.org/web/20181104151047/https://helgeklein.com/blog/2014/09/real-world-example-wix-msi-application-installer/
     -->
-      <Component Id="RegInstallLocation" Guid="BF67264A-28BB-44FF-A646-F118D814651E">
-        <RegistryKey Root="HKLM" Key="Software\Mattermost\Desktop">
-          <RegistryValue Name="InstallLocation" Value="[INSTALLDIR]" Type="string" KeyPath="yes" />
-        </RegistryKey>
-      </Component>
-    </Directory>
-    
-    <Feature Id='Complete' Level='1' ConfigurableDirectory='INSTALLDIR'>
-      <!-- Using heat to generate file and directory hierarchy
+            <Component Id="RegInstallLocation" Guid="BF67264A-28BB-44FF-A646-F118D814651E">
+                <RegistryKey Root="HKLM" Key="Software\Mattermost\Desktop">
+                    <RegistryValue Name="InstallLocation" Value="[INSTALLDIR]" Type="string" KeyPath="yes" />
+                </RegistryKey>
+            </Component>
+        </Directory>
+        <Feature Id="Complete" Level="1" ConfigurableDirectory="INSTALLDIR">
+            <!-- Using heat to generate file and directory hierarchy
            src.: https://stackoverflow.com/a/26558025/3514658
       -->
-      <ComponentGroupRef Id="MattermostDesktopFiles" />
-      <ComponentRef Id='MainExecutableShortcutDesktop' />
-      <ComponentRef Id='MainExecutableShortcutStartMenu' />
-      <ComponentRef Id='ProgramMenuDir' />
-      <ComponentRef Id='RegInstallLocation' />
-      <ComponentRef Id='GPODefinitionFile' />
-      <ComponentRef Id='GPOUSEnglishFiles' />
-    </Feature>   
-    
-    <InstallExecuteSequence>
-      <Custom Action='LaunchApp' After='InstallFinalize'>Installed</Custom>
-      <RemoveExistingProducts After="InstallFinalize" />
-    </InstallExecuteSequence>
-    <CustomAction Id='LaunchApp' FileKey='MattermostDesktopEXE' ExeCommand='' Return='asyncNoWait' />
+            <ComponentGroupRef Id="MattermostDesktopFiles" />
+            <ComponentRef Id="MainExecutableShortcutDesktop" />
+            <ComponentRef Id="MainExecutableShortcutStartMenu" />
+            <ComponentRef Id="ProgramMenuDir" />
+            <ComponentRef Id="RegInstallLocation" />
+            <ComponentRef Id="GPODefinitionFile" />
+            <ComponentRef Id="GPOUSEnglishFiles" />
+        </Feature>
+        <InstallExecuteSequence>
+            <Custom Action="LaunchApp" After="InstallFinalize">Installed</Custom>
+            <RemoveExistingProducts After="InstallFinalize" />
+        </InstallExecuteSequence>
+        <CustomAction Id="LaunchApp" FileKey="MattermostDesktopEXE" ExeCommand="" Return="asyncNoWait" />
+        <Icon Id="Mattermost.ico" SourceFile="../resources/icon.ico" />
+        <Property Id="ARPPRODUCTICON">Mattermost.ico</Property>
+        <Property Id="ARPCONTACT">https://pre-release.mattermost.com</Property>
+        <Property Id="ARPHELPLINK">https://docs.mattermost.com/</Property>
+        <Property Id="ARPURLINFOABOUT">https://mattermost.com/</Property>
+        <Property Id="ComponentDownload"><![CDATA[https://releases.mattermost.com/desktop/4.1.2/mattermost-setup-4.1.2-win64.msi]]></Property>
+        <Property Id="ADDDESKTOPSHORTCUT">true</Property>
+        <Property Id="ADDSTARTMENUSHORTCUT">true</Property>
+        <UI>
+            <Publish Dialog="SuccessDlg" Control="Finish" Order="1" Event="DoAction" Value="LaunchApp">LAUNCHAPPAFTERINSTALL</Publish>
+            <Property Id="ErrorDialog"><![CDATA[ErrorDlg]]></Property>
+            <Property Id="DefaultUIFont"><![CDATA[DlgFont8]]></Property>
+            <Dialog Id="AdminWelcomeDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+                <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
+                <Control Id="Instructions" Type="Text" X="10" Y="155" Width="350" Height="78" Transparent="yes" NoPrefix="yes">
+                    <Text>Welcome to the [ProductName] [Installer]
 
-    <Icon Id="Mattermost.ico" SourceFile="../resources/icon.ico" />
-    <Property Id='ARPPRODUCTICON'>Mattermost.ico</Property>
-    <Property Id='ARPCONTACT'>https://pre-release.mattermost.com</Property>
-    <Property Id='ARPHELPLINK'>https://docs.mattermost.com/</Property>
-    <Property Id='ARPURLINFOABOUT'>https://mattermost.com/</Property>
-    <Property Id="ComponentDownload"><![CDATA[https://releases.mattermost.com/desktop/4.1.2/mattermost-setup-4.1.2-win64.msi]]></Property>
-    <Property Id="ADDDESKTOPSHORTCUT">true</Property>
-    <Property Id="ADDSTARTMENUSHORTCUT">true</Property>
+The [Installer] will create a server image of [ProductName], at a specified network location.  Click Next to continue or Cancel to exit the [Installer].</Text>
+                </Control>
+                <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Next]">
+                    <Publish Property="InstallMode" Value="Server Image"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
+                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
+            </Dialog>
+            <Dialog Id="SuccessDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+                <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
+                <Control Id="Instructions" Type="Text" X="10" Y="155" Width="350" Height="78" Transparent="yes" NoPrefix="yes">
+                    <Text>!(loc.SuccessDlgInstructions)</Text>
+                </Control>
+                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
+                <Control Id="Finish" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Finish]">
+                    <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Cancel]" />
+            </Dialog>
+            <Dialog Id="FatalError" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+                <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
+                <Control Id="Instructions" Type="Text" X="10" Y="155" Width="350" Height="78" Transparent="yes" NoPrefix="yes">
+                    <Text>The [ProductName] [Installer] ended prematurely because of an error.  Your system has not been modified.  To install this program at a later time, please run the installation again.
 
-    <UI>
-      <Publish Dialog="SuccessDlg" Control="Finish" Order="1" Event="DoAction" Value="LaunchApp">LAUNCHAPPAFTERINSTALL</Publish>
-      <Property Id="ErrorDialog"><![CDATA[ErrorDlg]]></Property>
-      <Property Id="DefaultUIFont"><![CDATA[DlgFont8]]></Property>
-      <Dialog Id="AdminWelcomeDlg" Width="370" Height="270" Title="[ProductName] [Setup]" NoMinimize="yes">
-        <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Next]">
-          <Publish Property="InstallMode" Value="Server Image"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
-          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="Bitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="234" TabSkip="no" Text="[DialogBitmap]" />
-        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
-        <Control Id="Description" Type="Text" X="135" Y="70" Width="220" Height="30" Transparent="yes" NoPrefix="yes">
-          <Text>The [Wizard] will create a server image of [ProductName], at a specified network location.  Click Next to continue or Cancel to exit the [Wizard].</Text>
-        </Control>
-        <Control Id="Title" Type="Text" X="135" Y="20" Width="220" Height="60" Transparent="yes" NoPrefix="yes">
-          <Text>{\VerdanaBold13}Welcome to the [ProductName] [Wizard]</Text>
-        </Control>
-      </Dialog>
-      <Dialog Id="SuccessDlg" Width="370" Height="270" Title="[ProductName] [Setup]" NoMinimize="yes">
-        <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
+Click the Finish button to exit the [Installer].</Text>
+                </Control>
+                <Control Id="Finish" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Finish]">
+                    <Publish Event="EndDialog" Value="Exit"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Cancel]" />
+                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
+            </Dialog>
+            <Dialog Id="PrepareDlg" Width="370" Height="270" Title="[ProductName] [Installer]" Modeless="yes">
+                <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
+                <Control Id="Instructions" Type="Text" X="10" Y="155" Width="350" Height="78" Transparent="yes" NoPrefix="yes">
+                    <Text>Welcome to the [ProductName] [Installer]
 
-        <Control Id="Instructions" Type="Text" X="10" Y="155" Width="350" Height="78" Transparent="yes" NoPrefix="yes">
-          <Text>!(loc.SuccessDlgInstructions)</Text>
-        </Control>
+Please wait while the [Installer] prepares to guide you through the installation.</Text>
+                </Control>
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Cancel]">
+                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" TabSkip="yes" Text="[ButtonText_Back]" />
+                <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Disabled="yes" TabSkip="yes" Text="[ButtonText_Next]" />
+                <Control Id="ActionData" Type="Text" X="135" Y="125" Width="220" Height="30" Transparent="yes" NoPrefix="yes">
+                    <Subscribe Event="ActionData" Attribute="Text" />
+                </Control>
+                <Control Id="ActionText" Type="Text" X="135" Y="100" Width="220" Height="20" Transparent="yes" NoPrefix="yes">
+                    <Subscribe Event="ActionText" Attribute="Text" />
+                </Control>
+            </Dialog>
+            <Dialog Id="ProgressDlg" Width="370" Height="270" Title="[ProductName] [Installer]" Modeless="yes">
+                <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
+                <Control Id="Instructions" Type="Text" X="15" Y="155" Width="340" Height="45" Transparent="yes" NoPrefix="yes">
+                    <Text>!(loc.ProgressDlgInstructions)</Text>
+                </Control>
+                <Control Id="StatusLabel" Type="Text" X="15" Y="215" Width="35" Height="10" Text="!(loc.ProgressDlgStatusLabel)" />
+                <Control Id="ActionText" Type="Text" X="50" Y="215" Width="265" Height="10">
+                    <Subscribe Event="ActionText" Attribute="Text" />
+                </Control>
+                <Control Id="ProgressBar" Type="ProgressBar" X="15" Y="225" Width="340" Height="10" ProgressBlocks="yes" Text="Progress done">
+                    <Subscribe Event="SetProgress" Attribute="Progress" />
+                </Control>
+                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
+                <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Next]" />
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Cancel]">
+                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+                </Control>
+            </Dialog>
+            <Dialog Id="UserExitDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+                <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
+                <Control Id="Instructions" Type="Text" X="15" Y="155" Width="340" Height="85" Transparent="yes" NoPrefix="yes">
+                    <Text>!(loc.UserExitDlgInstructions)</Text>
+                </Control>
+                <Control Id="Finish" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Finish]">
+                    <Publish Event="EndDialog" Value="Exit"><![CDATA[1]]></Publish>
+                </Control>
+            </Dialog>
+            <Dialog Id="AdminBrowseDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+                <Control Id="PathEdit" Type="PathEdit" X="84" Y="212" Width="261" Height="15" Property="TARGETDIR" />
+                <Control Id="OK" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_OK]">
+                    <Publish Event="SetTargetPath" Value="TARGETDIR"><![CDATA[1]]></Publish>
+                    <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="Cancel" Type="PushButton" X="240" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
+                    <Publish Event="Reset" Value="0"><![CDATA[1]]></Publish>
+                    <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="ComboLabel" Type="Text" X="25" Y="98" Width="44" Height="10" TabSkip="no" Text="&amp;Look in:" />
+                <Control Id="DirectoryCombo" Type="DirectoryCombo" X="70" Y="95" Width="220" Height="16" Property="TARGETDIR" Removable="yes" Fixed="yes" Remote="yes">
+                    <Subscribe Event="IgnoreChange" Attribute="IgnoreChange" />
+                </Control>
+                <Control Id="Up" Type="PushButton" X="298" Y="95" Width="19" Height="19" ToolTip="Up One Level" Icon="yes" FixedSize="yes" IconSize="16" Text="Up">
+                    <Publish Event="DirectoryListUp" Value="0"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="NewFolder" Type="PushButton" X="325" Y="95" Width="19" Height="19" ToolTip="Create A New Folder" Icon="yes" FixedSize="yes" IconSize="16" Text="New">
+                    <Publish Event="DirectoryListNew" Value="0"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="DirectoryList" Type="DirectoryList" X="25" Y="123" Width="320" Height="81" Property="TARGETDIR" Sunken="yes" TabSkip="no" />
+                <Control Id="PathLabel" Type="Text" X="25" Y="215" Width="59" Height="10" TabSkip="no" Text="&amp;Folder name:" />
+                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+                <Control Id="Description" Type="Text" X="25" Y="73" Width="280" Height="15" Transparent="yes" NoPrefix="yes">
+                    <Text>Browse to the destination folder</Text>
+                </Control>
+                <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
+                    <Text>[DlgTitleFont]Change current destination folder</Text>
+                </Control>
+            </Dialog>
+            <Dialog Id="BrowseDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+                <Control Id="Instructions" Type="Text" X="10" Y="55" Width="350" Height="10" Transparent="yes" NoPrefix="yes">
+                    <Text>!(loc.BrowseDlgInstructions)</Text>
+                </Control>
+                <Control Id="DirectoryCombo" Type="DirectoryCombo" X="10" Y="70" Width="310" Height="20" Property="INSTALLDIR" Fixed="yes" Remote="yes">
+                    <Subscribe Event="IgnoreChange" Attribute="IgnoreChange" />
+                </Control>
+                <Control Id="Up" Type="PushButton" X="320" Y="70" Width="20" Height="20" ToolTip="!(loc.BrowseDlgUp)" Icon="yes" FixedSize="yes" IconSize="16" Text="Up">
+                    <Publish Event="DirectoryListUp" Value="0"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="NewFolder" Type="PushButton" X="340" Y="70" Width="20" Height="20" ToolTip="!(loc.BrowseDlgNewFolder)" Icon="yes" FixedSize="yes" IconSize="16" Text="New">
+                    <Publish Event="DirectoryListNew" Value="0"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="DirectoryList" Type="DirectoryList" X="10" Y="90" Width="350" Height="110" Property="INSTALLDIR" Sunken="yes" TabSkip="no" />
+                <Control Id="PathLabel" Type="Text" X="10" Y="205" Width="350" Height="15" TabSkip="no" Text="!(loc.BrowseDlgPathLabel)" />
+                <Control Id="PathEdit" Type="PathEdit" X="10" Y="220" Width="350" Height="17" Property="INSTALLDIR" />
+                <Control Id="OK" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_OK]">
+                    <Publish Event="SetTargetPath" Value="INSTALLDIR"><![CDATA[1]]></Publish>
+                    <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
+                    <Publish Event="Reset" Value="0"><![CDATA[1]]></Publish>
+                    <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[1]]></Publish>
+                </Control>
+            </Dialog>
+            <Dialog Id="CancelDlg" Width="260" Height="85" Title="[ProductName] [Installer]" NoMinimize="yes">
+                <Control Id="Icon" Type="Icon" X="15" Y="15" Width="24" Height="24" ToolTip="Information icon" FixedSize="yes" IconSize="32" Text="[QuestionIcon]" />
+                <Control Id="Text" Type="Text" X="48" Y="15" Width="194" Height="30">
+                    <Text>!(loc.CancelDlgText)</Text>
+                </Control>
+                <Control Id="Yes" Type="PushButton" X="72" Y="57" Width="56" Height="17" Text="[ButtonText_Yes]">
+                    <Publish Event="EndDialog" Value="Exit"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="No" Type="PushButton" X="132" Y="57" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_No]">
+                    <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
+                </Control>
+            </Dialog>
+            <Dialog Id="AdvancedDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes" TrackDiskSpace="yes">
+                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+                <Control Id="Instructions" Type="Text" X="10" Y="55" Width="350" Height="45" Transparent="yes" NoPrefix="yes">
+                    <Text>!(loc.AdvancedDlgInstructions)</Text>
+                </Control>
+                <Control Id="LocationLabel" Type="Text" X="10" Y="115" Width="350" Height="15" Text="!(loc.AdvancedDlgLocationLabel)">
+                    <Subscribe Event="SelectionPathOn" Attribute="Visible" />
+                    <Condition Action="hide"><![CDATA[Installed]]></Condition>
+                </Control>
+                <Control Type="PathEdit" Id="DestinationPath" X="10" Y="130" Width="282" Height="17" Property="INSTALLDIR" />
+                <Control Id="Browse" Type="PushButton" X="304" Y="130" Width="56" Height="17" Text="!(loc.AdvancedDlgBrowse)">
+                    <Publish Event="NewDialog" Value="BrowseDlg"><![CDATA[1]]></Publish>
+                    <Condition Action="hide"><![CDATA[Installed]]></Condition>
+                </Control>
+                <Control Type="CheckBox" Id="AddDesktopShortcut" X="10" Y="155" Width="350" Height="20" Property="ADDDESKTOPSHORTCUT" CheckBoxValue="true">
+                    <Text>!(loc.AdvancedDlgAddDesktopShortcut)</Text>
+                </Control>
+                <Control Type="CheckBox" Id="AddStartMenuShortcut" X="10" Y="170" Width="350" Height="20" Property="ADDSTARTMENUSHORTCUT" CheckBoxValue="true">
+                    <Text>!(loc.AdvancedDlgAddStartMenuShortcut)</Text>
+                </Control>
+                <Control Type="CheckBox" Id="LaunchAppAfterInstall" X="10" Y="195" Width="350" Height="20" Property="LAUNCHAPPAFTERINSTALL" CheckBoxValue="true">
+                    <Text>!(loc.AdvancedDlgLaunchAppAfterInstall)</Text>
+                </Control>
+                <Control Id="AcceptLicenseCheckBox" Type="CheckBox" X="10" Y="220" Width="350" Height="20" CheckBoxPropertyRef="LicenseAccepted" CheckBoxValue="true">
+                    <Text>!(loc.WelcomeDlgAcceptLicenseCheckBox)</Text>
+                </Control>
+                <Control Id="License" Type="PushButton" X="10" Y="243" Width="56" Height="17" Text="[ButtonText_License]">
+                    <Publish Event="NewDialog" Value="LicenseAgreementDlg"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="Reset" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Reset]">
+                    <Publish Event="Reset" Value="0"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="Install" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Install]" ElevationShield="yes">
+                    <Condition Action="disable"><![CDATA[LicenseAccepted <> "true"]]></Condition>
+                    <Condition Action="enable"><![CDATA[LicenseAccepted = "true"]]></Condition>
+                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
+                    <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
+                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+                    <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+                    <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
+                </Control>
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
+                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+                </Control>
+            </Dialog>
+            <Dialog Id="DiskCostDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+                <Control Id="OK" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_OK]">
+                    <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+                <Control Id="Text" Type="Text" X="20" Y="103" Width="330" Height="40">
+                    <Text>The highlighted volumes (if any) do not have enough disk space available for the currently selected features.  You can either remove some files from the highlighted volumes, or choose to install less features onto local drive(s), or select different destination drive(s).</Text>
+                </Control>
+                <Control Id="Description" Type="Text" X="20" Y="74" Width="280" Height="15" Transparent="yes" NoPrefix="yes">
+                    <Text>The disk space required for the installation of the selected features.</Text>
+                </Control>
+                <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
+                    <Text>[DlgTitleFont]Disk Space Requirements</Text>
+                </Control>
+                <Control Id="VolumeList" Type="VolumeCostList" X="20" Y="150" Width="330" Height="80" Sunken="yes" Fixed="yes" Remote="yes">
+                    <Text>{120}{70}{70}{70}{70}</Text>
+                </Control>
+            </Dialog>
+            <Dialog Id="ErrorDlg" Y="10" Width="270" Height="105" Title="Installer Information" ErrorDialog="yes" NoMinimize="yes">
+                <Control Id="ErrorText" Type="Text" X="48" Y="15" Width="205" Height="60" TabSkip="no" Text="Information text" />
+                <Control Id="Y" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_Yes]">
+                    <Publish Event="EndDialog" Value="ErrorYes"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="A" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_Cancel]">
+                    <Publish Event="EndDialog" Value="ErrorAbort"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="C" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_Cancel]">
+                    <Publish Event="EndDialog" Value="ErrorCancel"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="ErrorIcon" Type="Icon" X="15" Y="15" Width="24" Height="24" ToolTip="Information icon" FixedSize="yes" IconSize="32" Text="[QuestionIcon]" />
+                <Control Id="I" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_Ignore]">
+                    <Publish Event="EndDialog" Value="ErrorIgnore"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="N" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_No]">
+                    <Publish Event="EndDialog" Value="ErrorNo"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="O" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_OK]">
+                    <Publish Event="EndDialog" Value="ErrorOk"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="R" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_Retry]">
+                    <Publish Event="EndDialog" Value="ErrorRetry"><![CDATA[1]]></Publish>
+                </Control>
+            </Dialog>
+            <Dialog Id="FilesInUse" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes" KeepModeless="yes">
+                <Control Id="Retry" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Retry]">
+                    <Publish Event="EndDialog" Value="Retry"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="Ignore" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Ignore]">
+                    <Publish Event="EndDialog" Value="Ignore"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="Exit" Type="PushButton" X="304" Y="243" Width="56" Height="17" Text="[ButtonText_Cancel]">
+                    <Publish Event="EndDialog" Value="Exit"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+                <Control Id="Description" Type="Text" X="20" Y="74" Width="280" Height="30" Transparent="yes" NoPrefix="yes">
+                    <Text>The following applications are using files that need to be updated by this installer. Close these applications and then click Retry to continue the installation or Cancel to exit the installer.</Text>
+                </Control>
+                <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
+                    <Text>[DlgTitleFont]Files in Use</Text>
+                </Control>
+                <Control Id="List" Type="ListBox" X="20" Y="117" Width="330" Height="81" Property="FileInUseProcess" Sunken="yes" TabSkip="no" />
+            </Dialog>
+            <Dialog Id="LicenseAgreementDlg" Width="370" Height="270" Title="[ProductName] License Agreement" NoMinimize="yes">
+                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+                <Control Id="AgreementText" Type="ScrollableText" X="0" Y="44" Width="370" Height="189" Sunken="no" TabSkip="yes">
+                    <Text SourceFile="../resources/windows/license.rtf" />
+                </Control>
+                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Back]">
+                    <Publish Event="NewDialog" Value="WelcomeDlg"><![CDATA[1]]></Publish>
+                    <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[LicenseAccepted = "true"]]></Publish>
+                </Control>
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
+                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+                </Control>
+            </Dialog>
+            <Dialog Id="MaintenanceTypeDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+                <Control Id="ChangeLabel" Type="Text" X="105" Y="95" Width="100" Height="10" TabSkip="no">
+                    <Text>[DlgTitleFont]&amp;Modify</Text>
+                </Control>
+                <Control Id="ChangeButton" Type="PushButton" X="50" Y="95" Width="38" Height="38" ToolTip="Modify Installation" Default="yes" Icon="yes" FixedSize="yes" IconSize="32" Text="[ModifyIcon]">
+                    <Publish Property="InstallMode" Value="Change"><![CDATA[1]]></Publish>
+                    <Publish Property="Progress1" Value="Changing"><![CDATA[1]]></Publish>
+                    <Publish Property="Progress2" Value="Changes"><![CDATA[1]]></Publish>
+                    <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="RepairLabel" Type="Text" X="105" Y="144" Width="100" Height="10" TabSkip="no">
+                    <Text>[DlgTitleFont]Re&amp;pair</Text>
+                </Control>
+                <Control Id="RepairButton" Type="PushButton" X="50" Y="144" Width="38" Height="38" ToolTip="Repair Installation" Icon="yes" FixedSize="yes" IconSize="32" Text="[RepairIcon]">
+                    <Publish Property="InstallMode" Value="Repair"><![CDATA[1]]></Publish>
+                    <Publish Property="Progress1" Value="Repairing"><![CDATA[1]]></Publish>
+                    <Publish Property="Progress2" Value="Repairs"><![CDATA[1]]></Publish>
+                    <Publish Event="NewDialog" Value="VerifyRepairDlg"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="RemoveLabel" Type="Text" X="105" Y="193" Width="100" Height="10" TabSkip="no">
+                    <Text>[DlgTitleFont]&amp;Uninstall</Text>
+                </Control>
+                <Control Id="RemoveButton" Type="PushButton" X="50" Y="193" Width="38" Height="38" ToolTip="Remove Installation" Icon="yes" FixedSize="yes" IconSize="32" Text="[RemoveIcon]">
+                    <Publish Property="InstallMode" Value="Uninstall"><![CDATA[1]]></Publish>
+                    <Publish Property="Progress1" Value="Uninstalling"><![CDATA[1]]></Publish>
+                    <Publish Property="Progress2" Value="Uninstall"><![CDATA[1]]></Publish>
+                    <Publish Event="NewDialog" Value="VerifyRemoveDlg"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Back]">
+                    <Publish Event="NewDialog" Value="MaintenanceWelcomeDlg"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Next]" />
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
+                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+                <Control Id="Description" Type="Text" X="25" Y="74" Width="280" Height="20" Transparent="yes" NoPrefix="yes">
+                    <Text>Select the operation you wish to perform.</Text>
+                </Control>
+                <Control Id="Title" Type="Text" X="15" Y="56" Width="240" Height="15" Transparent="yes" NoPrefix="yes">
+                    <Text>[DlgTitleFont]Modify, repair or uninstall </Text>
+                </Control>
+                <Control Id="ChangeText" Type="Text" X="105" Y="108" Width="230" Height="20">
+                    <Text>Change the installation directory</Text>
+                </Control>
+                <Control Id="RemoveText" Type="Text" X="105" Y="206" Width="230" Height="20">
+                    <Text>Uninstalls [ProductName] from your computer.</Text>
+                </Control>
+                <Control Id="RepairText" Type="Text" X="105" Y="157" Width="230" Height="30">
+                    <Text>Fix missing or corrupt files, shortcuts and registry entries.</Text>
+                </Control>
+            </Dialog>
+            <Dialog Id="MaintenanceWelcomeDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+                <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
+                <Control Id="Instructions" Type="Text" X="10" Y="155" Width="350" Height="45" Transparent="yes" NoPrefix="yes">
+                    <Text>!(loc.MaintenanceWelcomeDlgInstructions)</Text>
+                </Control>
+                <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Next]">
+                    <Publish Event="SpawnWaitDialog" Value="WaitForCostingDlg"><![CDATA[CostingComplete = 1]]></Publish>
+                    <Publish Event="NewDialog" Value="MaintenanceTypeDlg"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
+                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
+            </Dialog>
+            <Dialog Id="OutOfDiskDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+                <Control Id="OK" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_OK]">
+                    <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+                <Control Id="Text" Type="Text" X="20" Y="103" Width="330" Height="40">
+                    <Text>The highlighted volumes do not have enough disk space available for the currently selected features.  You can either remove some files from the highlighted volumes, or choose to install less features onto local drive(s), or select different destination drive(s).</Text>
+                </Control>
+                <Control Id="Description" Type="Text" X="20" Y="74" Width="280" Height="20" Transparent="yes" NoPrefix="yes">
+                    <Text>Disk space required for the installation exceeds available disk space.</Text>
+                </Control>
+                <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
+                    <Text>[DlgTitleFont]Out of Disk Space</Text>
+                </Control>
+                <Control Id="VolumeList" Type="VolumeCostList" X="20" Y="150" Width="330" Height="80" Sunken="yes" Fixed="yes" Remote="yes">
+                    <Text>{120}{70}{70}{70}{70}</Text>
+                </Control>
+            </Dialog>
+            <Dialog Id="OutOfRbDiskDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+                <Control Id="No" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_No]">
+                    <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="Yes" Type="PushButton" X="240" Y="243" Width="56" Height="17" Text="[ButtonText_Yes]">
+                    <Publish Event="EnableRollback" Value="False"><![CDATA[1]]></Publish>
+                    <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+                <Control Id="Text" Type="Text" X="20" Y="90" Width="330" Height="30">
+                    <Text>The highlighted volumes do not have enough disk space available for the currently selected features.  You can either remove some files from the highlighted volumes, or choose to install less features onto local drive(s), or select different destination drive(s).</Text>
+                </Control>
+                <Control Id="Description" Type="Text" X="20" Y="74" Width="280" Height="15" Transparent="yes" NoPrefix="yes">
+                    <Text>Disk space required for the installation exceeds available disk space.</Text>
+                </Control>
+                <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
+                    <Text>[DlgTitleFont]Out of Disk Space</Text>
+                </Control>
+                <Control Id="VolumeList" Type="VolumeCostList" X="20" Y="165" Width="330" Height="65" Sunken="yes" Fixed="yes" Remote="yes" ShowRollbackCost="yes">
+                    <Text>{120}{70}{70}{70}{70}</Text>
+                </Control>
+                <Control Id="Text2" Type="Text" X="20" Y="125" Width="330" Height="40">
+                    <Text>Alternatively, you may choose to disable the installer's rollback functionality.  This allows the installer to restore your computer's original state should the installation be interrupted in any way.  Click Yes if you wish to take the risk to disable rollback.</Text>
+                </Control>
+            </Dialog>
+            <Dialog Id="ResumeDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+                <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
+                <Control Id="Instructions" Type="Text" X="15" Y="155" Width="340" Height="45" Transparent="yes" NoPrefix="yes">
+                    <Text>Resuming the [ProductName] [Installer]
 
-        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
-        <Control Id="Finish" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Finish]">
-          <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Cancel]" />
-      </Dialog>
-      <Dialog Id="FatalError" Width="370" Height="270" Title="[ProductName] [Setup]" NoMinimize="yes">
-        <Control Id="Finish" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Finish]">
-          <Publish Event="EndDialog" Value="Exit"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Cancel]" />
-        <Control Id="Bitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="234" TabSkip="no" Text="[DialogBitmap]" />
-        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
-        <Control Id="Title" Type="Text" X="135" Y="20" Width="220" Height="60" Transparent="yes" NoPrefix="yes">
-          <Text>{\VerdanaBold13}[ProductName] [Wizard] ended prematurely</Text>
-        </Control>
-        <Control Id="Description1" Type="Text" X="135" Y="70" Width="220" Height="40" Transparent="yes" NoPrefix="yes">
-          <Text>[ProductName] setup ended prematurely because of an error.  Your system has not been modified.  To install this program at a later time, please run the installation again.</Text>
-        </Control>
-        <Control Id="Description2" Type="Text" X="135" Y="115" Width="220" Height="20" Transparent="yes" NoPrefix="yes">
-          <Text>Click the Finish button to exit the [Wizard].</Text>
-        </Control>
-      </Dialog>
-      <Dialog Id="PrepareDlg" Width="370" Height="270" Title="[ProductName] [Setup]" Modeless="yes">
-        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Cancel]">
-          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="Bitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="234" TabSkip="no" Text="[DialogBitmap]" />
-        <Control Id="Description" Type="Text" X="135" Y="70" Width="220" Height="20" Transparent="yes" NoPrefix="yes">
-          <Text>Please wait while the [Wizard] prepares to guide you through the installation.</Text>
-        </Control>
-        <Control Id="Title" Type="Text" X="135" Y="20" Width="220" Height="60" Transparent="yes" NoPrefix="yes">
-          <Text>{\VerdanaBold13}Welcome to the [ProductName] [Wizard]</Text>
-        </Control>
-        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" TabSkip="yes" Text="[ButtonText_Back]" />
-        <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Disabled="yes" TabSkip="yes" Text="[ButtonText_Next]" />
-        <Control Id="ActionData" Type="Text" X="135" Y="125" Width="220" Height="30" Transparent="yes" NoPrefix="yes">
-          <Subscribe Event="ActionData" Attribute="Text" />
-        </Control>
-        <Control Id="ActionText" Type="Text" X="135" Y="100" Width="220" Height="20" Transparent="yes" NoPrefix="yes">
-          <Subscribe Event="ActionText" Attribute="Text" />
-        </Control>
-      </Dialog>
-      <Dialog Id="ProgressDlg" Width="370" Height="270" Title="[ProductName] [Setup]" Modeless="yes">
-        <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
-        
-        <Control Id="Instructions" Type="Text" X="15" Y="155" Width="340" Height="45" Transparent="yes" NoPrefix="yes">
-          <Text>!(loc.ProgressDlgInstructions)</Text>
-        </Control>
-
-        <Control Id="StatusLabel" Type="Text" X="15" Y="215" Width="35" Height="10" Text="!(loc.ProgressDlgStatusLabel)" />
-        <Control Id="ActionText" Type="Text" X="50" Y="215" Width="265" Height="10">
-          <Subscribe Event="ActionText" Attribute="Text" />
-        </Control>
-        <Control Id="ProgressBar" Type="ProgressBar" X="15" Y="225" Width="340" Height="10" ProgressBlocks="yes" Text="Progress done">
-          <Subscribe Event="SetProgress" Attribute="Progress" />
-        </Control>
-        
-        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
-        <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Next]" />
-        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Cancel]">
-          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-        </Control>
-
-      </Dialog>
-      <Dialog Id="UserExitDlg" Width="370" Height="270" Title="[ProductName] [Setup]" NoMinimize="yes">
-        <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
-
-        <Control Id="Instructions" Type="Text" X="15" Y="155" Width="340" Height="85" Transparent="yes" NoPrefix="yes">
-          <Text>!(loc.UserExitDlgInstructions)</Text>
-        </Control>
-      
-        <Control Id="Finish" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Finish]">
-          <Publish Event="EndDialog" Value="Exit"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Cancel]" />
-        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />        
-      </Dialog>
-      <Dialog Id="AdminBrowseDlg" Width="370" Height="270" Title="[ProductName] [Setup]" NoMinimize="yes">
-        <Control Id="PathEdit" Type="PathEdit" X="84" Y="202" Width="261" Height="17" Property="TARGETDIR" />
-        <Control Id="OK" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_OK]">
-          <Publish Event="SetTargetPath" Value="TARGETDIR"><![CDATA[1]]></Publish>
-          <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="Cancel" Type="PushButton" X="240" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
-          <Publish Event="Reset" Value="0"><![CDATA[1]]></Publish>
-          <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="ComboLabel" Type="Text" X="25" Y="58" Width="44" Height="10" TabSkip="no" Text="&amp;Look in:" />
-        <Control Id="DirectoryCombo" Type="DirectoryCombo" X="70" Y="55" Width="220" Height="80" Property="TARGETDIR" Removable="yes" Fixed="yes" Remote="yes">
-          <Subscribe Event="IgnoreChange" Attribute="IgnoreChange" />
-        </Control>
-        <Control Id="Up" Type="PushButton" X="298" Y="55" Width="19" Height="19" ToolTip="Up One Level" Icon="yes" FixedSize="yes" IconSize="16" Text="Up">
-          <Publish Event="DirectoryListUp" Value="0"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="NewFolder" Type="PushButton" X="325" Y="55" Width="19" Height="19" ToolTip="Create A New Folder" Icon="yes" FixedSize="yes" IconSize="16" Text="New">
-          <Publish Event="DirectoryListNew" Value="0"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="DirectoryList" Type="DirectoryList" X="25" Y="83" Width="320" Height="110" Property="TARGETDIR" Sunken="yes" TabSkip="no" />
-        <Control Id="PathLabel" Type="Text" X="25" Y="205" Width="59" Height="10" TabSkip="no" Text="&amp;Folder name:" />
-        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-        <Control Id="Description" Type="Text" X="25" Y="23" Width="280" Height="15" Transparent="yes" NoPrefix="yes">
-          <Text>Browse to the destination folder</Text>
-        </Control>
-        <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
-          <Text>[DlgTitleFont]Change current destination folder</Text>
-        </Control>
-      </Dialog>
-      <Dialog Id="BrowseDlg" Width="370" Height="270" Title="[ProductName] [Setup]" NoMinimize="yes">
-        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-        
-        <Control Id="Instructions" Type="Text" X="10" Y="55" Width="350" Height="10" Transparent="yes" NoPrefix="yes">
-          <Text>!(loc.BrowseDlgInstructions)</Text>
-        </Control>
-        
-        <Control Id="DirectoryCombo" Type="DirectoryCombo" X="10" Y="70" Width="310" Height="20" Property="INSTALLDIR" Fixed="yes" Remote="yes">
-          <Subscribe Event="IgnoreChange" Attribute="IgnoreChange" />
-        </Control>
-        <Control Id="Up" Type="PushButton" X="320" Y="70" Width="20" Height="20" ToolTip="!(loc.BrowseDlgUp)" Icon="yes" FixedSize="yes" IconSize="16" Text="Up">
-          <Publish Event="DirectoryListUp" Value="0"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="NewFolder" Type="PushButton" X="340" Y="70" Width="20" Height="20" ToolTip="!(loc.BrowseDlgNewFolder)" Icon="yes" FixedSize="yes" IconSize="16" Text="New">
-          <Publish Event="DirectoryListNew" Value="0"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="DirectoryList" Type="DirectoryList" X="10" Y="90" Width="350" Height="110" Property="INSTALLDIR" Sunken="yes" TabSkip="no" />
-        
-        <Control Id="PathLabel" Type="Text" X="10" Y="205" Width="350" Height="15" TabSkip="no" Text="!(loc.BrowseDlgPathLabel)" />
-        <Control Id="PathEdit" Type="PathEdit" X="10" Y="220" Width="350" Height="17" Property="INSTALLDIR" />
-        
-        <Control Id="OK" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_OK]">
-          <Publish Event="SetTargetPath" Value="INSTALLDIR"><![CDATA[1]]></Publish>
-          <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
-          <Publish Event="Reset" Value="0"><![CDATA[1]]></Publish>
-          <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[1]]></Publish>
-        </Control>
-      </Dialog>
-      <Dialog Id="CancelDlg" Width="260" Height="85" Title="[ProductName] [Setup]" NoMinimize="yes">
-        <Control Id="Icon" Type="Icon" X="15" Y="15" Width="24" Height="24" ToolTip="Information icon" FixedSize="yes" IconSize="32" Text="[QuestionIcon]" />
-        <Control Id="Text" Type="Text" X="48" Y="15" Width="194" Height="30">
-          <Text>!(loc.CancelDlgText)</Text>
-        </Control>
-        <Control Id="Yes" Type="PushButton" X="72" Y="57" Width="56" Height="17" Text="[ButtonText_Yes]">
-          <Publish Event="EndDialog" Value="Exit"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="No" Type="PushButton" X="132" Y="57" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_No]">
-          <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
-        </Control>
-      </Dialog>
-      <Dialog Id="AdvancedDlg" Width="370" Height="270" Title="!(loc.AdvancedDlgTitle)" NoMinimize="yes" TrackDiskSpace="yes">
-        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-        
-        <Control Id="Instructions" Type="Text" X="10" Y="55" Width="350" Height="45" Transparent="yes" NoPrefix="yes">
-          <Text>!(loc.AdvancedDlgInstructions)</Text>
-        </Control>
-        
-        <Control Id="LocationLabel" Type="Text" X="10" Y="115" Width="350" Height="15" Text="!(loc.AdvancedDlgLocationLabel)">
-          <Subscribe Event="SelectionPathOn" Attribute="Visible" />
-          <Condition Action="hide"><![CDATA[Installed]]></Condition>
-        </Control>
-        <Control Type="PathEdit" Id="DestinationPath" X="10" Y="130" Width="282" Height="17" Property="INSTALLDIR" />
-        <Control Id="Browse" Type="PushButton" X="304" Y="130" Width="56" Height="17" Text="!(loc.AdvancedDlgBrowse)">
-          <Publish Event="NewDialog" Value="BrowseDlg"><![CDATA[1]]></Publish>
-          <Condition Action="hide"><![CDATA[Installed]]></Condition>
-        </Control>
- 
-        <Control Type="CheckBox" Id="AddDesktopShortcut" X="10" Y="155" Width="350" Height="20" Property="ADDDESKTOPSHORTCUT" CheckBoxValue="true">
-          <Text>!(loc.AdvancedDlgAddDesktopShortcut)</Text>
-        </Control>
-        <Control Type="CheckBox" Id="AddStartMenuShortcut" X="10" Y="170" Width="350" Height="20" Property="ADDSTARTMENUSHORTCUT" CheckBoxValue="true">
-          <Text>!(loc.AdvancedDlgAddStartMenuShortcut)</Text>
-        </Control>
-        <Control Type="CheckBox" Id="LaunchAppAfterInstall" X="10" Y="195" Width="350" Height="20" Property="LAUNCHAPPAFTERINSTALL" CheckBoxValue="true">
-          <Text>!(loc.AdvancedDlgLaunchAppAfterInstall)</Text>
-        </Control>
-
-        <Control Id="AcceptLicenseCheckBox" Type="CheckBox" X="10" Y="220" Width="350" Height="20" CheckBoxPropertyRef="LicenseAccepted" CheckBoxValue="true">
-          <Text>!(loc.WelcomeDlgAcceptLicenseCheckBox)</Text>
-        </Control>        
-        
-        <Control Id="License" Type="PushButton" X="10" Y="243" Width="56" Height="17" Text="[ButtonText_License]">
-          <Publish Event="NewDialog" Value="LicenseAgreementDlg"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="Reset" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Reset]">
-          <Publish Event="Reset" Value="0"><![CDATA[1]]></Publish>
-        </Control>
-        
-        <Control Id="Install" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Install]" ElevationShield="yes">
-          <Condition Action="disable"><![CDATA[LicenseAccepted <> "true"]]></Condition>
-          <Condition Action="enable"><![CDATA[LicenseAccepted = "true"]]></Condition>
-          <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
-          <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
-          <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-          <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-          <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
-        </Control>
-        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
-          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-        </Control>
-    </Dialog>
-      <Dialog Id="DiskCostDlg" Width="370" Height="270" Title="[ProductName] [Setup]" NoMinimize="yes">
-        <Control Id="OK" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_OK]">
-          <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-        <Control Id="Text" Type="Text" X="20" Y="53" Width="330" Height="40">
-          <Text>The highlighted volumes (if any) do not have enough disk space available for the currently selected features.  You can either remove some files from the highlighted volumes, or choose to install less features onto local drive(s), or select different destination drive(s).</Text>
-        </Control>
-        <Control Id="Description" Type="Text" X="20" Y="20" Width="280" Height="20" Transparent="yes" NoPrefix="yes">
-          <Text>The disk space required for the installation of the selected features.</Text>
-        </Control>
-        <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
-          <Text>[DlgTitleFont]Disk Space Requirements</Text>
-        </Control>
-        <Control Id="VolumeList" Type="VolumeCostList" X="20" Y="100" Width="330" Height="120" Sunken="yes" Fixed="yes" Remote="yes">
-          <Text>{120}{70}{70}{70}{70}</Text>
-        </Control>
-      </Dialog>
-      <Dialog Id="ErrorDlg" Y="10" Width="270" Height="105" Title="Installer Information" ErrorDialog="yes" NoMinimize="yes">
-        <Control Id="ErrorText" Type="Text" X="48" Y="15" Width="205" Height="60" TabSkip="no" Text="Information text" />
-        <Control Id="Y" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_Yes]">
-          <Publish Event="EndDialog" Value="ErrorYes"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="A" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_Cancel]">
-          <Publish Event="EndDialog" Value="ErrorAbort"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="C" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_Cancel]">
-          <Publish Event="EndDialog" Value="ErrorCancel"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="ErrorIcon" Type="Icon" X="15" Y="15" Width="24" Height="24" ToolTip="Information icon" FixedSize="yes" IconSize="32" Text="[QuestionIcon]" />
-        <Control Id="I" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_Ignore]">
-          <Publish Event="EndDialog" Value="ErrorIgnore"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="N" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_No]">
-          <Publish Event="EndDialog" Value="ErrorNo"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="O" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_OK]">
-          <Publish Event="EndDialog" Value="ErrorOk"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="R" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_Retry]">
-          <Publish Event="EndDialog" Value="ErrorRetry"><![CDATA[1]]></Publish>
-        </Control>
-      </Dialog>
-      <Dialog Id="FilesInUse" Width="370" Height="270" Title="[ProductName] [Setup]" NoMinimize="yes" KeepModeless="yes">
-        <Control Id="Retry" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Retry]">
-          <Publish Event="EndDialog" Value="Retry"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="Ignore" Type="PushButton" X="235" Y="243" Width="56" Height="17" Text="[ButtonText_Ignore]">
-          <Publish Event="EndDialog" Value="Ignore"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="Exit" Type="PushButton" X="166" Y="243" Width="56" Height="17" Text="[ButtonText_Exit]">
-          <Publish Event="EndDialog" Value="Exit"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-        <Control Id="Text" Type="Text" X="20" Y="55" Width="330" Height="30">
-          <Text>The following applications are using files that need to be updated by this setup. Close these applications and then click Retry to continue the installation or Cancel to exit it.</Text>
-        </Control>
-        <Control Id="Description" Type="Text" X="20" Y="23" Width="280" Height="20" Transparent="yes" NoPrefix="yes">
-          <Text>Some files that need to be updated are currently in use.</Text>
-        </Control>
-        <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
-          <Text>[DlgTitleFont]Files in Use</Text>
-        </Control>
-        <Control Id="List" Type="ListBox" X="20" Y="87" Width="330" Height="130" Property="FileInUseProcess" Sunken="yes" TabSkip="no" />
-      </Dialog>
-      <Dialog Id="LicenseAgreementDlg" Width="370" Height="270" Title="[ProductName] License Agreement" NoMinimize="yes">
-        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-        
-        <Control Id="AgreementText" Type="ScrollableText" X="0" Y="44" Width="370" Height="189" Sunken="no" TabSkip="yes">
-          <Text SourceFile="../resources/windows/license.rtf" />
-        </Control>
-        
-        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Back]">
-          <Publish Event="NewDialog" Value="WelcomeDlg"><![CDATA[1]]></Publish>
-          <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[LicenseAccepted = "true"]]></Publish>
-        </Control>
-        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
-          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-        </Control>
-      </Dialog>
-      <Dialog Id="MaintenanceTypeDlg" Width="370" Height="270" Title="[ProductName] [Setup]" NoMinimize="yes">
-        <Control Id="ChangeLabel" Type="Text" X="105" Y="65" Width="100" Height="10" TabSkip="no">
-          <Text>[DlgTitleFont]&amp;Modify</Text>
-        </Control>
-        <Control Id="ChangeButton" Type="PushButton" X="50" Y="65" Width="38" Height="38" ToolTip="Modify Installation" Default="yes" Icon="yes" FixedSize="yes" IconSize="32" Text="[ModifyIcon]">
-          <Publish Property="InstallMode" Value="Change"><![CDATA[1]]></Publish>
-          <Publish Property="Progress1" Value="Changing"><![CDATA[1]]></Publish>
-          <Publish Property="Progress2" Value="changes"><![CDATA[1]]></Publish>
-          <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="RepairLabel" Type="Text" X="105" Y="114" Width="100" Height="10" TabSkip="no">
-          <Text>[DlgTitleFont]Re&amp;pair</Text>
-        </Control>
-        <Control Id="RepairButton" Type="PushButton" X="50" Y="114" Width="38" Height="38" ToolTip="Repair Installation" Icon="yes" FixedSize="yes" IconSize="32" Text="[RepairIcon]">
-          <Publish Property="InstallMode" Value="Repair"><![CDATA[1]]></Publish>
-          <Publish Property="Progress1" Value="Repairing"><![CDATA[1]]></Publish>
-          <Publish Property="Progress2" Value="repaires"><![CDATA[1]]></Publish>
-          <Publish Event="NewDialog" Value="VerifyRepairDlg"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="RemoveLabel" Type="Text" X="105" Y="163" Width="100" Height="10" TabSkip="no">
-          <Text>[DlgTitleFont]&amp;Remove</Text>
-        </Control>
-        <Control Id="RemoveButton" Type="PushButton" X="50" Y="163" Width="38" Height="38" ToolTip="Remove Installation" Icon="yes" FixedSize="yes" IconSize="32" Text="[RemoveIcon]">
-          <Publish Property="InstallMode" Value="Remove"><![CDATA[1]]></Publish>
-          <Publish Property="Progress1" Value="Removing"><![CDATA[1]]></Publish>
-          <Publish Property="Progress2" Value="removes"><![CDATA[1]]></Publish>
-          <Publish Event="NewDialog" Value="VerifyRemoveDlg"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Back]">
-          <Publish Event="NewDialog" Value="MaintenanceWelcomeDlg"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Next]" />
-        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
-          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-        <Control Id="Description" Type="Text" X="25" Y="23" Width="280" Height="20" Transparent="yes" NoPrefix="yes">
-          <Text>Select the operation you wish to perform.</Text>
-        </Control>
-        <Control Id="Title" Type="Text" X="15" Y="6" Width="240" Height="15" Transparent="yes" NoPrefix="yes">
-          <Text>[DlgTitleFont]Modify, Repair or Remove installation</Text>
-        </Control>
-        <Control Id="ChangeText" Type="Text" X="105" Y="78" Width="230" Height="20">
-          <Text>Allows users to change the way features are installed.</Text>
-        </Control>
-        <Control Id="RemoveText" Type="Text" X="105" Y="176" Width="230" Height="20">
-          <Text>Removes [ProductName] from your computer.</Text>
-        </Control>
-        <Control Id="RepairText" Type="Text" X="105" Y="127" Width="230" Height="30">
-          <Text>Repairs errors in the most recent installation state - fixes missing or corrupt files, shortcuts and registry entries.</Text>
-        </Control>
-      </Dialog>
-      <Dialog Id="MaintenanceWelcomeDlg" Width="370" Height="270" Title="[ProductName] [Setup]" NoMinimize="yes">
-        <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Next]">
-          <Publish Event="SpawnWaitDialog" Value="WaitForCostingDlg"><![CDATA[CostingComplete = 1]]></Publish>
-          <Publish Event="NewDialog" Value="MaintenanceTypeDlg"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
-          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="Bitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="234" TabSkip="no" Text="[DialogBitmap]" />
-        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
-        <Control Id="Description" Type="Text" X="135" Y="70" Width="220" Height="60" Transparent="yes" NoPrefix="yes">
-          <Text>The [Wizard] will allow you to change the way [ProductName] features are installed on your computer or even to remove [ProductName] from your computer.  Click Next to continue or Cancel to exit the [Wizard].</Text>
-        </Control>
-        <Control Id="Title" Type="Text" X="135" Y="20" Width="220" Height="60" Transparent="yes" NoPrefix="yes">
-          <Text>{\VerdanaBold13}Welcome to the [ProductName] [Wizard]</Text>
-        </Control>
-      </Dialog>
-      <Dialog Id="OutOfDiskDlg" Width="370" Height="270" Title="[ProductName] [Setup]" NoMinimize="yes">
-        <Control Id="OK" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_OK]">
-          <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-        <Control Id="Text" Type="Text" X="20" Y="53" Width="330" Height="40">
-          <Text>The highlighted volumes do not have enough disk space available for the currently selected features.  You can either remove some files from the highlighted volumes, or choose to install less features onto local drive(s), or select different destination drive(s).</Text>
-        </Control>
-        <Control Id="Description" Type="Text" X="20" Y="20" Width="280" Height="20" Transparent="yes" NoPrefix="yes">
-          <Text>Disk space required for the installation exceeds available disk space.</Text>
-        </Control>
-        <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
-          <Text>[DlgTitleFont]Out of Disk Space</Text>
-        </Control>
-        <Control Id="VolumeList" Type="VolumeCostList" X="20" Y="100" Width="330" Height="120" Sunken="yes" Fixed="yes" Remote="yes">
-          <Text>{120}{70}{70}{70}{70}</Text>
-        </Control>
-      </Dialog>
-      <Dialog Id="OutOfRbDiskDlg" Width="370" Height="270" Title="[ProductName] [Setup]" NoMinimize="yes">
-        <Control Id="No" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_No]">
-          <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="Yes" Type="PushButton" X="240" Y="243" Width="56" Height="17" Text="[ButtonText_Yes]">
-          <Publish Event="EnableRollback" Value="False"><![CDATA[1]]></Publish>
-          <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-        <Control Id="Text" Type="Text" X="20" Y="53" Width="330" Height="40">
-          <Text>The highlighted volumes do not have enough disk space available for the currently selected features.  You can either remove some files from the highlighted volumes, or choose to install less features onto local drive(s), or select different destination drive(s).</Text>
-        </Control>
-        <Control Id="Description" Type="Text" X="20" Y="20" Width="280" Height="20" Transparent="yes" NoPrefix="yes">
-          <Text>Disk space required for the installation exceeds available disk space.</Text>
-        </Control>
-        <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
-          <Text>[DlgTitleFont]Out of Disk Space</Text>
-        </Control>
-        <Control Id="VolumeList" Type="VolumeCostList" X="20" Y="140" Width="330" Height="80" Sunken="yes" Fixed="yes" Remote="yes" ShowRollbackCost="yes">
-          <Text>{120}{70}{70}{70}{70}</Text>
-        </Control>
-        <Control Id="Text2" Type="Text" X="20" Y="94" Width="330" Height="40">
-          <Text>Alternatively, you may choose to disable the installer's rollback functionality.  This allows the installer to restore your computer's original state should the installation be interrupted in any way.  Click Yes if you wish to take the risk to disable rollback.</Text>
-        </Control>
-      </Dialog>
-      <Dialog Id="ResumeDlg" Width="370" Height="270" Title="[ProductName] [Setup]" NoMinimize="yes">
-        <Control Id="Install" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Install]">
-          <Publish Event="SpawnWaitDialog" Value="WaitForCostingDlg"><![CDATA[CostingComplete = 1]]></Publish>
-          <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
-          <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
-          <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-          <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-          <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
-        </Control>
-        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
-          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="Bitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="234" TabSkip="no" Text="[DialogBitmap]" />
-        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
-        <Control Id="Description" Type="Text" X="135" Y="70" Width="220" Height="30" Transparent="yes" NoPrefix="yes">
-          <Text>The [Wizard] will complete the installation of [ProductName] on your computer.  Click Install to continue or Cancel to exit the [Wizard].</Text>
-        </Control>
-        <Control Id="Title" Type="Text" X="135" Y="20" Width="220" Height="60" Transparent="yes" NoPrefix="yes">
-          <Text>{\VerdanaBold13}Resuming the [ProductName] [Wizard]</Text>
-        </Control>
-      </Dialog>
-      <Dialog Id="VerifyReadyDlg" Width="370" Height="270" Title="[ProductName] [Setup]" NoMinimize="yes" TrackDiskSpace="yes">
-        <Control Id="Install" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Install]">
-          <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
-          <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
-          <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-          <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-          <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
-        </Control>
-        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
-          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Back]">
-          <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[InstallMode = "Custom" OR InstallMode = "Change"]]></Publish>
-          <Publish Event="NewDialog" Value="MaintenanceTypeDlg"><![CDATA[InstallMode = "Repair"]]></Publish>
-        </Control>
-        <Control Id="Text" Type="Text" X="25" Y="70" Width="320" Height="20">
-          <Text>Click Install to begin the installation.  If you want to review or change any of your installation settings, click Back.  Click Cancel to exit the wizard.</Text>
-        </Control>
-        <Control Id="Description" Type="Text" X="25" Y="23" Width="280" Height="15" Transparent="yes" NoPrefix="yes">
-          <Text>The [Wizard] is ready to begin the [InstallMode] installation</Text>
-        </Control>
-        <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
-          <Text>[DlgTitleFont]Ready to Install</Text>
-        </Control>
-      </Dialog>
-      <Dialog Id="VerifyRemoveDlg" Width="370" Height="270" Title="[ProductName] [Setup]" NoMinimize="yes" TrackDiskSpace="yes">
-        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Back]">
-          <Publish Event="NewDialog" Value="MaintenanceTypeDlg"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="Remove" Type="PushButton" X="236" Y="243" Width="56" Height="17" Text="[ButtonText_Remove]">
-          <Publish Event="Remove" Value="All"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
-          <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
-          <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
-          <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-          <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-          <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
-        </Control>
-        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
-          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-        <Control Id="Text" Type="Text" X="25" Y="70" Width="320" Height="30">
-          <Text>Click Remove to remove [ProductName] from your computer.  If you want to review or change any of your installation settings, click Back.  Click Cancel to exit the wizard.</Text>
-        </Control>
-        <Control Id="Description" Type="Text" X="25" Y="23" Width="280" Height="15" Transparent="yes" NoPrefix="yes">
-          <Text>You have chosen to remove the program from your computer.</Text>
-        </Control>
-        <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
-          <Text>[DlgTitleFont]Remove [ProductName]</Text>
-        </Control>
-      </Dialog>
-      <Dialog Id="VerifyRepairDlg" Width="370" Height="270" Title="[ProductName] [Setup]" NoMinimize="yes" TrackDiskSpace="yes">
-        <Control Id="Repair" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Repair]">
-          <Publish Event="ReinstallMode" Value="ecmus"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
-          <Publish Event="Reinstall" Value="All"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
-          <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
-          <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
-          <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-          <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-          <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
-        </Control>
-        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
-          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Back]">
-          <Publish Event="NewDialog" Value="MaintenanceTypeDlg"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="Text" Type="Text" X="25" Y="70" Width="320" Height="30">
-          <Text>Click Repair to repair the installation of [ProductName].  If you want to review or change any of your installation settings, click Back.  Click Cancel to exit the wizard.</Text>
-        </Control>
-        <Control Id="Description" Type="Text" X="25" Y="23" Width="280" Height="15" Transparent="yes" NoPrefix="yes">
-          <Text>The [Wizard] is ready to begin the repair of [ProductName].</Text>
-        </Control>
-        <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
-          <Text>[DlgTitleFont]Repair [ProductName]</Text>
-        </Control>
-      </Dialog>
-      <Dialog Id="WaitForCostingDlg" Y="10" Width="260" Height="85" Title="[ProductName] [Setup]" NoMinimize="yes">
-        <Control Id="Return" Type="PushButton" X="102" Y="57" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Return]">
-          <Publish Event="EndDialog" Value="Exit"><![CDATA[1]]></Publish>
-        </Control>
-        <Control Id="Text" Type="Text" X="48" Y="15" Width="194" Height="30">
-          <Text>Please wait while the installer finishes determining your disk space requirements.</Text>
-        </Control>
-        <Control Id="Icon" Type="Icon" X="15" Y="15" Width="24" Height="24" ToolTip="Exclamation icon" FixedSize="yes" IconSize="32" Text="[WarningIcon]" />
-      </Dialog>
-      <Dialog Id="WelcomeDlg" Width="370" Height="270" Title="[ProductName] [Setup]" NoMinimize="yes">
-          <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
-
-          <Control Id="Instructions" Type="Text" X="10" Y="155" Width="350" Height="45" Transparent="yes" NoPrefix="yes">
-            <Text>!(loc.WelcomeDlgInstructions)</Text>
-          </Control>
-          <Control Id="AcceptLicenseCheckBox" Type="CheckBox" X="10" Y="220" Width="350" Height="20" Property="LicenseAccepted" CheckBoxValue="true">
-            <Text>!(loc.WelcomeDlgAcceptLicenseCheckBox)</Text>
-          </Control>
-
-          <!-- TabSkip is needed in order to hack the zindex and make the button appear above the background image -->
-          <Control Id="License" Type="PushButton" X="10" Y="243" Width="56" Height="17" Text="[ButtonText_License]">
-            <Publish Event="NewDialog" Value="LicenseAgreementDlg"><![CDATA[1]]></Publish>
-          </Control>
-          <Control Id="Advanced" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_AdvancedInstall]">
-            <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[1]]></Publish>
-          </Control>
-          <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" TabSkip="yes" Default="yes" ElevationShield="yes" Text="[ButtonText_Install]">
-            <Condition Action="disable"><![CDATA[LicenseAccepted <> "true"]]></Condition>
-            <Condition Action="enable"><![CDATA[LicenseAccepted = "true"]]></Condition>
-            <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
-            <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
-            <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-            <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-            <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
-          </Control>
-          <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" TabSkip="yes" Cancel="yes" Text="[ButtonText_Cancel]">
-            <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-          </Control>
-      </Dialog>
-      <TextStyle Id="DlgFont8" FaceName="Segoe UI" Size="8" />
-      <TextStyle Id="White8" FaceName="Segoe UI" Size="8" Red="255" Green="255" Blue="255" />
-      <TextStyle Id="DlgFontBold8" FaceName="Segoe UI" Size="8" Bold="yes" />
-      <TextStyle Id="VerdanaBold13" FaceName="Verdana" Size="13" Bold="yes" />
-      <UIText Id="AbsentPath" />
-      <UIText Id="bytes">bytes</UIText>
-      <UIText Id="GB">GB</UIText>
-      <UIText Id="KB">KB</UIText>
-      <UIText Id="MB">MB</UIText>
-      <UIText Id="MenuAbsent">Entire feature will be unavailable</UIText>
-      <UIText Id="MenuAdvertise">Feature will be installed when required</UIText>
-      <UIText Id="MenuAllCD">Entire feature will be installed to run from CD</UIText>
-      <UIText Id="MenuAllLocal">Entire feature will be installed on local hard drive</UIText>
-      <UIText Id="MenuAllNetwork">Entire feature will be installed to run from network</UIText>
-      <UIText Id="MenuCD">Will be installed to run from CD</UIText>
-      <UIText Id="MenuLocal">Will be installed on local hard drive</UIText>
-      <UIText Id="MenuNetwork">Will be installed to run from network</UIText>
-      <UIText Id="ScriptInProgress">Gathering required information...</UIText>
-      <UIText Id="SelAbsentAbsent">This feature will remain uninstalled</UIText>
-      <UIText Id="SelAbsentAdvertise">This feature will be set to be installed when required</UIText>
-      <UIText Id="SelAbsentCD">This feature will be installed to run from CD</UIText>
-      <UIText Id="SelAbsentLocal">This feature will be installed on the local hard drive</UIText>
-      <UIText Id="SelAbsentNetwork">This feature will be installed to run from the network</UIText>
-      <UIText Id="SelAdvertiseAbsent">This feature will become unavailable</UIText>
-      <UIText Id="SelAdvertiseAdvertise">Will be installed when required</UIText>
-      <UIText Id="SelAdvertiseCD">This feature will be available to run from CD</UIText>
-      <UIText Id="SelAdvertiseLocal">This feature will be installed on your local hard drive</UIText>
-      <UIText Id="SelAdvertiseNetwork">This feature will be available to run from the network</UIText>
-      <UIText Id="SelCDAbsent">This feature will be uninstalled completely, you won't be able to run it from CD</UIText>
-      <UIText Id="SelCDAdvertise">This feature will change from run from CD state to set to be installed when required</UIText>
-      <UIText Id="SelCDCD">This feature will remain to be run from CD</UIText>
-      <UIText Id="SelCDLocal">This feature will change from run from CD state to be installed on the local hard drive</UIText>
-      <UIText Id="SelChildCostNeg">This feature frees up [1] on your hard drive.</UIText>
-      <UIText Id="SelChildCostPos">This feature requires [1] on your hard drive.</UIText>
-      <UIText Id="SelCostPending">Compiling cost for this feature...</UIText>
-      <UIText Id="SelLocalAbsent">This feature will be completely removed</UIText>
-      <UIText Id="SelLocalAdvertise">This feature will be removed from your local hard drive, but will be set to be installed when required</UIText>
-      <UIText Id="SelLocalCD">This feature will be removed from your local hard drive, but will be still available to run from CD</UIText>
-      <UIText Id="SelLocalLocal">This feature will remain on you local hard drive</UIText>
-      <UIText Id="SelLocalNetwork">This feature will be removed from your local hard drive, but will be still available to run from the network</UIText>
-      <UIText Id="SelNetworkAbsent">This feature will be uninstalled completely, you won't be able to run it from the network</UIText>
-      <UIText Id="SelNetworkAdvertise">This feature will change from run from network state to set to be installed when required</UIText>
-      <UIText Id="SelNetworkLocal">This feature will change from run from network state to be installed on the local hard drive</UIText>
-      <UIText Id="SelNetworkNetwork">This feature will remain to be run from the network</UIText>
-      <UIText Id="SelParentCostNegNeg">This feature frees up [1] on your hard drive. It has [2] of [3] subfeatures selected. The subfeatures free up [4] on your hard drive.</UIText>
-      <UIText Id="SelParentCostNegPos">This feature frees up [1] on your hard drive. It has [2] of [3] subfeatures selected. The subfeatures require [4] on your hard drive.</UIText>
-      <UIText Id="SelParentCostPosNeg">This feature requires [1] on your hard drive. It has [2] of [3] subfeatures selected. The subfeatures free up [4] on your hard drive.</UIText>
-      <UIText Id="SelParentCostPosPos">This feature requires [1] on your hard drive. It has [2] of [3] subfeatures selected. The subfeatures require [4] on your hard drive.</UIText>
-      <UIText Id="TimeRemaining">Time remaining: {[1] minutes }{[2] seconds}</UIText>
-      <UIText Id="VolumeCostAvailable">Available</UIText>
-      <UIText Id="VolumeCostDifference">Difference</UIText>
-      <UIText Id="VolumeCostRequired">Required</UIText>
-      <UIText Id="VolumeCostSize">Disk Size</UIText>
-      <UIText Id="VolumeCostVolume">Volume</UIText>
-      <ProgressText Action="InstallValidate">Validating install</ProgressText>
-      <ProgressText Action="InstallFiles" Template="File: [1],  Directory: [9],  Size: [6]">Copying new files</ProgressText>
-      <ProgressText Action="InstallAdminPackage" Template="File: [1], Directory: [9], Size: [6]">Copying network install files</ProgressText>
-      <ProgressText Action="FileCost">Computing space requirements</ProgressText>
-      <ProgressText Action="CostInitialize">Computing space requirements</ProgressText>
-      <ProgressText Action="CostFinalize">Computing space requirements</ProgressText>
-      <ProgressText Action="CreateShortcuts" Template="Shortcut: [1]">Creating shortcuts</ProgressText>
-      <ProgressText Action="PublishComponents" Template="Component ID: [1], Qualifier: [2]">Publishing Qualified Components</ProgressText>
-      <ProgressText Action="PublishFeatures" Template="Feature: [1]">Publishing Product Features</ProgressText>
-      <ProgressText Action="PublishProduct">Publishing product information</ProgressText>
-      <ProgressText Action="RegisterClassInfo" Template="Class Id: [1]">Registering Class servers</ProgressText>
-      <ProgressText Action="RegisterExtensionInfo" Template="Extension: [1]">Registering extension servers</ProgressText>
-      <ProgressText Action="RegisterMIMEInfo" Template="MIME Content Type: [1], Extension: [2]">Registering MIME info</ProgressText>
-      <ProgressText Action="RegisterProgIdInfo" Template="ProgId: [1]">Registering program identifiers</ProgressText>
-      <ProgressText Action="AllocateRegistrySpace" Template="Free space: [1]">Allocating registry space</ProgressText>
-      <ProgressText Action="AppSearch" Template="Property: [1], Signature: [2]">Searching for installed applications</ProgressText>
-      <ProgressText Action="BindImage" Template="File: [1]">Binding executables</ProgressText>
-      <ProgressText Action="CCPSearch">Searching for qualifying products</ProgressText>
-      <ProgressText Action="CreateFolders" Template="Folder: [1]">Creating folders</ProgressText>
-      <ProgressText Action="DeleteServices" Template="Service: [1]">Deleting services</ProgressText>
-      <ProgressText Action="DuplicateFiles" Template="File: [1],  Directory: [9],  Size: [6]">Creating duplicate files</ProgressText>
-      <ProgressText Action="FindRelatedProducts" Template="Found application: [1]">Searching for related applications</ProgressText>
-      <ProgressText Action="InstallODBC">Installing ODBC components</ProgressText>
-      <ProgressText Action="InstallServices" Template="Service: [2]">Installing new services</ProgressText>
-      <ProgressText Action="LaunchConditions">Evaluating launch conditions</ProgressText>
-      <ProgressText Action="MigrateFeatureStates" Template="Application: [1]">Migrating feature states from related applications</ProgressText>
-      <ProgressText Action="MoveFiles" Template="File: [1],  Directory: [9],  Size: [6]">Moving files</ProgressText>
-      <ProgressText Action="PatchFiles" Template="File: [1],  Directory: [2],  Size: [3]">Patching files</ProgressText>
-      <ProgressText Action="ProcessComponents">Updating component registration</ProgressText>
-      <ProgressText Action="RegisterComPlus" Template="AppId: [1]{{, AppType: [2], Users: [3], RSN: [4]}}">Registering COM+ Applications and Components</ProgressText>
-      <ProgressText Action="RegisterFonts" Template="Font: [1]">Registering fonts</ProgressText>
-      <ProgressText Action="RegisterProduct" Template="[1]">Registering product</ProgressText>
-      <ProgressText Action="RegisterTypeLibraries" Template="LibID: [1]">Registering type libraries</ProgressText>
-      <ProgressText Action="RegisterUser" Template="[1]">Registering user</ProgressText>
-      <ProgressText Action="RemoveDuplicateFiles" Template="File: [1], Directory: [9]">Removing duplicated files</ProgressText>
-      <ProgressText Action="RemoveEnvironmentStrings" Template="Name: [1], Value: [2], Action [3]">Updating environment strings</ProgressText>
-      <ProgressText Action="RemoveExistingProducts" Template="Application: [1], Command line: [2]">Removing applications</ProgressText>
-      <ProgressText Action="RemoveFiles" Template="File: [1], Directory: [9]">Removing files</ProgressText>
-      <ProgressText Action="RemoveFolders" Template="Folder: [1]">Removing folders</ProgressText>
-      <ProgressText Action="RemoveIniValues" Template="File: [1],  Section: [2],  Key: [3], Value: [4]">Removing INI files entries</ProgressText>
-      <ProgressText Action="RemoveODBC">Removing ODBC components</ProgressText>
-      <ProgressText Action="RemoveRegistryValues" Template="Key: [1], Name: [2]">Removing system registry values</ProgressText>
-      <ProgressText Action="RemoveShortcuts" Template="Shortcut: [1]">Removing shortcuts</ProgressText>
-      <ProgressText Action="RMCCPSearch">Searching for qualifying products</ProgressText>
-      <ProgressText Action="SelfRegModules" Template="File: [1], Folder: [2]">Registering modules</ProgressText>
-      <ProgressText Action="SelfUnregModules" Template="File: [1], Folder: [2]">Unregistering modules</ProgressText>
-      <ProgressText Action="SetODBCFolders">Initializing ODBC directories</ProgressText>
-      <ProgressText Action="StartServices" Template="Service: [1]">Starting services</ProgressText>
-      <ProgressText Action="StopServices" Template="Service: [1]">Stopping services</ProgressText>
-      <ProgressText Action="UnpublishComponents" Template="Component ID: [1], Qualifier: [2]">Unpublishing Qualified Components</ProgressText>
-      <ProgressText Action="UnpublishFeatures" Template="Feature: [1]">Unpublishing Product Features</ProgressText>
-      <ProgressText Action="UnregisterClassInfo" Template="Class Id: [1]">Unregister Class servers</ProgressText>
-      <ProgressText Action="UnregisterComPlus" Template="AppId: [1]{{, AppType: [2]}}">Unregistering COM+ Applications and Components</ProgressText>
-      <ProgressText Action="UnregisterExtensionInfo" Template="Extension: [1]">Unregistering extension servers</ProgressText>
-      <ProgressText Action="UnregisterFonts" Template="Font: [1]">Unregistering fonts</ProgressText>
-      <ProgressText Action="UnregisterMIMEInfo" Template="MIME Content Type: [1], Extension: [2]">Unregistering MIME info</ProgressText>
-      <ProgressText Action="UnregisterProgIdInfo" Template="ProgId: [1]">Unregistering program identifiers</ProgressText>
-      <ProgressText Action="UnregisterTypeLibraries" Template="LibID: [1]">Unregistering type libraries</ProgressText>
-      <ProgressText Action="WriteEnvironmentStrings" Template="Name: [1], Value: [2], Action [3]">Updating environment strings</ProgressText>
-      <ProgressText Action="WriteIniValues" Template="File: [1],  Section: [2],  Key: [3], Value: [4]">Writing INI files values</ProgressText>
-      <ProgressText Action="WriteRegistryValues" Template="Key: [1], Name: [2], Value: [3]">Writing system registry values</ProgressText>
-      <ProgressText Action="Advertise">Advertising application</ProgressText>
-      <ProgressText Action="GenerateScript" Template="[1]">Generating script operations for action:</ProgressText>
-      <ProgressText Action="InstallSFPCatalogFile" Template="File: [1],  Dependencies: [2]">Installing system catalog</ProgressText>
-      <ProgressText Action="MsiPublishAssemblies" Template="Application Context:[1], Assembly Name:[2]">Publishing assembly information</ProgressText>
-      <ProgressText Action="MsiUnpublishAssemblies" Template="Application Context:[1], Assembly Name:[2]">Unpublishing assembly information</ProgressText>
-      <ProgressText Action="Rollback" Template="[1]">Rolling back action:</ProgressText>
-      <ProgressText Action="RollbackCleanup" Template="File: [1]">Removing backup files</ProgressText>
-      <ProgressText Action="UnmoveFiles" Template="File: [1], Directory: [9]">Removing moved files</ProgressText>
-      <ProgressText Action="UnpublishProduct">Unpublishing product information</ProgressText>
-      <Error Id="0">{{Fatal error: }}</Error>
-      <Error Id="1">{{Error [1]. }}</Error>
-      <Error Id="2">Warning [1]. </Error>
-      <Error Id="3" />
-      <Error Id="4">Info [1]. </Error>
-      <Error Id="5">The installer has encountered an unexpected error installing this package. This may indicate a problem with this package. The error code is [1]. {{The arguments are: [2], [3], [4]}}</Error>
-      <Error Id="6" />
-      <Error Id="7">{{Disk full: }}</Error>
-      <Error Id="8">Action [Time]: [1]. [2]</Error>
-      <Error Id="9">[ProductName]</Error>
-      <Error Id="10">{[2]}{, [3]}{, [4]}</Error>
-      <Error Id="11">Message type: [1], Argument: [2]</Error>
-      <Error Id="12">=== Logging started: [Date]  [Time] ===</Error>
-      <Error Id="13">=== Logging stopped: [Date]  [Time] ===</Error>
-      <Error Id="14">Action start [Time]: [1].</Error>
-      <Error Id="15">Action ended [Time]: [1]. Return value [2].</Error>
-      <Error Id="16">Time remaining: {[1] minutes }{[2] seconds}</Error>
-      <Error Id="17">Out of memory. Shut down other applications before retrying.</Error>
-      <Error Id="18">Installer is no longer responding.</Error>
-      <Error Id="19">Installer stopped prematurely.</Error>
-      <Error Id="20">Please wait while Windows configures [ProductName]</Error>
-      <Error Id="21">Gathering required information...</Error>
-      <Error Id="22">Removing older versions of this application...</Error>
-      <Error Id="23">Preparing to remove older versions of this application...</Error>
-      <Error Id="32">{[ProductName] }Setup completed successfully.</Error>
-      <Error Id="33">{[ProductName] }Setup failed.</Error>
-      <Error Id="1101">Error reading from file: [2]. {{ System error [3].}}  Verify that the file exists and that you can access it.</Error>
-      <Error Id="1301">Cannot create the file '[2]'.  A directory with this name already exists.  Cancel the install and try installing to a different location.</Error>
-      <Error Id="1302">Please insert the disk: [2]</Error>
-      <Error Id="1303">The installer has insufficient privileges to access this directory: [2].  The installation cannot continue.  Log on as administrator or contact your system administrator.</Error>
-      <Error Id="1304">Error writing to file: [2].  Verify that you have access to that directory.</Error>
-      <Error Id="1305">Error reading from file [2]. {{ System error [3].}} Verify that the file exists and that you can access it.</Error>
-      <Error Id="1306">Another application has exclusive access to the file '[2]'.  Please shut down all other applications, then click Retry.</Error>
-      <Error Id="1307">There is not enough disk space to install this file: [2].  Free some disk space and click Retry, or click Cancel to exit.</Error>
-      <Error Id="1308">Source file not found: [2].  Verify that the file exists and that you can access it.</Error>
-      <Error Id="1309">Error reading from file: [3]. {{ System error [2].}}  Verify that the file exists and that you can access it.</Error>
-      <Error Id="1310">Error writing to file: [3]. {{ System error [2].}}  Verify that you have access to that directory.</Error>
-      <Error Id="1311">Source file not found{{(cabinet)}}: [2].  Verify that the file exists and that you can access it.</Error>
-      <Error Id="1312">Cannot create the directory '[2]'.  A file with this name already exists.  Please rename or remove the file and click retry, or click Cancel to exit.</Error>
-      <Error Id="1313">The volume [2] is currently unavailable.  Please select another.</Error>
-      <Error Id="1314">The specified path '[2]' is unavailable.</Error>
-      <Error Id="1315">Unable to write to the specified folder: [2].</Error>
-      <Error Id="1316">A network error occurred while attempting to read from the file: [2]</Error>
-      <Error Id="1317">An error occurred while attempting to create the directory: [2]</Error>
-      <Error Id="1318">A network error occurred while attempting to create the directory: [2]</Error>
-      <Error Id="1319">A network error occurred while attempting to open the source file cabinet: [2]</Error>
-      <Error Id="1320">The specified path is too long: [2]</Error>
-      <Error Id="1321">The Installer has insufficient privileges to modify this file: [2].</Error>
-      <Error Id="1322">A portion of the folder path '[2]' is invalid.  It is either empty or exceeds the length allowed by the system.</Error>
-      <Error Id="1323">The folder path '[2]' contains words that are not valid in folder paths.</Error>
-      <Error Id="1324">The folder path '[2]' contains an invalid character.</Error>
-      <Error Id="1325">'[2]' is not a valid short file name.</Error>
-      <Error Id="1326">Error getting file security: [3] GetLastError: [2]</Error>
-      <Error Id="1327">Invalid Drive: [2]</Error>
-      <Error Id="1328">Error applying patch to file [2].  It has probably been updated by other means, and can no longer be modified by this patch.  For more information contact your patch vendor.  {{System Error: [3]}}</Error>
-      <Error Id="1329">A file that is required cannot be installed because the cabinet file [2] is not digitally signed.  This may indicate that the cabinet file is corrupt.</Error>
-      <Error Id="1330">A file that is required cannot be installed because the cabinet file [2] has an invalid digital signature.  This may indicate that the cabinet file is corrupt.{{  Error [3] was returned by WinVerifyTrust.}}</Error>
-      <Error Id="1331">Failed to correctly copy [2] file: CRC error.</Error>
-      <Error Id="1332">Failed to correctly move [2] file: CRC error.</Error>
-      <Error Id="1333">Failed to correctly patch [2] file: CRC error.</Error>
-      <Error Id="1334">The file '[2]' cannot be installed because the file cannot be found in cabinet file '[3]'. This could indicate a network error, an error reading from the CD-ROM, or a problem with this package.</Error>
-      <Error Id="1335">The cabinet file '[2]' required for this installation is corrupt and cannot be used. This could indicate a network error, an error reading from the CD-ROM, or a problem with this package.</Error>
-      <Error Id="1336">There was an error creating a temporary file that is needed to complete this installation.{{  Folder: [3]. System error code: [2]}}</Error>
-      <Error Id="1401">Could not create key: [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel. </Error>
-      <Error Id="1402">Could not open key: [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel. </Error>
-      <Error Id="1403">Could not delete value [2] from key [3]. {{ System error [4].}}  Verify that you have sufficient access to that key, or contact your support personnel. </Error>
-      <Error Id="1404">Could not delete key [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel. </Error>
-      <Error Id="1405">Could not read value [2] from key [3]. {{ System error [4].}}  Verify that you have sufficient access to that key, or contact your support personnel. </Error>
-      <Error Id="1406">Could not write value [2] to key [3]. {{ System error [4].}}  Verify that you have sufficient access to that key, or contact your support personnel.</Error>
-      <Error Id="1407">Could not get value names for key [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel.</Error>
-      <Error Id="1408">Could not get sub key names for key [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel.</Error>
-      <Error Id="1409">Could not read security information for key [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel.</Error>
-      <Error Id="1410">Could not increase the available registry space. [2] KB of free registry space is required for the installation of this application.</Error>
-      <Error Id="1500">Another installation is in progress. You must complete that installation before continuing this one.</Error>
-      <Error Id="1501">Error accessing secured data. Please make sure the Windows Installer is configured properly and try the install again.</Error>
-      <Error Id="1502">User '[2]' has previously initiated an install for product '[3]'.  That user will need to run that install again before they can use that product.  Your current install will now continue.</Error>
-      <Error Id="1503">User '[2]' has previously initiated an install for product '[3]'.  That user will need to run that install again before they can use that product.</Error>
-      <Error Id="1601">Out of disk space -- Volume: '[2]'; required space: [3] KB; available space: [4] KB.  Free some disk space and retry.</Error>
-      <Error Id="1602">Are you sure you want to cancel?</Error>
-      <Error Id="1603">The file [2][3] is being held in use{ by the following process: Name: [4], Id: [5], Window Title: '[6]'}.  Close that application and retry.</Error>
-      <Error Id="1604">The product '[2]' is already installed, preventing the installation of this product.  The two products are incompatible.</Error>
-      <Error Id="1605">There is not enough disk space on the volume '[2]' to continue the install with recovery enabled. [3] KB are required, but only [4] KB are available. Click Ignore to continue the install without saving recovery information, click Retry to check for available space again, or click Cancel to quit the installation.</Error>
-      <Error Id="1606">Could not access network location [2].</Error>
-      <Error Id="1607">The following applications should be closed before continuing the install:</Error>
-      <Error Id="1608">Could not find any previously installed compliant products on the machine for installing this product.</Error>
-      <Error Id="1609">An error occurred while applying security settings. [2] is not a valid user or group. This could be a problem with the package, or a problem connecting to a domain controller on the network. Check your network connection and click Retry, or Cancel to end the install. {{Unable to locate the user's SID, system error [3]}}</Error>
-      <Error Id="1701">The key [2] is not valid.  Verify that you entered the correct key.</Error>
-      <Error Id="1702">The installer must restart your system before configuration of [2] can continue.  Click Yes to restart now or No if you plan to manually restart later.</Error>
-      <Error Id="1703">You must restart your system for the configuration changes made to [2] to take effect. Click Yes to restart now or No if you plan to manually restart later.</Error>
-      <Error Id="1704">An installation for [2] is currently suspended.  You must undo the changes made by that installation to continue.  Do you want to undo those changes?</Error>
-      <Error Id="1705">A previous installation for this product is in progress.  You must undo the changes made by that installation to continue.  Do you want to undo those changes?</Error>
-      <Error Id="1706">An installation package for the product [2] cannot be found. Try the installation again using a valid copy of the installation package '[3]'.</Error>
-      <Error Id="1707">Installation completed successfully.</Error>
-      <Error Id="1708">Installation failed.</Error>
-      <Error Id="1709">Product: [2] -- [3]</Error>
-      <Error Id="1710">You may either restore your computer to its previous state or continue the install later. Would you like to restore?</Error>
-      <Error Id="1711">An error occurred while writing installation information to disk.  Check to make sure enough disk space is available, and click Retry, or Cancel to end the install.</Error>
-      <Error Id="1712">One or more of the files required to restore your computer to its previous state could not be found.  Restoration will not be possible.</Error>
-      <Error Id="1713">[2] cannot install one of its required products. Contact your technical support group.  {{System Error: [3].}}</Error>
-      <Error Id="1714">The older version of [2] cannot be removed.  Contact your technical support group.  {{System Error [3].}}</Error>
-      <Error Id="1715">Installed [2]</Error>
-      <Error Id="1716">Configured [2]</Error>
-      <Error Id="1717">Removed [2]</Error>
-      <Error Id="1718">File [2] was rejected by digital signature policy.</Error>
-      <Error Id="1719">The Windows Installer Service could not be accessed. This can occur if you are running Windows in safe mode, or if the Windows Installer is not correctly installed. Contact your support personnel for assistance.</Error>
-      <Error Id="1720">There is a problem with this Windows Installer package. A script required for this install to complete could not be run. Contact your support personnel or package vendor.  {{Custom action [2] script error [3], [4]: [5] Line [6], Column [7], [8] }}</Error>
-      <Error Id="1721">There is a problem with this Windows Installer package. A program required for this install to complete could not be run. Contact your support personnel or package vendor. {{Action: [2], location: [3], command: [4] }}</Error>
-      <Error Id="1722">There is a problem with this Windows Installer package. A program run as part of the setup did not finish as expected. Contact your support personnel or package vendor.  {{Action [2], location: [3], command: [4] }}</Error>
-      <Error Id="1723">There is a problem with this Windows Installer package. A DLL required for this install to complete could not be run. Contact your support personnel or package vendor.  {{Action [2], entry: [3], library: [4] }}</Error>
-      <Error Id="1724">Removal completed successfully.</Error>
-      <Error Id="1725">Removal failed.</Error>
-      <Error Id="1726">Advertisement completed successfully.</Error>
-      <Error Id="1727">Advertisement failed.</Error>
-      <Error Id="1728">Configuration completed successfully.</Error>
-      <Error Id="1729">Configuration failed.</Error>
-      <Error Id="1730">You must be an Administrator to remove this application. To remove this application, you can log on as an Administrator, or contact your technical support group for assistance.</Error>
-      <Error Id="1801">The path [2] is not valid.  Please specify a valid path.</Error>
-      <Error Id="1802">Out of memory. Shut down other applications before retrying.</Error>
-      <Error Id="1803">There is no disk in drive [2]. Please insert one and click Retry, or click Cancel to go back to the previously selected volume.</Error>
-      <Error Id="1804">There is no disk in drive [2]. Please insert one and click Retry, or click Cancel to return to the browse dialog and select a different volume.</Error>
-      <Error Id="1805">The folder [2] does not exist.  Please enter a path to an existing folder.</Error>
-      <Error Id="1806">You have insufficient privileges to read this folder.</Error>
-      <Error Id="1807">A valid destination folder for the install could not be determined.</Error>
-      <Error Id="1901">Error attempting to read from the source install database: [2].</Error>
-      <Error Id="1902">Scheduling reboot operation: Renaming file [2] to [3]. Must reboot to complete operation.</Error>
-      <Error Id="1903">Scheduling reboot operation: Deleting file [2]. Must reboot to complete operation.</Error>
-      <Error Id="1904">Module [2] failed to register.  HRESULT [3].  Contact your support personnel.</Error>
-      <Error Id="1905">Module [2] failed to unregister.  HRESULT [3].  Contact your support personnel.</Error>
-      <Error Id="1906">Failed to cache package [2]. Error: [3]. Contact your support personnel.</Error>
-      <Error Id="1907">Could not register font [2].  Verify that you have sufficient permissions to install fonts, and that the system supports this font.</Error>
-      <Error Id="1908">Could not unregister font [2]. Verify that you that you have sufficient permissions to remove fonts.</Error>
-      <Error Id="1909">Could not create Shortcut [2]. Verify that the destination folder exists and that you can access it.</Error>
-      <Error Id="1910">Could not remove Shortcut [2]. Verify that the shortcut file exists and that you can access it.</Error>
-      <Error Id="1911">Could not register type library for file [2].  Contact your support personnel.</Error>
-      <Error Id="1912">Could not unregister type library for file [2].  Contact your support personnel.</Error>
-      <Error Id="1913">Could not update the ini file [2][3].  Verify that the file exists and that you can access it.</Error>
-      <Error Id="1914">Could not schedule file [2] to replace file [3] on reboot.  Verify that you have write permissions to file [3].</Error>
-      <Error Id="1915">Error removing ODBC driver manager, ODBC error [2]: [3]. Contact your support personnel.</Error>
-      <Error Id="1916">Error installing ODBC driver manager, ODBC error [2]: [3]. Contact your support personnel.</Error>
-      <Error Id="1917">Error removing ODBC driver: [4], ODBC error [2]: [3]. Verify that you have sufficient privileges to remove ODBC drivers.</Error>
-      <Error Id="1918">Error installing ODBC driver: [4], ODBC error [2]: [3]. Verify that the file [4] exists and that you can access it.</Error>
-      <Error Id="1919">Error configuring ODBC data source: [4], ODBC error [2]: [3]. Verify that the file [4] exists and that you can access it.</Error>
-      <Error Id="1920">Service '[2]' ([3]) failed to start.  Verify that you have sufficient privileges to start system services.</Error>
-      <Error Id="1921">Service '[2]' ([3]) could not be stopped.  Verify that you have sufficient privileges to stop system services.</Error>
-      <Error Id="1922">Service '[2]' ([3]) could not be deleted.  Verify that you have sufficient privileges to remove system services.</Error>
-      <Error Id="1923">Service '[2]' ([3]) could not be installed.  Verify that you have sufficient privileges to install system services.</Error>
-      <Error Id="1924">Could not update environment variable '[2]'.  Verify that you have sufficient privileges to modify environment variables.</Error>
-      <Error Id="1925">You do not have sufficient privileges to complete this installation for all users of the machine.  Log on as administrator and then retry this installation.</Error>
-      <Error Id="1926">Could not set file security for file '[3]'. Error: [2].  Verify that you have sufficient privileges to modify the security permissions for this file.</Error>
-      <Error Id="1927">Component Services (COM+ 1.0) are not installed on this computer.  This installation requires Component Services in order to complete successfully.  Component Services are available on Windows 2000.</Error>
-      <Error Id="1928">Error registering COM+ Application.  Contact your support personnel for more information.</Error>
-      <Error Id="1929">Error unregistering COM+ Application.  Contact your support personnel for more information.</Error>
-      <Error Id="1930">The description for service '[2]' ([3]) could not be changed.</Error>
-      <Error Id="1931">The Windows Installer service cannot update the system file [2] because the file is protected by Windows.  You may need to update your operating system for this program to work correctly. {{Package version: [3], OS Protected version: [4]}}</Error>
-      <Error Id="1932">The Windows Installer service cannot update the protected Windows file [2]. {{Package version: [3], OS Protected version: [4], SFP Error: [5]}}</Error>
-      <Error Id="1933">The Windows Installer service cannot update one or more protected Windows files. {{SFP Error: [2].  List of protected files:\r\n[3]}}</Error>
-      <Error Id="1934">User installations are disabled via policy on the machine.</Error>
-      <Error Id="1935">An error occured during the installation of assembly component [2]. HRESULT: [3]. {{assembly interface: [4], function: [5], assembly name: [6]}}</Error>
-      <AdminUISequence>
-        <Show Dialog="FatalError" OnExit="error" />
-        <Show Dialog="UserExitDlg" OnExit="cancel" />
-        <Show Dialog="SuccessDlg" OnExit="success" />
-        <Show Dialog="PrepareDlg" Before="CostInitialize"><![CDATA[]]></Show>
-        <Show Dialog="AdminWelcomeDlg" After="CostFinalize" />
-        <Show Dialog="ProgressDlg" After="AdminWelcomeDlg" />
-      </AdminUISequence>
-      <InstallUISequence>
-        <Show Dialog="FatalError" OnExit="error" />
-        <Show Dialog="UserExitDlg" OnExit="cancel" />
-        <Show Dialog="SuccessDlg" OnExit="success" />
-        <Show Dialog="PrepareDlg" After="LaunchConditions" />
-        <Show Dialog="WelcomeDlg" After="MigrateFeatureStates"><![CDATA[NOT Installed]]></Show>
-        <Show Dialog="ResumeDlg" After="WelcomeDlg"><![CDATA[Installed AND (RESUME OR Preselected)]]></Show>
-        <Show Dialog="MaintenanceWelcomeDlg" After="ResumeDlg"><![CDATA[Installed AND NOT RESUME AND NOT Preselected]]></Show>
-        <Show Dialog="ProgressDlg" After="MaintenanceWelcomeDlg" />
-      </InstallUISequence>
-    </UI>
-    <Property Id="ButtonText_No"><![CDATA[&No]]></Property>
-    <Property Id="ButtonText_Install"><![CDATA[&Install]]></Property>
-    <Property Id="ButtonText_AdvancedInstall"><![CDATA[&Advanced]]></Property>
-    <Property Id="ButtonText_Next"><![CDATA[&Next >]]></Property>
-    <Property Id="Setup"><![CDATA[Setup]]></Property>
-    <Property Id="ButtonText_Browse"><![CDATA[Br&owse]]></Property>
-    <Property Id="ModifyIcon"><![CDATA[ModifyIcon]]></Property>
-    <Property Id="RepairIcon"><![CDATA[RepairIcon]]></Property>
-    <Property Id="WarningIcon"><![CDATA[WarningIcon]]></Property>
-    <Property Id="ButtonText_Repair"><![CDATA[&Repair]]></Property>
-    <Property Id="ButtonText_Back"><![CDATA[< &Back]]></Property>
-    <Property Id="InstallMode"><![CDATA[Typical]]></Property>
-    <Property Id="Progress2"><![CDATA[installs]]></Property>
-    <Property Id="Progress1"><![CDATA[Installing]]></Property>
-    <Property Id="Wizard"><![CDATA[Setup Wizard]]></Property>
-    <Property Id="RemoveIcon"><![CDATA[RemoveIcon]]></Property>
-    <Property Id="ButtonText_Yes"><![CDATA[&Yes]]></Property>
-    <Property Id="ButtonText_Ignore"><![CDATA[&Ignore]]></Property>
-    <Property Id="ButtonText_Reset"><![CDATA[&Reset]]></Property>
-    <Property Id="ButtonText_Remove"><![CDATA[&Remove]]></Property>
-    <Property Id="ButtonText_Exit"><![CDATA[&Exit]]></Property>
-    <Property Id="ButtonText_Return"><![CDATA[&Return]]></Property>
-    <Property Id="ButtonText_OK"><![CDATA[OK]]></Property>
-    <Property Id="ButtonText_License"><![CDATA[&License]]></Property>
-    <Property Id="ButtonText_Resume"><![CDATA[&Resume]]></Property>
-    <Property Id="ButtonText_Finish"><![CDATA[&Finish]]></Property>
-    <Property Id="DlgTitleFont"><![CDATA[{&DlgFontBold8}]]></Property>
-    <Property Id="ButtonText_Cancel"><![CDATA[Cancel]]></Property>
-    <Property Id="QuestionIcon"><![CDATA[QuestionIcon]]></Property>
-    <Property Id="ButtonText_Retry"><![CDATA[&Retry]]></Property>
-    <Property Id="IAgree"><![CDATA[No]]></Property>
-
-    <Property Id="BannerBitmap"><![CDATA[BannerBitmap]]></Property>
-    <Property Id="DialogBitmap"><![CDATA[DialogBitmap]]></Property>
-
-    <!-- Mattermost blue banners -->
-    <Binary Id="DialogBitmap" SourceFile="../resources/windows/msi_dialog_banner.png" />
-    <Binary Id="BannerBitmap" SourceFile="../resources/windows/msi_dialog_banner_small.png" />
-
-    <!-- Error and warnings -->
-    <Binary Id="WarningIcon" SourceFile="../resources/windows/msi_warning.ico" />
-    <Binary Id="QuestionIcon" SourceFile="../resources/windows/msi_question.ico" />
-
-    <!-- In BrowseDlg -->
-    <Binary Id="Up" SourceFile="../resources/windows/msi_up.ico" />
-    <Binary Id="New" SourceFile="../resources/windows/msi_create_folder.ico" />
-
-    <!-- In administrative install GUI -->
-    <Binary Id="ModifyIcon" SourceFile="../resources/windows/msi_modify.ico" />
-    <Binary Id="RepairIcon" SourceFile="../resources/windows/msi_repair.ico" />
-    <Binary Id="RemoveIcon" SourceFile="../resources/windows/msi_remove.ico" />
-
-  </Product>
+The [Installer] will complete the installation of [ProductName] on your computer.  Click Install to continue or Cancel to exit the [Installer].</Text>
+                </Control>
+                <Control Id="Install" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Install]">
+                    <Publish Event="SpawnWaitDialog" Value="WaitForCostingDlg"><![CDATA[CostingComplete = 1]]></Publish>
+                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
+                    <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
+                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+                    <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+                    <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
+                </Control>
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
+                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
+            </Dialog>
+            <Dialog Id="VerifyReadyDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes" TrackDiskSpace="yes">
+                <Control Id="Install" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Install]">
+                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
+                    <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
+                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+                    <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+                    <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
+                </Control>
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
+                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Back]">
+                    <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[InstallMode = "Custom" OR InstallMode = "Change"]]></Publish>
+                    <Publish Event="NewDialog" Value="MaintenanceTypeDlg"><![CDATA[InstallMode = "Repair"]]></Publish>
+                </Control>
+                <Control Id="Description" Type="Text" X="25" Y="74" Width="280" Height="30" Transparent="yes" NoPrefix="yes">
+                    <Text>Click Install to begin the installation.  If you want to review or change any of your installation settings, click Back.  Click Cancel to exit the [Installer].</Text>
+                </Control>
+                <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
+                    <Text>[DlgTitleFont]Ready to Install</Text>
+                </Control>
+            </Dialog>
+            <Dialog Id="VerifyRemoveDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes" TrackDiskSpace="yes">
+                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Back]">
+                    <Publish Event="NewDialog" Value="MaintenanceTypeDlg"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="Remove" Type="PushButton" X="236" Y="243" Width="56" Height="17" Text="[ButtonText_Uninstall]">
+                    <Publish Event="Remove" Value="All"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
+                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
+                    <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
+                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+                    <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+                    <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
+                </Control>
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
+                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+                <Control Id="Description" Type="Text" X="25" Y="74" Width="280" Height="30" Transparent="yes" NoPrefix="yes">
+                    <Text>Click Uninstall to remove [ProductName] from this computer. Click Cancel to exit the installer</Text>
+                </Control>
+                <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
+                    <Text>[DlgTitleFont]Uninstall [ProductName]</Text>
+                </Control>
+            </Dialog>
+            <Dialog Id="VerifyRepairDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes" TrackDiskSpace="yes">
+                <Control Id="Repair" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Repair]">
+                    <Publish Event="ReinstallMode" Value="ecmus"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
+                    <Publish Event="Reinstall" Value="All"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
+                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
+                    <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
+                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+                    <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+                    <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
+                </Control>
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
+                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Back]">
+                    <Publish Event="NewDialog" Value="MaintenanceTypeDlg"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="Description" Type="Text" X="25" Y="74" Width="280" Height="30" Transparent="yes" NoPrefix="yes">
+                    <Text>Click Repair to fix missing or corrupt files, shortcuts and registry entries. Click Cancel to exit the installer</Text>
+                </Control>
+                <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
+                    <Text>[DlgTitleFont]Repair [ProductName]</Text>
+                </Control>
+            </Dialog>
+            <Dialog Id="WaitForCostingDlg" Y="10" Width="260" Height="85" Title="[ProductName] [Installer]" NoMinimize="yes">
+                <Control Id="Return" Type="PushButton" X="102" Y="57" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Return]">
+                    <Publish Event="EndDialog" Value="Exit"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="Text" Type="Text" X="48" Y="15" Width="194" Height="30">
+                    <Text>Please wait while the installer finishes determining your disk space requirements.</Text>
+                </Control>
+                <Control Id="Icon" Type="Icon" X="15" Y="15" Width="24" Height="24" ToolTip="Exclamation icon" FixedSize="yes" IconSize="32" Text="[WarningIcon]" />
+            </Dialog>
+            <Dialog Id="WelcomeDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+                <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
+                <Control Id="Instructions" Type="Text" X="10" Y="155" Width="350" Height="45" Transparent="yes" NoPrefix="yes">
+                    <Text>!(loc.WelcomeDlgInstructions)</Text>
+                </Control>
+                <Control Id="AcceptLicenseCheckBox" Type="CheckBox" X="10" Y="220" Width="350" Height="20" Property="LicenseAccepted" CheckBoxValue="true">
+                    <Text>!(loc.WelcomeDlgAcceptLicenseCheckBox)</Text>
+                </Control>
+                <Control Id="License" Type="PushButton" X="10" Y="243" Width="56" Height="17" Text="[ButtonText_License]">
+                    <Publish Event="NewDialog" Value="LicenseAgreementDlg"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="Advanced" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_AdvancedInstall]">
+                    <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[1]]></Publish>
+                </Control>
+                <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" TabSkip="yes" Default="yes" ElevationShield="yes" Text="[ButtonText_Install]">
+                    <Condition Action="disable"><![CDATA[LicenseAccepted <> "true"]]></Condition>
+                    <Condition Action="enable"><![CDATA[LicenseAccepted = "true"]]></Condition>
+                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
+                    <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
+                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+                    <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+                    <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
+                </Control>
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" TabSkip="yes" Cancel="yes" Text="[ButtonText_Cancel]">
+                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+                </Control>
+            </Dialog>
+            <TextStyle Id="DlgFont8" FaceName="Segoe UI" Size="8" />
+            <TextStyle Id="White8" FaceName="Segoe UI" Size="8" Red="255" Green="255" Blue="255" />
+            <TextStyle Id="DlgFontBold8" FaceName="Segoe UI" Size="8" Bold="yes" />
+            <TextStyle Id="VerdanaBold13" FaceName="Verdana" Size="13" Bold="yes" />
+            <UIText Id="AbsentPath" />
+            <UIText Id="bytes">bytes</UIText>
+            <UIText Id="GB">GB</UIText>
+            <UIText Id="KB">KB</UIText>
+            <UIText Id="MB">MB</UIText>
+            <UIText Id="MenuAbsent">Entire feature will be unavailable</UIText>
+            <UIText Id="MenuAdvertise">Feature will be installed when required</UIText>
+            <UIText Id="MenuAllCD">Entire feature will be installed to run from CD</UIText>
+            <UIText Id="MenuAllLocal">Entire feature will be installed on local hard drive</UIText>
+            <UIText Id="MenuAllNetwork">Entire feature will be installed to run from network</UIText>
+            <UIText Id="MenuCD">Will be installed to run from CD</UIText>
+            <UIText Id="MenuLocal">Will be installed on local hard drive</UIText>
+            <UIText Id="MenuNetwork">Will be installed to run from network</UIText>
+            <UIText Id="ScriptInProgress">Gathering required information...</UIText>
+            <UIText Id="SelAbsentAbsent">This feature will remain uninstalled</UIText>
+            <UIText Id="SelAbsentAdvertise">This feature will be set to be installed when required</UIText>
+            <UIText Id="SelAbsentCD">This feature will be installed to run from CD</UIText>
+            <UIText Id="SelAbsentLocal">This feature will be installed on the local hard drive</UIText>
+            <UIText Id="SelAbsentNetwork">This feature will be installed to run from the network</UIText>
+            <UIText Id="SelAdvertiseAbsent">This feature will become unavailable</UIText>
+            <UIText Id="SelAdvertiseAdvertise">Will be installed when required</UIText>
+            <UIText Id="SelAdvertiseCD">This feature will be available to run from CD</UIText>
+            <UIText Id="SelAdvertiseLocal">This feature will be installed on your local hard drive</UIText>
+            <UIText Id="SelAdvertiseNetwork">This feature will be available to run from the network</UIText>
+            <UIText Id="SelCDAbsent">This feature will be uninstalled completely, you won't be able to run it from CD</UIText>
+            <UIText Id="SelCDAdvertise">This feature will change from run from CD state to set to be installed when required</UIText>
+            <UIText Id="SelCDCD">This feature will remain to be run from CD</UIText>
+            <UIText Id="SelCDLocal">This feature will change from run from CD state to be installed on the local hard drive</UIText>
+            <UIText Id="SelChildCostNeg">This feature frees up [1] on your hard drive.</UIText>
+            <UIText Id="SelChildCostPos">This feature requires [1] on your hard drive.</UIText>
+            <UIText Id="SelCostPending">Compiling cost for this feature...</UIText>
+            <UIText Id="SelLocalAbsent">This feature will be completely removed</UIText>
+            <UIText Id="SelLocalAdvertise">This feature will be removed from your local hard drive, but will be set to be installed when required</UIText>
+            <UIText Id="SelLocalCD">This feature will be removed from your local hard drive, but will be still available to run from CD</UIText>
+            <UIText Id="SelLocalLocal">This feature will remain on you local hard drive</UIText>
+            <UIText Id="SelLocalNetwork">This feature will be removed from your local hard drive, but will be still available to run from the network</UIText>
+            <UIText Id="SelNetworkAbsent">This feature will be uninstalled completely, you won't be able to run it from the network</UIText>
+            <UIText Id="SelNetworkAdvertise">This feature will change from run from network state to set to be installed when required</UIText>
+            <UIText Id="SelNetworkLocal">This feature will change from run from network state to be installed on the local hard drive</UIText>
+            <UIText Id="SelNetworkNetwork">This feature will remain to be run from the network</UIText>
+            <UIText Id="SelParentCostNegNeg">This feature frees up [1] on your hard drive. It has [2] of [3] subfeatures selected. The subfeatures free up [4] on your hard drive.</UIText>
+            <UIText Id="SelParentCostNegPos">This feature frees up [1] on your hard drive. It has [2] of [3] subfeatures selected. The subfeatures require [4] on your hard drive.</UIText>
+            <UIText Id="SelParentCostPosNeg">This feature requires [1] on your hard drive. It has [2] of [3] subfeatures selected. The subfeatures free up [4] on your hard drive.</UIText>
+            <UIText Id="SelParentCostPosPos">This feature requires [1] on your hard drive. It has [2] of [3] subfeatures selected. The subfeatures require [4] on your hard drive.</UIText>
+            <UIText Id="TimeRemaining">Time remaining: {[1] minutes }{[2] seconds}</UIText>
+            <UIText Id="VolumeCostAvailable">Available</UIText>
+            <UIText Id="VolumeCostDifference">Difference</UIText>
+            <UIText Id="VolumeCostRequired">Required</UIText>
+            <UIText Id="VolumeCostSize">Disk Size</UIText>
+            <UIText Id="VolumeCostVolume">Volume</UIText>
+            <ProgressText Action="InstallValidate">Validating install</ProgressText>
+            <ProgressText Action="InstallFiles" Template="File: [1],  Directory: [9],  Size: [6]">Copying new files</ProgressText>
+            <ProgressText Action="InstallAdminPackage" Template="File: [1], Directory: [9], Size: [6]">Copying network install files</ProgressText>
+            <ProgressText Action="FileCost">Computing space requirements</ProgressText>
+            <ProgressText Action="CostInitialize">Computing space requirements</ProgressText>
+            <ProgressText Action="CostFinalize">Computing space requirements</ProgressText>
+            <ProgressText Action="CreateShortcuts" Template="Shortcut: [1]">Creating shortcuts</ProgressText>
+            <ProgressText Action="PublishComponents" Template="Component ID: [1], Qualifier: [2]">Publishing Qualified Components</ProgressText>
+            <ProgressText Action="PublishFeatures" Template="Feature: [1]">Publishing Product Features</ProgressText>
+            <ProgressText Action="PublishProduct">Publishing product information</ProgressText>
+            <ProgressText Action="RegisterClassInfo" Template="Class Id: [1]">Registering Class servers</ProgressText>
+            <ProgressText Action="RegisterExtensionInfo" Template="Extension: [1]">Registering extension servers</ProgressText>
+            <ProgressText Action="RegisterMIMEInfo" Template="MIME Content Type: [1], Extension: [2]">Registering MIME info</ProgressText>
+            <ProgressText Action="RegisterProgIdInfo" Template="ProgId: [1]">Registering program identifiers</ProgressText>
+            <ProgressText Action="AllocateRegistrySpace" Template="Free space: [1]">Allocating registry space</ProgressText>
+            <ProgressText Action="AppSearch" Template="Property: [1], Signature: [2]">Searching for installed applications</ProgressText>
+            <ProgressText Action="BindImage" Template="File: [1]">Binding executables</ProgressText>
+            <ProgressText Action="CCPSearch">Searching for qualifying products</ProgressText>
+            <ProgressText Action="CreateFolders" Template="Folder: [1]">Creating folders</ProgressText>
+            <ProgressText Action="DeleteServices" Template="Service: [1]">Deleting services</ProgressText>
+            <ProgressText Action="DuplicateFiles" Template="File: [1],  Directory: [9],  Size: [6]">Creating duplicate files</ProgressText>
+            <ProgressText Action="FindRelatedProducts" Template="Found application: [1]">Searching for related applications</ProgressText>
+            <ProgressText Action="InstallODBC">Installing ODBC components</ProgressText>
+            <ProgressText Action="InstallServices" Template="Service: [2]">Installing new services</ProgressText>
+            <ProgressText Action="LaunchConditions">Evaluating launch conditions</ProgressText>
+            <ProgressText Action="MigrateFeatureStates" Template="Application: [1]">Migrating feature states from related applications</ProgressText>
+            <ProgressText Action="MoveFiles" Template="File: [1],  Directory: [9],  Size: [6]">Moving files</ProgressText>
+            <ProgressText Action="PatchFiles" Template="File: [1],  Directory: [2],  Size: [3]">Patching files</ProgressText>
+            <ProgressText Action="ProcessComponents">Updating component registration</ProgressText>
+            <ProgressText Action="RegisterComPlus" Template="AppId: [1]{{, AppType: [2], Users: [3], RSN: [4]}}">Registering COM+ Applications and Components</ProgressText>
+            <ProgressText Action="RegisterFonts" Template="Font: [1]">Registering fonts</ProgressText>
+            <ProgressText Action="RegisterProduct" Template="[1]">Registering product</ProgressText>
+            <ProgressText Action="RegisterTypeLibraries" Template="LibID: [1]">Registering type libraries</ProgressText>
+            <ProgressText Action="RegisterUser" Template="[1]">Registering user</ProgressText>
+            <ProgressText Action="RemoveDuplicateFiles" Template="File: [1], Directory: [9]">Removing duplicated files</ProgressText>
+            <ProgressText Action="RemoveEnvironmentStrings" Template="Name: [1], Value: [2], Action [3]">Updating environment strings</ProgressText>
+            <ProgressText Action="RemoveExistingProducts" Template="Application: [1], Command line: [2]">Removing applications</ProgressText>
+            <ProgressText Action="RemoveFiles" Template="File: [1], Directory: [9]">Removing files</ProgressText>
+            <ProgressText Action="RemoveFolders" Template="Folder: [1]">Removing folders</ProgressText>
+            <ProgressText Action="RemoveIniValues" Template="File: [1],  Section: [2],  Key: [3], Value: [4]">Removing INI files entries</ProgressText>
+            <ProgressText Action="RemoveODBC">Removing ODBC components</ProgressText>
+            <ProgressText Action="RemoveRegistryValues" Template="Key: [1], Name: [2]">Removing system registry values</ProgressText>
+            <ProgressText Action="RemoveShortcuts" Template="Shortcut: [1]">Removing shortcuts</ProgressText>
+            <ProgressText Action="RMCCPSearch">Searching for qualifying products</ProgressText>
+            <ProgressText Action="SelfRegModules" Template="File: [1], Folder: [2]">Registering modules</ProgressText>
+            <ProgressText Action="SelfUnregModules" Template="File: [1], Folder: [2]">Unregistering modules</ProgressText>
+            <ProgressText Action="SetODBCFolders">Initializing ODBC directories</ProgressText>
+            <ProgressText Action="StartServices" Template="Service: [1]">Starting services</ProgressText>
+            <ProgressText Action="StopServices" Template="Service: [1]">Stopping services</ProgressText>
+            <ProgressText Action="UnpublishComponents" Template="Component ID: [1], Qualifier: [2]">Unpublishing Qualified Components</ProgressText>
+            <ProgressText Action="UnpublishFeatures" Template="Feature: [1]">Unpublishing Product Features</ProgressText>
+            <ProgressText Action="UnregisterClassInfo" Template="Class Id: [1]">Unregister Class servers</ProgressText>
+            <ProgressText Action="UnregisterComPlus" Template="AppId: [1]{{, AppType: [2]}}">Unregistering COM+ Applications and Components</ProgressText>
+            <ProgressText Action="UnregisterExtensionInfo" Template="Extension: [1]">Unregistering extension servers</ProgressText>
+            <ProgressText Action="UnregisterFonts" Template="Font: [1]">Unregistering fonts</ProgressText>
+            <ProgressText Action="UnregisterMIMEInfo" Template="MIME Content Type: [1], Extension: [2]">Unregistering MIME info</ProgressText>
+            <ProgressText Action="UnregisterProgIdInfo" Template="ProgId: [1]">Unregistering program identifiers</ProgressText>
+            <ProgressText Action="UnregisterTypeLibraries" Template="LibID: [1]">Unregistering type libraries</ProgressText>
+            <ProgressText Action="WriteEnvironmentStrings" Template="Name: [1], Value: [2], Action [3]">Updating environment strings</ProgressText>
+            <ProgressText Action="WriteIniValues" Template="File: [1],  Section: [2],  Key: [3], Value: [4]">Writing INI files values</ProgressText>
+            <ProgressText Action="WriteRegistryValues" Template="Key: [1], Name: [2], Value: [3]">Writing system registry values</ProgressText>
+            <ProgressText Action="Advertise">Advertising application</ProgressText>
+            <ProgressText Action="GenerateScript" Template="[1]">Generating script operations for action:</ProgressText>
+            <ProgressText Action="InstallSFPCatalogFile" Template="File: [1],  Dependencies: [2]">Installing system catalog</ProgressText>
+            <ProgressText Action="MsiPublishAssemblies" Template="Application Context:[1], Assembly Name:[2]">Publishing assembly information</ProgressText>
+            <ProgressText Action="MsiUnpublishAssemblies" Template="Application Context:[1], Assembly Name:[2]">Unpublishing assembly information</ProgressText>
+            <ProgressText Action="Rollback" Template="[1]">Rolling back action:</ProgressText>
+            <ProgressText Action="RollbackCleanup" Template="File: [1]">Removing backup files</ProgressText>
+            <ProgressText Action="UnmoveFiles" Template="File: [1], Directory: [9]">Removing moved files</ProgressText>
+            <ProgressText Action="UnpublishProduct">Unpublishing product information</ProgressText>
+            <Error Id="0">{{Fatal error: }}</Error>
+            <Error Id="1">{{Error [1]. }}</Error>
+            <Error Id="2">Warning [1]. </Error>
+            <Error Id="3" />
+            <Error Id="4">Info [1]. </Error>
+            <Error Id="5">The installer has encountered an unexpected error installing this package. This may indicate a problem with this package. The error code is [1]. {{The arguments are: [2], [3], [4]}}</Error>
+            <Error Id="6" />
+            <Error Id="7">{{Disk full: }}</Error>
+            <Error Id="8">Action [Time]: [1]. [2]</Error>
+            <Error Id="9">[ProductName]</Error>
+            <Error Id="10">{[2]}{, [3]}{, [4]}</Error>
+            <Error Id="11">Message type: [1], Argument: [2]</Error>
+            <Error Id="12">=== Logging started: [Date]  [Time] ===</Error>
+            <Error Id="13">=== Logging stopped: [Date]  [Time] ===</Error>
+            <Error Id="14">Action start [Time]: [1].</Error>
+            <Error Id="15">Action ended [Time]: [1]. Return value [2].</Error>
+            <Error Id="16">Time remaining: {[1] minutes }{[2] seconds}</Error>
+            <Error Id="17">Out of memory. Shut down other applications before retrying.</Error>
+            <Error Id="18">Installer is no longer responding.</Error>
+            <Error Id="19">Installer stopped prematurely.</Error>
+            <Error Id="20">Please wait while Windows configures [ProductName]</Error>
+            <Error Id="21">Gathering required information...</Error>
+            <Error Id="22">Removing older versions of this application...</Error>
+            <Error Id="23">Preparing to remove older versions of this application...</Error>
+            <Error Id="32">{[ProductName] }Setup completed successfully.</Error>
+            <Error Id="33">{[ProductName] }Setup failed.</Error>
+            <Error Id="1101">Error reading from file: [2]. {{ System error [3].}}  Verify that the file exists and that you can access it.</Error>
+            <Error Id="1301">Cannot create the file '[2]'.  A directory with this name already exists.  Cancel the install and try installing to a different location.</Error>
+            <Error Id="1302">Please insert the disk: [2]</Error>
+            <Error Id="1303">The installer has insufficient privileges to access this directory: [2].  The installation cannot continue.  Log on as administrator or contact your system administrator.</Error>
+            <Error Id="1304">Error writing to file: [2].  Verify that you have access to that directory.</Error>
+            <Error Id="1305">Error reading from file [2]. {{ System error [3].}} Verify that the file exists and that you can access it.</Error>
+            <Error Id="1306">Another application has exclusive access to the file '[2]'.  Please shut down all other applications, then click Retry.</Error>
+            <Error Id="1307">There is not enough disk space to install this file: [2].  Free some disk space and click Retry, or click Cancel to exit.</Error>
+            <Error Id="1308">Source file not found: [2].  Verify that the file exists and that you can access it.</Error>
+            <Error Id="1309">Error reading from file: [3]. {{ System error [2].}}  Verify that the file exists and that you can access it.</Error>
+            <Error Id="1310">Error writing to file: [3]. {{ System error [2].}}  Verify that you have access to that directory.</Error>
+            <Error Id="1311">Source file not found{{(cabinet)}}: [2].  Verify that the file exists and that you can access it.</Error>
+            <Error Id="1312">Cannot create the directory '[2]'.  A file with this name already exists.  Please rename or remove the file and click retry, or click Cancel to exit.</Error>
+            <Error Id="1313">The volume [2] is currently unavailable.  Please select another.</Error>
+            <Error Id="1314">The specified path '[2]' is unavailable.</Error>
+            <Error Id="1315">Unable to write to the specified folder: [2].</Error>
+            <Error Id="1316">A network error occurred while attempting to read from the file: [2]</Error>
+            <Error Id="1317">An error occurred while attempting to create the directory: [2]</Error>
+            <Error Id="1318">A network error occurred while attempting to create the directory: [2]</Error>
+            <Error Id="1319">A network error occurred while attempting to open the source file cabinet: [2]</Error>
+            <Error Id="1320">The specified path is too long: [2]</Error>
+            <Error Id="1321">The Installer has insufficient privileges to modify this file: [2].</Error>
+            <Error Id="1322">A portion of the folder path '[2]' is invalid.  It is either empty or exceeds the length allowed by the system.</Error>
+            <Error Id="1323">The folder path '[2]' contains words that are not valid in folder paths.</Error>
+            <Error Id="1324">The folder path '[2]' contains an invalid character.</Error>
+            <Error Id="1325">'[2]' is not a valid short file name.</Error>
+            <Error Id="1326">Error getting file security: [3] GetLastError: [2]</Error>
+            <Error Id="1327">Invalid Drive: [2]</Error>
+            <Error Id="1328">Error applying patch to file [2].  It has probably been updated by other means, and can no longer be modified by this patch.  For more information contact your patch vendor.  {{System Error: [3]}}</Error>
+            <Error Id="1329">A file that is required cannot be installed because the cabinet file [2] is not digitally signed.  This may indicate that the cabinet file is corrupt.</Error>
+            <Error Id="1330">A file that is required cannot be installed because the cabinet file [2] has an invalid digital signature.  This may indicate that the cabinet file is corrupt.{{  Error [3] was returned by WinVerifyTrust.}}</Error>
+            <Error Id="1331">Failed to correctly copy [2] file: CRC error.</Error>
+            <Error Id="1332">Failed to correctly move [2] file: CRC error.</Error>
+            <Error Id="1333">Failed to correctly patch [2] file: CRC error.</Error>
+            <Error Id="1334">The file '[2]' cannot be installed because the file cannot be found in cabinet file '[3]'. This could indicate a network error, an error reading from the CD-ROM, or a problem with this package.</Error>
+            <Error Id="1335">The cabinet file '[2]' required for this installation is corrupt and cannot be used. This could indicate a network error, an error reading from the CD-ROM, or a problem with this package.</Error>
+            <Error Id="1336">There was an error creating a temporary file that is needed to complete this installation.{{  Folder: [3]. System error code: [2]}}</Error>
+            <Error Id="1401">Could not create key: [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel. </Error>
+            <Error Id="1402">Could not open key: [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel. </Error>
+            <Error Id="1403">Could not delete value [2] from key [3]. {{ System error [4].}}  Verify that you have sufficient access to that key, or contact your support personnel. </Error>
+            <Error Id="1404">Could not delete key [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel. </Error>
+            <Error Id="1405">Could not read value [2] from key [3]. {{ System error [4].}}  Verify that you have sufficient access to that key, or contact your support personnel. </Error>
+            <Error Id="1406">Could not write value [2] to key [3]. {{ System error [4].}}  Verify that you have sufficient access to that key, or contact your support personnel.</Error>
+            <Error Id="1407">Could not get value names for key [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel.</Error>
+            <Error Id="1408">Could not get sub key names for key [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel.</Error>
+            <Error Id="1409">Could not read security information for key [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel.</Error>
+            <Error Id="1410">Could not increase the available registry space. [2] KB of free registry space is required for the installation of this application.</Error>
+            <Error Id="1500">Another installation is in progress. You must complete that installation before continuing this one.</Error>
+            <Error Id="1501">Error accessing secured data. Please make sure the Windows Installer is configured properly and try the install again.</Error>
+            <Error Id="1502">User '[2]' has previously initiated an install for product '[3]'.  That user will need to run that install again before they can use that product.  Your current install will now continue.</Error>
+            <Error Id="1503">User '[2]' has previously initiated an install for product '[3]'.  That user will need to run that install again before they can use that product.</Error>
+            <Error Id="1601">Out of disk space -- Volume: '[2]'; required space: [3] KB; available space: [4] KB.  Free some disk space and retry.</Error>
+            <Error Id="1602">Are you sure you want to cancel?</Error>
+            <Error Id="1603">The file [2][3] is being held in use{ by the following process: Name: [4], Id: [5], Window Title: '[6]'}.  Close that application and retry.</Error>
+            <Error Id="1604">The product '[2]' is already installed, preventing the installation of this product.  The two products are incompatible.</Error>
+            <Error Id="1605">There is not enough disk space on the volume '[2]' to continue the install with recovery enabled. [3] KB are required, but only [4] KB are available. Click Ignore to continue the install without saving recovery information, click Retry to check for available space again, or click Cancel to quit the installation.</Error>
+            <Error Id="1606">Could not access network location [2].</Error>
+            <Error Id="1607">The following applications should be closed before continuing the install:</Error>
+            <Error Id="1608">Could not find any previously installed compliant products on the machine for installing this product.</Error>
+            <Error Id="1609">An error occurred while applying security settings. [2] is not a valid user or group. This could be a problem with the package, or a problem connecting to a domain controller on the network. Check your network connection and click Retry, or Cancel to end the install. {{Unable to locate the user's SID, system error [3]}}</Error>
+            <Error Id="1701">The key [2] is not valid.  Verify that you entered the correct key.</Error>
+            <Error Id="1702">The installer must restart your system before configuration of [2] can continue.  Click Yes to restart now or No if you plan to manually restart later.</Error>
+            <Error Id="1703">You must restart your system for the configuration changes made to [2] to take effect. Click Yes to restart now or No if you plan to manually restart later.</Error>
+            <Error Id="1704">An installation for [2] is currently suspended.  You must undo the changes made by that installation to continue.  Do you want to undo those changes?</Error>
+            <Error Id="1705">A previous installation for this product is in progress.  You must undo the changes made by that installation to continue.  Do you want to undo those changes?</Error>
+            <Error Id="1706">An installation package for the product [2] cannot be found. Try the installation again using a valid copy of the installation package '[3]'.</Error>
+            <Error Id="1707">Installation completed successfully.</Error>
+            <Error Id="1708">Installation failed.</Error>
+            <Error Id="1709">Product: [2] -- [3]</Error>
+            <Error Id="1710">You may either restore your computer to its previous state or continue the install later. Would you like to restore?</Error>
+            <Error Id="1711">An error occurred while writing installation information to disk.  Check to make sure enough disk space is available, and click Retry, or Cancel to end the install.</Error>
+            <Error Id="1712">One or more of the files required to restore your computer to its previous state could not be found.  Restoration will not be possible.</Error>
+            <Error Id="1713">[2] cannot install one of its required products. Contact your technical support group.  {{System Error: [3].}}</Error>
+            <Error Id="1714">The older version of [2] cannot be removed.  Contact your technical support group.  {{System Error [3].}}</Error>
+            <Error Id="1715">Installed [2]</Error>
+            <Error Id="1716">Configured [2]</Error>
+            <Error Id="1717">Removed [2]</Error>
+            <Error Id="1718">File [2] was rejected by digital signature policy.</Error>
+            <Error Id="1719">The Windows Installer Service could not be accessed. This can occur if you are running Windows in safe mode, or if the Windows Installer is not correctly installed. Contact your support personnel for assistance.</Error>
+            <Error Id="1720">There is a problem with this Windows Installer package. A script required for this install to complete could not be run. Contact your support personnel or package vendor.  {{Custom action [2] script error [3], [4]: [5] Line [6], Column [7], [8] }}</Error>
+            <Error Id="1721">There is a problem with this Windows Installer package. A program required for this install to complete could not be run. Contact your support personnel or package vendor. {{Action: [2], location: [3], command: [4] }}</Error>
+            <Error Id="1722">There is a problem with this Windows Installer package. A program run as part of the setup did not finish as expected. Contact your support personnel or package vendor.  {{Action [2], location: [3], command: [4] }}</Error>
+            <Error Id="1723">There is a problem with this Windows Installer package. A DLL required for this install to complete could not be run. Contact your support personnel or package vendor.  {{Action [2], entry: [3], library: [4] }}</Error>
+            <Error Id="1724">Removal completed successfully.</Error>
+            <Error Id="1725">Removal failed.</Error>
+            <Error Id="1726">Advertisement completed successfully.</Error>
+            <Error Id="1727">Advertisement failed.</Error>
+            <Error Id="1728">Configuration completed successfully.</Error>
+            <Error Id="1729">Configuration failed.</Error>
+            <Error Id="1730">You must be an Administrator to remove this application. To remove this application, you can log on as an Administrator, or contact your technical support group for assistance.</Error>
+            <Error Id="1801">The path [2] is not valid.  Please specify a valid path.</Error>
+            <Error Id="1802">Out of memory. Shut down other applications before retrying.</Error>
+            <Error Id="1803">There is no disk in drive [2]. Please insert one and click Retry, or click Cancel to go back to the previously selected volume.</Error>
+            <Error Id="1804">There is no disk in drive [2]. Please insert one and click Retry, or click Cancel to return to the browse dialog and select a different volume.</Error>
+            <Error Id="1805">The folder [2] does not exist.  Please enter a path to an existing folder.</Error>
+            <Error Id="1806">You have insufficient privileges to read this folder.</Error>
+            <Error Id="1807">A valid destination folder for the install could not be determined.</Error>
+            <Error Id="1901">Error attempting to read from the source install database: [2].</Error>
+            <Error Id="1902">Scheduling reboot operation: Renaming file [2] to [3]. Must reboot to complete operation.</Error>
+            <Error Id="1903">Scheduling reboot operation: Deleting file [2]. Must reboot to complete operation.</Error>
+            <Error Id="1904">Module [2] failed to register.  HRESULT [3].  Contact your support personnel.</Error>
+            <Error Id="1905">Module [2] failed to unregister.  HRESULT [3].  Contact your support personnel.</Error>
+            <Error Id="1906">Failed to cache package [2]. Error: [3]. Contact your support personnel.</Error>
+            <Error Id="1907">Could not register font [2].  Verify that you have sufficient permissions to install fonts, and that the system supports this font.</Error>
+            <Error Id="1908">Could not unregister font [2]. Verify that you that you have sufficient permissions to remove fonts.</Error>
+            <Error Id="1909">Could not create Shortcut [2]. Verify that the destination folder exists and that you can access it.</Error>
+            <Error Id="1910">Could not remove Shortcut [2]. Verify that the shortcut file exists and that you can access it.</Error>
+            <Error Id="1911">Could not register type library for file [2].  Contact your support personnel.</Error>
+            <Error Id="1912">Could not unregister type library for file [2].  Contact your support personnel.</Error>
+            <Error Id="1913">Could not update the ini file [2][3].  Verify that the file exists and that you can access it.</Error>
+            <Error Id="1914">Could not schedule file [2] to replace file [3] on reboot.  Verify that you have write permissions to file [3].</Error>
+            <Error Id="1915">Error removing ODBC driver manager, ODBC error [2]: [3]. Contact your support personnel.</Error>
+            <Error Id="1916">Error installing ODBC driver manager, ODBC error [2]: [3]. Contact your support personnel.</Error>
+            <Error Id="1917">Error removing ODBC driver: [4], ODBC error [2]: [3]. Verify that you have sufficient privileges to remove ODBC drivers.</Error>
+            <Error Id="1918">Error installing ODBC driver: [4], ODBC error [2]: [3]. Verify that the file [4] exists and that you can access it.</Error>
+            <Error Id="1919">Error configuring ODBC data source: [4], ODBC error [2]: [3]. Verify that the file [4] exists and that you can access it.</Error>
+            <Error Id="1920">Service '[2]' ([3]) failed to start.  Verify that you have sufficient privileges to start system services.</Error>
+            <Error Id="1921">Service '[2]' ([3]) could not be stopped.  Verify that you have sufficient privileges to stop system services.</Error>
+            <Error Id="1922">Service '[2]' ([3]) could not be deleted.  Verify that you have sufficient privileges to remove system services.</Error>
+            <Error Id="1923">Service '[2]' ([3]) could not be installed.  Verify that you have sufficient privileges to install system services.</Error>
+            <Error Id="1924">Could not update environment variable '[2]'.  Verify that you have sufficient privileges to modify environment variables.</Error>
+            <Error Id="1925">You do not have sufficient privileges to complete this installation for all users of the machine.  Log on as administrator and then retry this installation.</Error>
+            <Error Id="1926">Could not set file security for file '[3]'. Error: [2].  Verify that you have sufficient privileges to modify the security permissions for this file.</Error>
+            <Error Id="1927">Component Services (COM+ 1.0) are not installed on this computer.  This installation requires Component Services in order to complete successfully.  Component Services are available on Windows 2000.</Error>
+            <Error Id="1928">Error registering COM+ Application.  Contact your support personnel for more information.</Error>
+            <Error Id="1929">Error unregistering COM+ Application.  Contact your support personnel for more information.</Error>
+            <Error Id="1930">The description for service '[2]' ([3]) could not be changed.</Error>
+            <Error Id="1931">The Windows Installer service cannot update the system file [2] because the file is protected by Windows.  You may need to update your operating system for this program to work correctly. {{Package version: [3], OS Protected version: [4]}}</Error>
+            <Error Id="1932">The Windows Installer service cannot update the protected Windows file [2]. {{Package version: [3], OS Protected version: [4], SFP Error: [5]}}</Error>
+            <Error Id="1933">The Windows Installer service cannot update one or more protected Windows files. {{SFP Error: [2].  List of protected files:\r\n[3]}}</Error>
+            <Error Id="1934">User installations are disabled via policy on the machine.</Error>
+            <Error Id="1935">An error occured during the installation of assembly component [2]. HRESULT: [3]. {{assembly interface: [4], function: [5], assembly name: [6]}}</Error>
+            <AdminUISequence>
+                <Show Dialog="FatalError" OnExit="error" />
+                <Show Dialog="UserExitDlg" OnExit="cancel" />
+                <Show Dialog="SuccessDlg" OnExit="success" />
+                <Show Dialog="PrepareDlg" Before="CostInitialize"><![CDATA[]]></Show>
+                <Show Dialog="AdminWelcomeDlg" After="CostFinalize" />
+                <Show Dialog="ProgressDlg" After="AdminWelcomeDlg" />
+            </AdminUISequence>
+            <InstallUISequence>
+                <Show Dialog="FatalError" OnExit="error" />
+                <Show Dialog="UserExitDlg" OnExit="cancel" />
+                <Show Dialog="SuccessDlg" OnExit="success" />
+                <Show Dialog="PrepareDlg" After="LaunchConditions" />
+                <Show Dialog="WelcomeDlg" After="MigrateFeatureStates"><![CDATA[NOT Installed]]></Show>
+                <Show Dialog="ResumeDlg" After="WelcomeDlg"><![CDATA[Installed AND (RESUME OR Preselected)]]></Show>
+                <Show Dialog="MaintenanceWelcomeDlg" After="ResumeDlg"><![CDATA[Installed AND NOT RESUME AND NOT Preselected]]></Show>
+                <Show Dialog="ProgressDlg" After="MaintenanceWelcomeDlg" />
+            </InstallUISequence>
+        </UI>
+        <Property Id="ButtonText_No"><![CDATA[&No]]></Property>
+        <Property Id="ButtonText_Install"><![CDATA[&Install]]></Property>
+        <Property Id="ButtonText_AdvancedInstall"><![CDATA[&Advanced]]></Property>
+        <Property Id="ButtonText_Next"><![CDATA[&Next >]]></Property>
+        <Property Id="Setup"><![CDATA[Setup]]></Property>
+        <Property Id="ButtonText_Browse"><![CDATA[Br&owse]]></Property>
+        <Property Id="ModifyIcon"><![CDATA[ModifyIcon]]></Property>
+        <Property Id="RepairIcon"><![CDATA[RepairIcon]]></Property>
+        <Property Id="WarningIcon"><![CDATA[WarningIcon]]></Property>
+        <Property Id="ButtonText_Repair"><![CDATA[&Repair]]></Property>
+        <Property Id="ButtonText_Back"><![CDATA[< &Back]]></Property>
+        <Property Id="InstallMode"><![CDATA[Typical]]></Property>
+        <Property Id="Progress2"><![CDATA[Installation]]></Property>
+        <Property Id="Progress1"><![CDATA[Installing]]></Property>
+        <Property Id="Wizard"><![CDATA[Setup Wizard]]></Property>
+        <Property Id="RemoveIcon"><![CDATA[RemoveIcon]]></Property>
+        <Property Id="ButtonText_Yes"><![CDATA[&Yes]]></Property>
+        <Property Id="ButtonText_Ignore"><![CDATA[&Ignore]]></Property>
+        <Property Id="ButtonText_Reset"><![CDATA[&Reset]]></Property>
+        <Property Id="ButtonText_Remove"><![CDATA[&Remove]]></Property>
+        <Property Id="ButtonText_Exit"><![CDATA[&Exit]]></Property>
+        <Property Id="ButtonText_Return"><![CDATA[&Return]]></Property>
+        <Property Id="ButtonText_OK"><![CDATA[OK]]></Property>
+        <Property Id="ButtonText_License"><![CDATA[&License]]></Property>
+        <Property Id="ButtonText_Resume"><![CDATA[&Resume]]></Property>
+        <Property Id="ButtonText_Finish"><![CDATA[&Finish]]></Property>
+        <Property Id="DlgTitleFont"><![CDATA[{&DlgFontBold8}]]></Property>
+        <Property Id="ButtonText_Cancel"><![CDATA[Cancel]]></Property>
+        <Property Id="QuestionIcon"><![CDATA[QuestionIcon]]></Property>
+        <Property Id="ButtonText_Retry"><![CDATA[&Retry]]></Property>
+        <Property Id="IAgree"><![CDATA[No]]></Property>
+        <Property Id="BannerBitmap"><![CDATA[BannerBitmap]]></Property>
+        <Property Id="DialogBitmap"><![CDATA[DialogBitmap]]></Property>
+        <Property Id="Installer" Value="Installer" />
+        <Property Id="ButtonText_Uninstall" Value="&amp;Uninstall" />
+        <!-- Mattermost blue banners -->
+        <Binary Id="DialogBitmap" SourceFile="../resources/windows/msi_dialog_banner.png" />
+        <Binary Id="BannerBitmap" SourceFile="../resources/windows/msi_dialog_banner_small.png" />
+        <!-- Error and warnings -->
+        <Binary Id="WarningIcon" SourceFile="../resources/windows/msi_warning.ico" />
+        <Binary Id="QuestionIcon" SourceFile="../resources/windows/msi_question.ico" />
+        <!-- In BrowseDlg -->
+        <Binary Id="Up" SourceFile="../resources/windows/msi_up.ico" />
+        <Binary Id="New" SourceFile="../resources/windows/msi_create_folder.ico" />
+        <!-- In administrative install GUI -->
+        <Binary Id="ModifyIcon" SourceFile="../resources/windows/msi_modify.ico" />
+        <Binary Id="RepairIcon" SourceFile="../resources/windows/msi_repair.ico" />
+        <Binary Id="RemoveIcon" SourceFile="../resources/windows/msi_remove.ico" />
+    </Product>
 </Wix>

--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -122,10 +122,12 @@
       <ComponentRef Id="GPOUSEnglishFiles" />
     </Feature>
     <InstallExecuteSequence>
+      <Custom Action="KillApp" Before="InstallValidate" />
       <Custom Action="LaunchApp" After="InstallFinalize">Installed</Custom>
       <RemoveExistingProducts After="InstallFinalize" />
     </InstallExecuteSequence>
     <CustomAction Id="LaunchApp" FileKey="MattermostDesktopEXE" ExeCommand="" Return="asyncNoWait" />
+    <CustomAction Id="KillApp" Directory="INSTALLDIR" Return="ignore" ExeCommand="&quot;[SystemFolder]taskkill.exe&quot; /F /IM &quot;Mattermost.exe&quot;" />
     <Icon Id="Mattermost.ico" SourceFile="../resources/icon.ico" />
     <Property Id="ARPPRODUCTICON">Mattermost.ico</Property>
     <Property Id="ARPCONTACT">https://pre-release.mattermost.com</Property>

--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-    <!--
+  <!--
   Copyright (c) 2018-present William Gathoye
   See LICENSE.txt
   -->
-    <!--
+  <!--
   Determine wich bitness version of the msi to build depending on the
   variables passed as argument to candle.
   src.: http://wixtoolset.org/documentation/manual/v3/overview/preprocessor.html
@@ -17,16 +17,16 @@
     nodes have ProcessorArchitecture attribute set to x64.
   src.: https://msdn.microsoft.com/en-us/library/gg513929.aspx
   -->
-    <?if $(var.Platform) = x64 ?>
-    <?define Win64 = "yes" ?>
-    <?define ProgramFilesVersion = "ProgramFiles64Folder" ?>
-    <?define ReleaseDir = "../release/win-unpacked" ?>
-    <?else ?>
-    <?define Win64 = "no" ?>
-    <?define ProgramFilesVersion = "ProgramFilesFolder" ?>
-    <?define ReleaseDir = "../release/win-ia32-unpacked" ?>
-    <?endif ?>
-    <!-- 
+  <?if $(var.Platform) = x64 ?>
+  <?define Win64 = "yes" ?>
+  <?define ProgramFilesVersion = "ProgramFiles64Folder" ?>
+  <?define ReleaseDir = "../release/win-unpacked" ?>
+  <?else ?>
+  <?define Win64 = "no" ?>
+  <?define ProgramFilesVersion = "ProgramFilesFolder" ?>
+  <?define ReleaseDir = "../release/win-ia32-unpacked" ?>
+  <?endif ?>
+  <!-- 
   The product GUID must not be changed except when:
   - the old and new versions have to coexist on the user's computer
   - the .msi filename change for any reason
@@ -35,67 +35,67 @@
   - there are any changes in the feature hierarchy (child
     feature moving out of a parent, or a parent feature getting a new child).
   -->
-    <Product Id="*" UpgradeCode="8523DAF0-699D-4CC7-9A65-C5E696A9DE6D" Name="Mattermost Desktop" Manufacturer="Mattermost, Inc." Language="1033" Codepage="1252" Version="4.1.2">
-        <!--
+  <Product Id="*" UpgradeCode="8523DAF0-699D-4CC7-9A65-C5E696A9DE6D" Name="Mattermost Desktop" Manufacturer="Mattermost, Inc." Language="1033" Codepage="1252" Version="4.1.2">
+    <!--
     perMachine installs the app system wide (ALLUSERS is set to 1)
     src.: https://www.joyofsetup.com/2008/04/01/new-wix-feature-setting-package-installation-scope/
     -->
-        <Package Id="*" Keywords="Installer" Description="Mattermost Desktop Installer" Manufacturer="Mattermost, Inc." InstallerVersion="400" Languages="1033" Compressed="yes" SummaryCodepage="1252" Platform="$(var.Platform)" InstallScope="perMachine" />
-        <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
-        <!--
+    <Package Id="*" Keywords="Installer" Description="Mattermost Desktop Installer" Manufacturer="Mattermost, Inc." InstallerVersion="400" Languages="1033" Compressed="yes" SummaryCodepage="1252" Platform="$(var.Platform)" InstallScope="perMachine" />
+    <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
+    <!--
     Perform OS check requirements only if we are installing (not on repair/
     uninstall) the package. The state "installing" is meant by the
     Installed keyword. Even if the OR seems weird, this is what must be
     used according to the doc.
     src.: http://wixtoolset.org/documentation/manual/v3/howtos/redistributables_and_install_checks/block_install_on_os.html
     -->
-        <Condition Message="!(loc.OsRequirements)"><![CDATA[Installed OR (VersionNT >= 601)]]></Condition>
-        <?if $(var.Platform) != x64 ?>
-        <Condition Message="!(loc.Requires32Bit)"><![CDATA[NOT VersionNT64]]></Condition>
-        <?endif ?>
-        <!--<MajorUpgrade
+    <Condition Message="!(loc.OsRequirements)"><![CDATA[Installed OR (VersionNT >= 601)]]></Condition>
+    <?if $(var.Platform) != x64 ?>
+    <Condition Message="!(loc.Requires32Bit)"><![CDATA[NOT VersionNT64]]></Condition>
+    <?endif ?>
+    <!--<MajorUpgrade
       DowngradeErrorMessage="A later version of [ProductName] is already installed. Setup will now exit." />-->
-        <!-- Retrieve previous installation path -->
-        <Property Id="INSTALLDIR">
-            <RegistrySearch Id="DetermineInstallLocation" Type="raw" Root="HKLM" Key="Software\Mattermost\Desktop" Name="InstallLocation" Win64="$(var.Win64)" />
-        </Property>
-        <Directory Id="TARGETDIR" Name="SourceDir">
-            <Directory Id="$(var.ProgramFilesVersion)" Name="PFiles">
-                <Directory Id="MattermostFolder" Name="Mattermost">
-                    <Directory Id="INSTALLDIR" Name="Desktop">
-                        <Component Id="MainExecutableShortcutDesktop" Guid="9C71385D-C892-48BA-A35D-D89A661D2952" Win64="$(var.Win64)">
-                            <Condition><![CDATA[ADDDESKTOPSHORTCUT = "true"]]></Condition>
-                            <RegistryValue Id="RegShortcutDesktop" Root="HKCU" Key="SOFTWARE\Mattermost\Desktop\settings" Name="MattermostDesktopShortcutDesktop" Value="1" Type="integer" KeyPath="yes" />
-                            <Shortcut Id="MattermostDesktopShortcutDesktop" Directory="DesktopFolder" Name="Mattermost Desktop" WorkingDirectory="INSTALLDIR" Icon="Mattermost.ico" IconIndex="0" Advertise="no" Target="[INSTALLDIR]Mattermost.exe" />
-                        </Component>
-                        <Component Id="MainExecutableShortcutStartMenu" Guid="DF2028FF-7E03-407B-A46A-726E1B67DF83" Win64="$(var.Win64)">
-                            <Condition><![CDATA[ADDSTARTMENUSHORTCUT = "true"]]></Condition>
-                            <RegistryValue Id="RegShortcutStartMenu" Root="HKCU" Key="SOFTWARE\Mattermost\Desktop\settings" Name="MattermostDesktopShortcutStartMenu" Value="1" Type="integer" KeyPath="yes" />
-                            <Shortcut Id="MattermostDesktopShortcutStartMenu" Directory="ProgramMenuDir" Name="Mattermost Desktop" WorkingDirectory="INSTALLDIR" Icon="Mattermost.ico" IconIndex="0" Advertise="no" Target="[INSTALLDIR]Mattermost.exe" />
-                        </Component>
-                        <Directory Id="GPOFiles" Name="gpo">
-                            <Component Id="GPODefinitionFile" Guid="BE30D350-8727-41CB-9F8D-9E0B7B9572A9" Win64="$(var.Win64)">
-                                <File Id="MattermostAdmxFile" Name="mattermost.admx" Source="../resources/windows/gpo/mattermost.admx" KeyPath="yes" />
-                            </Component>
-                            <Directory Id="GPOUSEnglishFiles" Name="en-US">
-                                <Component Id="GPOUSEnglishFiles" Guid="1D49A24E-769C-4AF0-863E-0648628A4554" Win64="$(var.Win64)">
-                                    <File Id="MattermostAdmlFile" Name="mattermost.adml" Source="../resources/windows/gpo/en-US/mattermost.adml" KeyPath="yes" />
-                                </Component>
-                            </Directory>
-                        </Directory>
-                    </Directory>
-                </Directory>
+    <!-- Retrieve previous installation path -->
+    <Property Id="INSTALLDIR">
+      <RegistrySearch Id="DetermineInstallLocation" Type="raw" Root="HKLM" Key="Software\Mattermost\Desktop" Name="InstallLocation" Win64="$(var.Win64)" />
+    </Property>
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="$(var.ProgramFilesVersion)" Name="PFiles">
+        <Directory Id="MattermostFolder" Name="Mattermost">
+          <Directory Id="INSTALLDIR" Name="Desktop">
+            <Component Id="MainExecutableShortcutDesktop" Guid="9C71385D-C892-48BA-A35D-D89A661D2952" Win64="$(var.Win64)">
+              <Condition><![CDATA[ADDDESKTOPSHORTCUT = "true"]]></Condition>
+              <RegistryValue Id="RegShortcutDesktop" Root="HKCU" Key="SOFTWARE\Mattermost\Desktop\settings" Name="MattermostDesktopShortcutDesktop" Value="1" Type="integer" KeyPath="yes" />
+              <Shortcut Id="MattermostDesktopShortcutDesktop" Directory="DesktopFolder" Name="Mattermost Desktop" WorkingDirectory="INSTALLDIR" Icon="Mattermost.ico" IconIndex="0" Advertise="no" Target="[INSTALLDIR]Mattermost.exe" />
+            </Component>
+            <Component Id="MainExecutableShortcutStartMenu" Guid="DF2028FF-7E03-407B-A46A-726E1B67DF83" Win64="$(var.Win64)">
+              <Condition><![CDATA[ADDSTARTMENUSHORTCUT = "true"]]></Condition>
+              <RegistryValue Id="RegShortcutStartMenu" Root="HKCU" Key="SOFTWARE\Mattermost\Desktop\settings" Name="MattermostDesktopShortcutStartMenu" Value="1" Type="integer" KeyPath="yes" />
+              <Shortcut Id="MattermostDesktopShortcutStartMenu" Directory="ProgramMenuDir" Name="Mattermost Desktop" WorkingDirectory="INSTALLDIR" Icon="Mattermost.ico" IconIndex="0" Advertise="no" Target="[INSTALLDIR]Mattermost.exe" />
+            </Component>
+            <Directory Id="GPOFiles" Name="gpo">
+              <Component Id="GPODefinitionFile" Guid="BE30D350-8727-41CB-9F8D-9E0B7B9572A9" Win64="$(var.Win64)">
+                <File Id="MattermostAdmxFile" Name="mattermost.admx" Source="../resources/windows/gpo/mattermost.admx" KeyPath="yes" />
+              </Component>
+              <Directory Id="GPOUSEnglishFiles" Name="en-US">
+                <Component Id="GPOUSEnglishFiles" Guid="1D49A24E-769C-4AF0-863E-0648628A4554" Win64="$(var.Win64)">
+                  <File Id="MattermostAdmlFile" Name="mattermost.adml" Source="../resources/windows/gpo/en-US/mattermost.adml" KeyPath="yes" />
+                </Component>
+              </Directory>
             </Directory>
-            <Directory Id="ProgramMenuFolder" Name="Programs">
-                <Directory Id="ProgramMenuDir" Name="Mattermost Desktop">
-                    <Component Id="ProgramMenuDir" Guid="CA5C6FAF-C004-4909-AF1C-AA0A5F53C245">
-                        <RemoveFolder Id="ProgramMenuDir" On="uninstall" />
-                        <RegistryValue Root="HKCU" Key="Software\Mattermost\Desktop" Type="string" Value="" KeyPath="yes" />
-                    </Component>
-                </Directory>
-            </Directory>
-            <Directory Id="DesktopFolder" Name="Desktop" />
-            <!--
+          </Directory>
+        </Directory>
+      </Directory>
+      <Directory Id="ProgramMenuFolder" Name="Programs">
+        <Directory Id="ProgramMenuDir" Name="Mattermost Desktop">
+          <Component Id="ProgramMenuDir" Guid="CA5C6FAF-C004-4909-AF1C-AA0A5F53C245">
+            <RemoveFolder Id="ProgramMenuDir" On="uninstall" />
+            <RegistryValue Root="HKCU" Key="Software\Mattermost\Desktop" Type="string" Value="" KeyPath="yes" />
+          </Component>
+        </Directory>
+      </Directory>
+      <Directory Id="DesktopFolder" Name="Desktop" />
+      <!--
     We are creating a registry out of tree (i.e. that won't be removed at
     desinstallation) because the purpose here is to remember the install
     location across updates (important when installing a newer version,
@@ -103,897 +103,897 @@
     src.: https://web.archive.org/web/20180322000314/http://robmensching.com/blog/posts/2010/5/2/the-wix-toolsets-remember-property-pattern/
     src.: https://web.archive.org/web/20181104151047/https://helgeklein.com/blog/2014/09/real-world-example-wix-msi-application-installer/
     -->
-            <Component Id="RegInstallLocation" Guid="BF67264A-28BB-44FF-A646-F118D814651E">
-                <RegistryKey Root="HKLM" Key="Software\Mattermost\Desktop">
-                    <RegistryValue Name="InstallLocation" Value="[INSTALLDIR]" Type="string" KeyPath="yes" />
-                </RegistryKey>
-            </Component>
-        </Directory>
-        <Feature Id="Complete" Level="1" ConfigurableDirectory="INSTALLDIR">
-            <!-- Using heat to generate file and directory hierarchy
+      <Component Id="RegInstallLocation" Guid="BF67264A-28BB-44FF-A646-F118D814651E">
+        <RegistryKey Root="HKLM" Key="Software\Mattermost\Desktop">
+          <RegistryValue Name="InstallLocation" Value="[INSTALLDIR]" Type="string" KeyPath="yes" />
+        </RegistryKey>
+      </Component>
+    </Directory>
+    <Feature Id="Complete" Level="1" ConfigurableDirectory="INSTALLDIR">
+      <!-- Using heat to generate file and directory hierarchy
            src.: https://stackoverflow.com/a/26558025/3514658
       -->
-            <ComponentGroupRef Id="MattermostDesktopFiles" />
-            <ComponentRef Id="MainExecutableShortcutDesktop" />
-            <ComponentRef Id="MainExecutableShortcutStartMenu" />
-            <ComponentRef Id="ProgramMenuDir" />
-            <ComponentRef Id="RegInstallLocation" />
-            <ComponentRef Id="GPODefinitionFile" />
-            <ComponentRef Id="GPOUSEnglishFiles" />
-        </Feature>
-        <InstallExecuteSequence>
-            <Custom Action="LaunchApp" After="InstallFinalize">Installed</Custom>
-            <RemoveExistingProducts After="InstallFinalize" />
-        </InstallExecuteSequence>
-        <CustomAction Id="LaunchApp" FileKey="MattermostDesktopEXE" ExeCommand="" Return="asyncNoWait" />
-        <Icon Id="Mattermost.ico" SourceFile="../resources/icon.ico" />
-        <Property Id="ARPPRODUCTICON">Mattermost.ico</Property>
-        <Property Id="ARPCONTACT">https://pre-release.mattermost.com</Property>
-        <Property Id="ARPHELPLINK">https://docs.mattermost.com/</Property>
-        <Property Id="ARPURLINFOABOUT">https://mattermost.com/</Property>
-        <Property Id="ComponentDownload"><![CDATA[https://releases.mattermost.com/desktop/4.1.2/mattermost-setup-4.1.2-win64.msi]]></Property>
-        <Property Id="ADDDESKTOPSHORTCUT">true</Property>
-        <Property Id="ADDSTARTMENUSHORTCUT">true</Property>
-        <UI>
-            <Publish Dialog="SuccessDlg" Control="Finish" Order="1" Event="DoAction" Value="LaunchApp">LAUNCHAPPAFTERINSTALL</Publish>
-            <Property Id="ErrorDialog"><![CDATA[ErrorDlg]]></Property>
-            <Property Id="DefaultUIFont"><![CDATA[DlgFont8]]></Property>
-            <Dialog Id="AdminWelcomeDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
-                <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
-                <Control Id="Instructions" Type="Text" X="10" Y="155" Width="350" Height="78" Transparent="yes" NoPrefix="yes">
-                    <Text>Welcome to the [ProductName] [Installer]
+      <ComponentGroupRef Id="MattermostDesktopFiles" />
+      <ComponentRef Id="MainExecutableShortcutDesktop" />
+      <ComponentRef Id="MainExecutableShortcutStartMenu" />
+      <ComponentRef Id="ProgramMenuDir" />
+      <ComponentRef Id="RegInstallLocation" />
+      <ComponentRef Id="GPODefinitionFile" />
+      <ComponentRef Id="GPOUSEnglishFiles" />
+    </Feature>
+    <InstallExecuteSequence>
+      <Custom Action="LaunchApp" After="InstallFinalize">Installed</Custom>
+      <RemoveExistingProducts After="InstallFinalize" />
+    </InstallExecuteSequence>
+    <CustomAction Id="LaunchApp" FileKey="MattermostDesktopEXE" ExeCommand="" Return="asyncNoWait" />
+    <Icon Id="Mattermost.ico" SourceFile="../resources/icon.ico" />
+    <Property Id="ARPPRODUCTICON">Mattermost.ico</Property>
+    <Property Id="ARPCONTACT">https://pre-release.mattermost.com</Property>
+    <Property Id="ARPHELPLINK">https://docs.mattermost.com/</Property>
+    <Property Id="ARPURLINFOABOUT">https://mattermost.com/</Property>
+    <Property Id="ComponentDownload"><![CDATA[https://releases.mattermost.com/desktop/4.1.2/mattermost-setup-4.1.2-win64.msi]]></Property>
+    <Property Id="ADDDESKTOPSHORTCUT">true</Property>
+    <Property Id="ADDSTARTMENUSHORTCUT">true</Property>
+    <UI>
+      <Publish Dialog="SuccessDlg" Control="Finish" Order="1" Event="DoAction" Value="LaunchApp">LAUNCHAPPAFTERINSTALL</Publish>
+      <Property Id="ErrorDialog"><![CDATA[ErrorDlg]]></Property>
+      <Property Id="DefaultUIFont"><![CDATA[DlgFont8]]></Property>
+      <Dialog Id="AdminWelcomeDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+        <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
+        <Control Id="Instructions" Type="Text" X="10" Y="155" Width="350" Height="78" Transparent="yes" NoPrefix="yes">
+          <Text>Welcome to the [ProductName] [Installer]
 
 The [Installer] will create a server image of [ProductName], at a specified network location.  Click Next to continue or Cancel to exit the [Installer].</Text>
-                </Control>
-                <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Next]">
-                    <Publish Property="InstallMode" Value="Server Image"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
-                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
-            </Dialog>
-            <Dialog Id="SuccessDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
-                <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
-                <Control Id="Instructions" Type="Text" X="10" Y="155" Width="350" Height="78" Transparent="yes" NoPrefix="yes">
-                    <Text>!(loc.SuccessDlgInstructions)</Text>
-                </Control>
-                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
-                <Control Id="Finish" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Finish]">
-                    <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Cancel]" />
-            </Dialog>
-            <Dialog Id="FatalError" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
-                <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
-                <Control Id="Instructions" Type="Text" X="10" Y="155" Width="350" Height="78" Transparent="yes" NoPrefix="yes">
-                    <Text>The [ProductName] [Installer] ended prematurely because of an error.  Your system has not been modified.  To install this program at a later time, please run the installation again.
+        </Control>
+        <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Next]">
+          <Publish Property="InstallMode" Value="Server Image"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
+          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
+      </Dialog>
+      <Dialog Id="SuccessDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+        <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
+        <Control Id="Instructions" Type="Text" X="10" Y="155" Width="350" Height="78" Transparent="yes" NoPrefix="yes">
+          <Text>!(loc.SuccessDlgInstructions)</Text>
+        </Control>
+        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
+        <Control Id="Finish" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Finish]">
+          <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Cancel]" />
+      </Dialog>
+      <Dialog Id="FatalError" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+        <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
+        <Control Id="Instructions" Type="Text" X="10" Y="155" Width="350" Height="78" Transparent="yes" NoPrefix="yes">
+          <Text>The [ProductName] [Installer] ended prematurely because of an error.  Your system has not been modified.  To install this program at a later time, please run the installation again.
 
 Click the Finish button to exit the [Installer].</Text>
-                </Control>
-                <Control Id="Finish" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Finish]">
-                    <Publish Event="EndDialog" Value="Exit"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Cancel]" />
-                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
-            </Dialog>
-            <Dialog Id="PrepareDlg" Width="370" Height="270" Title="[ProductName] [Installer]" Modeless="yes">
-                <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
-                <Control Id="Instructions" Type="Text" X="10" Y="155" Width="350" Height="78" Transparent="yes" NoPrefix="yes">
-                    <Text>Welcome to the [ProductName] [Installer]
+        </Control>
+        <Control Id="Finish" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Finish]">
+          <Publish Event="EndDialog" Value="Exit"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Cancel]" />
+        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
+      </Dialog>
+      <Dialog Id="PrepareDlg" Width="370" Height="270" Title="[ProductName] [Installer]" Modeless="yes">
+        <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
+        <Control Id="Instructions" Type="Text" X="10" Y="155" Width="350" Height="78" Transparent="yes" NoPrefix="yes">
+          <Text>Welcome to the [ProductName] [Installer]
 
 Please wait while the [Installer] prepares to guide you through the installation.</Text>
-                </Control>
-                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Cancel]">
-                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" TabSkip="yes" Text="[ButtonText_Back]" />
-                <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Disabled="yes" TabSkip="yes" Text="[ButtonText_Next]" />
-                <Control Id="ActionData" Type="Text" X="135" Y="125" Width="220" Height="30" Transparent="yes" NoPrefix="yes">
-                    <Subscribe Event="ActionData" Attribute="Text" />
-                </Control>
-                <Control Id="ActionText" Type="Text" X="135" Y="100" Width="220" Height="20" Transparent="yes" NoPrefix="yes">
-                    <Subscribe Event="ActionText" Attribute="Text" />
-                </Control>
-            </Dialog>
-            <Dialog Id="ProgressDlg" Width="370" Height="270" Title="[ProductName] [Installer]" Modeless="yes">
-                <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
-                <Control Id="Instructions" Type="Text" X="15" Y="155" Width="340" Height="45" Transparent="yes" NoPrefix="yes">
-                    <Text>!(loc.ProgressDlgInstructions)</Text>
-                </Control>
-                <Control Id="StatusLabel" Type="Text" X="15" Y="215" Width="35" Height="10" Text="!(loc.ProgressDlgStatusLabel)" />
-                <Control Id="ActionText" Type="Text" X="50" Y="215" Width="265" Height="10">
-                    <Subscribe Event="ActionText" Attribute="Text" />
-                </Control>
-                <Control Id="ProgressBar" Type="ProgressBar" X="15" Y="225" Width="340" Height="10" ProgressBlocks="yes" Text="Progress done">
-                    <Subscribe Event="SetProgress" Attribute="Progress" />
-                </Control>
-                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
-                <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Next]" />
-                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Cancel]">
-                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-                </Control>
-            </Dialog>
-            <Dialog Id="UserExitDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
-                <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
-                <Control Id="Instructions" Type="Text" X="15" Y="155" Width="340" Height="85" Transparent="yes" NoPrefix="yes">
-                    <Text>!(loc.UserExitDlgInstructions)</Text>
-                </Control>
-                <Control Id="Finish" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Finish]">
-                    <Publish Event="EndDialog" Value="Exit"><![CDATA[1]]></Publish>
-                </Control>
-            </Dialog>
-            <Dialog Id="AdminBrowseDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
-                <Control Id="PathEdit" Type="PathEdit" X="84" Y="212" Width="261" Height="15" Property="TARGETDIR" />
-                <Control Id="OK" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_OK]">
-                    <Publish Event="SetTargetPath" Value="TARGETDIR"><![CDATA[1]]></Publish>
-                    <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="Cancel" Type="PushButton" X="240" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
-                    <Publish Event="Reset" Value="0"><![CDATA[1]]></Publish>
-                    <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="ComboLabel" Type="Text" X="25" Y="98" Width="44" Height="10" TabSkip="no" Text="&amp;Look in:" />
-                <Control Id="DirectoryCombo" Type="DirectoryCombo" X="70" Y="95" Width="220" Height="16" Property="TARGETDIR" Removable="yes" Fixed="yes" Remote="yes">
-                    <Subscribe Event="IgnoreChange" Attribute="IgnoreChange" />
-                </Control>
-                <Control Id="Up" Type="PushButton" X="298" Y="95" Width="19" Height="19" ToolTip="Up One Level" Icon="yes" FixedSize="yes" IconSize="16" Text="Up">
-                    <Publish Event="DirectoryListUp" Value="0"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="NewFolder" Type="PushButton" X="325" Y="95" Width="19" Height="19" ToolTip="Create A New Folder" Icon="yes" FixedSize="yes" IconSize="16" Text="New">
-                    <Publish Event="DirectoryListNew" Value="0"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="DirectoryList" Type="DirectoryList" X="25" Y="123" Width="320" Height="81" Property="TARGETDIR" Sunken="yes" TabSkip="no" />
-                <Control Id="PathLabel" Type="Text" X="25" Y="215" Width="59" Height="10" TabSkip="no" Text="&amp;Folder name:" />
-                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-                <Control Id="Description" Type="Text" X="25" Y="73" Width="280" Height="15" Transparent="yes" NoPrefix="yes">
-                    <Text>Browse to the destination folder</Text>
-                </Control>
-                <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
-                    <Text>[DlgTitleFont]Change current destination folder</Text>
-                </Control>
-            </Dialog>
-            <Dialog Id="BrowseDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
-                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-                <Control Id="Instructions" Type="Text" X="10" Y="55" Width="350" Height="10" Transparent="yes" NoPrefix="yes">
-                    <Text>!(loc.BrowseDlgInstructions)</Text>
-                </Control>
-                <Control Id="DirectoryCombo" Type="DirectoryCombo" X="10" Y="70" Width="310" Height="20" Property="INSTALLDIR" Fixed="yes" Remote="yes">
-                    <Subscribe Event="IgnoreChange" Attribute="IgnoreChange" />
-                </Control>
-                <Control Id="Up" Type="PushButton" X="320" Y="70" Width="20" Height="20" ToolTip="!(loc.BrowseDlgUp)" Icon="yes" FixedSize="yes" IconSize="16" Text="Up">
-                    <Publish Event="DirectoryListUp" Value="0"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="NewFolder" Type="PushButton" X="340" Y="70" Width="20" Height="20" ToolTip="!(loc.BrowseDlgNewFolder)" Icon="yes" FixedSize="yes" IconSize="16" Text="New">
-                    <Publish Event="DirectoryListNew" Value="0"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="DirectoryList" Type="DirectoryList" X="10" Y="90" Width="350" Height="110" Property="INSTALLDIR" Sunken="yes" TabSkip="no" />
-                <Control Id="PathLabel" Type="Text" X="10" Y="205" Width="350" Height="15" TabSkip="no" Text="!(loc.BrowseDlgPathLabel)" />
-                <Control Id="PathEdit" Type="PathEdit" X="10" Y="220" Width="350" Height="17" Property="INSTALLDIR" />
-                <Control Id="OK" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_OK]">
-                    <Publish Event="SetTargetPath" Value="INSTALLDIR"><![CDATA[1]]></Publish>
-                    <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
-                    <Publish Event="Reset" Value="0"><![CDATA[1]]></Publish>
-                    <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[1]]></Publish>
-                </Control>
-            </Dialog>
-            <Dialog Id="CancelDlg" Width="260" Height="85" Title="[ProductName] [Installer]" NoMinimize="yes">
-                <Control Id="Icon" Type="Icon" X="15" Y="15" Width="24" Height="24" ToolTip="Information icon" FixedSize="yes" IconSize="32" Text="[QuestionIcon]" />
-                <Control Id="Text" Type="Text" X="48" Y="15" Width="194" Height="30">
-                    <Text>!(loc.CancelDlgText)</Text>
-                </Control>
-                <Control Id="Yes" Type="PushButton" X="72" Y="57" Width="56" Height="17" Text="[ButtonText_Yes]">
-                    <Publish Event="EndDialog" Value="Exit"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="No" Type="PushButton" X="132" Y="57" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_No]">
-                    <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
-                </Control>
-            </Dialog>
-            <Dialog Id="AdvancedDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes" TrackDiskSpace="yes">
-                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-                <Control Id="Instructions" Type="Text" X="10" Y="55" Width="350" Height="45" Transparent="yes" NoPrefix="yes">
-                    <Text>!(loc.AdvancedDlgInstructions)</Text>
-                </Control>
-                <Control Id="LocationLabel" Type="Text" X="10" Y="115" Width="350" Height="15" Text="!(loc.AdvancedDlgLocationLabel)">
-                    <Subscribe Event="SelectionPathOn" Attribute="Visible" />
-                    <Condition Action="hide"><![CDATA[Installed]]></Condition>
-                </Control>
-                <Control Type="PathEdit" Id="DestinationPath" X="10" Y="130" Width="282" Height="17" Property="INSTALLDIR" />
-                <Control Id="Browse" Type="PushButton" X="304" Y="130" Width="56" Height="17" Text="!(loc.AdvancedDlgBrowse)">
-                    <Publish Event="NewDialog" Value="BrowseDlg"><![CDATA[1]]></Publish>
-                    <Condition Action="hide"><![CDATA[Installed]]></Condition>
-                </Control>
-                <Control Type="CheckBox" Id="AddDesktopShortcut" X="10" Y="155" Width="350" Height="20" Property="ADDDESKTOPSHORTCUT" CheckBoxValue="true">
-                    <Text>!(loc.AdvancedDlgAddDesktopShortcut)</Text>
-                </Control>
-                <Control Type="CheckBox" Id="AddStartMenuShortcut" X="10" Y="170" Width="350" Height="20" Property="ADDSTARTMENUSHORTCUT" CheckBoxValue="true">
-                    <Text>!(loc.AdvancedDlgAddStartMenuShortcut)</Text>
-                </Control>
-                <Control Type="CheckBox" Id="LaunchAppAfterInstall" X="10" Y="195" Width="350" Height="20" Property="LAUNCHAPPAFTERINSTALL" CheckBoxValue="true">
-                    <Text>!(loc.AdvancedDlgLaunchAppAfterInstall)</Text>
-                </Control>
-                <Control Id="AcceptLicenseCheckBox" Type="CheckBox" X="10" Y="220" Width="350" Height="20" CheckBoxPropertyRef="LicenseAccepted" CheckBoxValue="true">
-                    <Text>!(loc.WelcomeDlgAcceptLicenseCheckBox)</Text>
-                </Control>
-                <Control Id="License" Type="PushButton" X="10" Y="243" Width="56" Height="17" Text="[ButtonText_License]">
-                    <Publish Event="NewDialog" Value="LicenseAgreementDlg"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="Reset" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Reset]">
-                    <Publish Event="Reset" Value="0"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="Install" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Install]" ElevationShield="yes">
-                    <Condition Action="disable"><![CDATA[LicenseAccepted <> "true"]]></Condition>
-                    <Condition Action="enable"><![CDATA[LicenseAccepted = "true"]]></Condition>
-                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
-                    <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
-                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-                    <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-                    <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
-                </Control>
-                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
-                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-                </Control>
-            </Dialog>
-            <Dialog Id="DiskCostDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
-                <Control Id="OK" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_OK]">
-                    <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-                <Control Id="Text" Type="Text" X="20" Y="103" Width="330" Height="40">
-                    <Text>The highlighted volumes (if any) do not have enough disk space available for the currently selected features.  You can either remove some files from the highlighted volumes, or choose to install less features onto local drive(s), or select different destination drive(s).</Text>
-                </Control>
-                <Control Id="Description" Type="Text" X="20" Y="74" Width="280" Height="15" Transparent="yes" NoPrefix="yes">
-                    <Text>The disk space required for the installation of the selected features.</Text>
-                </Control>
-                <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
-                    <Text>[DlgTitleFont]Disk Space Requirements</Text>
-                </Control>
-                <Control Id="VolumeList" Type="VolumeCostList" X="20" Y="150" Width="330" Height="80" Sunken="yes" Fixed="yes" Remote="yes">
-                    <Text>{120}{70}{70}{70}{70}</Text>
-                </Control>
-            </Dialog>
-            <Dialog Id="ErrorDlg" Y="10" Width="270" Height="105" Title="Installer Information" ErrorDialog="yes" NoMinimize="yes">
-                <Control Id="ErrorText" Type="Text" X="48" Y="15" Width="205" Height="60" TabSkip="no" Text="Information text" />
-                <Control Id="Y" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_Yes]">
-                    <Publish Event="EndDialog" Value="ErrorYes"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="A" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_Cancel]">
-                    <Publish Event="EndDialog" Value="ErrorAbort"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="C" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_Cancel]">
-                    <Publish Event="EndDialog" Value="ErrorCancel"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="ErrorIcon" Type="Icon" X="15" Y="15" Width="24" Height="24" ToolTip="Information icon" FixedSize="yes" IconSize="32" Text="[QuestionIcon]" />
-                <Control Id="I" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_Ignore]">
-                    <Publish Event="EndDialog" Value="ErrorIgnore"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="N" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_No]">
-                    <Publish Event="EndDialog" Value="ErrorNo"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="O" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_OK]">
-                    <Publish Event="EndDialog" Value="ErrorOk"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="R" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_Retry]">
-                    <Publish Event="EndDialog" Value="ErrorRetry"><![CDATA[1]]></Publish>
-                </Control>
-            </Dialog>
-            <Dialog Id="FilesInUse" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes" KeepModeless="yes">
-                <Control Id="Retry" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Retry]">
-                    <Publish Event="EndDialog" Value="Retry"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="Ignore" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Ignore]">
-                    <Publish Event="EndDialog" Value="Ignore"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="Exit" Type="PushButton" X="304" Y="243" Width="56" Height="17" Text="[ButtonText_Cancel]">
-                    <Publish Event="EndDialog" Value="Exit"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-                <Control Id="Description" Type="Text" X="20" Y="74" Width="280" Height="30" Transparent="yes" NoPrefix="yes">
-                    <Text>The following applications are using files that need to be updated by this installer. Close these applications and then click Retry to continue the installation or Cancel to exit the installer.</Text>
-                </Control>
-                <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
-                    <Text>[DlgTitleFont]Files in Use</Text>
-                </Control>
-                <Control Id="List" Type="ListBox" X="20" Y="117" Width="330" Height="81" Property="FileInUseProcess" Sunken="yes" TabSkip="no" />
-            </Dialog>
-            <Dialog Id="LicenseAgreementDlg" Width="370" Height="270" Title="[ProductName] License Agreement" NoMinimize="yes">
-                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-                <Control Id="AgreementText" Type="ScrollableText" X="0" Y="44" Width="370" Height="189" Sunken="no" TabSkip="yes">
-                    <Text SourceFile="../resources/windows/license.rtf" />
-                </Control>
-                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Back]">
-                    <Publish Event="NewDialog" Value="WelcomeDlg"><![CDATA[1]]></Publish>
-                    <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[LicenseAccepted = "true"]]></Publish>
-                </Control>
-                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
-                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-                </Control>
-            </Dialog>
-            <Dialog Id="MaintenanceTypeDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
-                <Control Id="ChangeLabel" Type="Text" X="105" Y="95" Width="100" Height="10" TabSkip="no">
-                    <Text>[DlgTitleFont]&amp;Modify</Text>
-                </Control>
-                <Control Id="ChangeButton" Type="PushButton" X="50" Y="95" Width="38" Height="38" ToolTip="Modify Installation" Default="yes" Icon="yes" FixedSize="yes" IconSize="32" Text="[ModifyIcon]">
-                    <Publish Property="InstallMode" Value="Change"><![CDATA[1]]></Publish>
-                    <Publish Property="Progress1" Value="Changing"><![CDATA[1]]></Publish>
-                    <Publish Property="Progress2" Value="Changes"><![CDATA[1]]></Publish>
-                    <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="RepairLabel" Type="Text" X="105" Y="144" Width="100" Height="10" TabSkip="no">
-                    <Text>[DlgTitleFont]Re&amp;pair</Text>
-                </Control>
-                <Control Id="RepairButton" Type="PushButton" X="50" Y="144" Width="38" Height="38" ToolTip="Repair Installation" Icon="yes" FixedSize="yes" IconSize="32" Text="[RepairIcon]">
-                    <Publish Property="InstallMode" Value="Repair"><![CDATA[1]]></Publish>
-                    <Publish Property="Progress1" Value="Repairing"><![CDATA[1]]></Publish>
-                    <Publish Property="Progress2" Value="Repairs"><![CDATA[1]]></Publish>
-                    <Publish Event="NewDialog" Value="VerifyRepairDlg"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="RemoveLabel" Type="Text" X="105" Y="193" Width="100" Height="10" TabSkip="no">
-                    <Text>[DlgTitleFont]&amp;Uninstall</Text>
-                </Control>
-                <Control Id="RemoveButton" Type="PushButton" X="50" Y="193" Width="38" Height="38" ToolTip="Remove Installation" Icon="yes" FixedSize="yes" IconSize="32" Text="[RemoveIcon]">
-                    <Publish Property="InstallMode" Value="Uninstall"><![CDATA[1]]></Publish>
-                    <Publish Property="Progress1" Value="Uninstalling"><![CDATA[1]]></Publish>
-                    <Publish Property="Progress2" Value="Uninstall"><![CDATA[1]]></Publish>
-                    <Publish Event="NewDialog" Value="VerifyRemoveDlg"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Back]">
-                    <Publish Event="NewDialog" Value="MaintenanceWelcomeDlg"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Next]" />
-                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
-                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-                <Control Id="Description" Type="Text" X="25" Y="74" Width="280" Height="20" Transparent="yes" NoPrefix="yes">
-                    <Text>Select the operation you wish to perform.</Text>
-                </Control>
-                <Control Id="Title" Type="Text" X="15" Y="56" Width="240" Height="15" Transparent="yes" NoPrefix="yes">
-                    <Text>[DlgTitleFont]Modify, repair or uninstall </Text>
-                </Control>
-                <Control Id="ChangeText" Type="Text" X="105" Y="108" Width="230" Height="20">
-                    <Text>Change the installation directory</Text>
-                </Control>
-                <Control Id="RemoveText" Type="Text" X="105" Y="206" Width="230" Height="20">
-                    <Text>Uninstalls [ProductName] from your computer.</Text>
-                </Control>
-                <Control Id="RepairText" Type="Text" X="105" Y="157" Width="230" Height="30">
-                    <Text>Fix missing or corrupt files, shortcuts and registry entries.</Text>
-                </Control>
-            </Dialog>
-            <Dialog Id="MaintenanceWelcomeDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
-                <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
-                <Control Id="Instructions" Type="Text" X="10" Y="155" Width="350" Height="45" Transparent="yes" NoPrefix="yes">
-                    <Text>!(loc.MaintenanceWelcomeDlgInstructions)</Text>
-                </Control>
-                <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Next]">
-                    <Publish Event="SpawnWaitDialog" Value="WaitForCostingDlg"><![CDATA[CostingComplete = 1]]></Publish>
-                    <Publish Event="NewDialog" Value="MaintenanceTypeDlg"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
-                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
-            </Dialog>
-            <Dialog Id="OutOfDiskDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
-                <Control Id="OK" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_OK]">
-                    <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-                <Control Id="Text" Type="Text" X="20" Y="103" Width="330" Height="40">
-                    <Text>The highlighted volumes do not have enough disk space available for the currently selected features.  You can either remove some files from the highlighted volumes, or choose to install less features onto local drive(s), or select different destination drive(s).</Text>
-                </Control>
-                <Control Id="Description" Type="Text" X="20" Y="74" Width="280" Height="20" Transparent="yes" NoPrefix="yes">
-                    <Text>Disk space required for the installation exceeds available disk space.</Text>
-                </Control>
-                <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
-                    <Text>[DlgTitleFont]Out of Disk Space</Text>
-                </Control>
-                <Control Id="VolumeList" Type="VolumeCostList" X="20" Y="150" Width="330" Height="80" Sunken="yes" Fixed="yes" Remote="yes">
-                    <Text>{120}{70}{70}{70}{70}</Text>
-                </Control>
-            </Dialog>
-            <Dialog Id="OutOfRbDiskDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
-                <Control Id="No" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_No]">
-                    <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="Yes" Type="PushButton" X="240" Y="243" Width="56" Height="17" Text="[ButtonText_Yes]">
-                    <Publish Event="EnableRollback" Value="False"><![CDATA[1]]></Publish>
-                    <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-                <Control Id="Text" Type="Text" X="20" Y="90" Width="330" Height="30">
-                    <Text>The highlighted volumes do not have enough disk space available for the currently selected features.  You can either remove some files from the highlighted volumes, or choose to install less features onto local drive(s), or select different destination drive(s).</Text>
-                </Control>
-                <Control Id="Description" Type="Text" X="20" Y="74" Width="280" Height="15" Transparent="yes" NoPrefix="yes">
-                    <Text>Disk space required for the installation exceeds available disk space.</Text>
-                </Control>
-                <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
-                    <Text>[DlgTitleFont]Out of Disk Space</Text>
-                </Control>
-                <Control Id="VolumeList" Type="VolumeCostList" X="20" Y="165" Width="330" Height="65" Sunken="yes" Fixed="yes" Remote="yes" ShowRollbackCost="yes">
-                    <Text>{120}{70}{70}{70}{70}</Text>
-                </Control>
-                <Control Id="Text2" Type="Text" X="20" Y="125" Width="330" Height="40">
-                    <Text>Alternatively, you may choose to disable the installer's rollback functionality.  This allows the installer to restore your computer's original state should the installation be interrupted in any way.  Click Yes if you wish to take the risk to disable rollback.</Text>
-                </Control>
-            </Dialog>
-            <Dialog Id="ResumeDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
-                <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
-                <Control Id="Instructions" Type="Text" X="15" Y="155" Width="340" Height="45" Transparent="yes" NoPrefix="yes">
-                    <Text>Resuming the [ProductName] [Installer]
+        </Control>
+        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Cancel]">
+          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" TabSkip="yes" Text="[ButtonText_Back]" />
+        <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Disabled="yes" TabSkip="yes" Text="[ButtonText_Next]" />
+        <Control Id="ActionData" Type="Text" X="135" Y="125" Width="220" Height="30" Transparent="yes" NoPrefix="yes">
+          <Subscribe Event="ActionData" Attribute="Text" />
+        </Control>
+        <Control Id="ActionText" Type="Text" X="135" Y="100" Width="220" Height="20" Transparent="yes" NoPrefix="yes">
+          <Subscribe Event="ActionText" Attribute="Text" />
+        </Control>
+      </Dialog>
+      <Dialog Id="ProgressDlg" Width="370" Height="270" Title="[ProductName] [Installer]" Modeless="yes">
+        <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
+        <Control Id="Instructions" Type="Text" X="15" Y="155" Width="340" Height="45" Transparent="yes" NoPrefix="yes">
+          <Text>!(loc.ProgressDlgInstructions)</Text>
+        </Control>
+        <Control Id="StatusLabel" Type="Text" X="15" Y="215" Width="35" Height="10" Text="!(loc.ProgressDlgStatusLabel)" />
+        <Control Id="ActionText" Type="Text" X="50" Y="215" Width="265" Height="10">
+          <Subscribe Event="ActionText" Attribute="Text" />
+        </Control>
+        <Control Id="ProgressBar" Type="ProgressBar" X="15" Y="225" Width="340" Height="10" ProgressBlocks="yes" Text="Progress done">
+          <Subscribe Event="SetProgress" Attribute="Progress" />
+        </Control>
+        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
+        <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Next]" />
+        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Cancel]">
+          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+        </Control>
+      </Dialog>
+      <Dialog Id="UserExitDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+        <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
+        <Control Id="Instructions" Type="Text" X="15" Y="155" Width="340" Height="85" Transparent="yes" NoPrefix="yes">
+          <Text>!(loc.UserExitDlgInstructions)</Text>
+        </Control>
+        <Control Id="Finish" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Finish]">
+          <Publish Event="EndDialog" Value="Exit"><![CDATA[1]]></Publish>
+        </Control>
+      </Dialog>
+      <Dialog Id="AdminBrowseDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+        <Control Id="PathEdit" Type="PathEdit" X="84" Y="212" Width="261" Height="15" Property="TARGETDIR" />
+        <Control Id="OK" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_OK]">
+          <Publish Event="SetTargetPath" Value="TARGETDIR"><![CDATA[1]]></Publish>
+          <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="Cancel" Type="PushButton" X="240" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
+          <Publish Event="Reset" Value="0"><![CDATA[1]]></Publish>
+          <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="ComboLabel" Type="Text" X="25" Y="98" Width="44" Height="10" TabSkip="no" Text="&amp;Look in:" />
+        <Control Id="DirectoryCombo" Type="DirectoryCombo" X="70" Y="95" Width="220" Height="16" Property="TARGETDIR" Removable="yes" Fixed="yes" Remote="yes">
+          <Subscribe Event="IgnoreChange" Attribute="IgnoreChange" />
+        </Control>
+        <Control Id="Up" Type="PushButton" X="298" Y="95" Width="19" Height="19" ToolTip="Up One Level" Icon="yes" FixedSize="yes" IconSize="16" Text="Up">
+          <Publish Event="DirectoryListUp" Value="0"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="NewFolder" Type="PushButton" X="325" Y="95" Width="19" Height="19" ToolTip="Create A New Folder" Icon="yes" FixedSize="yes" IconSize="16" Text="New">
+          <Publish Event="DirectoryListNew" Value="0"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="DirectoryList" Type="DirectoryList" X="25" Y="123" Width="320" Height="81" Property="TARGETDIR" Sunken="yes" TabSkip="no" />
+        <Control Id="PathLabel" Type="Text" X="25" Y="215" Width="59" Height="10" TabSkip="no" Text="&amp;Folder name:" />
+        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+        <Control Id="Description" Type="Text" X="25" Y="73" Width="280" Height="15" Transparent="yes" NoPrefix="yes">
+          <Text>Browse to the destination folder</Text>
+        </Control>
+        <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
+          <Text>[DlgTitleFont]Change current destination folder</Text>
+        </Control>
+      </Dialog>
+      <Dialog Id="BrowseDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+        <Control Id="Instructions" Type="Text" X="10" Y="55" Width="350" Height="10" Transparent="yes" NoPrefix="yes">
+          <Text>!(loc.BrowseDlgInstructions)</Text>
+        </Control>
+        <Control Id="DirectoryCombo" Type="DirectoryCombo" X="10" Y="70" Width="310" Height="20" Property="INSTALLDIR" Fixed="yes" Remote="yes">
+          <Subscribe Event="IgnoreChange" Attribute="IgnoreChange" />
+        </Control>
+        <Control Id="Up" Type="PushButton" X="320" Y="70" Width="20" Height="20" ToolTip="!(loc.BrowseDlgUp)" Icon="yes" FixedSize="yes" IconSize="16" Text="Up">
+          <Publish Event="DirectoryListUp" Value="0"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="NewFolder" Type="PushButton" X="340" Y="70" Width="20" Height="20" ToolTip="!(loc.BrowseDlgNewFolder)" Icon="yes" FixedSize="yes" IconSize="16" Text="New">
+          <Publish Event="DirectoryListNew" Value="0"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="DirectoryList" Type="DirectoryList" X="10" Y="90" Width="350" Height="110" Property="INSTALLDIR" Sunken="yes" TabSkip="no" />
+        <Control Id="PathLabel" Type="Text" X="10" Y="205" Width="350" Height="15" TabSkip="no" Text="!(loc.BrowseDlgPathLabel)" />
+        <Control Id="PathEdit" Type="PathEdit" X="10" Y="220" Width="350" Height="17" Property="INSTALLDIR" />
+        <Control Id="OK" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_OK]">
+          <Publish Event="SetTargetPath" Value="INSTALLDIR"><![CDATA[1]]></Publish>
+          <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
+          <Publish Event="Reset" Value="0"><![CDATA[1]]></Publish>
+          <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[1]]></Publish>
+        </Control>
+      </Dialog>
+      <Dialog Id="CancelDlg" Width="260" Height="85" Title="[ProductName] [Installer]" NoMinimize="yes">
+        <Control Id="Icon" Type="Icon" X="15" Y="15" Width="24" Height="24" ToolTip="Information icon" FixedSize="yes" IconSize="32" Text="[QuestionIcon]" />
+        <Control Id="Text" Type="Text" X="48" Y="15" Width="194" Height="30">
+          <Text>!(loc.CancelDlgText)</Text>
+        </Control>
+        <Control Id="Yes" Type="PushButton" X="72" Y="57" Width="56" Height="17" Text="[ButtonText_Yes]">
+          <Publish Event="EndDialog" Value="Exit"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="No" Type="PushButton" X="132" Y="57" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_No]">
+          <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
+        </Control>
+      </Dialog>
+      <Dialog Id="AdvancedDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes" TrackDiskSpace="yes">
+        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+        <Control Id="Instructions" Type="Text" X="10" Y="55" Width="350" Height="45" Transparent="yes" NoPrefix="yes">
+          <Text>!(loc.AdvancedDlgInstructions)</Text>
+        </Control>
+        <Control Id="LocationLabel" Type="Text" X="10" Y="115" Width="350" Height="15" Text="!(loc.AdvancedDlgLocationLabel)">
+          <Subscribe Event="SelectionPathOn" Attribute="Visible" />
+          <Condition Action="hide"><![CDATA[Installed]]></Condition>
+        </Control>
+        <Control Type="PathEdit" Id="DestinationPath" X="10" Y="130" Width="282" Height="17" Property="INSTALLDIR" />
+        <Control Id="Browse" Type="PushButton" X="304" Y="130" Width="56" Height="17" Text="!(loc.AdvancedDlgBrowse)">
+          <Publish Event="NewDialog" Value="BrowseDlg"><![CDATA[1]]></Publish>
+          <Condition Action="hide"><![CDATA[Installed]]></Condition>
+        </Control>
+        <Control Type="CheckBox" Id="AddDesktopShortcut" X="10" Y="155" Width="350" Height="20" Property="ADDDESKTOPSHORTCUT" CheckBoxValue="true">
+          <Text>!(loc.AdvancedDlgAddDesktopShortcut)</Text>
+        </Control>
+        <Control Type="CheckBox" Id="AddStartMenuShortcut" X="10" Y="170" Width="350" Height="20" Property="ADDSTARTMENUSHORTCUT" CheckBoxValue="true">
+          <Text>!(loc.AdvancedDlgAddStartMenuShortcut)</Text>
+        </Control>
+        <Control Type="CheckBox" Id="LaunchAppAfterInstall" X="10" Y="195" Width="350" Height="20" Property="LAUNCHAPPAFTERINSTALL" CheckBoxValue="true">
+          <Text>!(loc.AdvancedDlgLaunchAppAfterInstall)</Text>
+        </Control>
+        <Control Id="AcceptLicenseCheckBox" Type="CheckBox" X="10" Y="220" Width="350" Height="20" CheckBoxPropertyRef="LicenseAccepted" CheckBoxValue="true">
+          <Text>!(loc.WelcomeDlgAcceptLicenseCheckBox)</Text>
+        </Control>
+        <Control Id="License" Type="PushButton" X="10" Y="243" Width="56" Height="17" Text="[ButtonText_License]">
+          <Publish Event="NewDialog" Value="LicenseAgreementDlg"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="Reset" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Reset]">
+          <Publish Event="Reset" Value="0"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="Install" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Install]" ElevationShield="yes">
+          <Condition Action="disable"><![CDATA[LicenseAccepted <> "true"]]></Condition>
+          <Condition Action="enable"><![CDATA[LicenseAccepted = "true"]]></Condition>
+          <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
+          <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
+          <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+          <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+          <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
+        </Control>
+        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
+          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+        </Control>
+      </Dialog>
+      <Dialog Id="DiskCostDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+        <Control Id="OK" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_OK]">
+          <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+        <Control Id="Text" Type="Text" X="20" Y="103" Width="330" Height="40">
+          <Text>The highlighted volumes (if any) do not have enough disk space available for the currently selected features.  You can either remove some files from the highlighted volumes, or choose to install less features onto local drive(s), or select different destination drive(s).</Text>
+        </Control>
+        <Control Id="Description" Type="Text" X="20" Y="74" Width="280" Height="15" Transparent="yes" NoPrefix="yes">
+          <Text>The disk space required for the installation of the selected features.</Text>
+        </Control>
+        <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
+          <Text>[DlgTitleFont]Disk Space Requirements</Text>
+        </Control>
+        <Control Id="VolumeList" Type="VolumeCostList" X="20" Y="150" Width="330" Height="80" Sunken="yes" Fixed="yes" Remote="yes">
+          <Text>{120}{70}{70}{70}{70}</Text>
+        </Control>
+      </Dialog>
+      <Dialog Id="ErrorDlg" Y="10" Width="270" Height="105" Title="Installer Information" ErrorDialog="yes" NoMinimize="yes">
+        <Control Id="ErrorText" Type="Text" X="48" Y="15" Width="205" Height="60" TabSkip="no" Text="Information text" />
+        <Control Id="Y" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_Yes]">
+          <Publish Event="EndDialog" Value="ErrorYes"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="A" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_Cancel]">
+          <Publish Event="EndDialog" Value="ErrorAbort"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="C" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_Cancel]">
+          <Publish Event="EndDialog" Value="ErrorCancel"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="ErrorIcon" Type="Icon" X="15" Y="15" Width="24" Height="24" ToolTip="Information icon" FixedSize="yes" IconSize="32" Text="[QuestionIcon]" />
+        <Control Id="I" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_Ignore]">
+          <Publish Event="EndDialog" Value="ErrorIgnore"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="N" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_No]">
+          <Publish Event="EndDialog" Value="ErrorNo"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="O" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_OK]">
+          <Publish Event="EndDialog" Value="ErrorOk"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="R" Type="PushButton" X="100" Y="80" Width="56" Height="17" TabSkip="yes" Text="[ButtonText_Retry]">
+          <Publish Event="EndDialog" Value="ErrorRetry"><![CDATA[1]]></Publish>
+        </Control>
+      </Dialog>
+      <Dialog Id="FilesInUse" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes" KeepModeless="yes">
+        <Control Id="Retry" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Retry]">
+          <Publish Event="EndDialog" Value="Retry"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="Ignore" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Ignore]">
+          <Publish Event="EndDialog" Value="Ignore"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="Exit" Type="PushButton" X="304" Y="243" Width="56" Height="17" Text="[ButtonText_Cancel]">
+          <Publish Event="EndDialog" Value="Exit"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+        <Control Id="Description" Type="Text" X="20" Y="74" Width="280" Height="30" Transparent="yes" NoPrefix="yes">
+          <Text>The following applications are using files that need to be updated by this installer. Close these applications and then click Retry to continue the installation or Cancel to exit the installer.</Text>
+        </Control>
+        <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
+          <Text>[DlgTitleFont]Files in Use</Text>
+        </Control>
+        <Control Id="List" Type="ListBox" X="20" Y="117" Width="330" Height="81" Property="FileInUseProcess" Sunken="yes" TabSkip="no" />
+      </Dialog>
+      <Dialog Id="LicenseAgreementDlg" Width="370" Height="270" Title="[ProductName] License Agreement" NoMinimize="yes">
+        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+        <Control Id="AgreementText" Type="ScrollableText" X="0" Y="44" Width="370" Height="189" Sunken="no" TabSkip="yes">
+          <Text SourceFile="../resources/windows/license.rtf" />
+        </Control>
+        <Control Id="Back" Type="PushButton" X="236" Y="243" Width="56" Height="17" Text="[ButtonText_Back]">
+          <Publish Event="NewDialog" Value="WelcomeDlg"><![CDATA[1]]></Publish>
+          <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[LicenseAccepted = "true"]]></Publish>
+        </Control>
+        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
+          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+        </Control>
+      </Dialog>
+      <Dialog Id="MaintenanceTypeDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+        <Control Id="ChangeLabel" Type="Text" X="105" Y="95" Width="100" Height="10" TabSkip="no">
+          <Text>[DlgTitleFont]&amp;Modify</Text>
+        </Control>
+        <Control Id="ChangeButton" Type="PushButton" X="50" Y="95" Width="38" Height="38" ToolTip="Modify Installation" Default="yes" Icon="yes" FixedSize="yes" IconSize="32" Text="[ModifyIcon]">
+          <Publish Property="InstallMode" Value="Change"><![CDATA[1]]></Publish>
+          <Publish Property="Progress1" Value="Changing"><![CDATA[1]]></Publish>
+          <Publish Property="Progress2" Value="Changes"><![CDATA[1]]></Publish>
+          <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="RepairLabel" Type="Text" X="105" Y="144" Width="100" Height="10" TabSkip="no">
+          <Text>[DlgTitleFont]Re&amp;pair</Text>
+        </Control>
+        <Control Id="RepairButton" Type="PushButton" X="50" Y="144" Width="38" Height="38" ToolTip="Repair Installation" Icon="yes" FixedSize="yes" IconSize="32" Text="[RepairIcon]">
+          <Publish Property="InstallMode" Value="Repair"><![CDATA[1]]></Publish>
+          <Publish Property="Progress1" Value="Repairing"><![CDATA[1]]></Publish>
+          <Publish Property="Progress2" Value="Repairs"><![CDATA[1]]></Publish>
+          <Publish Event="NewDialog" Value="VerifyRepairDlg"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="RemoveLabel" Type="Text" X="105" Y="193" Width="100" Height="10" TabSkip="no">
+          <Text>[DlgTitleFont]&amp;Uninstall</Text>
+        </Control>
+        <Control Id="RemoveButton" Type="PushButton" X="50" Y="193" Width="38" Height="38" ToolTip="Remove Installation" Icon="yes" FixedSize="yes" IconSize="32" Text="[RemoveIcon]">
+          <Publish Property="InstallMode" Value="Uninstall"><![CDATA[1]]></Publish>
+          <Publish Property="Progress1" Value="Uninstalling"><![CDATA[1]]></Publish>
+          <Publish Property="Progress2" Value="Uninstall"><![CDATA[1]]></Publish>
+          <Publish Event="NewDialog" Value="VerifyRemoveDlg"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Back]">
+          <Publish Event="NewDialog" Value="MaintenanceWelcomeDlg"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Next]" />
+        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
+          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+        <Control Id="Description" Type="Text" X="25" Y="74" Width="280" Height="20" Transparent="yes" NoPrefix="yes">
+          <Text>Select the operation you wish to perform.</Text>
+        </Control>
+        <Control Id="Title" Type="Text" X="15" Y="56" Width="240" Height="15" Transparent="yes" NoPrefix="yes">
+          <Text>[DlgTitleFont]Modify, repair or uninstall </Text>
+        </Control>
+        <Control Id="ChangeText" Type="Text" X="105" Y="108" Width="230" Height="20">
+          <Text>Change the installation directory</Text>
+        </Control>
+        <Control Id="RemoveText" Type="Text" X="105" Y="206" Width="230" Height="20">
+          <Text>Uninstalls [ProductName] from your computer.</Text>
+        </Control>
+        <Control Id="RepairText" Type="Text" X="105" Y="157" Width="230" Height="30">
+          <Text>Fix missing or corrupt files, shortcuts and registry entries.</Text>
+        </Control>
+      </Dialog>
+      <Dialog Id="MaintenanceWelcomeDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+        <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
+        <Control Id="Instructions" Type="Text" X="10" Y="155" Width="350" Height="45" Transparent="yes" NoPrefix="yes">
+          <Text>!(loc.MaintenanceWelcomeDlgInstructions)</Text>
+        </Control>
+        <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Next]">
+          <Publish Event="SpawnWaitDialog" Value="WaitForCostingDlg"><![CDATA[CostingComplete = 1]]></Publish>
+          <Publish Event="NewDialog" Value="MaintenanceTypeDlg"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
+          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
+      </Dialog>
+      <Dialog Id="OutOfDiskDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+        <Control Id="OK" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_OK]">
+          <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+        <Control Id="Text" Type="Text" X="20" Y="103" Width="330" Height="40">
+          <Text>The highlighted volumes do not have enough disk space available for the currently selected features.  You can either remove some files from the highlighted volumes, or choose to install less features onto local drive(s), or select different destination drive(s).</Text>
+        </Control>
+        <Control Id="Description" Type="Text" X="20" Y="74" Width="280" Height="20" Transparent="yes" NoPrefix="yes">
+          <Text>Disk space required for the installation exceeds available disk space.</Text>
+        </Control>
+        <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
+          <Text>[DlgTitleFont]Out of Disk Space</Text>
+        </Control>
+        <Control Id="VolumeList" Type="VolumeCostList" X="20" Y="150" Width="330" Height="80" Sunken="yes" Fixed="yes" Remote="yes">
+          <Text>{120}{70}{70}{70}{70}</Text>
+        </Control>
+      </Dialog>
+      <Dialog Id="OutOfRbDiskDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+        <Control Id="No" Type="PushButton" X="304" Y="243" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_No]">
+          <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="Yes" Type="PushButton" X="240" Y="243" Width="56" Height="17" Text="[ButtonText_Yes]">
+          <Publish Event="EnableRollback" Value="False"><![CDATA[1]]></Publish>
+          <Publish Event="EndDialog" Value="Return"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+        <Control Id="Text" Type="Text" X="20" Y="90" Width="330" Height="30">
+          <Text>The highlighted volumes do not have enough disk space available for the currently selected features.  You can either remove some files from the highlighted volumes, or choose to install less features onto local drive(s), or select different destination drive(s).</Text>
+        </Control>
+        <Control Id="Description" Type="Text" X="20" Y="74" Width="280" Height="15" Transparent="yes" NoPrefix="yes">
+          <Text>Disk space required for the installation exceeds available disk space.</Text>
+        </Control>
+        <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
+          <Text>[DlgTitleFont]Out of Disk Space</Text>
+        </Control>
+        <Control Id="VolumeList" Type="VolumeCostList" X="20" Y="165" Width="330" Height="65" Sunken="yes" Fixed="yes" Remote="yes" ShowRollbackCost="yes">
+          <Text>{120}{70}{70}{70}{70}</Text>
+        </Control>
+        <Control Id="Text2" Type="Text" X="20" Y="125" Width="330" Height="40">
+          <Text>Alternatively, you may choose to disable the installer's rollback functionality.  This allows the installer to restore your computer's original state should the installation be interrupted in any way.  Click Yes if you wish to take the risk to disable rollback.</Text>
+        </Control>
+      </Dialog>
+      <Dialog Id="ResumeDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+        <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
+        <Control Id="Instructions" Type="Text" X="15" Y="155" Width="340" Height="45" Transparent="yes" NoPrefix="yes">
+          <Text>Resuming the [ProductName] [Installer]
 
 The [Installer] will complete the installation of [ProductName] on your computer.  Click Install to continue or Cancel to exit the [Installer].</Text>
-                </Control>
-                <Control Id="Install" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Install]">
-                    <Publish Event="SpawnWaitDialog" Value="WaitForCostingDlg"><![CDATA[CostingComplete = 1]]></Publish>
-                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
-                    <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
-                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-                    <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-                    <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
-                </Control>
-                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
-                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
-            </Dialog>
-            <Dialog Id="VerifyReadyDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes" TrackDiskSpace="yes">
-                <Control Id="Install" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Install]">
-                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
-                    <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
-                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-                    <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-                    <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
-                </Control>
-                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
-                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Back]">
-                    <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[InstallMode = "Custom" OR InstallMode = "Change"]]></Publish>
-                    <Publish Event="NewDialog" Value="MaintenanceTypeDlg"><![CDATA[InstallMode = "Repair"]]></Publish>
-                </Control>
-                <Control Id="Description" Type="Text" X="25" Y="74" Width="280" Height="30" Transparent="yes" NoPrefix="yes">
-                    <Text>Click Install to begin the installation.  If you want to review or change any of your installation settings, click Back.  Click Cancel to exit the [Installer].</Text>
-                </Control>
-                <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
-                    <Text>[DlgTitleFont]Ready to Install</Text>
-                </Control>
-            </Dialog>
-            <Dialog Id="VerifyRemoveDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes" TrackDiskSpace="yes">
-                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Back]">
-                    <Publish Event="NewDialog" Value="MaintenanceTypeDlg"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="Remove" Type="PushButton" X="236" Y="243" Width="56" Height="17" Text="[ButtonText_Uninstall]">
-                    <Publish Event="Remove" Value="All"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
-                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
-                    <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
-                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-                    <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-                    <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
-                </Control>
-                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
-                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-                <Control Id="Description" Type="Text" X="25" Y="74" Width="280" Height="30" Transparent="yes" NoPrefix="yes">
-                    <Text>Click Uninstall to remove [ProductName] from this computer. Click Cancel to exit the installer</Text>
-                </Control>
-                <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
-                    <Text>[DlgTitleFont]Uninstall [ProductName]</Text>
-                </Control>
-            </Dialog>
-            <Dialog Id="VerifyRepairDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes" TrackDiskSpace="yes">
-                <Control Id="Repair" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Repair]">
-                    <Publish Event="ReinstallMode" Value="ecmus"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
-                    <Publish Event="Reinstall" Value="All"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
-                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
-                    <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
-                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-                    <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-                    <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
-                </Control>
-                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
-                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
-                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Back]">
-                    <Publish Event="NewDialog" Value="MaintenanceTypeDlg"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="Description" Type="Text" X="25" Y="74" Width="280" Height="30" Transparent="yes" NoPrefix="yes">
-                    <Text>Click Repair to fix missing or corrupt files, shortcuts and registry entries. Click Cancel to exit the installer</Text>
-                </Control>
-                <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
-                    <Text>[DlgTitleFont]Repair [ProductName]</Text>
-                </Control>
-            </Dialog>
-            <Dialog Id="WaitForCostingDlg" Y="10" Width="260" Height="85" Title="[ProductName] [Installer]" NoMinimize="yes">
-                <Control Id="Return" Type="PushButton" X="102" Y="57" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Return]">
-                    <Publish Event="EndDialog" Value="Exit"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="Text" Type="Text" X="48" Y="15" Width="194" Height="30">
-                    <Text>Please wait while the installer finishes determining your disk space requirements.</Text>
-                </Control>
-                <Control Id="Icon" Type="Icon" X="15" Y="15" Width="24" Height="24" ToolTip="Exclamation icon" FixedSize="yes" IconSize="32" Text="[WarningIcon]" />
-            </Dialog>
-            <Dialog Id="WelcomeDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
-                <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
-                <Control Id="Instructions" Type="Text" X="10" Y="155" Width="350" Height="45" Transparent="yes" NoPrefix="yes">
-                    <Text>!(loc.WelcomeDlgInstructions)</Text>
-                </Control>
-                <Control Id="AcceptLicenseCheckBox" Type="CheckBox" X="10" Y="220" Width="350" Height="20" Property="LicenseAccepted" CheckBoxValue="true">
-                    <Text>!(loc.WelcomeDlgAcceptLicenseCheckBox)</Text>
-                </Control>
-                <Control Id="License" Type="PushButton" X="10" Y="243" Width="56" Height="17" Text="[ButtonText_License]">
-                    <Publish Event="NewDialog" Value="LicenseAgreementDlg"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="Advanced" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_AdvancedInstall]">
-                    <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[1]]></Publish>
-                </Control>
-                <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" TabSkip="yes" Default="yes" ElevationShield="yes" Text="[ButtonText_Install]">
-                    <Condition Action="disable"><![CDATA[LicenseAccepted <> "true"]]></Condition>
-                    <Condition Action="enable"><![CDATA[LicenseAccepted = "true"]]></Condition>
-                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
-                    <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
-                    <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-                    <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
-                    <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
-                </Control>
-                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" TabSkip="yes" Cancel="yes" Text="[ButtonText_Cancel]">
-                    <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
-                </Control>
-            </Dialog>
-            <TextStyle Id="DlgFont8" FaceName="Segoe UI" Size="8" />
-            <TextStyle Id="White8" FaceName="Segoe UI" Size="8" Red="255" Green="255" Blue="255" />
-            <TextStyle Id="DlgFontBold8" FaceName="Segoe UI" Size="8" Bold="yes" />
-            <TextStyle Id="VerdanaBold13" FaceName="Verdana" Size="13" Bold="yes" />
-            <UIText Id="AbsentPath" />
-            <UIText Id="bytes">bytes</UIText>
-            <UIText Id="GB">GB</UIText>
-            <UIText Id="KB">KB</UIText>
-            <UIText Id="MB">MB</UIText>
-            <UIText Id="MenuAbsent">Entire feature will be unavailable</UIText>
-            <UIText Id="MenuAdvertise">Feature will be installed when required</UIText>
-            <UIText Id="MenuAllCD">Entire feature will be installed to run from CD</UIText>
-            <UIText Id="MenuAllLocal">Entire feature will be installed on local hard drive</UIText>
-            <UIText Id="MenuAllNetwork">Entire feature will be installed to run from network</UIText>
-            <UIText Id="MenuCD">Will be installed to run from CD</UIText>
-            <UIText Id="MenuLocal">Will be installed on local hard drive</UIText>
-            <UIText Id="MenuNetwork">Will be installed to run from network</UIText>
-            <UIText Id="ScriptInProgress">Gathering required information...</UIText>
-            <UIText Id="SelAbsentAbsent">This feature will remain uninstalled</UIText>
-            <UIText Id="SelAbsentAdvertise">This feature will be set to be installed when required</UIText>
-            <UIText Id="SelAbsentCD">This feature will be installed to run from CD</UIText>
-            <UIText Id="SelAbsentLocal">This feature will be installed on the local hard drive</UIText>
-            <UIText Id="SelAbsentNetwork">This feature will be installed to run from the network</UIText>
-            <UIText Id="SelAdvertiseAbsent">This feature will become unavailable</UIText>
-            <UIText Id="SelAdvertiseAdvertise">Will be installed when required</UIText>
-            <UIText Id="SelAdvertiseCD">This feature will be available to run from CD</UIText>
-            <UIText Id="SelAdvertiseLocal">This feature will be installed on your local hard drive</UIText>
-            <UIText Id="SelAdvertiseNetwork">This feature will be available to run from the network</UIText>
-            <UIText Id="SelCDAbsent">This feature will be uninstalled completely, you won't be able to run it from CD</UIText>
-            <UIText Id="SelCDAdvertise">This feature will change from run from CD state to set to be installed when required</UIText>
-            <UIText Id="SelCDCD">This feature will remain to be run from CD</UIText>
-            <UIText Id="SelCDLocal">This feature will change from run from CD state to be installed on the local hard drive</UIText>
-            <UIText Id="SelChildCostNeg">This feature frees up [1] on your hard drive.</UIText>
-            <UIText Id="SelChildCostPos">This feature requires [1] on your hard drive.</UIText>
-            <UIText Id="SelCostPending">Compiling cost for this feature...</UIText>
-            <UIText Id="SelLocalAbsent">This feature will be completely removed</UIText>
-            <UIText Id="SelLocalAdvertise">This feature will be removed from your local hard drive, but will be set to be installed when required</UIText>
-            <UIText Id="SelLocalCD">This feature will be removed from your local hard drive, but will be still available to run from CD</UIText>
-            <UIText Id="SelLocalLocal">This feature will remain on you local hard drive</UIText>
-            <UIText Id="SelLocalNetwork">This feature will be removed from your local hard drive, but will be still available to run from the network</UIText>
-            <UIText Id="SelNetworkAbsent">This feature will be uninstalled completely, you won't be able to run it from the network</UIText>
-            <UIText Id="SelNetworkAdvertise">This feature will change from run from network state to set to be installed when required</UIText>
-            <UIText Id="SelNetworkLocal">This feature will change from run from network state to be installed on the local hard drive</UIText>
-            <UIText Id="SelNetworkNetwork">This feature will remain to be run from the network</UIText>
-            <UIText Id="SelParentCostNegNeg">This feature frees up [1] on your hard drive. It has [2] of [3] subfeatures selected. The subfeatures free up [4] on your hard drive.</UIText>
-            <UIText Id="SelParentCostNegPos">This feature frees up [1] on your hard drive. It has [2] of [3] subfeatures selected. The subfeatures require [4] on your hard drive.</UIText>
-            <UIText Id="SelParentCostPosNeg">This feature requires [1] on your hard drive. It has [2] of [3] subfeatures selected. The subfeatures free up [4] on your hard drive.</UIText>
-            <UIText Id="SelParentCostPosPos">This feature requires [1] on your hard drive. It has [2] of [3] subfeatures selected. The subfeatures require [4] on your hard drive.</UIText>
-            <UIText Id="TimeRemaining">Time remaining: {[1] minutes }{[2] seconds}</UIText>
-            <UIText Id="VolumeCostAvailable">Available</UIText>
-            <UIText Id="VolumeCostDifference">Difference</UIText>
-            <UIText Id="VolumeCostRequired">Required</UIText>
-            <UIText Id="VolumeCostSize">Disk Size</UIText>
-            <UIText Id="VolumeCostVolume">Volume</UIText>
-            <ProgressText Action="InstallValidate">Validating install</ProgressText>
-            <ProgressText Action="InstallFiles" Template="File: [1],  Directory: [9],  Size: [6]">Copying new files</ProgressText>
-            <ProgressText Action="InstallAdminPackage" Template="File: [1], Directory: [9], Size: [6]">Copying network install files</ProgressText>
-            <ProgressText Action="FileCost">Computing space requirements</ProgressText>
-            <ProgressText Action="CostInitialize">Computing space requirements</ProgressText>
-            <ProgressText Action="CostFinalize">Computing space requirements</ProgressText>
-            <ProgressText Action="CreateShortcuts" Template="Shortcut: [1]">Creating shortcuts</ProgressText>
-            <ProgressText Action="PublishComponents" Template="Component ID: [1], Qualifier: [2]">Publishing Qualified Components</ProgressText>
-            <ProgressText Action="PublishFeatures" Template="Feature: [1]">Publishing Product Features</ProgressText>
-            <ProgressText Action="PublishProduct">Publishing product information</ProgressText>
-            <ProgressText Action="RegisterClassInfo" Template="Class Id: [1]">Registering Class servers</ProgressText>
-            <ProgressText Action="RegisterExtensionInfo" Template="Extension: [1]">Registering extension servers</ProgressText>
-            <ProgressText Action="RegisterMIMEInfo" Template="MIME Content Type: [1], Extension: [2]">Registering MIME info</ProgressText>
-            <ProgressText Action="RegisterProgIdInfo" Template="ProgId: [1]">Registering program identifiers</ProgressText>
-            <ProgressText Action="AllocateRegistrySpace" Template="Free space: [1]">Allocating registry space</ProgressText>
-            <ProgressText Action="AppSearch" Template="Property: [1], Signature: [2]">Searching for installed applications</ProgressText>
-            <ProgressText Action="BindImage" Template="File: [1]">Binding executables</ProgressText>
-            <ProgressText Action="CCPSearch">Searching for qualifying products</ProgressText>
-            <ProgressText Action="CreateFolders" Template="Folder: [1]">Creating folders</ProgressText>
-            <ProgressText Action="DeleteServices" Template="Service: [1]">Deleting services</ProgressText>
-            <ProgressText Action="DuplicateFiles" Template="File: [1],  Directory: [9],  Size: [6]">Creating duplicate files</ProgressText>
-            <ProgressText Action="FindRelatedProducts" Template="Found application: [1]">Searching for related applications</ProgressText>
-            <ProgressText Action="InstallODBC">Installing ODBC components</ProgressText>
-            <ProgressText Action="InstallServices" Template="Service: [2]">Installing new services</ProgressText>
-            <ProgressText Action="LaunchConditions">Evaluating launch conditions</ProgressText>
-            <ProgressText Action="MigrateFeatureStates" Template="Application: [1]">Migrating feature states from related applications</ProgressText>
-            <ProgressText Action="MoveFiles" Template="File: [1],  Directory: [9],  Size: [6]">Moving files</ProgressText>
-            <ProgressText Action="PatchFiles" Template="File: [1],  Directory: [2],  Size: [3]">Patching files</ProgressText>
-            <ProgressText Action="ProcessComponents">Updating component registration</ProgressText>
-            <ProgressText Action="RegisterComPlus" Template="AppId: [1]{{, AppType: [2], Users: [3], RSN: [4]}}">Registering COM+ Applications and Components</ProgressText>
-            <ProgressText Action="RegisterFonts" Template="Font: [1]">Registering fonts</ProgressText>
-            <ProgressText Action="RegisterProduct" Template="[1]">Registering product</ProgressText>
-            <ProgressText Action="RegisterTypeLibraries" Template="LibID: [1]">Registering type libraries</ProgressText>
-            <ProgressText Action="RegisterUser" Template="[1]">Registering user</ProgressText>
-            <ProgressText Action="RemoveDuplicateFiles" Template="File: [1], Directory: [9]">Removing duplicated files</ProgressText>
-            <ProgressText Action="RemoveEnvironmentStrings" Template="Name: [1], Value: [2], Action [3]">Updating environment strings</ProgressText>
-            <ProgressText Action="RemoveExistingProducts" Template="Application: [1], Command line: [2]">Removing applications</ProgressText>
-            <ProgressText Action="RemoveFiles" Template="File: [1], Directory: [9]">Removing files</ProgressText>
-            <ProgressText Action="RemoveFolders" Template="Folder: [1]">Removing folders</ProgressText>
-            <ProgressText Action="RemoveIniValues" Template="File: [1],  Section: [2],  Key: [3], Value: [4]">Removing INI files entries</ProgressText>
-            <ProgressText Action="RemoveODBC">Removing ODBC components</ProgressText>
-            <ProgressText Action="RemoveRegistryValues" Template="Key: [1], Name: [2]">Removing system registry values</ProgressText>
-            <ProgressText Action="RemoveShortcuts" Template="Shortcut: [1]">Removing shortcuts</ProgressText>
-            <ProgressText Action="RMCCPSearch">Searching for qualifying products</ProgressText>
-            <ProgressText Action="SelfRegModules" Template="File: [1], Folder: [2]">Registering modules</ProgressText>
-            <ProgressText Action="SelfUnregModules" Template="File: [1], Folder: [2]">Unregistering modules</ProgressText>
-            <ProgressText Action="SetODBCFolders">Initializing ODBC directories</ProgressText>
-            <ProgressText Action="StartServices" Template="Service: [1]">Starting services</ProgressText>
-            <ProgressText Action="StopServices" Template="Service: [1]">Stopping services</ProgressText>
-            <ProgressText Action="UnpublishComponents" Template="Component ID: [1], Qualifier: [2]">Unpublishing Qualified Components</ProgressText>
-            <ProgressText Action="UnpublishFeatures" Template="Feature: [1]">Unpublishing Product Features</ProgressText>
-            <ProgressText Action="UnregisterClassInfo" Template="Class Id: [1]">Unregister Class servers</ProgressText>
-            <ProgressText Action="UnregisterComPlus" Template="AppId: [1]{{, AppType: [2]}}">Unregistering COM+ Applications and Components</ProgressText>
-            <ProgressText Action="UnregisterExtensionInfo" Template="Extension: [1]">Unregistering extension servers</ProgressText>
-            <ProgressText Action="UnregisterFonts" Template="Font: [1]">Unregistering fonts</ProgressText>
-            <ProgressText Action="UnregisterMIMEInfo" Template="MIME Content Type: [1], Extension: [2]">Unregistering MIME info</ProgressText>
-            <ProgressText Action="UnregisterProgIdInfo" Template="ProgId: [1]">Unregistering program identifiers</ProgressText>
-            <ProgressText Action="UnregisterTypeLibraries" Template="LibID: [1]">Unregistering type libraries</ProgressText>
-            <ProgressText Action="WriteEnvironmentStrings" Template="Name: [1], Value: [2], Action [3]">Updating environment strings</ProgressText>
-            <ProgressText Action="WriteIniValues" Template="File: [1],  Section: [2],  Key: [3], Value: [4]">Writing INI files values</ProgressText>
-            <ProgressText Action="WriteRegistryValues" Template="Key: [1], Name: [2], Value: [3]">Writing system registry values</ProgressText>
-            <ProgressText Action="Advertise">Advertising application</ProgressText>
-            <ProgressText Action="GenerateScript" Template="[1]">Generating script operations for action:</ProgressText>
-            <ProgressText Action="InstallSFPCatalogFile" Template="File: [1],  Dependencies: [2]">Installing system catalog</ProgressText>
-            <ProgressText Action="MsiPublishAssemblies" Template="Application Context:[1], Assembly Name:[2]">Publishing assembly information</ProgressText>
-            <ProgressText Action="MsiUnpublishAssemblies" Template="Application Context:[1], Assembly Name:[2]">Unpublishing assembly information</ProgressText>
-            <ProgressText Action="Rollback" Template="[1]">Rolling back action:</ProgressText>
-            <ProgressText Action="RollbackCleanup" Template="File: [1]">Removing backup files</ProgressText>
-            <ProgressText Action="UnmoveFiles" Template="File: [1], Directory: [9]">Removing moved files</ProgressText>
-            <ProgressText Action="UnpublishProduct">Unpublishing product information</ProgressText>
-            <Error Id="0">{{Fatal error: }}</Error>
-            <Error Id="1">{{Error [1]. }}</Error>
-            <Error Id="2">Warning [1]. </Error>
-            <Error Id="3" />
-            <Error Id="4">Info [1]. </Error>
-            <Error Id="5">The installer has encountered an unexpected error installing this package. This may indicate a problem with this package. The error code is [1]. {{The arguments are: [2], [3], [4]}}</Error>
-            <Error Id="6" />
-            <Error Id="7">{{Disk full: }}</Error>
-            <Error Id="8">Action [Time]: [1]. [2]</Error>
-            <Error Id="9">[ProductName]</Error>
-            <Error Id="10">{[2]}{, [3]}{, [4]}</Error>
-            <Error Id="11">Message type: [1], Argument: [2]</Error>
-            <Error Id="12">=== Logging started: [Date]  [Time] ===</Error>
-            <Error Id="13">=== Logging stopped: [Date]  [Time] ===</Error>
-            <Error Id="14">Action start [Time]: [1].</Error>
-            <Error Id="15">Action ended [Time]: [1]. Return value [2].</Error>
-            <Error Id="16">Time remaining: {[1] minutes }{[2] seconds}</Error>
-            <Error Id="17">Out of memory. Shut down other applications before retrying.</Error>
-            <Error Id="18">Installer is no longer responding.</Error>
-            <Error Id="19">Installer stopped prematurely.</Error>
-            <Error Id="20">Please wait while Windows configures [ProductName]</Error>
-            <Error Id="21">Gathering required information...</Error>
-            <Error Id="22">Removing older versions of this application...</Error>
-            <Error Id="23">Preparing to remove older versions of this application...</Error>
-            <Error Id="32">{[ProductName] }Setup completed successfully.</Error>
-            <Error Id="33">{[ProductName] }Setup failed.</Error>
-            <Error Id="1101">Error reading from file: [2]. {{ System error [3].}}  Verify that the file exists and that you can access it.</Error>
-            <Error Id="1301">Cannot create the file '[2]'.  A directory with this name already exists.  Cancel the install and try installing to a different location.</Error>
-            <Error Id="1302">Please insert the disk: [2]</Error>
-            <Error Id="1303">The installer has insufficient privileges to access this directory: [2].  The installation cannot continue.  Log on as administrator or contact your system administrator.</Error>
-            <Error Id="1304">Error writing to file: [2].  Verify that you have access to that directory.</Error>
-            <Error Id="1305">Error reading from file [2]. {{ System error [3].}} Verify that the file exists and that you can access it.</Error>
-            <Error Id="1306">Another application has exclusive access to the file '[2]'.  Please shut down all other applications, then click Retry.</Error>
-            <Error Id="1307">There is not enough disk space to install this file: [2].  Free some disk space and click Retry, or click Cancel to exit.</Error>
-            <Error Id="1308">Source file not found: [2].  Verify that the file exists and that you can access it.</Error>
-            <Error Id="1309">Error reading from file: [3]. {{ System error [2].}}  Verify that the file exists and that you can access it.</Error>
-            <Error Id="1310">Error writing to file: [3]. {{ System error [2].}}  Verify that you have access to that directory.</Error>
-            <Error Id="1311">Source file not found{{(cabinet)}}: [2].  Verify that the file exists and that you can access it.</Error>
-            <Error Id="1312">Cannot create the directory '[2]'.  A file with this name already exists.  Please rename or remove the file and click retry, or click Cancel to exit.</Error>
-            <Error Id="1313">The volume [2] is currently unavailable.  Please select another.</Error>
-            <Error Id="1314">The specified path '[2]' is unavailable.</Error>
-            <Error Id="1315">Unable to write to the specified folder: [2].</Error>
-            <Error Id="1316">A network error occurred while attempting to read from the file: [2]</Error>
-            <Error Id="1317">An error occurred while attempting to create the directory: [2]</Error>
-            <Error Id="1318">A network error occurred while attempting to create the directory: [2]</Error>
-            <Error Id="1319">A network error occurred while attempting to open the source file cabinet: [2]</Error>
-            <Error Id="1320">The specified path is too long: [2]</Error>
-            <Error Id="1321">The Installer has insufficient privileges to modify this file: [2].</Error>
-            <Error Id="1322">A portion of the folder path '[2]' is invalid.  It is either empty or exceeds the length allowed by the system.</Error>
-            <Error Id="1323">The folder path '[2]' contains words that are not valid in folder paths.</Error>
-            <Error Id="1324">The folder path '[2]' contains an invalid character.</Error>
-            <Error Id="1325">'[2]' is not a valid short file name.</Error>
-            <Error Id="1326">Error getting file security: [3] GetLastError: [2]</Error>
-            <Error Id="1327">Invalid Drive: [2]</Error>
-            <Error Id="1328">Error applying patch to file [2].  It has probably been updated by other means, and can no longer be modified by this patch.  For more information contact your patch vendor.  {{System Error: [3]}}</Error>
-            <Error Id="1329">A file that is required cannot be installed because the cabinet file [2] is not digitally signed.  This may indicate that the cabinet file is corrupt.</Error>
-            <Error Id="1330">A file that is required cannot be installed because the cabinet file [2] has an invalid digital signature.  This may indicate that the cabinet file is corrupt.{{  Error [3] was returned by WinVerifyTrust.}}</Error>
-            <Error Id="1331">Failed to correctly copy [2] file: CRC error.</Error>
-            <Error Id="1332">Failed to correctly move [2] file: CRC error.</Error>
-            <Error Id="1333">Failed to correctly patch [2] file: CRC error.</Error>
-            <Error Id="1334">The file '[2]' cannot be installed because the file cannot be found in cabinet file '[3]'. This could indicate a network error, an error reading from the CD-ROM, or a problem with this package.</Error>
-            <Error Id="1335">The cabinet file '[2]' required for this installation is corrupt and cannot be used. This could indicate a network error, an error reading from the CD-ROM, or a problem with this package.</Error>
-            <Error Id="1336">There was an error creating a temporary file that is needed to complete this installation.{{  Folder: [3]. System error code: [2]}}</Error>
-            <Error Id="1401">Could not create key: [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel. </Error>
-            <Error Id="1402">Could not open key: [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel. </Error>
-            <Error Id="1403">Could not delete value [2] from key [3]. {{ System error [4].}}  Verify that you have sufficient access to that key, or contact your support personnel. </Error>
-            <Error Id="1404">Could not delete key [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel. </Error>
-            <Error Id="1405">Could not read value [2] from key [3]. {{ System error [4].}}  Verify that you have sufficient access to that key, or contact your support personnel. </Error>
-            <Error Id="1406">Could not write value [2] to key [3]. {{ System error [4].}}  Verify that you have sufficient access to that key, or contact your support personnel.</Error>
-            <Error Id="1407">Could not get value names for key [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel.</Error>
-            <Error Id="1408">Could not get sub key names for key [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel.</Error>
-            <Error Id="1409">Could not read security information for key [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel.</Error>
-            <Error Id="1410">Could not increase the available registry space. [2] KB of free registry space is required for the installation of this application.</Error>
-            <Error Id="1500">Another installation is in progress. You must complete that installation before continuing this one.</Error>
-            <Error Id="1501">Error accessing secured data. Please make sure the Windows Installer is configured properly and try the install again.</Error>
-            <Error Id="1502">User '[2]' has previously initiated an install for product '[3]'.  That user will need to run that install again before they can use that product.  Your current install will now continue.</Error>
-            <Error Id="1503">User '[2]' has previously initiated an install for product '[3]'.  That user will need to run that install again before they can use that product.</Error>
-            <Error Id="1601">Out of disk space -- Volume: '[2]'; required space: [3] KB; available space: [4] KB.  Free some disk space and retry.</Error>
-            <Error Id="1602">Are you sure you want to cancel?</Error>
-            <Error Id="1603">The file [2][3] is being held in use{ by the following process: Name: [4], Id: [5], Window Title: '[6]'}.  Close that application and retry.</Error>
-            <Error Id="1604">The product '[2]' is already installed, preventing the installation of this product.  The two products are incompatible.</Error>
-            <Error Id="1605">There is not enough disk space on the volume '[2]' to continue the install with recovery enabled. [3] KB are required, but only [4] KB are available. Click Ignore to continue the install without saving recovery information, click Retry to check for available space again, or click Cancel to quit the installation.</Error>
-            <Error Id="1606">Could not access network location [2].</Error>
-            <Error Id="1607">The following applications should be closed before continuing the install:</Error>
-            <Error Id="1608">Could not find any previously installed compliant products on the machine for installing this product.</Error>
-            <Error Id="1609">An error occurred while applying security settings. [2] is not a valid user or group. This could be a problem with the package, or a problem connecting to a domain controller on the network. Check your network connection and click Retry, or Cancel to end the install. {{Unable to locate the user's SID, system error [3]}}</Error>
-            <Error Id="1701">The key [2] is not valid.  Verify that you entered the correct key.</Error>
-            <Error Id="1702">The installer must restart your system before configuration of [2] can continue.  Click Yes to restart now or No if you plan to manually restart later.</Error>
-            <Error Id="1703">You must restart your system for the configuration changes made to [2] to take effect. Click Yes to restart now or No if you plan to manually restart later.</Error>
-            <Error Id="1704">An installation for [2] is currently suspended.  You must undo the changes made by that installation to continue.  Do you want to undo those changes?</Error>
-            <Error Id="1705">A previous installation for this product is in progress.  You must undo the changes made by that installation to continue.  Do you want to undo those changes?</Error>
-            <Error Id="1706">An installation package for the product [2] cannot be found. Try the installation again using a valid copy of the installation package '[3]'.</Error>
-            <Error Id="1707">Installation completed successfully.</Error>
-            <Error Id="1708">Installation failed.</Error>
-            <Error Id="1709">Product: [2] -- [3]</Error>
-            <Error Id="1710">You may either restore your computer to its previous state or continue the install later. Would you like to restore?</Error>
-            <Error Id="1711">An error occurred while writing installation information to disk.  Check to make sure enough disk space is available, and click Retry, or Cancel to end the install.</Error>
-            <Error Id="1712">One or more of the files required to restore your computer to its previous state could not be found.  Restoration will not be possible.</Error>
-            <Error Id="1713">[2] cannot install one of its required products. Contact your technical support group.  {{System Error: [3].}}</Error>
-            <Error Id="1714">The older version of [2] cannot be removed.  Contact your technical support group.  {{System Error [3].}}</Error>
-            <Error Id="1715">Installed [2]</Error>
-            <Error Id="1716">Configured [2]</Error>
-            <Error Id="1717">Removed [2]</Error>
-            <Error Id="1718">File [2] was rejected by digital signature policy.</Error>
-            <Error Id="1719">The Windows Installer Service could not be accessed. This can occur if you are running Windows in safe mode, or if the Windows Installer is not correctly installed. Contact your support personnel for assistance.</Error>
-            <Error Id="1720">There is a problem with this Windows Installer package. A script required for this install to complete could not be run. Contact your support personnel or package vendor.  {{Custom action [2] script error [3], [4]: [5] Line [6], Column [7], [8] }}</Error>
-            <Error Id="1721">There is a problem with this Windows Installer package. A program required for this install to complete could not be run. Contact your support personnel or package vendor. {{Action: [2], location: [3], command: [4] }}</Error>
-            <Error Id="1722">There is a problem with this Windows Installer package. A program run as part of the setup did not finish as expected. Contact your support personnel or package vendor.  {{Action [2], location: [3], command: [4] }}</Error>
-            <Error Id="1723">There is a problem with this Windows Installer package. A DLL required for this install to complete could not be run. Contact your support personnel or package vendor.  {{Action [2], entry: [3], library: [4] }}</Error>
-            <Error Id="1724">Removal completed successfully.</Error>
-            <Error Id="1725">Removal failed.</Error>
-            <Error Id="1726">Advertisement completed successfully.</Error>
-            <Error Id="1727">Advertisement failed.</Error>
-            <Error Id="1728">Configuration completed successfully.</Error>
-            <Error Id="1729">Configuration failed.</Error>
-            <Error Id="1730">You must be an Administrator to remove this application. To remove this application, you can log on as an Administrator, or contact your technical support group for assistance.</Error>
-            <Error Id="1801">The path [2] is not valid.  Please specify a valid path.</Error>
-            <Error Id="1802">Out of memory. Shut down other applications before retrying.</Error>
-            <Error Id="1803">There is no disk in drive [2]. Please insert one and click Retry, or click Cancel to go back to the previously selected volume.</Error>
-            <Error Id="1804">There is no disk in drive [2]. Please insert one and click Retry, or click Cancel to return to the browse dialog and select a different volume.</Error>
-            <Error Id="1805">The folder [2] does not exist.  Please enter a path to an existing folder.</Error>
-            <Error Id="1806">You have insufficient privileges to read this folder.</Error>
-            <Error Id="1807">A valid destination folder for the install could not be determined.</Error>
-            <Error Id="1901">Error attempting to read from the source install database: [2].</Error>
-            <Error Id="1902">Scheduling reboot operation: Renaming file [2] to [3]. Must reboot to complete operation.</Error>
-            <Error Id="1903">Scheduling reboot operation: Deleting file [2]. Must reboot to complete operation.</Error>
-            <Error Id="1904">Module [2] failed to register.  HRESULT [3].  Contact your support personnel.</Error>
-            <Error Id="1905">Module [2] failed to unregister.  HRESULT [3].  Contact your support personnel.</Error>
-            <Error Id="1906">Failed to cache package [2]. Error: [3]. Contact your support personnel.</Error>
-            <Error Id="1907">Could not register font [2].  Verify that you have sufficient permissions to install fonts, and that the system supports this font.</Error>
-            <Error Id="1908">Could not unregister font [2]. Verify that you that you have sufficient permissions to remove fonts.</Error>
-            <Error Id="1909">Could not create Shortcut [2]. Verify that the destination folder exists and that you can access it.</Error>
-            <Error Id="1910">Could not remove Shortcut [2]. Verify that the shortcut file exists and that you can access it.</Error>
-            <Error Id="1911">Could not register type library for file [2].  Contact your support personnel.</Error>
-            <Error Id="1912">Could not unregister type library for file [2].  Contact your support personnel.</Error>
-            <Error Id="1913">Could not update the ini file [2][3].  Verify that the file exists and that you can access it.</Error>
-            <Error Id="1914">Could not schedule file [2] to replace file [3] on reboot.  Verify that you have write permissions to file [3].</Error>
-            <Error Id="1915">Error removing ODBC driver manager, ODBC error [2]: [3]. Contact your support personnel.</Error>
-            <Error Id="1916">Error installing ODBC driver manager, ODBC error [2]: [3]. Contact your support personnel.</Error>
-            <Error Id="1917">Error removing ODBC driver: [4], ODBC error [2]: [3]. Verify that you have sufficient privileges to remove ODBC drivers.</Error>
-            <Error Id="1918">Error installing ODBC driver: [4], ODBC error [2]: [3]. Verify that the file [4] exists and that you can access it.</Error>
-            <Error Id="1919">Error configuring ODBC data source: [4], ODBC error [2]: [3]. Verify that the file [4] exists and that you can access it.</Error>
-            <Error Id="1920">Service '[2]' ([3]) failed to start.  Verify that you have sufficient privileges to start system services.</Error>
-            <Error Id="1921">Service '[2]' ([3]) could not be stopped.  Verify that you have sufficient privileges to stop system services.</Error>
-            <Error Id="1922">Service '[2]' ([3]) could not be deleted.  Verify that you have sufficient privileges to remove system services.</Error>
-            <Error Id="1923">Service '[2]' ([3]) could not be installed.  Verify that you have sufficient privileges to install system services.</Error>
-            <Error Id="1924">Could not update environment variable '[2]'.  Verify that you have sufficient privileges to modify environment variables.</Error>
-            <Error Id="1925">You do not have sufficient privileges to complete this installation for all users of the machine.  Log on as administrator and then retry this installation.</Error>
-            <Error Id="1926">Could not set file security for file '[3]'. Error: [2].  Verify that you have sufficient privileges to modify the security permissions for this file.</Error>
-            <Error Id="1927">Component Services (COM+ 1.0) are not installed on this computer.  This installation requires Component Services in order to complete successfully.  Component Services are available on Windows 2000.</Error>
-            <Error Id="1928">Error registering COM+ Application.  Contact your support personnel for more information.</Error>
-            <Error Id="1929">Error unregistering COM+ Application.  Contact your support personnel for more information.</Error>
-            <Error Id="1930">The description for service '[2]' ([3]) could not be changed.</Error>
-            <Error Id="1931">The Windows Installer service cannot update the system file [2] because the file is protected by Windows.  You may need to update your operating system for this program to work correctly. {{Package version: [3], OS Protected version: [4]}}</Error>
-            <Error Id="1932">The Windows Installer service cannot update the protected Windows file [2]. {{Package version: [3], OS Protected version: [4], SFP Error: [5]}}</Error>
-            <Error Id="1933">The Windows Installer service cannot update one or more protected Windows files. {{SFP Error: [2].  List of protected files:\r\n[3]}}</Error>
-            <Error Id="1934">User installations are disabled via policy on the machine.</Error>
-            <Error Id="1935">An error occured during the installation of assembly component [2]. HRESULT: [3]. {{assembly interface: [4], function: [5], assembly name: [6]}}</Error>
-            <AdminUISequence>
-                <Show Dialog="FatalError" OnExit="error" />
-                <Show Dialog="UserExitDlg" OnExit="cancel" />
-                <Show Dialog="SuccessDlg" OnExit="success" />
-                <Show Dialog="PrepareDlg" Before="CostInitialize"><![CDATA[]]></Show>
-                <Show Dialog="AdminWelcomeDlg" After="CostFinalize" />
-                <Show Dialog="ProgressDlg" After="AdminWelcomeDlg" />
-            </AdminUISequence>
-            <InstallUISequence>
-                <Show Dialog="FatalError" OnExit="error" />
-                <Show Dialog="UserExitDlg" OnExit="cancel" />
-                <Show Dialog="SuccessDlg" OnExit="success" />
-                <Show Dialog="PrepareDlg" After="LaunchConditions" />
-                <Show Dialog="WelcomeDlg" After="MigrateFeatureStates"><![CDATA[NOT Installed]]></Show>
-                <Show Dialog="ResumeDlg" After="WelcomeDlg"><![CDATA[Installed AND (RESUME OR Preselected)]]></Show>
-                <Show Dialog="MaintenanceWelcomeDlg" After="ResumeDlg"><![CDATA[Installed AND NOT RESUME AND NOT Preselected]]></Show>
-                <Show Dialog="ProgressDlg" After="MaintenanceWelcomeDlg" />
-            </InstallUISequence>
-        </UI>
-        <Property Id="ButtonText_No"><![CDATA[&No]]></Property>
-        <Property Id="ButtonText_Install"><![CDATA[&Install]]></Property>
-        <Property Id="ButtonText_AdvancedInstall"><![CDATA[&Advanced]]></Property>
-        <Property Id="ButtonText_Next"><![CDATA[&Next >]]></Property>
-        <Property Id="Setup"><![CDATA[Setup]]></Property>
-        <Property Id="ButtonText_Browse"><![CDATA[Br&owse]]></Property>
-        <Property Id="ModifyIcon"><![CDATA[ModifyIcon]]></Property>
-        <Property Id="RepairIcon"><![CDATA[RepairIcon]]></Property>
-        <Property Id="WarningIcon"><![CDATA[WarningIcon]]></Property>
-        <Property Id="ButtonText_Repair"><![CDATA[&Repair]]></Property>
-        <Property Id="ButtonText_Back"><![CDATA[< &Back]]></Property>
-        <Property Id="InstallMode"><![CDATA[Typical]]></Property>
-        <Property Id="Progress2"><![CDATA[Installation]]></Property>
-        <Property Id="Progress1"><![CDATA[Installing]]></Property>
-        <Property Id="Wizard"><![CDATA[Setup Wizard]]></Property>
-        <Property Id="RemoveIcon"><![CDATA[RemoveIcon]]></Property>
-        <Property Id="ButtonText_Yes"><![CDATA[&Yes]]></Property>
-        <Property Id="ButtonText_Ignore"><![CDATA[&Ignore]]></Property>
-        <Property Id="ButtonText_Reset"><![CDATA[&Reset]]></Property>
-        <Property Id="ButtonText_Remove"><![CDATA[&Remove]]></Property>
-        <Property Id="ButtonText_Exit"><![CDATA[&Exit]]></Property>
-        <Property Id="ButtonText_Return"><![CDATA[&Return]]></Property>
-        <Property Id="ButtonText_OK"><![CDATA[OK]]></Property>
-        <Property Id="ButtonText_License"><![CDATA[&License]]></Property>
-        <Property Id="ButtonText_Resume"><![CDATA[&Resume]]></Property>
-        <Property Id="ButtonText_Finish"><![CDATA[&Finish]]></Property>
-        <Property Id="DlgTitleFont"><![CDATA[{&DlgFontBold8}]]></Property>
-        <Property Id="ButtonText_Cancel"><![CDATA[Cancel]]></Property>
-        <Property Id="QuestionIcon"><![CDATA[QuestionIcon]]></Property>
-        <Property Id="ButtonText_Retry"><![CDATA[&Retry]]></Property>
-        <Property Id="IAgree"><![CDATA[No]]></Property>
-        <Property Id="BannerBitmap"><![CDATA[BannerBitmap]]></Property>
-        <Property Id="DialogBitmap"><![CDATA[DialogBitmap]]></Property>
-        <Property Id="Installer" Value="Installer" />
-        <Property Id="ButtonText_Uninstall" Value="&amp;Uninstall" />
-        <!-- Mattermost blue banners -->
-        <Binary Id="DialogBitmap" SourceFile="../resources/windows/msi_dialog_banner.png" />
-        <Binary Id="BannerBitmap" SourceFile="../resources/windows/msi_dialog_banner_small.png" />
-        <!-- Error and warnings -->
-        <Binary Id="WarningIcon" SourceFile="../resources/windows/msi_warning.ico" />
-        <Binary Id="QuestionIcon" SourceFile="../resources/windows/msi_question.ico" />
-        <!-- In BrowseDlg -->
-        <Binary Id="Up" SourceFile="../resources/windows/msi_up.ico" />
-        <Binary Id="New" SourceFile="../resources/windows/msi_create_folder.ico" />
-        <!-- In administrative install GUI -->
-        <Binary Id="ModifyIcon" SourceFile="../resources/windows/msi_modify.ico" />
-        <Binary Id="RepairIcon" SourceFile="../resources/windows/msi_repair.ico" />
-        <Binary Id="RemoveIcon" SourceFile="../resources/windows/msi_remove.ico" />
-    </Product>
+        </Control>
+        <Control Id="Install" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Install]">
+          <Publish Event="SpawnWaitDialog" Value="WaitForCostingDlg"><![CDATA[CostingComplete = 1]]></Publish>
+          <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
+          <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
+          <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+          <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+          <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
+        </Control>
+        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
+          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Disabled="yes" Text="[ButtonText_Back]" />
+      </Dialog>
+      <Dialog Id="VerifyReadyDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes" TrackDiskSpace="yes">
+        <Control Id="Install" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Install]">
+          <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
+          <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
+          <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+          <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+          <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
+        </Control>
+        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
+          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Back]">
+          <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[InstallMode = "Custom" OR InstallMode = "Change"]]></Publish>
+          <Publish Event="NewDialog" Value="MaintenanceTypeDlg"><![CDATA[InstallMode = "Repair"]]></Publish>
+        </Control>
+        <Control Id="Description" Type="Text" X="25" Y="74" Width="280" Height="30" Transparent="yes" NoPrefix="yes">
+          <Text>Click Install to begin the installation.  If you want to review or change any of your installation settings, click Back.  Click Cancel to exit the [Installer].</Text>
+        </Control>
+        <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
+          <Text>[DlgTitleFont]Ready to Install</Text>
+        </Control>
+      </Dialog>
+      <Dialog Id="VerifyRemoveDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes" TrackDiskSpace="yes">
+        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Back]">
+          <Publish Event="NewDialog" Value="MaintenanceTypeDlg"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="Remove" Type="PushButton" X="236" Y="243" Width="56" Height="17" Text="[ButtonText_Uninstall]">
+          <Publish Event="Remove" Value="All"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
+          <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
+          <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
+          <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+          <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+          <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
+        </Control>
+        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
+          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+        <Control Id="Description" Type="Text" X="25" Y="74" Width="280" Height="30" Transparent="yes" NoPrefix="yes">
+          <Text>Click Uninstall to remove [ProductName] from this computer. Click Cancel to exit the installer</Text>
+        </Control>
+        <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
+          <Text>[DlgTitleFont]Uninstall [ProductName]</Text>
+        </Control>
+      </Dialog>
+      <Dialog Id="VerifyRepairDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes" TrackDiskSpace="yes">
+        <Control Id="Repair" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="[ButtonText_Repair]">
+          <Publish Event="ReinstallMode" Value="ecmus"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
+          <Publish Event="Reinstall" Value="All"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
+          <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
+          <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
+          <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+          <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+          <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
+        </Control>
+        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="[ButtonText_Cancel]">
+          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="[BannerBitmap]" />
+        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_Back]">
+          <Publish Event="NewDialog" Value="MaintenanceTypeDlg"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="Description" Type="Text" X="25" Y="74" Width="280" Height="30" Transparent="yes" NoPrefix="yes">
+          <Text>Click Repair to fix missing or corrupt files, shortcuts and registry entries. Click Cancel to exit the installer</Text>
+        </Control>
+        <Control Id="Title" Type="Text" X="15" Y="56" Width="200" Height="15" Transparent="yes" NoPrefix="yes">
+          <Text>[DlgTitleFont]Repair [ProductName]</Text>
+        </Control>
+      </Dialog>
+      <Dialog Id="WaitForCostingDlg" Y="10" Width="260" Height="85" Title="[ProductName] [Installer]" NoMinimize="yes">
+        <Control Id="Return" Type="PushButton" X="102" Y="57" Width="56" Height="17" Default="yes" Cancel="yes" Text="[ButtonText_Return]">
+          <Publish Event="EndDialog" Value="Exit"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="Text" Type="Text" X="48" Y="15" Width="194" Height="30">
+          <Text>Please wait while the installer finishes determining your disk space requirements.</Text>
+        </Control>
+        <Control Id="Icon" Type="Icon" X="15" Y="15" Width="24" Height="24" ToolTip="Exclamation icon" FixedSize="yes" IconSize="32" Text="[WarningIcon]" />
+      </Dialog>
+      <Dialog Id="WelcomeDlg" Width="370" Height="270" Title="[ProductName] [Installer]" NoMinimize="yes">
+        <Control Id="BackgroundBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="140" TabSkip="no" Text="[DialogBitmap]" />
+        <Control Id="Instructions" Type="Text" X="10" Y="155" Width="350" Height="45" Transparent="yes" NoPrefix="yes">
+          <Text>!(loc.WelcomeDlgInstructions)</Text>
+        </Control>
+        <Control Id="AcceptLicenseCheckBox" Type="CheckBox" X="10" Y="220" Width="350" Height="20" Property="LicenseAccepted" CheckBoxValue="true">
+          <Text>!(loc.WelcomeDlgAcceptLicenseCheckBox)</Text>
+        </Control>
+        <Control Id="License" Type="PushButton" X="10" Y="243" Width="56" Height="17" Text="[ButtonText_License]">
+          <Publish Event="NewDialog" Value="LicenseAgreementDlg"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="Advanced" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="[ButtonText_AdvancedInstall]">
+          <Publish Event="NewDialog" Value="AdvancedDlg"><![CDATA[1]]></Publish>
+        </Control>
+        <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" TabSkip="yes" Default="yes" ElevationShield="yes" Text="[ButtonText_Install]">
+          <Condition Action="disable"><![CDATA[LicenseAccepted <> "true"]]></Condition>
+          <Condition Action="enable"><![CDATA[LicenseAccepted = "true"]]></Condition>
+          <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace <> 1]]></Publish>
+          <Publish Event="SpawnDialog" Value="OutOfRbDiskDlg"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND (PROMPTROLLBACKCOST="P" OR NOT PROMPTROLLBACKCOST)]]></Publish>
+          <Publish Event="EndDialog" Value="Return"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+          <Publish Event="EnableRollback" Value="False"><![CDATA[OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 0 AND PROMPTROLLBACKCOST="D"]]></Publish>
+          <Publish Event="SpawnDialog" Value="OutOfDiskDlg"><![CDATA[(OutOfDiskSpace = 1 AND OutOfNoRbDiskSpace = 1) OR (OutOfDiskSpace = 1 AND PROMPTROLLBACKCOST="F")]]></Publish>
+        </Control>
+        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" TabSkip="yes" Cancel="yes" Text="[ButtonText_Cancel]">
+          <Publish Event="SpawnDialog" Value="CancelDlg"><![CDATA[1]]></Publish>
+        </Control>
+      </Dialog>
+      <TextStyle Id="DlgFont8" FaceName="Segoe UI" Size="8" />
+      <TextStyle Id="White8" FaceName="Segoe UI" Size="8" Red="255" Green="255" Blue="255" />
+      <TextStyle Id="DlgFontBold8" FaceName="Segoe UI" Size="8" Bold="yes" />
+      <TextStyle Id="VerdanaBold13" FaceName="Verdana" Size="13" Bold="yes" />
+      <UIText Id="AbsentPath" />
+      <UIText Id="bytes">bytes</UIText>
+      <UIText Id="GB">GB</UIText>
+      <UIText Id="KB">KB</UIText>
+      <UIText Id="MB">MB</UIText>
+      <UIText Id="MenuAbsent">Entire feature will be unavailable</UIText>
+      <UIText Id="MenuAdvertise">Feature will be installed when required</UIText>
+      <UIText Id="MenuAllCD">Entire feature will be installed to run from CD</UIText>
+      <UIText Id="MenuAllLocal">Entire feature will be installed on local hard drive</UIText>
+      <UIText Id="MenuAllNetwork">Entire feature will be installed to run from network</UIText>
+      <UIText Id="MenuCD">Will be installed to run from CD</UIText>
+      <UIText Id="MenuLocal">Will be installed on local hard drive</UIText>
+      <UIText Id="MenuNetwork">Will be installed to run from network</UIText>
+      <UIText Id="ScriptInProgress">Gathering required information...</UIText>
+      <UIText Id="SelAbsentAbsent">This feature will remain uninstalled</UIText>
+      <UIText Id="SelAbsentAdvertise">This feature will be set to be installed when required</UIText>
+      <UIText Id="SelAbsentCD">This feature will be installed to run from CD</UIText>
+      <UIText Id="SelAbsentLocal">This feature will be installed on the local hard drive</UIText>
+      <UIText Id="SelAbsentNetwork">This feature will be installed to run from the network</UIText>
+      <UIText Id="SelAdvertiseAbsent">This feature will become unavailable</UIText>
+      <UIText Id="SelAdvertiseAdvertise">Will be installed when required</UIText>
+      <UIText Id="SelAdvertiseCD">This feature will be available to run from CD</UIText>
+      <UIText Id="SelAdvertiseLocal">This feature will be installed on your local hard drive</UIText>
+      <UIText Id="SelAdvertiseNetwork">This feature will be available to run from the network</UIText>
+      <UIText Id="SelCDAbsent">This feature will be uninstalled completely, you won't be able to run it from CD</UIText>
+      <UIText Id="SelCDAdvertise">This feature will change from run from CD state to set to be installed when required</UIText>
+      <UIText Id="SelCDCD">This feature will remain to be run from CD</UIText>
+      <UIText Id="SelCDLocal">This feature will change from run from CD state to be installed on the local hard drive</UIText>
+      <UIText Id="SelChildCostNeg">This feature frees up [1] on your hard drive.</UIText>
+      <UIText Id="SelChildCostPos">This feature requires [1] on your hard drive.</UIText>
+      <UIText Id="SelCostPending">Compiling cost for this feature...</UIText>
+      <UIText Id="SelLocalAbsent">This feature will be completely removed</UIText>
+      <UIText Id="SelLocalAdvertise">This feature will be removed from your local hard drive, but will be set to be installed when required</UIText>
+      <UIText Id="SelLocalCD">This feature will be removed from your local hard drive, but will be still available to run from CD</UIText>
+      <UIText Id="SelLocalLocal">This feature will remain on you local hard drive</UIText>
+      <UIText Id="SelLocalNetwork">This feature will be removed from your local hard drive, but will be still available to run from the network</UIText>
+      <UIText Id="SelNetworkAbsent">This feature will be uninstalled completely, you won't be able to run it from the network</UIText>
+      <UIText Id="SelNetworkAdvertise">This feature will change from run from network state to set to be installed when required</UIText>
+      <UIText Id="SelNetworkLocal">This feature will change from run from network state to be installed on the local hard drive</UIText>
+      <UIText Id="SelNetworkNetwork">This feature will remain to be run from the network</UIText>
+      <UIText Id="SelParentCostNegNeg">This feature frees up [1] on your hard drive. It has [2] of [3] subfeatures selected. The subfeatures free up [4] on your hard drive.</UIText>
+      <UIText Id="SelParentCostNegPos">This feature frees up [1] on your hard drive. It has [2] of [3] subfeatures selected. The subfeatures require [4] on your hard drive.</UIText>
+      <UIText Id="SelParentCostPosNeg">This feature requires [1] on your hard drive. It has [2] of [3] subfeatures selected. The subfeatures free up [4] on your hard drive.</UIText>
+      <UIText Id="SelParentCostPosPos">This feature requires [1] on your hard drive. It has [2] of [3] subfeatures selected. The subfeatures require [4] on your hard drive.</UIText>
+      <UIText Id="TimeRemaining">Time remaining: {[1] minutes }{[2] seconds}</UIText>
+      <UIText Id="VolumeCostAvailable">Available</UIText>
+      <UIText Id="VolumeCostDifference">Difference</UIText>
+      <UIText Id="VolumeCostRequired">Required</UIText>
+      <UIText Id="VolumeCostSize">Disk Size</UIText>
+      <UIText Id="VolumeCostVolume">Volume</UIText>
+      <ProgressText Action="InstallValidate">Validating install</ProgressText>
+      <ProgressText Action="InstallFiles" Template="File: [1],  Directory: [9],  Size: [6]">Copying new files</ProgressText>
+      <ProgressText Action="InstallAdminPackage" Template="File: [1], Directory: [9], Size: [6]">Copying network install files</ProgressText>
+      <ProgressText Action="FileCost">Computing space requirements</ProgressText>
+      <ProgressText Action="CostInitialize">Computing space requirements</ProgressText>
+      <ProgressText Action="CostFinalize">Computing space requirements</ProgressText>
+      <ProgressText Action="CreateShortcuts" Template="Shortcut: [1]">Creating shortcuts</ProgressText>
+      <ProgressText Action="PublishComponents" Template="Component ID: [1], Qualifier: [2]">Publishing Qualified Components</ProgressText>
+      <ProgressText Action="PublishFeatures" Template="Feature: [1]">Publishing Product Features</ProgressText>
+      <ProgressText Action="PublishProduct">Publishing product information</ProgressText>
+      <ProgressText Action="RegisterClassInfo" Template="Class Id: [1]">Registering Class servers</ProgressText>
+      <ProgressText Action="RegisterExtensionInfo" Template="Extension: [1]">Registering extension servers</ProgressText>
+      <ProgressText Action="RegisterMIMEInfo" Template="MIME Content Type: [1], Extension: [2]">Registering MIME info</ProgressText>
+      <ProgressText Action="RegisterProgIdInfo" Template="ProgId: [1]">Registering program identifiers</ProgressText>
+      <ProgressText Action="AllocateRegistrySpace" Template="Free space: [1]">Allocating registry space</ProgressText>
+      <ProgressText Action="AppSearch" Template="Property: [1], Signature: [2]">Searching for installed applications</ProgressText>
+      <ProgressText Action="BindImage" Template="File: [1]">Binding executables</ProgressText>
+      <ProgressText Action="CCPSearch">Searching for qualifying products</ProgressText>
+      <ProgressText Action="CreateFolders" Template="Folder: [1]">Creating folders</ProgressText>
+      <ProgressText Action="DeleteServices" Template="Service: [1]">Deleting services</ProgressText>
+      <ProgressText Action="DuplicateFiles" Template="File: [1],  Directory: [9],  Size: [6]">Creating duplicate files</ProgressText>
+      <ProgressText Action="FindRelatedProducts" Template="Found application: [1]">Searching for related applications</ProgressText>
+      <ProgressText Action="InstallODBC">Installing ODBC components</ProgressText>
+      <ProgressText Action="InstallServices" Template="Service: [2]">Installing new services</ProgressText>
+      <ProgressText Action="LaunchConditions">Evaluating launch conditions</ProgressText>
+      <ProgressText Action="MigrateFeatureStates" Template="Application: [1]">Migrating feature states from related applications</ProgressText>
+      <ProgressText Action="MoveFiles" Template="File: [1],  Directory: [9],  Size: [6]">Moving files</ProgressText>
+      <ProgressText Action="PatchFiles" Template="File: [1],  Directory: [2],  Size: [3]">Patching files</ProgressText>
+      <ProgressText Action="ProcessComponents">Updating component registration</ProgressText>
+      <ProgressText Action="RegisterComPlus" Template="AppId: [1]{{, AppType: [2], Users: [3], RSN: [4]}}">Registering COM+ Applications and Components</ProgressText>
+      <ProgressText Action="RegisterFonts" Template="Font: [1]">Registering fonts</ProgressText>
+      <ProgressText Action="RegisterProduct" Template="[1]">Registering product</ProgressText>
+      <ProgressText Action="RegisterTypeLibraries" Template="LibID: [1]">Registering type libraries</ProgressText>
+      <ProgressText Action="RegisterUser" Template="[1]">Registering user</ProgressText>
+      <ProgressText Action="RemoveDuplicateFiles" Template="File: [1], Directory: [9]">Removing duplicated files</ProgressText>
+      <ProgressText Action="RemoveEnvironmentStrings" Template="Name: [1], Value: [2], Action [3]">Updating environment strings</ProgressText>
+      <ProgressText Action="RemoveExistingProducts" Template="Application: [1], Command line: [2]">Removing applications</ProgressText>
+      <ProgressText Action="RemoveFiles" Template="File: [1], Directory: [9]">Removing files</ProgressText>
+      <ProgressText Action="RemoveFolders" Template="Folder: [1]">Removing folders</ProgressText>
+      <ProgressText Action="RemoveIniValues" Template="File: [1],  Section: [2],  Key: [3], Value: [4]">Removing INI files entries</ProgressText>
+      <ProgressText Action="RemoveODBC">Removing ODBC components</ProgressText>
+      <ProgressText Action="RemoveRegistryValues" Template="Key: [1], Name: [2]">Removing system registry values</ProgressText>
+      <ProgressText Action="RemoveShortcuts" Template="Shortcut: [1]">Removing shortcuts</ProgressText>
+      <ProgressText Action="RMCCPSearch">Searching for qualifying products</ProgressText>
+      <ProgressText Action="SelfRegModules" Template="File: [1], Folder: [2]">Registering modules</ProgressText>
+      <ProgressText Action="SelfUnregModules" Template="File: [1], Folder: [2]">Unregistering modules</ProgressText>
+      <ProgressText Action="SetODBCFolders">Initializing ODBC directories</ProgressText>
+      <ProgressText Action="StartServices" Template="Service: [1]">Starting services</ProgressText>
+      <ProgressText Action="StopServices" Template="Service: [1]">Stopping services</ProgressText>
+      <ProgressText Action="UnpublishComponents" Template="Component ID: [1], Qualifier: [2]">Unpublishing Qualified Components</ProgressText>
+      <ProgressText Action="UnpublishFeatures" Template="Feature: [1]">Unpublishing Product Features</ProgressText>
+      <ProgressText Action="UnregisterClassInfo" Template="Class Id: [1]">Unregister Class servers</ProgressText>
+      <ProgressText Action="UnregisterComPlus" Template="AppId: [1]{{, AppType: [2]}}">Unregistering COM+ Applications and Components</ProgressText>
+      <ProgressText Action="UnregisterExtensionInfo" Template="Extension: [1]">Unregistering extension servers</ProgressText>
+      <ProgressText Action="UnregisterFonts" Template="Font: [1]">Unregistering fonts</ProgressText>
+      <ProgressText Action="UnregisterMIMEInfo" Template="MIME Content Type: [1], Extension: [2]">Unregistering MIME info</ProgressText>
+      <ProgressText Action="UnregisterProgIdInfo" Template="ProgId: [1]">Unregistering program identifiers</ProgressText>
+      <ProgressText Action="UnregisterTypeLibraries" Template="LibID: [1]">Unregistering type libraries</ProgressText>
+      <ProgressText Action="WriteEnvironmentStrings" Template="Name: [1], Value: [2], Action [3]">Updating environment strings</ProgressText>
+      <ProgressText Action="WriteIniValues" Template="File: [1],  Section: [2],  Key: [3], Value: [4]">Writing INI files values</ProgressText>
+      <ProgressText Action="WriteRegistryValues" Template="Key: [1], Name: [2], Value: [3]">Writing system registry values</ProgressText>
+      <ProgressText Action="Advertise">Advertising application</ProgressText>
+      <ProgressText Action="GenerateScript" Template="[1]">Generating script operations for action:</ProgressText>
+      <ProgressText Action="InstallSFPCatalogFile" Template="File: [1],  Dependencies: [2]">Installing system catalog</ProgressText>
+      <ProgressText Action="MsiPublishAssemblies" Template="Application Context:[1], Assembly Name:[2]">Publishing assembly information</ProgressText>
+      <ProgressText Action="MsiUnpublishAssemblies" Template="Application Context:[1], Assembly Name:[2]">Unpublishing assembly information</ProgressText>
+      <ProgressText Action="Rollback" Template="[1]">Rolling back action:</ProgressText>
+      <ProgressText Action="RollbackCleanup" Template="File: [1]">Removing backup files</ProgressText>
+      <ProgressText Action="UnmoveFiles" Template="File: [1], Directory: [9]">Removing moved files</ProgressText>
+      <ProgressText Action="UnpublishProduct">Unpublishing product information</ProgressText>
+      <Error Id="0">{{Fatal error: }}</Error>
+      <Error Id="1">{{Error [1]. }}</Error>
+      <Error Id="2">Warning [1]. </Error>
+      <Error Id="3" />
+      <Error Id="4">Info [1]. </Error>
+      <Error Id="5">The installer has encountered an unexpected error installing this package. This may indicate a problem with this package. The error code is [1]. {{The arguments are: [2], [3], [4]}}</Error>
+      <Error Id="6" />
+      <Error Id="7">{{Disk full: }}</Error>
+      <Error Id="8">Action [Time]: [1]. [2]</Error>
+      <Error Id="9">[ProductName]</Error>
+      <Error Id="10">{[2]}{, [3]}{, [4]}</Error>
+      <Error Id="11">Message type: [1], Argument: [2]</Error>
+      <Error Id="12">=== Logging started: [Date]  [Time] ===</Error>
+      <Error Id="13">=== Logging stopped: [Date]  [Time] ===</Error>
+      <Error Id="14">Action start [Time]: [1].</Error>
+      <Error Id="15">Action ended [Time]: [1]. Return value [2].</Error>
+      <Error Id="16">Time remaining: {[1] minutes }{[2] seconds}</Error>
+      <Error Id="17">Out of memory. Shut down other applications before retrying.</Error>
+      <Error Id="18">Installer is no longer responding.</Error>
+      <Error Id="19">Installer stopped prematurely.</Error>
+      <Error Id="20">Please wait while Windows configures [ProductName]</Error>
+      <Error Id="21">Gathering required information...</Error>
+      <Error Id="22">Removing older versions of this application...</Error>
+      <Error Id="23">Preparing to remove older versions of this application...</Error>
+      <Error Id="32">{[ProductName] }Setup completed successfully.</Error>
+      <Error Id="33">{[ProductName] }Setup failed.</Error>
+      <Error Id="1101">Error reading from file: [2]. {{ System error [3].}}  Verify that the file exists and that you can access it.</Error>
+      <Error Id="1301">Cannot create the file '[2]'.  A directory with this name already exists.  Cancel the install and try installing to a different location.</Error>
+      <Error Id="1302">Please insert the disk: [2]</Error>
+      <Error Id="1303">The installer has insufficient privileges to access this directory: [2].  The installation cannot continue.  Log on as administrator or contact your system administrator.</Error>
+      <Error Id="1304">Error writing to file: [2].  Verify that you have access to that directory.</Error>
+      <Error Id="1305">Error reading from file [2]. {{ System error [3].}} Verify that the file exists and that you can access it.</Error>
+      <Error Id="1306">Another application has exclusive access to the file '[2]'.  Please shut down all other applications, then click Retry.</Error>
+      <Error Id="1307">There is not enough disk space to install this file: [2].  Free some disk space and click Retry, or click Cancel to exit.</Error>
+      <Error Id="1308">Source file not found: [2].  Verify that the file exists and that you can access it.</Error>
+      <Error Id="1309">Error reading from file: [3]. {{ System error [2].}}  Verify that the file exists and that you can access it.</Error>
+      <Error Id="1310">Error writing to file: [3]. {{ System error [2].}}  Verify that you have access to that directory.</Error>
+      <Error Id="1311">Source file not found{{(cabinet)}}: [2].  Verify that the file exists and that you can access it.</Error>
+      <Error Id="1312">Cannot create the directory '[2]'.  A file with this name already exists.  Please rename or remove the file and click retry, or click Cancel to exit.</Error>
+      <Error Id="1313">The volume [2] is currently unavailable.  Please select another.</Error>
+      <Error Id="1314">The specified path '[2]' is unavailable.</Error>
+      <Error Id="1315">Unable to write to the specified folder: [2].</Error>
+      <Error Id="1316">A network error occurred while attempting to read from the file: [2]</Error>
+      <Error Id="1317">An error occurred while attempting to create the directory: [2]</Error>
+      <Error Id="1318">A network error occurred while attempting to create the directory: [2]</Error>
+      <Error Id="1319">A network error occurred while attempting to open the source file cabinet: [2]</Error>
+      <Error Id="1320">The specified path is too long: [2]</Error>
+      <Error Id="1321">The Installer has insufficient privileges to modify this file: [2].</Error>
+      <Error Id="1322">A portion of the folder path '[2]' is invalid.  It is either empty or exceeds the length allowed by the system.</Error>
+      <Error Id="1323">The folder path '[2]' contains words that are not valid in folder paths.</Error>
+      <Error Id="1324">The folder path '[2]' contains an invalid character.</Error>
+      <Error Id="1325">'[2]' is not a valid short file name.</Error>
+      <Error Id="1326">Error getting file security: [3] GetLastError: [2]</Error>
+      <Error Id="1327">Invalid Drive: [2]</Error>
+      <Error Id="1328">Error applying patch to file [2].  It has probably been updated by other means, and can no longer be modified by this patch.  For more information contact your patch vendor.  {{System Error: [3]}}</Error>
+      <Error Id="1329">A file that is required cannot be installed because the cabinet file [2] is not digitally signed.  This may indicate that the cabinet file is corrupt.</Error>
+      <Error Id="1330">A file that is required cannot be installed because the cabinet file [2] has an invalid digital signature.  This may indicate that the cabinet file is corrupt.{{  Error [3] was returned by WinVerifyTrust.}}</Error>
+      <Error Id="1331">Failed to correctly copy [2] file: CRC error.</Error>
+      <Error Id="1332">Failed to correctly move [2] file: CRC error.</Error>
+      <Error Id="1333">Failed to correctly patch [2] file: CRC error.</Error>
+      <Error Id="1334">The file '[2]' cannot be installed because the file cannot be found in cabinet file '[3]'. This could indicate a network error, an error reading from the CD-ROM, or a problem with this package.</Error>
+      <Error Id="1335">The cabinet file '[2]' required for this installation is corrupt and cannot be used. This could indicate a network error, an error reading from the CD-ROM, or a problem with this package.</Error>
+      <Error Id="1336">There was an error creating a temporary file that is needed to complete this installation.{{  Folder: [3]. System error code: [2]}}</Error>
+      <Error Id="1401">Could not create key: [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel. </Error>
+      <Error Id="1402">Could not open key: [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel. </Error>
+      <Error Id="1403">Could not delete value [2] from key [3]. {{ System error [4].}}  Verify that you have sufficient access to that key, or contact your support personnel. </Error>
+      <Error Id="1404">Could not delete key [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel. </Error>
+      <Error Id="1405">Could not read value [2] from key [3]. {{ System error [4].}}  Verify that you have sufficient access to that key, or contact your support personnel. </Error>
+      <Error Id="1406">Could not write value [2] to key [3]. {{ System error [4].}}  Verify that you have sufficient access to that key, or contact your support personnel.</Error>
+      <Error Id="1407">Could not get value names for key [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel.</Error>
+      <Error Id="1408">Could not get sub key names for key [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel.</Error>
+      <Error Id="1409">Could not read security information for key [2]. {{ System error [3].}}  Verify that you have sufficient access to that key, or contact your support personnel.</Error>
+      <Error Id="1410">Could not increase the available registry space. [2] KB of free registry space is required for the installation of this application.</Error>
+      <Error Id="1500">Another installation is in progress. You must complete that installation before continuing this one.</Error>
+      <Error Id="1501">Error accessing secured data. Please make sure the Windows Installer is configured properly and try the install again.</Error>
+      <Error Id="1502">User '[2]' has previously initiated an install for product '[3]'.  That user will need to run that install again before they can use that product.  Your current install will now continue.</Error>
+      <Error Id="1503">User '[2]' has previously initiated an install for product '[3]'.  That user will need to run that install again before they can use that product.</Error>
+      <Error Id="1601">Out of disk space -- Volume: '[2]'; required space: [3] KB; available space: [4] KB.  Free some disk space and retry.</Error>
+      <Error Id="1602">Are you sure you want to cancel?</Error>
+      <Error Id="1603">The file [2][3] is being held in use{ by the following process: Name: [4], Id: [5], Window Title: '[6]'}.  Close that application and retry.</Error>
+      <Error Id="1604">The product '[2]' is already installed, preventing the installation of this product.  The two products are incompatible.</Error>
+      <Error Id="1605">There is not enough disk space on the volume '[2]' to continue the install with recovery enabled. [3] KB are required, but only [4] KB are available. Click Ignore to continue the install without saving recovery information, click Retry to check for available space again, or click Cancel to quit the installation.</Error>
+      <Error Id="1606">Could not access network location [2].</Error>
+      <Error Id="1607">The following applications should be closed before continuing the install:</Error>
+      <Error Id="1608">Could not find any previously installed compliant products on the machine for installing this product.</Error>
+      <Error Id="1609">An error occurred while applying security settings. [2] is not a valid user or group. This could be a problem with the package, or a problem connecting to a domain controller on the network. Check your network connection and click Retry, or Cancel to end the install. {{Unable to locate the user's SID, system error [3]}}</Error>
+      <Error Id="1701">The key [2] is not valid.  Verify that you entered the correct key.</Error>
+      <Error Id="1702">The installer must restart your system before configuration of [2] can continue.  Click Yes to restart now or No if you plan to manually restart later.</Error>
+      <Error Id="1703">You must restart your system for the configuration changes made to [2] to take effect. Click Yes to restart now or No if you plan to manually restart later.</Error>
+      <Error Id="1704">An installation for [2] is currently suspended.  You must undo the changes made by that installation to continue.  Do you want to undo those changes?</Error>
+      <Error Id="1705">A previous installation for this product is in progress.  You must undo the changes made by that installation to continue.  Do you want to undo those changes?</Error>
+      <Error Id="1706">An installation package for the product [2] cannot be found. Try the installation again using a valid copy of the installation package '[3]'.</Error>
+      <Error Id="1707">Installation completed successfully.</Error>
+      <Error Id="1708">Installation failed.</Error>
+      <Error Id="1709">Product: [2] -- [3]</Error>
+      <Error Id="1710">You may either restore your computer to its previous state or continue the install later. Would you like to restore?</Error>
+      <Error Id="1711">An error occurred while writing installation information to disk.  Check to make sure enough disk space is available, and click Retry, or Cancel to end the install.</Error>
+      <Error Id="1712">One or more of the files required to restore your computer to its previous state could not be found.  Restoration will not be possible.</Error>
+      <Error Id="1713">[2] cannot install one of its required products. Contact your technical support group.  {{System Error: [3].}}</Error>
+      <Error Id="1714">The older version of [2] cannot be removed.  Contact your technical support group.  {{System Error [3].}}</Error>
+      <Error Id="1715">Installed [2]</Error>
+      <Error Id="1716">Configured [2]</Error>
+      <Error Id="1717">Removed [2]</Error>
+      <Error Id="1718">File [2] was rejected by digital signature policy.</Error>
+      <Error Id="1719">The Windows Installer Service could not be accessed. This can occur if you are running Windows in safe mode, or if the Windows Installer is not correctly installed. Contact your support personnel for assistance.</Error>
+      <Error Id="1720">There is a problem with this Windows Installer package. A script required for this install to complete could not be run. Contact your support personnel or package vendor.  {{Custom action [2] script error [3], [4]: [5] Line [6], Column [7], [8] }}</Error>
+      <Error Id="1721">There is a problem with this Windows Installer package. A program required for this install to complete could not be run. Contact your support personnel or package vendor. {{Action: [2], location: [3], command: [4] }}</Error>
+      <Error Id="1722">There is a problem with this Windows Installer package. A program run as part of the setup did not finish as expected. Contact your support personnel or package vendor.  {{Action [2], location: [3], command: [4] }}</Error>
+      <Error Id="1723">There is a problem with this Windows Installer package. A DLL required for this install to complete could not be run. Contact your support personnel or package vendor.  {{Action [2], entry: [3], library: [4] }}</Error>
+      <Error Id="1724">Removal completed successfully.</Error>
+      <Error Id="1725">Removal failed.</Error>
+      <Error Id="1726">Advertisement completed successfully.</Error>
+      <Error Id="1727">Advertisement failed.</Error>
+      <Error Id="1728">Configuration completed successfully.</Error>
+      <Error Id="1729">Configuration failed.</Error>
+      <Error Id="1730">You must be an Administrator to remove this application. To remove this application, you can log on as an Administrator, or contact your technical support group for assistance.</Error>
+      <Error Id="1801">The path [2] is not valid.  Please specify a valid path.</Error>
+      <Error Id="1802">Out of memory. Shut down other applications before retrying.</Error>
+      <Error Id="1803">There is no disk in drive [2]. Please insert one and click Retry, or click Cancel to go back to the previously selected volume.</Error>
+      <Error Id="1804">There is no disk in drive [2]. Please insert one and click Retry, or click Cancel to return to the browse dialog and select a different volume.</Error>
+      <Error Id="1805">The folder [2] does not exist.  Please enter a path to an existing folder.</Error>
+      <Error Id="1806">You have insufficient privileges to read this folder.</Error>
+      <Error Id="1807">A valid destination folder for the install could not be determined.</Error>
+      <Error Id="1901">Error attempting to read from the source install database: [2].</Error>
+      <Error Id="1902">Scheduling reboot operation: Renaming file [2] to [3]. Must reboot to complete operation.</Error>
+      <Error Id="1903">Scheduling reboot operation: Deleting file [2]. Must reboot to complete operation.</Error>
+      <Error Id="1904">Module [2] failed to register.  HRESULT [3].  Contact your support personnel.</Error>
+      <Error Id="1905">Module [2] failed to unregister.  HRESULT [3].  Contact your support personnel.</Error>
+      <Error Id="1906">Failed to cache package [2]. Error: [3]. Contact your support personnel.</Error>
+      <Error Id="1907">Could not register font [2].  Verify that you have sufficient permissions to install fonts, and that the system supports this font.</Error>
+      <Error Id="1908">Could not unregister font [2]. Verify that you that you have sufficient permissions to remove fonts.</Error>
+      <Error Id="1909">Could not create Shortcut [2]. Verify that the destination folder exists and that you can access it.</Error>
+      <Error Id="1910">Could not remove Shortcut [2]. Verify that the shortcut file exists and that you can access it.</Error>
+      <Error Id="1911">Could not register type library for file [2].  Contact your support personnel.</Error>
+      <Error Id="1912">Could not unregister type library for file [2].  Contact your support personnel.</Error>
+      <Error Id="1913">Could not update the ini file [2][3].  Verify that the file exists and that you can access it.</Error>
+      <Error Id="1914">Could not schedule file [2] to replace file [3] on reboot.  Verify that you have write permissions to file [3].</Error>
+      <Error Id="1915">Error removing ODBC driver manager, ODBC error [2]: [3]. Contact your support personnel.</Error>
+      <Error Id="1916">Error installing ODBC driver manager, ODBC error [2]: [3]. Contact your support personnel.</Error>
+      <Error Id="1917">Error removing ODBC driver: [4], ODBC error [2]: [3]. Verify that you have sufficient privileges to remove ODBC drivers.</Error>
+      <Error Id="1918">Error installing ODBC driver: [4], ODBC error [2]: [3]. Verify that the file [4] exists and that you can access it.</Error>
+      <Error Id="1919">Error configuring ODBC data source: [4], ODBC error [2]: [3]. Verify that the file [4] exists and that you can access it.</Error>
+      <Error Id="1920">Service '[2]' ([3]) failed to start.  Verify that you have sufficient privileges to start system services.</Error>
+      <Error Id="1921">Service '[2]' ([3]) could not be stopped.  Verify that you have sufficient privileges to stop system services.</Error>
+      <Error Id="1922">Service '[2]' ([3]) could not be deleted.  Verify that you have sufficient privileges to remove system services.</Error>
+      <Error Id="1923">Service '[2]' ([3]) could not be installed.  Verify that you have sufficient privileges to install system services.</Error>
+      <Error Id="1924">Could not update environment variable '[2]'.  Verify that you have sufficient privileges to modify environment variables.</Error>
+      <Error Id="1925">You do not have sufficient privileges to complete this installation for all users of the machine.  Log on as administrator and then retry this installation.</Error>
+      <Error Id="1926">Could not set file security for file '[3]'. Error: [2].  Verify that you have sufficient privileges to modify the security permissions for this file.</Error>
+      <Error Id="1927">Component Services (COM+ 1.0) are not installed on this computer.  This installation requires Component Services in order to complete successfully.  Component Services are available on Windows 2000.</Error>
+      <Error Id="1928">Error registering COM+ Application.  Contact your support personnel for more information.</Error>
+      <Error Id="1929">Error unregistering COM+ Application.  Contact your support personnel for more information.</Error>
+      <Error Id="1930">The description for service '[2]' ([3]) could not be changed.</Error>
+      <Error Id="1931">The Windows Installer service cannot update the system file [2] because the file is protected by Windows.  You may need to update your operating system for this program to work correctly. {{Package version: [3], OS Protected version: [4]}}</Error>
+      <Error Id="1932">The Windows Installer service cannot update the protected Windows file [2]. {{Package version: [3], OS Protected version: [4], SFP Error: [5]}}</Error>
+      <Error Id="1933">The Windows Installer service cannot update one or more protected Windows files. {{SFP Error: [2].  List of protected files:\r\n[3]}}</Error>
+      <Error Id="1934">User installations are disabled via policy on the machine.</Error>
+      <Error Id="1935">An error occured during the installation of assembly component [2]. HRESULT: [3]. {{assembly interface: [4], function: [5], assembly name: [6]}}</Error>
+      <AdminUISequence>
+        <Show Dialog="FatalError" OnExit="error" />
+        <Show Dialog="UserExitDlg" OnExit="cancel" />
+        <Show Dialog="SuccessDlg" OnExit="success" />
+        <Show Dialog="PrepareDlg" Before="CostInitialize"><![CDATA[]]></Show>
+        <Show Dialog="AdminWelcomeDlg" After="CostFinalize" />
+        <Show Dialog="ProgressDlg" After="AdminWelcomeDlg" />
+      </AdminUISequence>
+      <InstallUISequence>
+        <Show Dialog="FatalError" OnExit="error" />
+        <Show Dialog="UserExitDlg" OnExit="cancel" />
+        <Show Dialog="SuccessDlg" OnExit="success" />
+        <Show Dialog="PrepareDlg" After="LaunchConditions" />
+        <Show Dialog="WelcomeDlg" After="MigrateFeatureStates"><![CDATA[NOT Installed]]></Show>
+        <Show Dialog="ResumeDlg" After="WelcomeDlg"><![CDATA[Installed AND (RESUME OR Preselected)]]></Show>
+        <Show Dialog="MaintenanceWelcomeDlg" After="ResumeDlg"><![CDATA[Installed AND NOT RESUME AND NOT Preselected]]></Show>
+        <Show Dialog="ProgressDlg" After="MaintenanceWelcomeDlg" />
+      </InstallUISequence>
+    </UI>
+    <Property Id="ButtonText_No"><![CDATA[&No]]></Property>
+    <Property Id="ButtonText_Install"><![CDATA[&Install]]></Property>
+    <Property Id="ButtonText_AdvancedInstall"><![CDATA[&Advanced]]></Property>
+    <Property Id="ButtonText_Next"><![CDATA[&Next >]]></Property>
+    <Property Id="Setup"><![CDATA[Setup]]></Property>
+    <Property Id="ButtonText_Browse"><![CDATA[Br&owse]]></Property>
+    <Property Id="ModifyIcon"><![CDATA[ModifyIcon]]></Property>
+    <Property Id="RepairIcon"><![CDATA[RepairIcon]]></Property>
+    <Property Id="WarningIcon"><![CDATA[WarningIcon]]></Property>
+    <Property Id="ButtonText_Repair"><![CDATA[&Repair]]></Property>
+    <Property Id="ButtonText_Back"><![CDATA[< &Back]]></Property>
+    <Property Id="InstallMode"><![CDATA[Typical]]></Property>
+    <Property Id="Progress2"><![CDATA[Installation]]></Property>
+    <Property Id="Progress1"><![CDATA[Installing]]></Property>
+    <Property Id="Wizard"><![CDATA[Setup Wizard]]></Property>
+    <Property Id="RemoveIcon"><![CDATA[RemoveIcon]]></Property>
+    <Property Id="ButtonText_Yes"><![CDATA[&Yes]]></Property>
+    <Property Id="ButtonText_Ignore"><![CDATA[&Ignore]]></Property>
+    <Property Id="ButtonText_Reset"><![CDATA[&Reset]]></Property>
+    <Property Id="ButtonText_Remove"><![CDATA[&Remove]]></Property>
+    <Property Id="ButtonText_Exit"><![CDATA[&Exit]]></Property>
+    <Property Id="ButtonText_Return"><![CDATA[&Return]]></Property>
+    <Property Id="ButtonText_OK"><![CDATA[OK]]></Property>
+    <Property Id="ButtonText_License"><![CDATA[&License]]></Property>
+    <Property Id="ButtonText_Resume"><![CDATA[&Resume]]></Property>
+    <Property Id="ButtonText_Finish"><![CDATA[&Finish]]></Property>
+    <Property Id="DlgTitleFont"><![CDATA[{&DlgFontBold8}]]></Property>
+    <Property Id="ButtonText_Cancel"><![CDATA[Cancel]]></Property>
+    <Property Id="QuestionIcon"><![CDATA[QuestionIcon]]></Property>
+    <Property Id="ButtonText_Retry"><![CDATA[&Retry]]></Property>
+    <Property Id="IAgree"><![CDATA[No]]></Property>
+    <Property Id="BannerBitmap"><![CDATA[BannerBitmap]]></Property>
+    <Property Id="DialogBitmap"><![CDATA[DialogBitmap]]></Property>
+    <Property Id="Installer" Value="Installer" />
+    <Property Id="ButtonText_Uninstall" Value="&amp;Uninstall" />
+    <!-- Mattermost blue banners -->
+    <Binary Id="DialogBitmap" SourceFile="../resources/windows/msi_dialog_banner.png" />
+    <Binary Id="BannerBitmap" SourceFile="../resources/windows/msi_dialog_banner_small.png" />
+    <!-- Error and warnings -->
+    <Binary Id="WarningIcon" SourceFile="../resources/windows/msi_warning.ico" />
+    <Binary Id="QuestionIcon" SourceFile="../resources/windows/msi_question.ico" />
+    <!-- In BrowseDlg -->
+    <Binary Id="Up" SourceFile="../resources/windows/msi_up.ico" />
+    <Binary Id="New" SourceFile="../resources/windows/msi_create_folder.ico" />
+    <!-- In administrative install GUI -->
+    <Binary Id="ModifyIcon" SourceFile="../resources/windows/msi_modify.ico" />
+    <Binary Id="RepairIcon" SourceFile="../resources/windows/msi_repair.ico" />
+    <Binary Id="RemoveIcon" SourceFile="../resources/windows/msi_remove.ico" />
+  </Product>
 </Wix>

--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -76,6 +76,16 @@
     <Condition Message="!(loc.OsRequirements)">
       <![CDATA[Installed OR (VersionNT >= 601)]]>
     </Condition>
+
+    <?if $(var.Platform) = x64 ?>
+      <Condition Message="!(loc.Requires64Bit)">
+        <![CDATA[VersionNT64]]>
+      </Condition>
+    <?else ?>
+      <Condition Message="!(loc.Requires32Bit)">
+        <![CDATA[NOT VersionNT64]]>
+      </Condition>
+    <?endif ?>
     
     <!--<MajorUpgrade
       DowngradeErrorMessage="A later version of [ProductName] is already installed. Setup will now exit." />-->


### PR DESCRIPTION
This PR includes work for several Jira tickets as follows:

- [MM-15392](https://mattermost.atlassian.net/browse/MM-15392) – kill running app during (un)install
- [MM-15389](https://mattermost.atlassian.net/browse/MM-15389) – prevent 32bit install on 64bit windows
- [MM-15385](https://mattermost.atlassian.net/browse/MM-15385) – always show license button
- [MM-15388](https://mattermost.atlassian.net/browse/MM-15388) – integrate GPO files into installer
- [MM-15713](https://mattermost.atlassian.net/browse/MM-15713) – tie license checkbox's in normal and advanced screens to each other

Merging into branch `release-test-msi` as the current "master" for MSI related functionality. Does not need a final 2-dev code review as the `release-test-msi` branch still needs a final review against actual `master`.