### PR TITLE
Fixed email links being rejected by will-navigate

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -389,6 +389,9 @@ function handleAppWebContentsCreated(dc, contents) {
     if (isTrustedURL(parsedURL) || isTrustedPopupWindow(event.sender)) {
       return;
     }
+    if (parsedURL.protocol === 'mailto:') {
+      return;
+    }
     if (customLogins[contentID].inProgress) {
       return;
     }


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
The changes we made to enforce the use of trusted URLs has shut off the `mailto` protocol. This PR adds an exception for it.

**Issue link**
https://mattermost.atlassian.net/browse/MM-19596
