### PR TITLE
[MM-19208] Allow hidden tabs to still receive unread/mention updates

### DIFF
--- a/src/browser/css/components/MattermostView.css
+++ b/src/browser/css/components/MattermostView.css
@@ -19,9 +19,8 @@
 }
 
 .mattermostView-hidden webview {
-  flex: 0 1;
-  width: 0px;
-  height: 0px;
+  visibility: hidden;
+  z-index: -1;
 }
 
 .mattermostView-loadingScreen {


### PR DESCRIPTION
**Summary**
Desktop v4.3-rc2 was not updating mention/unread status in inactive tabs - seems Chrome related. This PR changes the mechanism for showing/hiding tabs to allow them to continue updating while inactive.

More details: it seems that setting the width/height on inactive tabs' `webview` to 0px/0px is causing Chrome to stop updating them, preventing the scraping mechanism from updating the count on the tabs.

**Issue link**
https://mattermost.atlassian.net/browse/MM-19208