### PR TITLE
[MM-15812] Upgrade Electron to latest 4.x version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1360,9 +1360,9 @@
       }
     },
     "@types/node": {
-      "version": "8.10.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.39.tgz",
-      "integrity": "sha512-rE7fktr02J8ybFf6eysife+WF+L4sAHWzw09DgdCebEu+qDwMvv4zl6Bc+825ttGZP73kCKxa3dhJOoGJ8+5mA==",
+      "version": "10.14.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.9.tgz",
+      "integrity": "sha512-NelG/dSahlXYtSoVPErrp06tYFrvzj8XLWmKA+X8x0W//4MqbUyZu++giUG/v0bjAT6/Qxa8IjodrfdACyb0Fg==",
       "dev": true
     },
     "@webassemblyjs/ast": {
@@ -4418,12 +4418,12 @@
       "dev": true
     },
     "electron": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-4.0.0.tgz",
-      "integrity": "sha512-3XPG/3IXlvnT1oe1K6zEushoD0SKbP8xwdrL10EWGe6k2iOV4hSHqJ8vWnR8yZ7VbSXmBRfomEFDNAo/q/cwKw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-4.2.4.tgz",
+      "integrity": "sha512-d4wEwJluMsRyRgbukLmFVTb6l1J+mc3RLB1ctbpMlSWDFvs+zknPWa+cHBzTWwrdgwINLddr69qsAW1ku6FqYw==",
       "dev": true,
       "requires": {
-        "@types/node": "^8.0.24",
+        "@types/node": "^10.12.18",
         "electron-download": "^4.1.0",
         "extract-zip": "^1.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "cross-env": "^5.2.0",
     "css-loader": "^1.0.1",
     "devtron": "^1.4.0",
-    "electron": "^4.0.0",
+    "electron": "^4.2.4",
     "electron-builder": "20.38.2",
     "electron-connect": "^0.6.3",
     "eslint": "^5.9.0",


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

**Summary**
This PR upgrades electron to the lastest 4.x version (4.2.4) to fix the quit menu keyboard shortcut not working in Windows. Seems the shortcut broke with the Electron 4.0.0 upgrade but is fixed in the latest 4.x.

**Issue link**
[MM-15812](https://mattermost.atlassian.net/browse/MM-15812)
