### PR TITLE
[MM-19051] [MM-14180] [MM-19330] Release helpers, push to github and aws, fix weird name on msi at UAC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,10 +187,10 @@ jobs:
       - win_make:
           operation: "build"
       - run: mkdir -p ./dist/win-release
-      - run: cp -r release/*.exe ./dist/win-release
+      #- run: cp -r release/*.exe ./dist/win-release
       - run: cp -r release/*.zip ./dist/win-release
       - run: cp -r release/*.msi ./dist/win-release
-      - run: cp -r release/*.blockmap ./dist/win-release
+      #- run: cp -r release/*.blockmap ./dist/win-release
 
       - persist_to_workspace:
           root: ./dist/
@@ -230,8 +230,7 @@ jobs:
           at: ./dist
       - aws-s3/copy:
           from: ./dist/
-          #to: s3://releases.mattermost.com/desktop/$(jq -r .version package.json)/
-          to: s3://releasetest.mattermost.com/desktop/$(jq -r .version package.json)/
+          to: s3://releases.mattermost.com/desktop/$(jq -r .version package.json)/
           arguments: --acl public-read --cache-control "no-cache" --recursive
   upload_to_github:
     executor: github
@@ -249,10 +248,12 @@ jobs:
           command: |
             go get github.com/tcnksm/ghr
             VERSION=$(jq -r .version package.json)
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} --draft \
+            RELEASE_TITLE="${VERSION} ($(date -u "+%Y-%m-%d"))"
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -draft \
               --body="$(./scripts/generate_release_markdown.sh $VERSION)" \
-              -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} \
-              $( [[ $VERSION =~ "-rc" ]] && printf %s "-prerelease") ./ghr-dist
+              --name="${RELEASE_TITLE}" $( [[ $VERSION =~ "-rc" ]] && printf %s "-prerelease") \
+              -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} \
+              -delete ${VERSION} ./ghr-dist
 
 workflows:
   version: 2
@@ -269,7 +270,6 @@ workflows:
             branches:
               ignore:
                 - /^release-\d+\.\d+\.\d+?(-rc.*)?/
-                - release-helpers # delete me before merging
       - build-mac-no-dmg:
           requires:
             - check
@@ -277,7 +277,6 @@ workflows:
             branches:
               ignore:
                 - /^release-\d+\.\d+(\.\d+)?(-rc.*)?/
-                - release-helpers # delete me before merging
       - msi_installer:
           requires:
             - check
@@ -289,7 +288,6 @@ workflows:
                 # release-XX.YY.ZZ
                 # release-XX.YY.ZZ-rc-something
                 - /^release-\d+\.\d+\.\d+?(-rc.*)?/
-                - release-helpers # delete me before merging
       - mac_installer:
           requires:
             - check
@@ -298,7 +296,6 @@ workflows:
             branches:
               only:
                 - /^release-\d+\.\d+\.\d+?(-rc.*)?/
-                - release-helpers # delete me before merging
       - store_artifacts:
           # for master/PR builds
           requires:
@@ -320,7 +317,6 @@ workflows:
             tags:
               only:
                 - /^v\d+\.\d+\.\d+?$/
-                - release-helpers # delete me before merging
       - upload_to_github:
           requires:
             - msi_installer
@@ -331,5 +327,3 @@ workflows:
             branches:
               only:
                 - /^release-\d+\.\d+\.\d+?(-rc.*)?/
-                - release-helpers # delete me before merging
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,8 @@
 version: 2.1
 orbs:
   win: circleci/windows@1.0.0
+  aws-s3: circleci/aws-s3@1.0.11
+
 executors:
   wine-chrome:
     working_directory: ~/mattermost-desktop
@@ -16,6 +18,14 @@ executors:
     working_directory: ~/mattermost-desktop
     macos:
       xcode: "10.3.0"
+  aws:
+    working_directory: ~/mattermost-desktop
+    docker:
+      - image: 'circleci/python:2.7'
+  github:
+    working_directory: ~/mattermost-desktop
+    docker:
+      - image: circleci/golang:1.12
 commands:
   update_image:
     description: "Update base image"
@@ -212,6 +222,38 @@ jobs:
           path: ./dist
           destination: packages
 
+  upload_to_s3:
+    executor: aws
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./dist
+      - aws-s3/copy:
+          from: ./dist/
+          #to: s3://releases.mattermost.com/desktop/$(jq -r .version package.json)/
+          to: s3://releasetest.mattermost.com/desktop/$(jq -r .version package.json)/
+          arguments: --acl public-read --cache-control "no-cache" --recursive
+  upload_to_github:
+    executor: github
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./dist
+      - run:
+          name: "Setup files for ghr"
+          command: |
+            mkdir -p ./ghr-dist
+            cp ./dist/{macos-release,win-release,linux}/* ./ghr-dist
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            go get github.com/tcnksm/ghr
+            VERSION=$(jq -r .version package.json)
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} --draft \
+              --body="$(./scripts/generate_release_markdown.sh $VERSION)" \
+              -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} \
+              $( [[ $VERSION =~ "-rc" ]] && printf %s "-prerelease") ./ghr-dist
+
 workflows:
   version: 2
   build_and_test:
@@ -227,6 +269,7 @@ workflows:
             branches:
               ignore:
                 - /^release-\d+\.\d+\.\d+?(-rc.*)?/
+                - release-helpers # delete me before merging
       - build-mac-no-dmg:
           requires:
             - check
@@ -234,6 +277,7 @@ workflows:
             branches:
               ignore:
                 - /^release-\d+\.\d+(\.\d+)?(-rc.*)?/
+                - release-helpers # delete me before merging
       - msi_installer:
           requires:
             - check
@@ -245,7 +289,7 @@ workflows:
                 # release-XX.YY.ZZ
                 # release-XX.YY.ZZ-rc-something
                 - /^release-\d+\.\d+\.\d+?(-rc.*)?/
-
+                - release-helpers # delete me before merging
       - mac_installer:
           requires:
             - check
@@ -254,6 +298,7 @@ workflows:
             branches:
               only:
                 - /^release-\d+\.\d+\.\d+?(-rc.*)?/
+                - release-helpers # delete me before merging
       - store_artifacts:
           # for master/PR builds
           requires:
@@ -264,13 +309,27 @@ workflows:
             branches:
               ignore:
                 - /^release-\d+\.\d+\.\d+?(-rc.*)?/
-      - store_artifacts:
-          # for release and rc builds
+      - upload_to_s3:
+          # for release builds
           requires:
             - msi_installer
             - mac_installer
             - build-linux
+          context: mattermost-ci-s3
+          filters:
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+?$/
+                - release-helpers # delete me before merging
+      - upload_to_github:
+          requires:
+            - msi_installer
+            - mac_installer
+            - build-linux
+          context: matterbuild-github-token
           filters:
             branches:
               only:
                 - /^release-\d+\.\d+\.\d+?(-rc.*)?/
+                - release-helpers # delete me before merging
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,6 +288,7 @@ workflows:
                 # release-XX.YY.ZZ
                 # release-XX.YY.ZZ-rc-something
                 - /^release-\d+\.\d+\.\d+?(-rc.*)?/
+                - release-helpers # remove me
       - mac_installer:
           requires:
             - check
@@ -296,6 +297,7 @@ workflows:
             branches:
               only:
                 - /^release-\d+\.\d+\.\d+?(-rc.*)?/
+                - release-helpers # remove-me
       - store_artifacts:
           # for master/PR builds
           requires:
@@ -317,6 +319,8 @@ workflows:
             tags:
               only:
                 - /^v\d+\.\d+\.\d+?$/
+                - release-helpers # remove me
+
       - upload_to_github:
           requires:
             - msi_installer
@@ -327,3 +331,4 @@ workflows:
             branches:
               only:
                 - /^release-\d+\.\d+\.\d+?(-rc.*)?/
+                - release-helpers # remove me

--- a/scripts/Makefile.ps1
+++ b/scripts/Makefile.ps1
@@ -405,22 +405,22 @@ function Run-BuildMsi {
         # Dual signing is not supported on msi files. Is it recommended to sign with 256 hash.
         # src.: https://security.stackexchange.com/a/124685/84134
         # src.: https://social.msdn.microsoft.com/Forums/windowsdesktop/en-us/d4b70ecd-a883-4289-8047-cc9cde28b492#0b3e3b80-6b3b-463f-ac1e-1bf0dc831952
-        signtool.exe sign /f "resources\windows\certificate\mattermost-desktop-windows.pfx" /p "$env:COM_MATTERMOST_MAKEFILE_CERTIFICATE_PRIVATE_KEY_ENCRYPTED" /tr "http://timestamp.digicert.com" /fd sha256 /td sha256 "release\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x86.msi"
+        signtool.exe sign /f "resources\windows\certificate\mattermost-desktop-windows.pfx" /p "$env:COM_MATTERMOST_MAKEFILE_CERTIFICATE_PRIVATE_KEY_ENCRYPTED" /tr "http://timestamp.digicert.com" /fd sha256 /td sha256 "release\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x86.msi" /d "mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x86.msi"
 
         Print-Info "Signing mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x64.msi (waiting for 15 seconds)..."
         Start-Sleep -s 15
-        signtool.exe sign /f "resources\windows\certificate\mattermost-desktop-windows.pfx" /p "$env:COM_MATTERMOST_MAKEFILE_CERTIFICATE_PRIVATE_KEY_ENCRYPTED" /tr "http://timestamp.digicert.com" /fd sha256 /td sha256 "release\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x64.msi"
+        signtool.exe sign /f "resources\windows\certificate\mattermost-desktop-windows.pfx" /p "$env:COM_MATTERMOST_MAKEFILE_CERTIFICATE_PRIVATE_KEY_ENCRYPTED" /tr "http://timestamp.digicert.com" /fd sha256 /td sha256 "release\mattermost-desktop-\$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x64.msi" /d "mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x64.msi"
     } elseif (Test-Path 'env:PFX') {
         Print-Info "Signing mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x86.msi (waiting for 15 seconds)..."
         Start-Sleep -s 15
         # Dual signing is not supported on msi files. Is it recommended to sign with 256 hash.
         # src.: https://security.stackexchange.com/a/124685/84134
         # src.: https://social.msdn.microsoft.com/Forums/windowsdesktop/en-us/d4b70ecd-a883-4289-8047-cc9cde28b492#0b3e3b80-6b3b-463f-ac1e-1bf0dc831952
-        signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "http://timestamp.digicert.com" /fd sha256 /td sha256 "release\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x86.msi"
+        signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "http://timestamp.digicert.com" /fd sha256 /td sha256 "release\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x86.msi" /d "release\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x86.msi"
 
         Print-Info "Signing mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x64.msi (waiting for 15 seconds)..."
         Start-Sleep -s 15
-        signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "http://timestamp.digicert.com" /fd sha256 /td sha256 "release\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x64.msi"
+        signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "http://timestamp.digicert.com" /fd sha256 /td sha256 "release\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x64.msi" /d "release\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x64.msi"
     } else {
         Print-Info "Not signing msi"
     }

--- a/scripts/cp_artifacts.sh
+++ b/scripts/cp_artifacts.sh
@@ -20,11 +20,12 @@ if [[ -f "${SRC}/mattermost-desktop-${VERSION}-win-x64.zip" ]]; then
     cp "${SRC}/mattermost-desktop-${VERSION}-win-x64.zip" "${DEST}/mattermost-desktop-${VERSION}-win64.zip"
     SOMETHING_COPIED=$(($SOMETHING_COPIED + 2))
 fi
-if [[ -f "${SRC}/mattermost-desktop-setup-${VERSION}-win.exe" ]]; then
-    echo "Copying win-no-arch\n"
-    cp "${SRC}/mattermost-desktop-setup-${VERSION}-win.exe" "${DEST}/"
-    SOMETHING_COPIED=$(($SOMETHING_COPIED + 4))
-fi
+# we are not supplying this since we supply the msi
+# if [[ -f "${SRC}/mattermost-desktop-setup-${VERSION}-win.exe" ]]; then
+#     echo "Copying win-no-arch\n"
+#     cp "${SRC}/mattermost-desktop-setup-${VERSION}-win.exe" "${DEST}/"
+#     SOMETHING_COPIED=`expr $SOMETHING_COPIED + 4`
+# fi
 if [[ -f "${SRC}"/mattermost-desktop-${VERSION}-mac.zip ]]; then
     echo "Copying mac\n"
     cp "${SRC}"/mattermost-desktop-*-mac.* "${DEST}/"

--- a/scripts/cp_artifacts.sh
+++ b/scripts/cp_artifacts.sh
@@ -1,48 +1,49 @@
 #!/usr/bin/env bash
 set -eu
 
-VERSION=$(cat package.json | jq -r '.version')
+VERSION="$(jq -r '.version' <package.json)"
 SRC="${1}"
 DEST="${2}"
 SOMETHING_COPIED=0
 if [[ ! -d "${DEST}" ]]; then
-    echo "Can't find destination. Creating ${DEST}"
-    mkdir -p ${DEST}
+    echo "Can't find destination. Creating \"${DEST}\""
+    mkdir -p "${DEST}"
 fi
 
 if [[ -f "${SRC}/mattermost-desktop-${VERSION}-win-ia32.zip" ]]; then
-    echo "Copying Win32\n"
+    echo -e "Copying Win32\n"
     cp "${SRC}/mattermost-desktop-${VERSION}-win-ia32.zip" "${DEST}/mattermost-desktop-${VERSION}-win32.zip"
     SOMETHING_COPIED=1
 fi
 if [[ -f "${SRC}/mattermost-desktop-${VERSION}-win-x64.zip" ]]; then
-    echo "Copying Win64\n"
+    echo -e "Copying Win64\n"
     cp "${SRC}/mattermost-desktop-${VERSION}-win-x64.zip" "${DEST}/mattermost-desktop-${VERSION}-win64.zip"
-    SOMETHING_COPIED=$(($SOMETHING_COPIED + 2))
+    SOMETHING_COPIED=$((SOMETHING_COPIED + 2))
 fi
-# we are not supplying this since we supply the msi
+# We are not supplying this since we supply the msi
 # if [[ -f "${SRC}/mattermost-desktop-setup-${VERSION}-win.exe" ]]; then
-#     echo "Copying win-no-arch\n"
+#     echo -e "Copying win-no-arch\n"
 #     cp "${SRC}/mattermost-desktop-setup-${VERSION}-win.exe" "${DEST}/"
-#     SOMETHING_COPIED=`expr $SOMETHING_COPIED + 4`
+#     SOMETHING_COPIED=$((SOMETHING_COPIED + 4))
 # fi
-if [[ -f "${SRC}"/mattermost-desktop-${VERSION}-mac.zip ]]; then
-    echo "Copying mac\n"
+if [[ -f "${SRC}/mattermost-desktop-${VERSION}-mac.zip" ]]; then
+    echo -e "Copying mac\n"
     cp "${SRC}"/mattermost-desktop-*-mac.* "${DEST}/"
     if [[ -f "${SRC}"/mattermost-desktop-${VERSION}-mac.dmg ]]; then
         cp "${SRC}"/*.blockmap "${DEST}/"
     fi
-    SOMETHING_COPIED=$(($SOMETHING_COPIED + 8))
+    SOMETHING_COPIED=$((SOMETHING_COPIED + 8))
 fi
 if [[ -f "${SRC}"/mattermost-desktop-${VERSION}-linux-x64.tar.gz ]]; then
-    echo "Copying linux"
+    echo -e "Copying linux\n"
     cp "${SRC}"/mattermost-desktop-*-linux-* "${DEST}/"
-    SOMETHING_COPIED=$(($SOMETHING_COPIED + 16))
+    SOMETHING_COPIED=$((SOMETHING_COPIED + 16))
 fi
 
 if [[ $SOMETHING_COPIED -eq 0 ]]; then
-    echo "didn't find anything to copy, seems like something failed"
-    exit -1
+    echo "Didn't find anything to copy, it seems like something failed"
+    # Bash only returns 0-255 values
+    exit 1
 fi
 
 cp "${SRC}"/*.yml "${DEST}/"

--- a/scripts/generate_release_markdown.sh
+++ b/scripts/generate_release_markdown.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -eu
 
+# Requires sha256sum, on osx you can do
+# brew install coreutils
+
 function print_link {
   local URL="${1}"
   local CHECKSUM="$(curl -s -S -L "${URL}" | sha256sum | awk '{print $1}')"
@@ -15,9 +18,12 @@ cat <<-MD
 ### Mattermost Desktop ${VERSION} has been cut!
 The download links can be found below.
 
-#### Windows
-$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-x64.msi")
-$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-x86.msi")
+#### Windows - msi files (beta)
+$(print_link "${BASE_URL}/mattermost-desktop-v${VERSION}-x64.msi")
+$(print_link "${BASE_URL}/mattermost-desktop-v${VERSION}-x86.msi")
+
+#### Windows - setup exe files
+$(print_link "${BASE_URL}/mattermost-desktop-setup-${VERSION}-win.exe")
 
 #### Windows - zip files
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win-ia32.zip")

--- a/scripts/generate_release_markdown.sh
+++ b/scripts/generate_release_markdown.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 
-function print_link() {
+function print_link {
   local URL="${1}"
   local CHECKSUM="$(curl -s -S -L "${URL}" | sha256sum | awk '{print $1}')"
   echo "- ${URL}"

--- a/scripts/generate_release_markdown.sh
+++ b/scripts/generate_release_markdown.sh
@@ -16,12 +16,12 @@ cat <<-MD
 The download links can be found below.
 
 #### Windows
-$(print_link "${BASE_URL}/mattermost-setup-${VERSION}-win32.exe")
-$(print_link "${BASE_URL}/mattermost-setup-${VERSION}-win64.exe")
+$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-x64.msi")
+$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-x86.msi")
 
 #### Windows - zip files
-$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win32.zip")
-$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win64.zip")
+$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win-ia32.zip")
+$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win-x64.zip")
 
 #### Mac
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-mac.dmg")

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,28 +3,15 @@
 # exit when any command fails
 set -e
 
-function writeError {
-    echo "[ERROR  ] $@"
+function print_error {
+    echo -e "[ERROR  ] $*"
 }
-function writeWarning {
-    echo "[WARNING] $@"
+function print_warning {
+    echo -e "[WARNING] $*"
 }
-function writeInfo {
-    echo "[INFO   ] $@"
+function print_info {
+    echo -e "[INFO   ] $*"
 }
-
-# keep track of the last executed command
-trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
-# echo an error message before exiting
-trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
-
-# mattermost repo might not be the origin one, we don't want to enforce that.
-org="github.com:mattermost"
-gitOrigin=`git remote -v | grep $org | grep push | awk '{print $1}'`
-if [[ -z gitOrigin ]]; then
-    msg="Can't find a mattermost remote, defaulting to origin"
-    gitOrigin="origin"
-fi
 
 function tag {
     # not forcing tags, this might fail on purpose if tags are already created 
@@ -34,168 +21,161 @@ function tag {
     git tag -a "v${1}" -m "Desktop Version ${2}"
 }
 
-function writePackageVersion {
-    tempfile=$(mktemp -t "package.json")
-    jq ".version = \"${1}\"" ./package.json > ${tempfile} && mv ${tempfile} ./package.json
-    tempfile=$(mktemp -t "package-lock.json")
-    jq ".version = \"${1}\"" ./package-lock.json > ${tempfile} && mv ${tempfile} ./package-lock.json
-    tempfile=$(mktemp -t "src-package.json")
-    jq ".version = \"${1}\"" ./src/package.json > ${tempfile} && mv ${tempfile} ./src/package.json
-    tempfile=$(mktemp -t "src-package-lock.json")
-    jq ".version = \"${1}\"" ./src/package-lock.json > ${tempfile} && mv ${tempfile} ./src/package-lock.json
+function write_package_version {
+    temp_file="$(mktemp -t package.json)"
+    jq ".version = \"${1}\"" ./package.json > "${temp_file}" && mv "${temp_file}" ./package.json
+    temp_file="$(mktemp -t package-lock.json)"
+    jq ".version = \"${1}\"" ./package-lock.json > "${temp_file}" && mv "${temp_file}" ./package-lock.json
+    temp_file="$(mktemp -t ./src-package.json)"
+    jq ".version = \"${1}\"" ./src/package.json > "${temp_file}" && mv "${temp_file}" ./src/package.json
+    temp_file="$(mktemp -t ./src-package-lock.json)"
+    jq ".version = \"${1}\"" ./src/package-lock.json > "${temp_file}" && mv "${temp_file}" ./src/package-lock.json
     
     git add ./package.json ./package-lock.json ./src/package.json ./src/package-lock.json
     git commit -qm "Bump to version ${1}"
 }
 
+
+# keep track of the last executed command
+# src.: https://stackoverflow.com/a/6110446/3514658
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# echo an error message before exiting
+trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
+
+# mattermost repo might not be the origin one, we don't want to enforce that.
+org="github.com:mattermost"
+git_origin="$(git remote -v | grep ${org} | grep push | awk '{print $1}')"
+if [[ -z "${git_origin}" ]]; then
+    print_warning "Can't find a mattermost remote, defaulting to origin"
+    git_origin="origin"
+fi
+
 # get original git branch
-branch_name=$(git symbolic-ref -q HEAD)
+branch_name="$(git symbolic-ref -q HEAD)"
 branch_name="${branch_name##refs/heads/}"
 branch_name="${branch_name:-HEAD}"
 
 # don't run if branch is dirty, releases shouldn't be done on a dirty branch
-dirty=$(git diff --quiet && echo 0 || echo 1)
-if (( $dirty == 1 )); then
-    msg="Please use this script on a clean branch"
-    writeError $msg
-    exit -10
+dirty="$(git diff --quiet && echo 0 || echo 1)"
+if (( dirty == 1 )); then
+    print_error "Please use this script on a clean branch"
+    exit 10
 fi
 
 # require jq
-if [[ ! $(command -v jq) ]]; then
-    error="this script requires jq to run"
-    writeError $error
-    exit -11
+if ! type jq >/dev/null 2>&1; then
+    print_error "This script requires jq to run"
+    exit 11
 fi
 
 # get version
-PKG_VERSION=$(jq -r .version package.json)
+pkg_version="$(jq -r .version package.json)"
 # remove trailing
-CURRENT_VERSION="${PKG_VERSION%-develop}"
-CURRENT_VERSION="${PKG_VERSION%-rc*}"
+current_version="${pkg_version%-develop}"
+current_version="${pkg_version%-rc*}"
 # parse version
-IFS='.' read MAJOR MINOR MICRO <<<"$CURRENT_VERSION"
-case $1 in
+IFS='.' read -r major min micro <<<"${current_version}"
+case "${1}" in
     "help")
         echo "todo"
     ;;
     "rc")
-        if [[ $branch_name =~ "release-" ]]; then
-            if [[ $PKG_VERSION =~ "-rc" ]]; then
-                RC="${PKG_VERSION#*-rc}"
+        if [[ "${branch_name}" =~ "release-" ]]; then
+            if [[ "${pkg_version}" =~ "-rc" ]]; then
+                rc="${pkg_version#*-rc}"
             else
-                msg="No release candidate on the version, assuming 0"
-                writeWarning ${msg}
-                RC=0
+                print_warning "No release candidate on the version, assuming 0"
+                rc=0
             fi
-            case "${RC}" in
+            case "${rc}" in
                 ''|*[!0-9]*) 
-                    msg="Can't guess release candidate from version, assuming 0"
-                    writeWarning ${msg}
-                    RC=1
+                    print_warning "Can't guess release candidate from version, assuming 0"
+                    rc=1
                 ;;
                 *)
-                    RC=$(( RC + 1 ))
+                    rc=$(( rc + 1 ))
                 ;;
             esac
-            msg="Generating ${CURRENT_VERSION} release candidate ${RC}"
-            writeInfo ${msg}
-            NEW_PKG_VERSION="${CURRENT_VERSION}-rc${RC}"
-            writePackageVersion "${NEW_PKG_VERSION}"
-            tag_description="Release candidate ${RC}"
-            tag "${NEW_PKG_VERSION}" "${tag_description}"
-            msg="locally created an rc. In order to build you'll have to"
-            writeInfo "${msg}"
-            echo "$ git push --follow-tags ${gitOrigin} ${branch_name}:${branch_name}\n"
+            print_info "Generating ${current_version} release candidate ${rc}"
+            new_pkg_version="${current_version}-rc${rc}"
+            write_package_version "${new_pkg_version}"
+            tag "${new_pkg_version}" "Release candidate ${rc}"
+            print_info "Locally created an rc. In order to build you'll have to:"
+            print_info "$ git push --follow-tags ${git_origin} ${branch_name}:${branch_name}"
         else
-            error="Can't generate a release candidate on a non release-X.Y branch"
-            writeError ${error}
-            exit -2
+            print_error "Can't generate a release candidate on a non release-X.Y branch"
+            exit 2
 
         fi
     ;;
     "final")
-        if [[ $branch_name =~ "release-" ]]; then
-            msg="Releasing v${CURRENT_VERSION}"
-            writeInfo $msg
-            NEW_PKG_VERSION=${CURRENT_VERSION}
-            writePackageVersion $NEW_PKG_VERSION
-            tag_description="Released on `date -u`" 
-            tag $NEW_PKG_VERSION $tag_description
-            msg="locally created a release. In order to build you'll have to:"
-            writeInfo $msg
-            echo "$ git push --follow-tags ${gitOrigin} ${branch_name}:${branch_name}"
+        if [[ "${branch_name}" =~ "release-" ]]; then
+            print_info "Releasing v${current_version}"
+            new_pkg_version="${current_version}"
+            write_package_version "${new_pkg_version}"
+            tag "${new_pkg_version}" "Released on $(date -u)"
+            print_info "Locally created an rc. In order to build you'll have to:"
+            print_info "$ git push --follow-tags ${git_origin} ${branch_name}:${branch_name}"
         else
-            error="Can't release on a non release-X.Y branch"
-            writeError $error
-            exit -2
+            print_error "Can't release on a non release-X.Y branch"
+            exit 2
         fi
     ;;
     "branch")
         # Quality releases should run from a release branch
-        if [[ $branch_name =~ "release-" ]]; then
-            NEW_BRANCH_VERSION="${MAJOR}.$(( MINOR + 1 ))"
-            NEW_BRANCH_NAME="release-${NEW_BRANCH_VERSION}"
-            msg="Doing a quality branch: ${NEW_BRANCH_NAME}"
-            writeInfo $msg
+        if [[ "${branch_name}" =~ "release-" ]]; then
+            new_branch_version="${major}.$(( min + 1 ))"
+            new_branch_name="release-${new_branch_version}"
+            print_info "Doing a quality branch: ${new_branch_name}"
 
-            if git show-ref --verify --quiet refs/heads/${NEW_BRANCH_NAME}; then
-                error="branch ${NEW_BRANCH_NAME} exists"
-                writeError $error
-                exit -3
+            if git show-ref --verify --quiet "refs/heads/${new_branch_name}"; then
+                print_error "Branch ${new_branch_name} exists"
+                exit 3
             fi
 
-            NEW_PKG_VERSION="${NEW_BRANCH_VERSION}.0-rc0"
-            git checkout -b "${NEW_BRANCH_NAME}"
-            writePackageVersion "${NEW_PKG_VERSION}"
-            tagDescription="Quality branch"
-            tag "${NEW_PKG_VERSION}" "${tagDescription}"
-            msg="locally created quality branch. In order to build you'll have to"
-            writeInfo $msg
-            echo "$ git push --follow-tags ${gitOrigin} ${NEW_BRANCH_NAME}:${NEW_BRANCH_NAME}"
+            new_pkg_version="${new_branch_version}.0-rc0"
+            git checkout -b "${new_branch_name}"
+            write_package_version "${new_pkg_version}"
+            tag "${new_pkg_version}" "Quality branch"
+            print_info "Locally created quality branch. In order to build you'll have to:"
+            print_info "$ git push --follow-tags ${git_origin} ${new_branch_name}:${new_branch_name}"
 
         else
-            if [[ $branch_name != "master" ]]; then
-                msg="You are branching on ${branch_name} instead of master or a relase-branch"
-                writeWarning $msg
+            if [[ "${branch_name}" != "master" ]]; then
+                print_warning "You are branching on ${branch_name} instead of master or a release-branch"
                 read -p "Do you wish to continue? [y/n]" -n 1 -r
-                if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+                if [[ ! "${REPLY}" =~ ^[Yy]$ ]]; then
                     exit 1
                 fi
             fi
-            NEW_BRANCH_VERSION="${MAJOR}.${MINOR}"
-            NEW_BRANCH_NAME="release-${NEW_BRANCH_VERSION}"
-            NEW_PKG_VERSION="${NEW_BRANCH_VERSION}.0-rc0"
-            MASTER_PKG_VERSION="${MAJOR}.$(( MINOR + 2 )).0-develop"
-            msg="Creating a new features branch: ${NEW_BRANCH_NAME}"
-            writeInfo $msg
+            new_branch_version="${major}.${min}"
+            new_branch_name="release-${new_branch_version}"
+            new_pkg_version="${new_branch_version}.0-rc0"
+            master_pkg_version="${major}.$(( min + 2 )).0-develop"
+            print_info "Creating a new features branch: ${new_branch_name}"
 
-            if git show-ref --verify --quiet refs/heads/${NEW_BRANCH_NAME}; then
-                error="branch ${NEW_BRANCH_NAME} exists"
-                writeError $error
-                exit -3
+            if git show-ref --verify --quiet "refs/heads/${new_branch_name}"; then
+                print_error "Branch ${new_branch_name} exists"
+                exit 3
             fi
 
-            git branch "${NEW_BRANCH_NAME}"
-            msg="Writing new package version for development: ${MASTER_PKG_VERSION}"
-            writeInfo $msg
-            writePackageVersion "${MASTER_PKG_VERSION}"
-            git checkout "${NEW_BRANCH_NAME}"
-            writePackageVersion "${NEW_PKG_VERSION}"
-            tagDescription="NewFeatures branch"
-            tag "${NEW_PKG_VERSION}" "${tagDescription}"
-            msg="Locally created new features branch. In order to build you'll have to"
-            writeInfo $msg
-            echo "$ git push --follow-tags ${gitOrigin} ${NEW_BRANCH_NAME}:${NEW_BRANCH_NAME}"
-            echo "For writing master changes you'll need to:"
-            echo "$ git push ${gitOrigin} ${branch_name}:${branch_name}"
-
+            git branch "${new_branch_name}"
+            print_info "Writing new package version for development: ${master_pkg_version}"
+            write_package_version "${master_pkg_version}"
+            git checkout "${new_branch_name}"
+            write_package_version "${new_pkg_version}"
+            tag "${new_pkg_version}" "New features branch"
+            print_info "Locally created new features branch. In order to build you'll have to:"
+            print_info "$ git push --follow-tags ${git_origin} ${new_branch_name}:${new_branch_name}"
+            print_info "For writing master changes you'll need to:"
+            print_info "$ git push ${git_origin} ${branch_name}:${branch_name}"
         fi
     ;;
     *)
-        writeError "Only branch|rc|final parameters are accepted"
-        exit -1
+        print_error "Only branch|rc|final parameters are accepted"
+        exit 1
     ;;
 esac
 
 trap - EXIT
+

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -26,9 +26,9 @@ function write_package_version {
     jq ".version = \"${1}\"" ./package.json > "${temp_file}" && mv "${temp_file}" ./package.json
     temp_file="$(mktemp -t package-lock.json)"
     jq ".version = \"${1}\"" ./package-lock.json > "${temp_file}" && mv "${temp_file}" ./package-lock.json
-    temp_file="$(mktemp -t ./src-package.json)"
+    temp_file="$(mktemp -t src-package.json)"
     jq ".version = \"${1}\"" ./src/package.json > "${temp_file}" && mv "${temp_file}" ./src/package.json
-    temp_file="$(mktemp -t ./src-package-lock.json)"
+    temp_file="$(mktemp -t src-package-lock.json)"
     jq ".version = \"${1}\"" ./src/package-lock.json > "${temp_file}" && mv "${temp_file}" ./src/package-lock.json
     
     git add ./package.json ./package-lock.json ./src/package.json ./src/package-lock.json

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -44,7 +44,7 @@ function writePackageVersion {
     tempfile=$(mktemp -t "src-package-lock.json")
     jq ".version = \"${1}\"" ./src/package-lock.json > ${tempfile} && mv ${tempfile} ./src/package-lock.json
     
-    git add ./package.json ./package-lock.json
+    git add ./package.json ./package-lock.json ./src/package.json ./src/package-lock.json
     git commit -qm "Bump to version ${1}"
 }
 
@@ -197,4 +197,5 @@ case $1 in
         exit -1
     ;;
 esac
-exit 0
+
+trap - EXIT

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+
+# exit when any command fails
+set -e
+
+function writeError {
+    echo "[ERROR  ] $@"
+}
+function writeWarning {
+    echo "[WARNING] $@"
+}
+function writeInfo {
+    echo "[INFO   ] $@"
+}
+
+# keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# echo an error message before exiting
+trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
+
+# mattermost repo might not be the origin one, we don't want to enforce that.
+org="github.com:mattermost"
+gitOrigin=`git remote -v | grep $org | grep push | awk '{print $1}'`
+if [[ -z gitOrigin ]]; then
+    msg="Can't find a mattermost remote, defaulting to origin"
+    gitOrigin="origin"
+fi
+
+function tag {
+    # not forcing tags, this might fail on purpose if tags are already created 
+    # as we don't want to overwrite automatically.
+    # if this happens, you should check that versions are ok and see if there are
+    # any tags locally or upstream that might conflict.
+    git tag -a "v${1}" -m "Desktop Version ${2}"
+}
+
+function writePackageVersion {
+    tempfile=`mktemp -t "package.json"`
+    jq ".version = \"${1}\"" ./package.json > $tempfile && mv $tempfile ./package.json
+    tempfile=`mktemp -t "package-lock.json"`
+    jq ".version = \"${1}\"" ./package-lock.json > $tempfile && mv $tempfile ./package-lock.json
+    tempfile=`mktemp -t "src-package.json"`
+    jq ".version = \"${1}\"" ./src/package.json > $tempfile && mv $tempfile ./src/package.json
+    tempfile=`mktemp -t "src-package-lock.json"`
+    jq ".version = \"${1}\"" ./src/package-lock.json > $tempfile && mv $tempfile ./src/package-lock.json
+    
+    git add ./package.json ./package-lock.json
+    git commit -qm "Bump to version ${1}"
+}
+
+# get original git branch
+branch_name=$(git symbolic-ref -q HEAD)
+branch_name=${branch_name##refs/heads/}
+branch_name=${branch_name:-HEAD}
+
+# don't run if branch is dirty, releases shouldn't be done on a dirty branch
+dirty=`git diff --quiet && echo 0 || echo 1`
+if [[ $dirty -eq 1 ]]; then
+    msg="Please use this script on a clean branch"
+    writeError $msg
+    exit -10
+fi
+
+# require jq
+if [[ ! `command -v jq` ]]; then
+    error="this script requires jq to run"
+    writeError $error
+    exit -11
+fi
+
+# get version
+PKG_VERSION=`jq -r .version package.json`
+# remove trailing
+CURRENT_VERSION=${PKG_VERSION%-develop}
+CURRENT_VERSION=${PKG_VERSION%-rc*}
+# parse version
+IFS='.' read MAJOR MINOR MICRO <<<"$CURRENT_VERSION"
+case $1 in
+    "help")
+        echo "todo"
+    ;;
+    "rc")
+        if [[ $branch_name =~ "release-" ]]; then
+            if [[ $PKG_VERSION =~ "-rc" ]]; then
+                RC=${PKG_VERSION#*-rc}
+            else
+                msg="No release candidate on the version, assuming 0"
+                writeWarning $msg
+                RC=0
+            fi
+            case $RC in
+            ''|*[!0-9]*) 
+                msg="Can't guess release candidate from version, assuming 0"
+                writeWarning $msg
+                RC=1
+            ;;
+            *)
+                RC=$(( RC + 1 ))
+            ;;
+            esac
+            msg="Generating ${CURRENT_VERSION} release candidate ${RC}"
+            writeInfo $msg
+            NEW_PKG_VERSION="${CURRENT_VERSION}-rc${RC}"
+            writePackageVersion "$NEW_PKG_VERSION"
+            tagDescription="Release candidate ${RC}"
+            tag $NEW_PKG_VERSION "$tagDescription"
+            msg="locally created an rc. In order to build you'll have to"
+            writeInfo $msg
+            echo "$ git push --follow-tags ${gitOrigin} ${branch_name}:${branch_name}\n"
+        else
+            error="Can't generate a release candidate on a non release-X.Y branch"
+            writeError $error
+            exit -2
+
+        fi
+    ;;
+    "final")
+        if [[ $branch_name =~ "release-" ]]; then
+            msg="Releasing v${CURRENT_VERSION}"
+            writeInfo $msg
+            NEW_PKG_VERSION=${CURRENT_VERSION}
+            writePackageVersion $NEW_PKG_VERSION
+            tagDescription="Released on `date -u`" 
+            tag $NEW_PKG_VERSION $tagDescription
+            msg="locally created a release. In order to build you'll have to:"
+            writeInfo $msg
+            echo "$ git push --follow-tags ${gitOrigin} ${branch_name}:${branch_name}"
+        else
+            error="Can't release on a non release-X.Y branch"
+            writeError $error
+            exit -2
+        fi
+    ;;
+    "branch")
+        # Quality releases should run from a release branch
+        if [[ $branch_name =~ "release-" ]]; then
+            NEW_BRANCH_VERSION="${MAJOR}.$(( MINOR + 1 ))"
+            NEW_BRANCH_NAME="release-${NEW_BRANCH_VERSION}"
+            msg="Doing a quality branch: ${NEW_BRANCH_NAME}"
+            writeInfo $msg
+
+            if git show-ref --verify --quiet refs/heads/${NEW_BRANCH_NAME}; then
+                error="branch ${NEW_BRANCH_NAME} exists"
+                writeError $error
+                exit -3
+            fi
+
+            NEW_PKG_VERSION="${NEW_BRANCH_VERSION}.0-rc0"
+            git checkout -b "${NEW_BRANCH_NAME}"
+            writePackageVersion "${NEW_PKG_VERSION}"
+            tagDescription="Quality branch"
+            tag "${NEW_PKG_VERSION}" "${tagDescription}"
+            msg="locally created quality branch. In order to build you'll have to"
+            writeInfo $msg
+            echo "$ git push --follow-tags ${gitOrigin} ${NEW_BRANCH_NAME}:${NEW_BRANCH_NAME}"
+
+        else
+            if [[ $branch_name != "master" ]]; then
+                msg="You are branching on ${branch_name} instead of master or a relase-branch"
+                writeWarning $msg
+                read -p "Do you wish to continue? [y/n]" -n 1 -r
+                if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+                    exit 1
+                fi
+            fi
+            NEW_BRANCH_VERSION="${MAJOR}.${MINOR}"
+            NEW_BRANCH_NAME="release-${NEW_BRANCH_VERSION}"
+            NEW_PKG_VERSION="${NEW_BRANCH_VERSION}.0-rc0"
+            MASTER_PKG_VERSION="${MAJOR}.$(( MINOR + 2 )).0-develop"
+            msg="Creating a new features branch: ${NEW_BRANCH_NAME}"
+            writeInfo $msg
+
+            if git show-ref --verify --quiet refs/heads/${NEW_BRANCH_NAME}; then
+                error="branch ${NEW_BRANCH_NAME} exists"
+                writeError $error
+                exit -3
+            fi
+
+            git branch "${NEW_BRANCH_NAME}"
+            msg="Writing new package version for development: ${MASTER_PKG_VERSION}"
+            writeInfo $msg
+            writePackageVersion "${MASTER_PKG_VERSION}"
+            git checkout "${NEW_BRANCH_NAME}"
+            writePackageVersion "${NEW_PKG_VERSION}"
+            tagDescription="NewFeatures branch"
+            tag "${NEW_PKG_VERSION}" "${tagDescription}"
+            msg="Locally created new features branch. In order to build you'll have to"
+            writeInfo $msg
+            echo "$ git push --follow-tags ${gitOrigin} ${NEW_BRANCH_NAME}:${NEW_BRANCH_NAME}"
+            echo "For writing master changes you'll need to:"
+            echo "$ git push ${gitOrigin} ${branch_name}:${branch_name}"
+
+        fi
+    ;;
+    *)
+        writeError "Only branch|rc|final parameters are accepted"
+        exit -1
+    ;;
+esac
+exit 0


### PR DESCRIPTION
**Summary**

- Added a release script to handle tick-tock branching and general release process to make sure versions are consistents between builds
- fixed [MM-14180](https://mattermost.atlassian.net/browse/MM-14180). When installing on windows, msi installer would have a weird alfanumeric name.
- push artifacts onto github release. release is generated as draft, so someone has to go to github and finish publishing. This is to prevent publishing in the wrong time and to have time to review what's going to be published.

**Issue link**

- [MM-14180](https://mattermost.atlassian.net/browse/MM-14180)
- [MM-19051](https://mattermost.atlassian.net/browse/MM-19051)
- [MM-19330](https://mattermost.atlassian.net/browse/MM-19330)

**Additional Notes**
there is room for improvement, we can add messaging to the community server so people is aware of the state of the release cutting process, but this is a good first step.

adding @cpanato and @crspeller as they asked me to review how I setup circle to talk with aws and github to ensure there is no security issue and that we release as the rest of the projects