### PR TITLE
Disable AutoUpdate GPO

### DIFF
--- a/resources/windows/gpo/en-US/mattermost.adml
+++ b/resources/windows/gpo/en-US/mattermost.adml
@@ -6,8 +6,10 @@
 		<stringTable >
 			<string id="RequiresMattermost43">Requires Mattermost Desktop 4.3 or later</string>
 			<string id="mattermost">Mattermost</string>
-			<string id="EnableAutoUpdater">EnableAutoUpdater</string>
+			<!--
+      <string id="EnableAutoUpdater">EnableAutoUpdater</string>
 			<string id="EnableAutoUpdaterDescription">If this policy is enabled, users will receive notifications when new versions of the desktop app are available. System Administrator privilages on the computer are required to install the update.</string>
+      -->
 			<string id="EnableServerManagement">EnableServerManagement</string>
 			<string id="EnableServerManagementDescription">If this policy is enabled, users can add or remove servers in their app settings, even if default servers are configured in DefaultServerList.
 

--- a/resources/windows/gpo/mattermost.admx
+++ b/resources/windows/gpo/mattermost.admx
@@ -13,7 +13,8 @@
 		<category displayName="$(string.mattermost)" name="mattermost"></category>
 	</categories>
 	<policies>
-		<policy name="EnableAutoUpdater" class="Machine" displayName="$(string.EnableAutoUpdater)" explainText="$(string.EnableAutoUpdaterDescription)" key="Software\Policies\Mattermost" valueName="EnableAutoUpdater">
+		<!--
+    <policy name="EnableAutoUpdater" class="Machine" displayName="$(string.EnableAutoUpdater)" explainText="$(string.EnableAutoUpdaterDescription)" key="Software\Policies\Mattermost" valueName="EnableAutoUpdater">
 			<parentCategory ref="mattermost"/>
 			<supportedOn ref="RequiresMattermost43"/>
 			<enabledValue>
@@ -23,6 +24,7 @@
 				<decimal value="0"/>
 			</disabledValue>
 		</policy>
+    -->
 		<policy name="EnableServerManagement" class="Both" displayName="$(string.EnableServerManagement)" explainText="$(string.EnableServerManagementDescription)" key="Software\Policies\Mattermost" valueName="EnableServerManagement">
 			<parentCategory ref="mattermost"/>
 			<supportedOn ref="RequiresMattermost43"/>


### PR DESCRIPTION
Before submitting, please confirm you've
 - [X] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [X] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [ ] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
This pull request disable the GPO for controlling the AutoUpdate feature as Eric remove it here: 

https://github.com/mattermost/docs/pull/3067/files#diff-dcc9ba198b59be56a71e3af640d71201L47
