### PR TITLE
[MM 17255] Fix OneLogin and other OAUTH/SAML custom login attempts

### DIFF
--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -117,7 +117,10 @@ export default class MattermostView extends React.Component {
     // So this would be emitted again when reloading a webview
     webview.addEventListener('dom-ready', () => {
       // webview.openDevTools();
-
+      // Remove this once https://github.com/electron/electron/issues/14474 is fixed
+      // - fixes missing cursor bug in electron
+      webview.blur();
+      webview.focus();
       if (!this.state.isContextMenuAdded) {
         contextMenu.setup(webview, {
           useSpellChecker: this.props.useSpellChecker,

--- a/src/main.js
+++ b/src/main.js
@@ -81,7 +81,7 @@ const customLoginRegexPaths = [
   /^\/login\/sso\/saml$/i,
 ];
 let customLoginInProgress = false;
-let customLoginHostname = null;
+let temporaryTrustedLoginHostname = null;
 
 /**
  * Main entry point for the application, ensures that everything initializes in the proper order
@@ -375,7 +375,7 @@ function handleAppWebContentsCreated(dc, contents) {
   contents.on('will-navigate', (event, url) => {
     const parsedUrl = new URL(url);
     const urlIsTrusted = isTrustedURL(parsedUrl);
-    const urlIsCustomLoginPath = parsedUrl.hostname === customLoginHostname;
+    const urlIsCustomLoginPath = parsedUrl.hostname === temporaryTrustedLoginHostname;
 
     // don't prevent custom login attempts (oath, saml)
     if (!urlIsTrusted && !urlIsCustomLoginPath) {
@@ -398,16 +398,16 @@ function handleAppWebContentsCreated(dc, contents) {
 
     if (urlIsTrusted && urlIsCustomLoginPath && !customLoginInProgress && triggerPage.includes('/login')) {
       customLoginInProgress = true;
-    } else if (urlIsTrusted && customLoginInProgress && customLoginHostname) {
+    } else if (urlIsTrusted && customLoginInProgress && temporaryTrustedLoginHostname) {
       customLoginInProgress = false;
-      customLoginHostname = null;
+      temporaryTrustedLoginHostname = null;
     }
   });
   contents.on('will-redirect', (event, url) => {
     const parsedUrl = new URL(url);
     const urlIsTrusted = isTrustedURL(parsedUrl);
-    if (!urlIsTrusted && customLoginInProgress && !customLoginHostname) {
-      customLoginHostname = parsedUrl.hostname;
+    if (!urlIsTrusted && customLoginInProgress && !temporaryTrustedLoginHostname) {
+      temporaryTrustedLoginHostname = parsedUrl.hostname;
     }
   });
   contents.on('new-window', (event) => {


### PR DESCRIPTION
**Summary**
A security update added in [this commit](https://github.com/mattermost/desktop/commit/6b09eec4c51ffb02422ade4c866581aef30d0953) causes custom authentication paths (OAUTH, SAML) to fail as the 3rd party URLs used in the authentication process are not in the list of trusted domains. This fix detects navigation to any trusted custom authentication paths, grabs the domain of the resulting 3rd party authentication site and uses that to temporarily trust any further navigation changes that occur within the 3rd party domain until navigation is returned to MM, at which point the temporary trust is cleared.

Incidentally also adds a workaround for an electron bug preventing the cursor from showing when navigation occurs in the webview, as reported in [this ticket](https://mattermost.atlassian.net/browse/MM-17419).

**Issue link**
https://mattermost.atlassian.net/browse/MM-17255
https://mattermost.atlassian.net/browse/MM-17419

**Test Cases**
OneLogin (SAML)
1. Install v4.3 build of the Desktop app using this PR
2. Add the https://community.mattermost.com server
3. Login using OneLogin option
4. Verify that login succeeds

Google (OAUTH):
1. Install v4.3 build of the Desktop app using this PR
2. Add a server that support Google Authentication (mysql.test.mattermost.com for instance)
3. Login using Google Authentication
4. Verify that login succeeds

Cursor Bug:
1. Install v4.3 build of the Desktop app using this PR
2. Add the https://community.mattermost.com server
3. Click the OneLogin button
4. Verify that the cursor is still visible (prior to this fix, the cursor is consistently missing when navigating to the OneLogin credentials page)

**Additional Notes**

Steps followed during custom login:

1. User lands on the `/login` page to authenticate (process has to start from here)

2. User clicks on a custom login button (Google, Office356, OneLogin etc.):
    - user is directed to a local path that handles initiating OAUTH/SAML login requests (eg. `/login/sso/saml`) – only works through one of these paths (defined in `customLoginRegexPaths`, ln 71)
    - `will-navigate` event listener captures the navigation change
      `urlIsTrusted = true` as the path is local to the server hostname/domain
      `urlIsTrustedExternalLoginPath = false` as the default state
      > Given the above variable states, the navigation request is allowed to proceed
    - `did-start-navigation` event listener captures the navigation change
      `urlIsTrusted = true` as the path is local to the server hostname/domain
      `urlIsCustomLoginPath = true` as the `href` of the button clicked links to one of the pre-defined OAUTH/SAML paths (defined in `customLoginRegexPaths`, ln 71)
      `inProgress = undefined` as the default state
      `previousPage = .../login` as the page just navigated from (custom login can only be started from the /login page)
      > Given the above variable states, `inProgress` is set to true to remember that the user initiated a custom login request

3. The server does a 302 redirect to the 3rd party authentication service:
    - `will-redirect` event listener captures the 302 redirect navigation change
      `urlIsTrusted = false` as the 3rd party authentication service has a different hostname/domain
      `inProgress = true` as set in the last step
      `externalHostname = undefined` as the default/reset state
      `previousPage = .../login` as the page this process started from
      `previousPageIsTrusted = true` as the `.../login` page is trusted
      > Given the above variable states, `externalHostname` is set to the hostname of the 3rd party service

4. Any further navigation within the 3rd party site while the authenticaiton process is ongoing:
    - `will-navigate` event listener captures the navigation change
      `urlIsTrusted = false` as the path is not local to the server hostname/domain
      `urlIsTrustedExternalLoginPath = true` as the url hostname/domain matches what's stored in `externalHostname`
      > Given the above variable states, the navigation request is allowed to proceed
    - `did-start-navigation` event listener captures the navigation change
      `urlIsTrusted = false` as the 3rd party authentication service has a different hostname/domain
      `inProgress = true` as previously set
      `externalHostname = [3rd party hostname/domain]`
      > Given the above variable states, nothing happens

5. Any further 302 redirects within the 3rd party site while the authenticaiton process is ongoing:
    - `will-redirect` event listener captures the 302 redirect navigation change
      `urlIsTrusted = false` as the 3rd party authentication service has a different hostname/domain
      `inProgress = true` as previously set
      `externalHostname = [3rd party hostname/domain]`
      > Given the above variable states, nothing happens

6. Any navigation outside the server and 3rd party login site that gets captured by `will-navigate`:
    - `will-navigate` event listener captures the navigation change
      `urlIsTrusted = false` as the path is not local to the server hostname/domain
      `urlIsTrustedExternalLoginPath = false` as the url hostname/domain does not match what's stored in `externalHostname`
      > Given the above variable states, the navigation request is allowed to proceed, custom login is cancelled and user is redirected back to starting point

6. Once the authentication process is complete on the 3rd party site and redirects back through one of the pre-defined OAUTH/SAML paths (defined in `customLoginRegexPaths`):
    - `will-navigate` event listener could capture the navigation change
      `urlIsTrusted = true` as the path is local to the server hostname/domain
      `urlIsTrustedExternalLoginPath = false` as the path is local to the server hostname/domain
      > Given the above variable states, the navigation request is allowed to proceed
    - `did-start-navigation` event listener captures the navigation change
      `urlIsTrusted = true` as the path is local to the server hostname/domain
      `inProgress = true` as previously set
      `externalHostname = [3rd party hostname/domain]`
      > Given the above variable states, `inProgress` and `externalHostname` are cleared

7. Login is complete and the user moves past the login screen
