### PR TITLE
[MM-19515] Sign electron builder executable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,7 +227,6 @@ workflows:
             branches:
               ignore:
                 - /^release-\d+\.\d+\.\d+?(-rc.*)?/
-                - eb-win-sign
       - build-mac-no-dmg:
           requires:
             - check
@@ -246,7 +245,6 @@ workflows:
                 # release-XX.YY.ZZ
                 # release-XX.YY.ZZ-rc-something
                 - /^release-\d+\.\d+\.\d+?(-rc.*)?/
-                - eb-win-sign
 
       - mac_installer:
           requires:
@@ -256,7 +254,6 @@ workflows:
             branches:
               only:
                 - /^release-\d+\.\d+\.\d+?(-rc.*)?/
-                - eb-win-sign
       - store_artifacts:
           # for master/PR builds
           requires:
@@ -267,7 +264,6 @@ workflows:
             branches:
               ignore:
                 - /^release-\d+\.\d+\.\d+?(-rc.*)?/
-                - eb-win-sign
       - store_artifacts:
           # for release and rc builds
           requires:
@@ -278,4 +274,3 @@ workflows:
             branches:
               only:
                 - /^release-\d+\.\d+\.\d+?(-rc.*)?/
-                - eb-win-sign

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,6 +227,7 @@ workflows:
             branches:
               ignore:
                 - /^release-\d+\.\d+\.\d+?(-rc.*)?/
+                - eb-win-sign
       - build-mac-no-dmg:
           requires:
             - check
@@ -245,6 +246,7 @@ workflows:
                 # release-XX.YY.ZZ
                 # release-XX.YY.ZZ-rc-something
                 - /^release-\d+\.\d+\.\d+?(-rc.*)?/
+                - eb-win-sign
 
       - mac_installer:
           requires:
@@ -254,6 +256,7 @@ workflows:
             branches:
               only:
                 - /^release-\d+\.\d+\.\d+?(-rc.*)?/
+                - eb-win-sign
       - store_artifacts:
           # for master/PR builds
           requires:
@@ -264,6 +267,7 @@ workflows:
             branches:
               ignore:
                 - /^release-\d+\.\d+\.\d+?(-rc.*)?/
+                - eb-win-sign
       - store_artifacts:
           # for release and rc builds
           requires:
@@ -274,3 +278,4 @@ workflows:
             branches:
               only:
                 - /^release-\d+\.\d+\.\d+?(-rc.*)?/
+                - eb-win-sign

--- a/scripts/Makefile.ps1
+++ b/scripts/Makefile.ps1
@@ -448,10 +448,10 @@ function Remove-Cert {
 function Run-Build {
     Check-Deps -Verbose -Throwable
     Prepare-Path
+    Get-Cert
     Run-BuildId
     Run-BuildChangelog
     Run-BuildElectron
-    Get-Cert
     Run-BuildForceSignature
     Run-BuildLicense
     Run-BuildMsi
@@ -497,6 +497,12 @@ function Main {
             }
             "debug" {
                 Enable-AppVeyorRDP
+            }
+            "install-cert" {
+                Get-Cert
+            }
+            "remove-cert" {
+                Remove-Cert
             }
             default {
                 Print-Error "Makefile argument ""$_"" is invalid. Build process aborted."


### PR DESCRIPTION

**Summary**
While electron builder setup executable will eventually go away, we might distribute it if something happens with msi. For that reason it should be signed.

**Issue link**

[MM-19515](https://mattermost.atlassian.net/browse/MM-19515)

**Test Cases**

Use signtool to verify signature
installation should not complain about it not being signed

results from test branch can be found in a previous run: https://circleci.com/gh/mattermost/desktop/3551#artifacts/containers/0

**Additional Notes**
