### PR TITLE
[MM-18936] Guard against bad server url so app doesn't crash

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -764,12 +764,17 @@ function handleMainWindowWebContentsCrashed() {
 //
 
 function isTrustedURL(url) {
+  if (!url) {
+    return false;
+  }
+
   let parsedUrl = url;
   if (typeof url === 'string') {
-    parsedUrl = new URL(url);
-  }
-  if (!parsedUrl) {
-    return false;
+    try {
+      parsedUrl = new URL(url);
+    } catch (e) {
+      return false;
+    }
   }
 
   const trustedURLs = config.teams.map((team) => new URL(team.url));

--- a/src/main.js
+++ b/src/main.js
@@ -768,6 +768,10 @@ function isTrustedURL(url) {
   if (typeof url === 'string') {
     parsedUrl = new URL(url);
   }
+  if (!parsedUrl) {
+    return false;
+  }
+
   const trustedURLs = config.teams.map((team) => new URL(team.url));
 
   for (const trustedURL of trustedURLs) {


### PR DESCRIPTION
**Summary**

This PR fixes an issue where entering `https://google.com` as a server url causes the desktop app to crash.

**Issue link**

https://mattermost.atlassian.net/browse/MM-18936

**Additional Notes**

Subsequent crashes occur upon restart, unless you edit the `AppData/Mattermost/config.json` file manually.