### PR TITLE
[MM-18750] Fixed a typo that was causing tray icon to constantly show up

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -494,7 +494,7 @@ function initializeAfterAppReady() {
   // start monitoring user activity (needs to be started after the app is ready)
   userActivityMonitor.startMonitoring();
 
-  if (shouldShowTrayIcon) {
+  if (shouldShowTrayIcon()) {
     // set up tray icon
     trayIcon = new Tray(trayImages.normal);
     if (process.platform === 'darwin') {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
The call to `shouldShowTrayIcon()` was not actually a call at all, it was just checking if the function existed. As a result, the tray icon always showed up. This fixes that typo.

**Issue link**
https://mattermost.atlassian.net/browse/MM-18750

**Test Cases**
1. Open the desktop app on Mac
2. In settings, turn off 'Show Mattermost icon in the menu bar'
3. Restart the app
4. See that the menu icon no longer appears.