### PR TITLE
[MM-19340] Re-focus renderer process

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -187,6 +187,7 @@ export default class MainPage extends React.Component {
     ipcRenderer.send('update-title', {
       title: webview.getTitle(),
     });
+    window.focus();
     webview.focus();
     this.handleOnTeamFocused(newKey);
   }


### PR DESCRIPTION
**Summary**
Using the menu hotkeys was causing the renderer to somehow loose focus, preventing further hotkeys from working. Refocusing the renderer process just prior to focusing the webview corrects the issue in the linked ticket ... deceptively simple 😛

**Issue link**
https://mattermost.atlassian.net/browse/MM-19340