### PR TITLE
MM-16373: Change `help` menu shortcut on Windows

### DIFF
--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -237,7 +237,7 @@ function createTemplate(mainWindow, config, isDev) {
     enabled: false,
   });
 
-  template.push({label: '&Help', submenu});
+  template.push({label: 'Hel&p', submenu});
   return template;
 }
 


### PR DESCRIPTION
**Summary**
The Desktop app menu has the `History` and `Help` menu items sharing the same shortcut letter. This PR corrects that by assigning the `p` as the shortcut letter for the `Help` menu.

**Issue link**
https://mattermost.atlassian.net/browse/MM-16373

**Test Cases**
1. Install and run the v4.3.0 Windows desktop app with this fix applied
2. Press and release the ALT key.

Expected: The `Help` menu should have the `p` character underlined and subsequently pressing the `p` key should open the `Help` menu.
