### PR TITLE
[MM18929] Open 3rd party auth-site links in browser during custom login.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -833,7 +833,7 @@ function getURLPrimaryDomain(url) {
 
   const domainSegments = parsedURL.hostname.split('.').slice(-2); // eslint-disable-line no-magic-numbers
 
-  if (domainSegments.length >= 2) {
+  if (domainSegments.length === 2) {
     return domainSegments.join('.');
   }
   return null;


### PR DESCRIPTION
**Summary**
Recent updates for security enhancements and subsequent fixes to 3rd party authentication (oauth, saml) led to links on 3rd party login pages not working.

This PR adds the ability to open 3rd party links that share the same primary domain in a browser window. It also adds some additional validation and cleanup to URL parsing used in several locations.

**Issue link**
https://mattermost.atlassian.net/browse/MM-18936

**Test Cases**

1. Use the Desktop app to access `https://community-daily.mattermost.com`.
2. Click on the OneLogin button from the MM login screen
3. On the resulting OneLogin page, click on links in the footer.

Expected: Links should all open in a browser window.