### PR TITLE
include team bar in mention counts

### DIFF
--- a/src/browser/webview/mattermost.js
+++ b/src/browser/webview/mattermost.js
@@ -127,7 +127,7 @@ function getUnreadCount() {
   }
 
   // mentionCount in sidebar
-  const elem = document.querySelectorAll('#sidebar-left .badge');
+  const elem = document.querySelectorAll('#sidebar-left .badge, #channel_view .badge');
   let mentionCount = 0;
   for (let i = 0; i < elem.length; i++) {
     if (isElementVisible(elem[i]) && !hasClass(elem[i], 'badge-notify')) {


### PR DESCRIPTION
**Summary**
Team sidebar was not being considered in determining the total number of mentions in the tab for a server. This PR (re)adds the sidebar to the calculation.

**Issue link**
https://mattermost.atlassian.net/browse/MM-19207
