### PR TITLE
[MM-18551] Remove (auto)updater from v4.3

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -17,8 +17,6 @@ import AutoLauncher from './main/AutoLauncher';
 import CriticalErrorHandler from './main/CriticalErrorHandler';
 import upgradeAutoLaunch from './main/autoLaunch';
 
-// disable (auto)updater in v4.3
-// import autoUpdater from './main/autoUpdater';
 import RegistryConfig from './common/config/RegistryConfig';
 import Config from './common/config';
 import CertificateStore from './main/certificateStore';
@@ -195,23 +193,12 @@ function initializeInterCommunicationEventListeners() {
   if (shouldShowTrayIcon()) {
     ipcMain.on('update-unread', handleUpdateUnreadEvent);
   }
-
-  // disable (auto)updater in v4.3
-  // if (!isDev && config.enableAutoUpdater) {
-  //   ipcMain.on('check-for-updates', autoUpdater.checkForUpdates);
-  // }
 }
 
 function initializeMainWindowListeners() {
   mainWindow.on('closed', handleMainWindowClosed);
   mainWindow.on('unresponsive', criticalErrorHandler.windowUnresponsiveHandler.bind(criticalErrorHandler));
   mainWindow.webContents.on('crashed', handleMainWindowWebContentsCrashed);
-  mainWindow.on('ready-to-show', handleMainWindowReadyToShow);
-
-  // disable (auto)updater in v4.3
-  // if (!isDev && config.enableAutoUpdater) {
-  //   mainWindow.once('show', handleMainWindowShow);
-  // }
 }
 
 //
@@ -520,22 +507,6 @@ function initializeAfterAppReady() {
   const trustedURLs = config.teams.map((team) => team.url);
   permissionManager = new PermissionManager(permissionFile, trustedURLs);
   session.defaultSession.setPermissionRequestHandler(permissionRequestHandler(mainWindow, permissionManager));
-
-  // disable (auto)updater in v4.3
-  // if (!isDev && config.enableAutoUpdater) {
-  //   const updaterConfig = autoUpdater.loadConfig();
-  //   autoUpdater.initialize(appState, mainWindow, updaterConfig.isNotifyOnly());
-  //   ipcMain.on('check-for-updates', autoUpdater.checkForUpdates);
-  //   mainWindow.once('show', () => {
-  //     if (autoUpdater.shouldCheckForUpdatesOnStart(appState.updateCheckedDate)) {
-  //       ipcMain.emit('check-for-updates');
-  //     } else {
-  //       setTimeout(() => {
-  //         ipcMain.emit('check-for-updates');
-  //       }, autoUpdater.UPDATER_INTERVAL_IN_MS);
-  //     }
-  //   });
-  // }
 }
 
 //
