### PR TITLE
Enable context isolation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -355,6 +355,7 @@ function handleAppWillFinishLaunching() {
 function handleAppWebContentsCreated(dc, contents) {
   contents.on('will-attach-webview', (event, webPreferences) => {
     webPreferences.nodeIntegration = false;
+    webPreferences.contextIsolation = true;
   });
   contents.on('will-navigate', (event, navigationUrl) => {
     const parsedUrl = new URL(navigationUrl);

--- a/src/main/mainWindow.js
+++ b/src/main/mainWindow.js
@@ -45,6 +45,7 @@ function createMainWindow(config, options) {
     fullscreen: false,
     webPreferences: {
       nodeIntegration: true,
+      contextIsolation: false,
       webviewTag: true,
     },
   });
@@ -71,6 +72,7 @@ function createMainWindow(config, options) {
 
   mainWindow.webContents.on('will-attach-webview', (event, webPreferences) => {
     webPreferences.nodeIntegration = false;
+    webPreferences.contextIsolation = true;
   });
 
   mainWindow.once('ready-to-show', () => {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
This PR turns on Context Isolation for increased security between the loaded MM Webapp and the users underlying OS.

**Issue link**
https://mattermost.atlassian.net/browse/MM-13609

**Test Cases**
Mac: A local build (`npm run build`) on a Mac is sufficient to test this PR.
Windows: A package needs to be generated locally (`npm run package:windows`) and then installed from the resulting `*setup*.exe` in the `./releases/` folder for notifications to work properly.

Once running:
* make sure you are logged into the same mm server with two different users, one within the running Desktop app.
* with the user not running in the Desktop app, at-mention the user running in the Desktop app in a team/channel other than the one currently open in the Desktop app.

Expected: an OS-level notification popup should show and when clicked, should focus the Desktop app if not already focused and take you to the team/channel the at-mention was posted in.

**Additional Notes**
To verify context isolation is on:
* from the `View` menu, choose `Developer Tools for Current Server` to open up the developer tools panel.
* in the `Console` tab of the resulting panel, click on the dropdown near the top left of the panel that says `top`. You should see a second item called `Electron Isolated Context`, indicating that context isolation is on (see pic below).

![image](https://user-images.githubusercontent.com/3245614/60737517-136e9300-9f29-11e9-8ee3-2a9482f3ee3c.png)
