### PR TITLE
[MM-15918] Pull reference counts from LHS only.

### DIFF
--- a/src/browser/webview/mattermost.js
+++ b/src/browser/webview/mattermost.js
@@ -90,7 +90,7 @@ function getUnreadCount() {
   }
 
   // mentionCount in sidebar
-  const elem = document.getElementsByClassName('badge');
+  const elem = document.querySelectorAll('#sidebar-left .badge');
   let mentionCount = 0;
   for (let i = 0; i < elem.length; i++) {
     if (isElementVisible(elem[i]) && !hasClass(elem[i], 'badge-notify')) {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

**Summary**
This PR updates the scraping mechanism that retrieves mentions from the DOM of the webapp for use in the mentions badge on the server tab (when visible). The mechanism now only pulls mentions from the LHS instead of anywhere in the DOM, which was previously causing the count in the tab to double whenever the suggestions drop-down was visible while the quick-switcher was open.

**Issue link**
[MM-15918](https://mattermost.atlassian.net/browse/MM-15918)