### PR TITLE
[MM-13267] Center badge count text and nomention dot

### DIFF
--- a/src/browser/css/components/TabBar.css
+++ b/src/browser/css/components/TabBar.css
@@ -50,17 +50,13 @@
   height: 18px;
   margin-left: 5px;
   margin-top: 5px;
-  border-radius: 50%;
+  padding: 0 5px;
+  border-radius: 9px;
   display: flex;
   justify-content: center;
   align-items: center;
   font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
-  padding-right: 1px;
   font-weight: 600;
-}
-
-.TabBar .TabBar-badge.TabBar-badge-nomention {
-  padding-right: 0px;
 }
 
 .TabBar .TabBar-badge.TabBar-badge-nomention:after {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

**Summary**
This PR adds some CSS tweaks to center mention badge counts and the nomention dot. Also adds some padding to better mimic the badges in the webapp.

**Issue link**
[MM-13267](https://mattermost.atlassian.net/browse/MM-13267)

**Additional Notes**
It is possible that not all combinations of OS's and the Desktop app will work identically for this solution as we are not currently embedding the font we use in the app so the font used on a particular system may not position as well. I have tested on Mac OS 10.14.5 and Windows 10 Pro.