### PR TITLE
[MM-18906] remove GPU acceleration option from GPO settings

### DIFF
--- a/resources/windows/gpo/en-US/mattermost.adml
+++ b/resources/windows/gpo/en-US/mattermost.adml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<policyDefinitionResources revision="0.1" schemaVersion="1.0" >
+<policyDefinitionResources revision="0.1" schemaVersion="1.0">
 	<displayName/>
 	<description/>
 	<resources >
@@ -14,8 +14,6 @@
 If this policy is disabled, the Server Management section is hidden in the app settings and only servers defined by Group Policy can be used.</string>
 			<string id="DefaultServerList">DefaultServerList</string>
 			<string id="DefaultServerListDescription">If this policy is enabled, you can define one or more Mattermost servers that will be pre-configured for users when they launch the app.</string>
-			<string id="EnableGpuAcceleration">EnableGpuAcceleration</string>
-			<string id="EnableGpuAccelerationDescription">If this policy is enabled, the Mattermost Desktop Application will use the GPU for hardware acceleration.</string>
 		</stringTable>
 		<presentationTable>
 			<presentation id="DefaultServerList">

--- a/resources/windows/gpo/mattermost.admx
+++ b/resources/windows/gpo/mattermost.admx
@@ -40,15 +40,5 @@
 				<list id="DefaultServerList" key="Software\Policies\Mattermost\DefaultServerList" additive="true" explicitValue="true" />
 			</elements>
 		</policy>
-		<policy name="EnableGpuAcceleration" class="Machine" displayName="$(string.EnableGpuAcceleration)" explainText="$(string.EnableGpuAccelerationDescription)" key="Software\Policies\Mattermost" valueName="EnableGpuAcceleration">
-			<parentCategory ref="mattermost"/>
-			<supportedOn ref="RequiresMattermost43"/>
-			<enabledValue>
-				<decimal value="1"/>
-			</enabledValue>
-			<disabledValue>
-				<decimal value="0"/>
-			</disabledValue>
-		</policy>
 	</policies>
 </policyDefinitions>


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**

Remove the option to switch GPU Acceleration as a GPO directive. Note that it can still be accessed from the settings page.

**Issue link**

[MM-18906](https://mattermost.atlassian.net/browse/MM-18906)

**Test Cases**

1. Add GPO configuration files to a compatible Windows install (eg. Windows 10 Pro) ala https://docs.mattermost.com/install/desktop-msi-gpo.html#download-group-policy-and-msi-installer-files (It is not necessary to install the Desktop app to verify)
2. Run gpedit from the Start menu's search box (https://docs.mattermost.com/install/desktop-msi-gpo.html#configure-mattermost-using-group-policy-settings)
3. Ensure that there isn't an option for configuring the GPU setting for the Desktop app

**Additional Notes**
