### PR TITLE
[MM 7970] Maintain online status while the Desktop App is in the background ... and other things.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -54,7 +54,6 @@
         "src/browser/updater.jsx",
         "src/browser/js/notification.js",
         "src/browser/js/badge.js",
-        "src/browser/js/WebappConnector.js",
         "src/browser/webview/mattermost.js",
         "src/browser/components/RemoveServerModal.jsx",
         "src/browser/components/MainPage.jsx",
@@ -101,7 +100,6 @@
         "src/main/downloadURL.js",
         "src/main/autoUpdater.js",
         "src/main/SpellChecker.js",
-        "src/main/UserActivityMonitor.js",
         "src/main/menus/app.js"
       ],
       "rules": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -54,6 +54,7 @@
         "src/browser/updater.jsx",
         "src/browser/js/notification.js",
         "src/browser/js/badge.js",
+        "src/browser/js/WebappConnector.js",
         "src/browser/webview/mattermost.js",
         "src/browser/components/RemoveServerModal.jsx",
         "src/browser/components/MainPage.jsx",
@@ -100,6 +101,7 @@
         "src/main/downloadURL.js",
         "src/main/autoUpdater.js",
         "src/main/SpellChecker.js",
+        "src/main/UserActivityMonitor.js",
         "src/main/menus/app.js"
       ],
       "rules": {

--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -45,6 +45,7 @@ export default class MattermostView extends React.Component {
     this.goForward = this.goForward.bind(this);
     this.getSrc = this.getSrc.bind(this);
     this.handleDeepLink = this.handleDeepLink.bind(this);
+    this.handleUserActivityUpdate = this.handleUserActivityUpdate.bind(this);
 
     this.webviewRef = React.createRef();
   }
@@ -186,6 +187,14 @@ export default class MattermostView extends React.Component {
         break;
       }
     });
