### PR TITLE
[MM-17616] v4.2: Update config.json file validation to prevent loosing config settings on upgrade

### DIFF
--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -6,6 +6,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {Modal, Button, FormGroup, FormControl, ControlLabel, HelpBlock} from 'react-bootstrap';
 
+import Utils from '../../utils/util';
+
 export default class NewTeamModal extends React.Component {
   constructor() {
     super();
@@ -53,6 +55,9 @@ export default class NewTeamModal extends React.Component {
     }
     if (!(/^https?:\/\/.*/).test(this.state.teamUrl.trim())) {
       return 'URL should start with http:// or https://.';
+    }
+    if (!Utils.isValidURL(this.state.teamUrl.trim())) {
+      return 'URL is not formatted correctly.';
     }
     return null;
   }

--- a/src/main/Validator.js
+++ b/src/main/Validator.js
@@ -2,6 +2,8 @@
 // See LICENSE.txt for license information.
 import Joi from 'joi';
 
+import Utils from '../utils/util';
+
 const defaultOptions = {
   stripUnknown: true,
 };
@@ -60,12 +62,12 @@ const configDataSchemaV1 = Joi.object({
     }).required(),
   })).default([]),
   showTrayIcon: Joi.boolean().default(false),
-  trayIconTheme: Joi.any().valid('light', 'dark').default('light'),
+  trayIconTheme: Joi.any().allow('').valid('light', 'dark').default('light'),
   minimizeToTray: Joi.boolean().default(false),
   notifications: Joi.object({
     flashWindow: Joi.any().valid(0, 2).default(0),
     bounceIcon: Joi.boolean().default(false),
-    bounceIconType: Joi.any().valid('informational', 'critical').default('informational'),
+    bounceIconType: Joi.any().allow('').valid('informational', 'critical').default('informational'),
   }),
   showUnreadBadge: Joi.boolean().default(true),
   useSpellChecker: Joi.boolean().default(true),
@@ -117,6 +119,22 @@ export function validateV0ConfigData(data) {
 
 // validate v.1 config.json
 export function validateV1ConfigData(data) {
+  if (Array.isArray(data.teams) && data.teams.length) {
+    // first replace possible backslashes with forward slashes
+    let teams = data.teams.map(({name, url}) => {
+      let updatedURL = url;
+      if (updatedURL.includes('\\')) {
+        updatedURL = updatedURL.toLowerCase().replace(/\\/gi, '/');
+      }
+      return {name, url: updatedURL};
+    });
+
+    // next filter out urls that are still invalid so all is not lost
+    teams = teams.filter(({url}) => Utils.isValidURL(url));
+
+    // replace original teams
+    data.teams = teams;
+  }
   return validateAgainstSchema(data, configDataSchemaV1);
 }
 

--- a/test/specs/browser/index_test.js
+++ b/test/specs/browser/index_test.js
@@ -106,7 +106,8 @@ describe('browser/index.html', function desc() {
       waitForVisible('#mattermostView0', 2000, true);
   });
 
-  it('should show error when using incorrect URL', async () => {
+  // validation now prevents incorrect url's from being used
+  it.skip('should show error when using incorrect URL', async () => {
     this.timeout(30000);
     fs.writeFileSync(env.configFilePath, JSON.stringify({
       version: 1,


### PR DESCRIPTION
**Summary**

After analyzing the `config.json` file from a client experiencing the disappearing server problem after updating from 4.2.1 to 4.2.2, it seems that in their `config.json` files, the `trayIconTheme` option was set to a blank string instead of the `light` or `dark` options. The Validator was written to expect either `light` or `dark` and so the validation was failing. Digging deeper into the code, it looks like it might actually be possible to have a blank value for that option (it's really only a Linux option), so the Validator has been updated to allow for that.

While the team URL wasn't actually the problem in this case it is still a possibility, so the validator has also been updated to convert any `\` characters to `/` characters and then further checks each updated URL individually to ensure they are each in fact a validly constructed URL. If any are not valid URLs they are individually filtered out, allowing the other URLs to remain instead of wiping out all configured servers for the sake of one.

In addition, the URL input in the `Add Server` modal now properly validates a URL provided by a user before saving to the `config.json` file.

These changes will need to be applied to the master branch as well as part of the pending security updates.

**Issue link**

https://mattermost.atlassian.net/browse/MM-17616

**Test Cases**

Test URL's:
1. Install fresh copy of Desktop 4.2.1 
2. Add new server using `https://community.mattermost.com\` (include the incorrect backslash) 
3. Verify that the new tab loads successfully 
4. Install Desktop 4.2.2 and launch 
5. Ensure that the server is still present and the URL has been corrected in the UI.

Test `trayIconTheme` option:
1. Install fresh copy of Desktop 4.2.1 
2. Add any new valid server
3. Verify that the new server loads successfully
4. Exit the Desktop application completely
5. Manually edit your `config.json` file to set the value for `trayIconTheme` to a blank string (`"trayIconTheme": ""`)
6. Install Desktop 4.2.2 and launch 
7. Ensure that the server is still present.
