### PR TITLE
[MM 19369] Add controlled support for popup windows.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -385,9 +385,8 @@ function handleAppWebContentsCreated(dc, contents) {
   contents.on('will-navigate', (event, url) => {
     const contentID = event.sender.id;
     const parsedURL = parseURL(url);
-    const isTrustedPopupWindow = popupWindow ? BrowserWindow.fromWebContents(event.sender) === popupWindow : false;
 
-    if (isTrustedURL(parsedURL) || isTrustedPopupWindow) {
+    if (isTrustedURL(parsedURL) || isTrustedPopupWindow(event.sender)) {
       return;
     }
     if (customLogins[contentID].inProgress) {
@@ -432,7 +431,6 @@ function handleAppWebContentsCreated(dc, contents) {
           webPreferences: {
             nodeIntegration: false,
             contextIsolation: true,
-            devTools: false,
           },
         });
         popupWindow.once('ready-to-show', () => {
@@ -797,6 +795,16 @@ function isTrustedURL(url) {
     }
   }
   return false;
+}
+
+function isTrustedPopupWindow(webContents) {
+  if (!webContents) {
+    return false;
+  }
+  if (!popupWindow) {
+    return false;
+  }
+  return BrowserWindow.fromWebContents(webContents) === popupWindow;
 }
 
 function isCustomLoginURL(url) {

--- a/src/main.js
+++ b/src/main.js
@@ -393,7 +393,7 @@ function handleAppWebContentsCreated(dc, contents) {
       return;
     }
 
-    log.warn(`Untrusted URL blocked: ${url}`);
+    log.info(`Untrusted URL blocked: ${url}`);
     event.preventDefault();
   });
 

--- a/src/main.js
+++ b/src/main.js
@@ -419,29 +419,31 @@ function handleAppWebContentsCreated(dc, contents) {
 
   contents.on('new-window', (event, url) => {
     event.preventDefault();
-    if (isTrustedURL(url)) {
-      if (popupWindow && popupWindow.getURL() === url) {
-        return;
-      }
-      if (!popupWindow) {
-        popupWindow = new BrowserWindow({
-          parent: mainWindow,
-          alwaysOnTop: true,
-          show: false,
-          webPreferences: {
-            nodeIntegration: false,
-            contextIsolation: true,
-          },
-        });
-        popupWindow.once('ready-to-show', () => {
-          popupWindow.show();
-        });
-        popupWindow.once('closed', () => {
-          popupWindow = null;
-        });
-      }
-      popupWindow.loadURL(url);
+    if (!isTrustedURL(url)) {
+      log.info(`Untrusted popup window blocked: ${url}`);
+      return;
     }
+    if (popupWindow && popupWindow.getURL() === url) {
+      return;
+    }
+    if (!popupWindow) {
+      popupWindow = new BrowserWindow({
+        parent: mainWindow,
+        alwaysOnTop: true,
+        show: false,
+        webPreferences: {
+          nodeIntegration: false,
+          contextIsolation: true,
+        },
+      });
+      popupWindow.once('ready-to-show', () => {
+        popupWindow.show();
+      });
+      popupWindow.once('closed', () => {
+        popupWindow = null;
+      });
+    }
+    popupWindow.loadURL(url);
   });
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -424,6 +424,7 @@ function handleAppWebContentsCreated(dc, contents) {
       return;
     }
     if (popupWindow && popupWindow.getURL() === url) {
+      log.info(`Popup window already open at provided url: ${url}`);
       return;
     }
     if (!popupWindow) {

--- a/src/main.js
+++ b/src/main.js
@@ -429,7 +429,6 @@ function handleAppWebContentsCreated(dc, contents) {
     if (!popupWindow) {
       popupWindow = new BrowserWindow({
         parent: mainWindow,
-        alwaysOnTop: true,
         show: false,
         webPreferences: {
           nodeIntegration: false,


### PR DESCRIPTION
**Summary**
A recent security enhancement to the desktop app was preventing the Jira v2 plugin from authenticating from a popup window when trying to connect it with MM using `/jira connect`.

This PR adds in the ability for a pop-up window triggered from within MM and having a destination URL within the same MM server, to open a controlled Electron BrowserWindow over top of the Desktop App. Further, the resulting BrowserWindow is allowed to navigate outside of the MM server domain for purposes of authentication.

This fix is specifically for Jira v2, but should apply to any plugin that needs to authenticate via SAML/OAUTH and first slingshots though a plugin-specific url on the MM server.

Note that to test this, it is necessary to do so from https://community.mattermost.com. See @mickmister for clarification if needed.

**Issue link**
https://mattermost.atlassian.net/browse/MM-19369