### PR TITLE
[MM-19329] Change `Mattermost Desktop` to `Mattermost` in MSI

### DIFF
--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -35,12 +35,12 @@
   - there are any changes in the feature hierarchy (child
     feature moving out of a parent, or a parent feature getting a new child).
   -->
-  <Product Id="*" UpgradeCode="8523DAF0-699D-4CC7-9A65-C5E696A9DE6D" Name="Mattermost Desktop" Manufacturer="Mattermost, Inc." Language="1033" Codepage="1252" Version="4.1.2">
+  <Product Id="*" UpgradeCode="8523DAF0-699D-4CC7-9A65-C5E696A9DE6D" Name="Mattermost" Manufacturer="Mattermost, Inc." Language="1033" Codepage="1252" Version="4.1.2">
     <!--
     perMachine installs the app system wide (ALLUSERS is set to 1)
     src.: https://www.joyofsetup.com/2008/04/01/new-wix-feature-setting-package-installation-scope/
     -->
-    <Package Id="*" Keywords="Installer" Description="Mattermost Desktop Installer" Manufacturer="Mattermost, Inc." InstallerVersion="400" Languages="1033" Compressed="yes" SummaryCodepage="1252" Platform="$(var.Platform)" InstallScope="perMachine" />
+    <Package Id="*" Keywords="Installer" Description="Mattermost Installer" Manufacturer="Mattermost, Inc." InstallerVersion="400" Languages="1033" Compressed="yes" SummaryCodepage="1252" Platform="$(var.Platform)" InstallScope="perMachine" />
     <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
     <!--
     Perform OS check requirements only if we are installing (not on repair/
@@ -66,12 +66,12 @@
             <Component Id="MainExecutableShortcutDesktop" Guid="9C71385D-C892-48BA-A35D-D89A661D2952" Win64="$(var.Win64)">
               <Condition><![CDATA[ADDDESKTOPSHORTCUT = "true"]]></Condition>
               <RegistryValue Id="RegShortcutDesktop" Root="HKCU" Key="SOFTWARE\Mattermost\Desktop\settings" Name="MattermostDesktopShortcutDesktop" Value="1" Type="integer" KeyPath="yes" />
-              <Shortcut Id="MattermostDesktopShortcutDesktop" Directory="DesktopFolder" Name="Mattermost Desktop" WorkingDirectory="INSTALLDIR" Icon="Mattermost.ico" IconIndex="0" Advertise="no" Target="[INSTALLDIR]Mattermost.exe" />
+              <Shortcut Id="MattermostDesktopShortcutDesktop" Directory="DesktopFolder" Name="Mattermost" WorkingDirectory="INSTALLDIR" Icon="Mattermost.ico" IconIndex="0" Advertise="no" Target="[INSTALLDIR]Mattermost.exe" />
             </Component>
             <Component Id="MainExecutableShortcutStartMenu" Guid="DF2028FF-7E03-407B-A46A-726E1B67DF83" Win64="$(var.Win64)">
               <Condition><![CDATA[ADDSTARTMENUSHORTCUT = "true"]]></Condition>
               <RegistryValue Id="RegShortcutStartMenu" Root="HKCU" Key="SOFTWARE\Mattermost\Desktop\settings" Name="MattermostDesktopShortcutStartMenu" Value="1" Type="integer" KeyPath="yes" />
-              <Shortcut Id="MattermostDesktopShortcutStartMenu" Directory="ProgramMenuDir" Name="Mattermost Desktop" WorkingDirectory="INSTALLDIR" Icon="Mattermost.ico" IconIndex="0" Advertise="no" Target="[INSTALLDIR]Mattermost.exe">
+              <Shortcut Id="MattermostDesktopShortcutStartMenu" Directory="ProgramMenuDir" Name="Mattermost" WorkingDirectory="INSTALLDIR" Icon="Mattermost.ico" IconIndex="0" Advertise="no" Target="[INSTALLDIR]Mattermost.exe">
                 <ShortcutProperty Key="System.AppUserModel.ID" Value="Mattermost.Desktop" />
                 <ShortcutProperty Key="System.AppUserModel.ToastActivatorCLSID" Value="{082F98DC-8BD8-4771-9D01-3A75930884D1}"></ShortcutProperty>
               </Shortcut>
@@ -90,7 +90,7 @@
         </Directory>
       </Directory>
       <Directory Id="ProgramMenuFolder" Name="Programs">
-        <Directory Id="ProgramMenuDir" Name="Mattermost Desktop">
+        <Directory Id="ProgramMenuDir" Name="Mattermost">
           <Component Id="ProgramMenuDir" Guid="CA5C6FAF-C004-4909-AF1C-AA0A5F53C245">
             <RemoveFolder Id="ProgramMenuDir" On="uninstall" />
             <RegistryValue Root="HKCU" Key="Software\Mattermost\Desktop" Type="string" Value="" KeyPath="yes" />


### PR DESCRIPTION
**Summary**
This PR changes all human readable references of `Mattermost Desktop` to just `Mattermost` in the MSI installer config file.

Needs to be built as release in CI to test (for now).

**Issue link**
https://mattermost.atlassian.net/browse/MM-19329
