### PR TITLE
remove jenkins

### DIFF
--- a/builds/pr/Jenkinsfile
+++ b/builds/pr/Jenkinsfile
@@ -1,7 +1,0 @@
-#!/usr/bin/groovy
-
-@Library('shared-pipelines') _
-
-desktop_pr {
-    
-}


### PR DESCRIPTION
removing jenkins, circleci is doing the same for building the PRs

- after we merge this I will remove the jenkins job and set the check to use the one from circleci