### PR TITLE
Bugfix: Initialize `chromeDriverArgs` property before using it

### DIFF
--- a/test/modules/environment.js
+++ b/test/modules/environment.js
@@ -52,6 +52,7 @@ module.exports = {
     const options = {
       path: electronBinaryPath,
       args: [`${path.join(sourceRootDir, 'src')}`, `--data-dir=${userDataDir}`, '--disable-dev-mode'],
+      chromeDriverArgs: [],
 
       // enable this if chromedriver hangs to see logs
       // chromeDriverLogPath: '../chromedriverlog.txt',


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
There was a small bug in the tests from recent pipeline changes that is only apparent on a mac. This PR fixes that bug.

**Issue link**
Piggy backs off of: https://github.com/mattermost/desktop/pull/1029
Related to: https://mattermost.atlassian.net/browse/MM-17955

**Test Cases**
Tests should run on a mac without errors.
