### PR TITLE
[MM-19187] Focus the webview on server selection

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -187,6 +187,7 @@ export default class MainPage extends React.Component {
     ipcRenderer.send('update-title', {
       title: webview.getTitle(),
     });
+    webview.focus();
     this.handleOnTeamFocused(newKey);
   }
 


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
The `BrowserWindow` did not have focus after the server was selected. This PR sets focus to the webView after the server is selected.

**Issue link**
https://mattermost.atlassian.net/browse/MM-19187