@@ -698,27 +669,6 @@ function handleMainWindowClosed() {
 function handleMainWindowWebContentsCrashed() {
   throw new Error('webContents \'crashed\' event has been emitted');
 }
-
-function handleMainWindowReadyToShow() {
-
-  // disable (auto)updater in v4.3
-  // if (!isDev) {
-  //   autoUpdater.checkForUpdates();
-  // }
-}
-
-// disable (auto)updater in v4.3
-// function handleMainWindowShow() {
-//   if (!isDev) {
-//     if (autoUpdater.shouldCheckForUpdatesOnStart(appState.updateCheckedDate)) {
-//       ipcMain.emit('check-for-updates');
-//     } else {
-//       setTimeout(() => {
-//         ipcMain.emit('check-for-updates');
-//       }, autoUpdater.UPDATER_INTERVAL_IN_MS);
-//     }
-//   }
-// }
 
 //
 // helper functions

--- a/src/main.js
+++ b/src/main.js
@@ -16,7 +16,9 @@ import {protocols} from '../electron-builder.json';
 import AutoLauncher from './main/AutoLauncher';
 import CriticalErrorHandler from './main/CriticalErrorHandler';
 import upgradeAutoLaunch from './main/autoLaunch';
-import autoUpdater from './main/autoUpdater';
+
+// disable (auto)updater in v4.3
+// import autoUpdater from './main/autoUpdater';
 import RegistryConfig from './common/config/RegistryConfig';
 import Config from './common/config';
 import CertificateStore from './main/certificateStore';
@@ -193,9 +195,11 @@ function initializeInterCommunicationEventListeners() {
   if (shouldShowTrayIcon()) {
     ipcMain.on('update-unread', handleUpdateUnreadEvent);
   }
-  if (!isDev && config.enableAutoUpdater) {
-    ipcMain.on('check-for-updates', autoUpdater.checkForUpdates);
-  }
+
+  // disable (auto)updater in v4.3
+  // if (!isDev && config.enableAutoUpdater) {
+  //   ipcMain.on('check-for-updates', autoUpdater.checkForUpdates);
+  // }
 }
 
 function initializeMainWindowListeners() {
@@ -203,9 +207,11 @@ function initializeMainWindowListeners() {
   mainWindow.on('unresponsive', criticalErrorHandler.windowUnresponsiveHandler.bind(criticalErrorHandler));
   mainWindow.webContents.on('crashed', handleMainWindowWebContentsCrashed);
   mainWindow.on('ready-to-show', handleMainWindowReadyToShow);
-  if (!isDev && config.enableAutoUpdater) {
-    mainWindow.once('show', handleMainWindowShow);
-  }
+
+  // disable (auto)updater in v4.3
+  // if (!isDev && config.enableAutoUpdater) {
+  //   mainWindow.once('show', handleMainWindowShow);
+  // }
 }
 
 //
@@ -515,20 +521,21 @@ function initializeAfterAppReady() {
   permissionManager = new PermissionManager(permissionFile, trustedURLs);
   session.defaultSession.setPermissionRequestHandler(permissionRequestHandler(mainWindow, permissionManager));
 
-  if (!isDev && config.enableAutoUpdater) {
-    const updaterConfig = autoUpdater.loadConfig();
-    autoUpdater.initialize(appState, mainWindow, updaterConfig.isNotifyOnly());
-    ipcMain.on('check-for-updates', autoUpdater.checkForUpdates);
-    mainWindow.once('show', () => {
-      if (autoUpdater.shouldCheckForUpdatesOnStart(appState.updateCheckedDate)) {
-        ipcMain.emit('check-for-updates');
-      } else {
-        setTimeout(() => {
-          ipcMain.emit('check-for-updates');
-        }, autoUpdater.UPDATER_INTERVAL_IN_MS);
-      }
-    });
-  }
+  // disable (auto)updater in v4.3
+  // if (!isDev && config.enableAutoUpdater) {
+  //   const updaterConfig = autoUpdater.loadConfig();
+  //   autoUpdater.initialize(appState, mainWindow, updaterConfig.isNotifyOnly());
+  //   ipcMain.on('check-for-updates', autoUpdater.checkForUpdates);
+  //   mainWindow.once('show', () => {
+  //     if (autoUpdater.shouldCheckForUpdatesOnStart(appState.updateCheckedDate)) {
+  //       ipcMain.emit('check-for-updates');
+  //     } else {
+  //       setTimeout(() => {
+  //         ipcMain.emit('check-for-updates');
+  //       }, autoUpdater.UPDATER_INTERVAL_IN_MS);
+  //     }
+  //   });
+  // }
 }
 
 //
@@ -693,22 +700,25 @@ function handleMainWindowWebContentsCrashed() {
 }
 
 function handleMainWindowReadyToShow() {
-  if (!isDev) {
-    autoUpdater.checkForUpdates();
-  }
+
+  // disable (auto)updater in v4.3
+  // if (!isDev) {
+  //   autoUpdater.checkForUpdates();
+  // }
 }
 
-function handleMainWindowShow() {
-  if (!isDev) {
-    if (autoUpdater.shouldCheckForUpdatesOnStart(appState.updateCheckedDate)) {
-      ipcMain.emit('check-for-updates');
-    } else {
-      setTimeout(() => {
-        ipcMain.emit('check-for-updates');
-      }, autoUpdater.UPDATER_INTERVAL_IN_MS);
-    }
-  }
-}
+// disable (auto)updater in v4.3
+// function handleMainWindowShow() {
+//   if (!isDev) {
+//     if (autoUpdater.shouldCheckForUpdatesOnStart(appState.updateCheckedDate)) {
+//       ipcMain.emit('check-for-updates');
+//     } else {
+//       setTimeout(() => {
+//         ipcMain.emit('check-for-updates');
+//       }, autoUpdater.UPDATER_INTERVAL_IN_MS);
+//     }
+//   }
+// }
 
 //
 // helper functions

--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -237,16 +237,6 @@ function createTemplate(mainWindow, config, isDev) {
     enabled: false,
   });
 
-  // disable (auto)updater in v4.3
-  // if (config.enableAutoUpdater) {
-  //   submenu.push({
-  //     label: 'Check for Updates...',
-  //     click() {
-  //       ipcMain.emit('check-for-updates', true);
-  //     },
-  //   });
-  // }
-
   template.push({label: '&Help', submenu});
   return template;
 }

--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -3,7 +3,7 @@
 // See LICENSE.txt for license information.
 'use strict';
 
-import {app, dialog, ipcMain, Menu, shell} from 'electron';
+import {app, dialog, Menu, shell} from 'electron';
 
 function createTemplate(mainWindow, config, isDev) {
   const settingsURL = isDev ? 'http://localhost:8080/browser/settings.html' : `file://${app.getAppPath()}/browser/settings.html`;
@@ -236,14 +236,17 @@ function createTemplate(mainWindow, config, isDev) {
     label: `Version ${app.getVersion()}`,
     enabled: false,
   });
-  if (config.enableAutoUpdater) {
-    submenu.push({
-      label: 'Check for Updates...',
-      click() {
-        ipcMain.emit('check-for-updates', true);
-      },
-    });
-  }
+
+  // disable (auto)updater in v4.3
+  // if (config.enableAutoUpdater) {
+  //   submenu.push({
+  //     label: 'Check for Updates...',
+  //     click() {
+  //       ipcMain.emit('check-for-updates', true);
+  //     },
+  //   });
+  // }
+
   template.push({label: '&Help', submenu});
   return template;
 }


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
This PR comments out the code that was added to implement (auto)updating on v4.3 to remove it from the v4.3 release. Will be added back in in a future release.

**Issue link**
https://mattermost.atlassian.net/browse/MM-18551
