### PR TITLE
MM-19095 – Stop cursor bug fix from running in inactive tabs

### DIFF
--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -145,10 +145,14 @@ export default class MattermostView extends React.Component {
     // So this would be emitted again when reloading a webview
     webview.addEventListener('dom-ready', () => {
       // webview.openDevTools();
+
       // Remove this once https://github.com/electron/electron/issues/14474 is fixed
       // - fixes missing cursor bug in electron
-      webview.blur();
-      webview.focus();
+      // - only apply this focus fix if the current view is active
+      if (this.props.active) {
+        webview.blur();
+        webview.focus();
+      }
       if (!this.state.isContextMenuAdded) {
         contextMenu.setup(webview, {
           useSpellChecker: this.props.useSpellChecker,


### PR DESCRIPTION
**Summary**
A fix applied in [this PR](https://github.com/mattermost/desktop/pull/1025) to resolve an Electron cursor/focus bug has been messing up focus for the currently active tab when a server defined in an inactive tab is not able to load (offline). The problem is that the desktop app keeps trying to load the offline server and with each attempt, the cursor/focus fix is run again stealing focus from the active tab.

This PR adds a check to make sure a tab is active before running the fix.

**Issue link**
https://mattermost.atlassian.net/browse/MM-19095