### PR TITLE
MM-19096 – simplify custom login process

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -761,10 +761,10 @@ function isTrustedURL(url) {
   const teamURLs = config.teams.reduce((urls, team) => {
     const parsedTeamURL = parseURL(team.url);
     if (parsedTeamURL) {
-      return urls.push(parsedTeamURL);
+      return urls.concat(parsedTeamURL);
     }
     return urls;
-  });
+  }, []);
   for (const teamURL of teamURLs) {
     if (parsedURL.origin === teamURL.origin) {
       return true;

--- a/src/main.js
+++ b/src/main.js
@@ -382,9 +382,8 @@ function handleAppWebContentsCreated(dc, contents) {
   contents.on('will-navigate', (event, url) => {
     const contentID = event.sender.id;
     const parsedURL = parseURL(url);
-    const urlIsTrusted = isTrustedURL(parsedURL);
 
-    if (urlIsTrusted) {
+    if (isTrustedURL(parsedURL)) {
       return;
     }
     if (customLogins[contentID].inProgress) {
@@ -402,8 +401,8 @@ function handleAppWebContentsCreated(dc, contents) {
   contents.on('did-start-navigation', (event, url) => {
     const contentID = event.sender.id;
     const parsedURL = parseURL(url);
-    const urlIsTrusted = isTrustedURL(parsedURL);
-    if (!urlIsTrusted) {
+
+    if (!isTrustedURL(parsedURL)) {
       return;
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -406,9 +406,7 @@ function handleAppWebContentsCreated(dc, contents) {
       return;
     }
 
-    const urlIsCustomLoginPath = isCustomLoginURL(parsedURL);
-    const previousPage = parseURL(event.sender.history[event.sender.history.length - 1]);
-    if (urlIsCustomLoginPath && previousPage && previousPage.pathname.endsWith('/login')) {
+    if (isCustomLoginURL(parsedURL)) {
       customLogins[contentID].inProgress = true;
     } else if (customLogins[contentID].inProgress) {
       customLogins[contentID].inProgress = false;

--- a/src/main.js
+++ b/src/main.js
@@ -372,8 +372,6 @@ function handleAppWebContentsCreated(dc, contents) {
   // initialize custom login tracking
   customLogins[contents.id] = {
     inProgress: false,
-    startingURL: null,
-    externalHostname: null,
   };
 
   contents.on('will-attach-webview', (event, webPreferences) => {
@@ -383,60 +381,31 @@ function handleAppWebContentsCreated(dc, contents) {
 
   contents.on('will-navigate', (event, url) => {
     const contentID = event.sender.id;
-    const parsedUrl = new URL(url);
-    const urlIsTrusted = isTrustedURL(parsedUrl);
-    const urlIsTrustedExternalLoginPath = parsedUrl.hostname === customLogins[contentID].externalHostname;
+    const parsedURL = parseURL(url);
+    const urlIsTrusted = isTrustedURL(parsedURL);
 
     // don't prevent custom login attempts (oath, saml)
-    if (!urlIsTrusted && !urlIsTrustedExternalLoginPath) {
+    if (!urlIsTrusted && !customLogins[contentID].inProgress) {
       event.preventDefault();
-
-      // reset custom login if in progress
-      if (customLogins[contentID].inProgress) {
-        customLogins[contentID].inProgress = false;
-        customLogins[contentID].externalHostname = null;
-
-        // redirect to starting url if set
-        if (customLogins[contentID].startingURL) {
-          event.sender.loadURL(customLogins[contentID].startingURL);
-          customLogins[contentID].startingURL = null;
-        }
-      }
     }
   });
 
   // handle custom login requests (oath, saml):
-  // 1. are we navigating to a supported local custom login path from the `/login` page? (did-start-navigation listener)
-  //    - indicate custom login is in progress and store starting point for possible reset
-  // 2. is a custom login in progress but we don't have the 3rd party hostname yet? (will-redirect listener)
-  //    - store 3rd party hostname to trust subsequent navigation changes within that hostname
-  // 3. are we finished with the custom login process? (did-start-navigation listener)
-  //    - indicate custom login is NOT in progress and clear any stored 3rd party hostname's
+  // 1. are we navigating to a supported local custom login path from the `/login` page?
+  //    - indicate custom login is in progress
+  // 2. are we finished with the custom login process?
+  //    - indicate custom login is NOT in progress
   contents.on('did-start-navigation', (event, url) => {
     const contentID = event.sender.id;
-    const parsedUrl = new URL(url);
-    const urlIsTrusted = isTrustedURL(parsedUrl);
-    const urlIsCustomLoginPath = isCustomLoginURL(parsedUrl);
+    const parsedURL = parseURL(url);
+    const urlIsTrusted = isTrustedURL(parsedURL);
+    const urlIsCustomLoginPath = isCustomLoginURL(parsedURL);
     const previousPage = event.sender.history[event.sender.history.length - 1];
 
     if (urlIsTrusted && urlIsCustomLoginPath && !customLogins[contentID].inProgress && previousPage.endsWith('/login')) {
       customLogins[contentID].inProgress = true;
-      customLogins[contentID].startingURL = event.sender.getURL();
-    } else if (urlIsTrusted && customLogins[contentID].inProgress && customLogins[contentID].externalHostname) {
+    } else if (urlIsTrusted && customLogins[contentID].inProgress) {
       customLogins[contentID].inProgress = false;
-      customLogins[contentID].externalHostname = null;
-    }
-  });
-
-  contents.on('will-redirect', (event, url) => {
-    const contentID = event.sender.id;
-    const parsedUrl = new URL(url);
-    const urlIsTrusted = isTrustedURL(parsedUrl);
-    const previousPage = event.sender.history[event.sender.history.length - 1];
-    const previousPageIsTrusted = isTrustedURL(previousPage);
-
-    if (!urlIsTrusted && previousPageIsTrusted && customLogins[contentID].inProgress && !customLogins[contentID].externalHostname) {
-      customLogins[contentID].externalHostname = parsedUrl.hostname;
     }
   });
 
@@ -763,40 +732,44 @@ function handleMainWindowWebContentsCrashed() {
 // helper functions
 //
 
-function isTrustedURL(url) {
+function parseURL(url) {
   if (!url) {
-    return false;
+    return null;
   }
-
-  let parsedUrl = url;
+  let parsedURL = url;
   if (typeof url === 'string') {
     try {
-      parsedUrl = new URL(url);
+      parsedURL = new URL(url);
     } catch (e) {
-      return false;
+      return null;
     }
   }
+  return parsedURL;
+}
 
-  const trustedURLs = config.teams.map((team) => new URL(team.url));
-
+function isTrustedURL(url) {
+  const parsedURL = parseURL(url);
+  if (!parsedURL) {
+    return false;
+  }
+  const trustedURLs = config.teams.map((team) => parseURL(team.url));
   for (const trustedURL of trustedURLs) {
-    if (parsedUrl.origin === trustedURL.origin) {
+    if (parsedURL.origin === trustedURL.origin) {
       return true;
     }
   }
-
   return false;
 }
 
 function isCustomLoginURL(url) {
-  if (!isTrustedURL(url)) {
+  const parsedURL = parseURL(url);
+  if (!parsedURL) {
     return false;
   }
-  let parsedUrl = url;
-  if (typeof url === 'string') {
-    parsedUrl = new URL(url);
+  if (!isTrustedURL(parsedURL)) {
+    return false;
   }
-  const urlPath = parsedUrl.pathname;
+  const urlPath = parsedURL.pathname;
   for (const regexPath of customLoginRegexPaths) {
     if (urlPath.match(regexPath)) {
       return true;


### PR DESCRIPTION
**Summary**
The new functionality added to support 3rd party custom login mechanisms (SAML, OAUTH) following a security enhancement attempted to determine the 3rd party hostname and temporarily trust it for the duration of the login request. This temporary trust created some challenges during testing and it was subsequently decided that this aspect of the feature was too brittle given we ultimately can't control what an IDP does on their end to validate an authentication request, nor can we control the kinds of linkable resources an end user might be presented with during the login process.

This PR removes the temporary trust aspect of the feature and solely relies on appropriately flagging a custom login is in progress, during which any navigation that needs to occur until the user is returned to MM will be allowed to occur. Once the login process completes, the flag is reset and normal navigation handling resumes.

As a by-product of the change, this PR now allows links on IDP pages to function as intended, fixing the issue [reported here](https://mattermost.atlassian.net/browse/MM-18936).

**Issue links**
Primary: https://mattermost.atlassian.net/browse/MM-19096
Secondary: https://mattermost.atlassian.net/browse/MM-18936
Original feature: https://mattermost.atlassian.net/browse/MM-17255