+
+    // start listening for user status updates from main
+    ipcRenderer.on('user-activity-update', this.handleUserActivityUpdate);
+  }
+
+  componentWillUnmount() {
+    // stop listening for user status updates from main
+    ipcRenderer.removeListener('user-activity-update', this.handleUserActivityUpdate);
   }
 
   reload() {
@@ -251,6 +260,11 @@ export default class MattermostView extends React.Component {
     webview.executeJavaScript(
       'dispatchEvent(new PopStateEvent("popstate", null));'
     );
+  }
+
+  handleUserActivityUpdate(event, status) {
+    // pass user activity update to the webview
+    this.webviewRef.current.send('user-activity-update', status);
   }
 
   render() {

--- a/src/browser/js/WebappConnector.js
+++ b/src/browser/js/WebappConnector.js
@@ -1,0 +1,18 @@
+// Copyright (c) 2015-2016 Yuya Ochiai
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import EventEmitter from 'events';
+
+/**
+* Provides the bridging infrastructure to connect the desktop and webapp together
+*/
+export default class WebappConnector extends EventEmitter {
+  constructor() {
+    super();
+
+    this.active = true;
+
+    window.webappConnector = this;
+  }
+}

--- a/src/browser/js/WebappConnector.js
+++ b/src/browser/js/WebappConnector.js
@@ -1,4 +1,3 @@
-// Copyright (c) 2015-2016 Yuya Ochiai
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 

--- a/src/browser/webview/mattermost.js
+++ b/src/browser/webview/mattermost.js
@@ -6,10 +6,13 @@
 import {ipcRenderer, webFrame} from 'electron';
 
 import EnhancedNotification from '../js/notification';
+import WebappConnector from '../js/WebappConnector';
 
 const UNREAD_COUNT_INTERVAL = 1000;
 //eslint-disable-next-line no-magic-numbers
 const CLEAR_CACHE_INTERVAL = 6 * 60 * 60 * 1000; // 6 hours
+
+const webappConnector = new WebappConnector();
 
 Notification = EnhancedNotification; // eslint-disable-line no-global-assign, no-native-reassign
 
@@ -193,6 +196,11 @@ function setSpellChecker() {
 }
 setSpellChecker();
 ipcRenderer.on('set-spellchecker', setSpellChecker);
+
+// push user activity updates to the webapp via the communication bridge
+ipcRenderer.on('user-activity-update', (event, {userIsActive, isSystemEvent}) => {
+  webappConnector.emit('user-activity-update', {userIsActive, manual: isSystemEvent});
+});
 
 // mattermost-webapp is SPA. So cache is not cleared due to no navigation.
 // We needed to manually clear cache to free memory in long-term-use.

--- a/src/main/UserActivityMonitor.js
+++ b/src/main/UserActivityMonitor.js
@@ -22,9 +22,9 @@ export default class UserActivityMonitor extends EventEmitter {
     this.systemIdleTimeIntervalID = -1;
 
     this.config = {
-      internalUpdateFrequencyMs: 1 * 1000,
-      statusUpdateThresholdMs: 60 * 1000,
-      activityTimeoutSec: 5 * 60,
+      internalUpdateFrequencyMs: 1 * 1000, // eslint-disable-line no-magic-numbers
+      statusUpdateThresholdMs: 60 * 1000, // eslint-disable-line no-magic-numbers
+      activityTimeoutSec: 5 * 60, // eslint-disable-line no-magic-numbers
     };
 
     // NOTE: binding needed to prevent error; fat arrow class methods don't work in current setup

--- a/src/main/UserActivityMonitor.js
+++ b/src/main/UserActivityMonitor.js
@@ -1,4 +1,3 @@
-// Copyright (c) 2015-2016 Yuya Ochiai
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 

--- a/src/main/UserActivityMonitor.js
+++ b/src/main/UserActivityMonitor.js
@@ -1,0 +1,159 @@
+// Copyright (c) 2015-2016 Yuya Ochiai
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import EventEmitter from 'events';
+
+import electron from 'electron';
+
+const {app} = electron;
+
+/**
+ * Monitors system idle time, listens for system events and fires status updates as needed
+ */
+export default class UserActivityMonitor extends EventEmitter {
+  constructor() {
+    super();
+
+    this.isActive = true;
+    this.forceInactive = false;
+    this.idleTime = 0;
+    this.lastStatusUpdate = 0;
+    this.systemIdleTimeIntervalID = -1;
+
+    this.config = {
+      internalUpdateFrequencyMs: 1 * 1000,
+      statusUpdateThresholdMs: 60 * 1000,
+      activityTimeoutSec: 5 * 60,
+    };
+
+    // NOTE: binding needed to prevent error; fat arrow class methods don't work in current setup
+    // Error: "Error: async hook stack has become corrupted (actual: #, expected: #)"
+    this.handleSystemGoingAway = this.handleSystemGoingAway.bind(this);
+    this.handleSystemComingBack = this.handleSystemComingBack.bind(this);
+  }
+
+  get userIsActive() {
+    return this.forceInactive ? false : this.isActive;
+  }
+
+  get userIdleTime() {
+    return this.idleTime;
+  }
+
+  /**
+   * Begin monitoring system events and idle time at defined frequency
+   *
+   * @param {Object} config - overide internal configuration defaults
+   * @param {nunber} config.internalUpdateFrequencyMs
+   * @param {nunber} config.statusUpdateThresholdMs
+   * @param {nunber} config.activityTimeoutSec
+   * @emits {error} emitted when method is called before the app is ready
+   * @emits {error} emitted when this method has previously been called but not subsequently stopped
+   */
+  startMonitoring(config = {}) {
+    if (!app.isReady()) {
+      this.emit('error', new Error('UserActivityMonitor.startMonitoring can only be called after app is ready'));
+      return;
+    }
+
+    if (this.systemIdleTimeIntervalID >= 0) {
+      this.emit('error', new Error('User activity monitoring is already in progress'));
+      return;
+    }
+
+    this.config = Object.assign({}, this.config, config);
+
+    // NOTE: electron.powerMonitor cannot be referenced until the app is ready
+    electron.powerMonitor.on('suspend', this.handleSystemGoingAway);
+    electron.powerMonitor.on('resume', this.handleSystemComingBack);
+    electron.powerMonitor.on('shutdown', this.handleSystemGoingAway);
+    electron.powerMonitor.on('lock-screen', this.handleSystemGoingAway);
+    electron.powerMonitor.on('unlock-screen', this.handleSystemComingBack);
+
+    this.systemIdleTimeIntervalID = setInterval(() => {
+      try {
+        electron.powerMonitor.querySystemIdleTime((idleTime) => {
+          this.updateIdleTime(idleTime);
+        });
+      } catch (err) {
+        console.log('Error getting system idle time:', err);
+      }
+    }, this.config.internalUpdateFrequencyMs);
+  }
+
+  /**
+   * Stop monitoring system events and idle time
+   */
+  stopMonitoring() {
+    electron.powerMonitor.off('suspend', this.handleSystemGoingAway);
+    electron.powerMonitor.off('resume', this.handleSystemComingBack);
+    electron.powerMonitor.off('shutdown', this.handleSystemGoingAway);
+    electron.powerMonitor.off('lock-screen', this.handleSystemGoingAway);
+    electron.powerMonitor.off('unlock-screen', this.handleSystemComingBack);
+
+    clearInterval(this.systemIdleTimeIntervalID);
+  }
+
+  /**
+   * Updates internal idle time properties and conditionally triggers updates to user activity status
+   *
+   * @param {integer} idleTime
+   * @private
+   */
+  updateIdleTime(idleTime) {
+    this.idleTime = idleTime;
+
+    if (this.idleTime > this.config.activityTimeoutSec) {
+      this.updateUserActivityStatus(false);
+    } else if (!this.forceInactive && this.idleTime < this.config.activityTimeoutSec) {
+      this.updateUserActivityStatus(true);
+    }
+  }
+
+  /**
+   * Updates user activity status if changed and triggers a status update
+   *
+   * @param {boolean} isActive
+   * @param {boolean} isSystemEvent – indicates whether the update was triggered by a system event (log in/out, screesaver on/off etc)
+   * @private
+   */
+  updateUserActivityStatus(isActive = false, isSystemEvent = false) {
+    const now = Date.now();
+    if (isActive !== this.isActive) {
+      this.isActive = isActive;
+      this.sendStatusUpdate(now, isSystemEvent);
+    } else if (now - this.lastStatusUpdate > this.config.statusUpdateThresholdMs) {
+      this.sendStatusUpdate(now, isSystemEvent);
+    }
+  }
+
+  /**
+   * Sends an update with user activity status and current system idle time
+   *
+   * @emits {status} emitted at regular, definable intervals providing an update on user active status and idle time
+   * @private
+   */
+  sendStatusUpdate(now = Date.now(), isSystemEvent = false) {
+    this.lastStatusUpdate = now;
+    this.emit('status', {
+      userIsActive: this.isActive,
+      idleTime: this.idleTime,
+      isSystemEvent,
+    });
+  }
+
+  /**
+   * System event handlers
+   *
+   * @private
+   */
+  handleSystemGoingAway() {
+    this.forceInactive = true;
+    this.updateUserActivityStatus(false, true);
+  }
+  handleSystemComingBack() {
+    this.forceInactive = false;
+    this.updateUserActivityStatus(true, true);
+  }
+}

--- a/test/specs/main/user_activity_monitor_test.js
+++ b/test/specs/main/user_activity_monitor_test.js
@@ -1,0 +1,70 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import assert from 'assert';
+
+import UserActivityMonitor from '../../../src/main/UserActivityMonitor';
+
+describe('UserActivityMonitor', () => { // mark
+
+  describe('updateIdleTime', () => { // mark
+    it('should set idle time to provided value', () => {
+      const userActivityMonitor = new UserActivityMonitor();
+      const idleTime = Math.round(Date.now() / 1000);
+      userActivityMonitor.updateIdleTime(idleTime);
+      assert.equal(userActivityMonitor.userIdleTime, idleTime);
+    });
+  });
+
+  describe('updateUserActivityStatus', () => {
+    let userActivityMonitor;
+
+    beforeEach(() => {
+      userActivityMonitor = new UserActivityMonitor();
+    });
+
+    it('should set user status to active', () => {
+      userActivityMonitor.updateUserActivityStatus(true);
+      assert.equal(userActivityMonitor.userIsActive, true);
+    });
+    it('should set user status to inactive', () => {
+      userActivityMonitor.updateUserActivityStatus(false);
+      assert.equal(userActivityMonitor.userIsActive, false);
+    });
+  });
+
+  describe('sendStatusUpdate', () => {
+    let userActivityMonitor;
+
+    beforeEach(() => {
+      userActivityMonitor = new UserActivityMonitor();
+    });
+
+    it('should emit a non-system triggered status event indicating a user is active', () => {
+      userActivityMonitor.on('status', ({userIsActive, isSystemEvent}) => {
+        assert.equal(userIsActive && !isSystemEvent, true);
+      });
+      userActivityMonitor.updateUserActivityStatus(true, false);
+    });
+
+    it('should emit a non-system triggered status event indicating a user is inactive', () => {
+      userActivityMonitor.on('status', ({userIsActive, isSystemEvent}) => {
+        assert.equal(!userIsActive && !isSystemEvent, true);
+      });
+      userActivityMonitor.updateUserActivityStatus(false, false);
+    });
+
+    it('should emit a system triggered status event indicating a user is active', () => {
+      userActivityMonitor.on('status', ({userIsActive, isSystemEvent}) => {
+        assert.equal(userIsActive && isSystemEvent, true);
+      });
+      userActivityMonitor.updateUserActivityStatus(true, true);
+    });
+
+    it('should emit a system triggered status event indicating a user is inactive', () => {
+      userActivityMonitor.on('status', ({userIsActive, isSystemEvent}) => {
+        assert.equal(!userIsActive && isSystemEvent, true);
+      });
+      userActivityMonitor.updateUserActivityStatus(false, true);
+    });
+  });
+});

--- a/test/specs/main/user_activity_monitor_test.js
+++ b/test/specs/main/user_activity_monitor_test.js
@@ -4,9 +4,8 @@ import assert from 'assert';
 
 import UserActivityMonitor from '../../../src/main/UserActivityMonitor';
 
-describe('UserActivityMonitor', () => { // mark
-
-  describe('updateIdleTime', () => { // mark
+describe('UserActivityMonitor', () => {
+  describe('updateIdleTime', () => {
     it('should set idle time to provided value', () => {
       const userActivityMonitor = new UserActivityMonitor();
       const idleTime = Math.round(Date.now() / 1000);
@@ -29,6 +28,26 @@ describe('UserActivityMonitor', () => { // mark
     it('should set user status to inactive', () => {
       userActivityMonitor.updateUserActivityStatus(false);
       assert.equal(userActivityMonitor.userIsActive, false);
+    });
+  });
+
+  describe('handleSystemGoingAway', () => {
+    it('should set user status to inactive and forceInactive to true', () => {
+      const userActivityMonitor = new UserActivityMonitor();
+      userActivityMonitor.isActive = true;
+      userActivityMonitor.forceInactive = false;
+      userActivityMonitor.handleSystemGoingAway();
+      assert.equal(!userActivityMonitor.userIsActive && userActivityMonitor.forceInactive, true);
+    });
+  });
+
+  describe('handleSystemComingBack', () => {
+    it('should set user status to active and forceInactive to false', () => {
+      const userActivityMonitor = new UserActivityMonitor();
+      userActivityMonitor.isActive = false;
+      userActivityMonitor.forceInactive = true;
+      userActivityMonitor.handleSystemComingBack();
+      assert.equal(userActivityMonitor.userIsActive && !userActivityMonitor.forceInactive, true);
     });
   });
 


### PR DESCRIPTION
Before submitting, please confirm you've
 - [X] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [X] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [X] executed `npm run lint:js` for proper code formatting

**Summary**
This PR and related Webapp & Server PR's support maintaining a user's online status while the Desktop app is in the background as well as automatically setting the user to away/online if the screensaver goes on/off, the user locks/unlocks their computer or shuts down their computer.

**PR's**
Desktop: [MM-7970](https://github.com/mattermost/desktop/pull/993) (this PR)
Webapp: [MM-7970](https://github.com/mattermost/mattermost-webapp/pull/2992)
Server: [MM-14582](https://github.com/mattermost/mattermost-server/pull/11312)

**Issue links**
Jira 1: [MM-7970](https://mattermost.atlassian.net/browse/MM-7970)
Jira 2: [MM-14582](https://mattermost.atlassian.net/browse/MM-14582)
Jira 3: [MM-16153](https://mattermost.atlassian.net/browse/MM-16153)

**Test Cases**
1. With the updated server and webapp running locally, build and run the updated Desktop App.
2. Create a server in the Desktop App pointing at the locally running instance of server/webapp
3. Put the Desktop App in the background and continue to use your computer without focusing on the Desktop App for more than the default 5min of inactivity the Webapp uses to determine if a user is away. The Desktop App should not change to away while actively using the computer.
4. Stop using your computer for more than the default 5min of inactivity the Webapp uses to determine if a user is away. The Desktop App should change to away after about 5mins while not using the computer. (The screensaver timer should be set to more than 5 minutes in order to observe this behaviour)
5. Log into another user on your local install from another machine/device to observe the status of the first user.
6. Manually engage the screensaver or lock the computer running the desktop app. After a short period of time (about a minute at most), the second machine/device should show the first user as away instead of online.
7. Cancel the screensaver or unlock the computer running the desktop app. The user's status icon in the Desktop App should be back to online and after a short period of time (about a minute at most), the second machine/device should show the first user as online again as well.

**Additional Notes**
Without updating user status functionality on the server, this setup basically just manages keeping a user's status `online` or bringing them back `online` if the server had determined they went `away` based on normal user (in)activity. The server still handles setting the user to `away`.

That said, locking the screen, engaging the screensaver or shutting down will force the user's status to change to `away` by setting the `manual` option on the server side to true. Unlocking the screen or cancelling the screensaver will also necessarily force the user's status to change to online by setting the 'manual' option on the server side to true. This means that if a user had manually set themselves to away and then either lock their screen or the screensaver comes on, they will be automatically set back to online when they unlock their screen or the screensaver ends, and they will need to manually set themselves to away again if desired. I'm not sure this can be helped without some additional work on the server-side ... open to suggestions.