### PR TITLE
[MM-19266] Manually exit html fullscreen on macOS when in fullscreen

### DIFF
--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -50,6 +50,7 @@ export default class MattermostView extends React.Component {
     this.getSrc = this.getSrc.bind(this);
     this.handleDeepLink = this.handleDeepLink.bind(this);
     this.handleUserActivityUpdate = this.handleUserActivityUpdate.bind(this);
+    this.handleExitFullscreen = this.handleExitFullscreen.bind(this);
 
     this.webviewRef = React.createRef();
   }
@@ -223,11 +224,13 @@ export default class MattermostView extends React.Component {
 
     // start listening for user status updates from main
     ipcRenderer.on('user-activity-update', this.handleUserActivityUpdate);
+    ipcRenderer.on('exit-fullscreen', this.handleExitFullscreen);
   }
 
   componentWillUnmount() {
     // stop listening for user status updates from main
     ipcRenderer.removeListener('user-activity-update', this.handleUserActivityUpdate);
+    ipcRenderer.removeListener('exit-fullscreen', this.handleExitFullscreen);
   }
 
   reload() {
@@ -298,6 +301,11 @@ export default class MattermostView extends React.Component {
   handleUserActivityUpdate(event, status) {
     // pass user activity update to the webview
     this.webviewRef.current.send('user-activity-update', status);
+  }
+
+  handleExitFullscreen() {
+    // pass exit fullscreen request to the webview
+    this.webviewRef.current.send('exit-fullscreen');
   }
 
   render() {

--- a/src/browser/webview/mattermost.js
+++ b/src/browser/webview/mattermost.js
@@ -240,6 +240,13 @@ ipcRenderer.on('user-activity-update', (event, {userIsActive, isSystemEvent}) =>
   window.postMessage({type: 'user-activity-update', message: {userIsActive, manual: isSystemEvent}}, window.location.origin);
 });
 
+// exit fullscreen embedded elements like youtube - https://mattermost.atlassian.net/browse/MM-19226
+ipcRenderer.on('exit-fullscreen', () => {
+  if (document.fullscreenElement) {
+    document.exitFullscreen();
+  }
+});
+
 // mattermost-webapp is SPA. So cache is not cleared due to no navigation.
 // We needed to manually clear cache to free memory in long-term-use.
 // http://seenaburns.com/debugging-electron-memory-usage/

--- a/src/browser/webview/mattermost.js
+++ b/src/browser/webview/mattermost.js
@@ -6,7 +6,6 @@
 /* eslint-disable no-magic-numbers */
 
 import {ipcRenderer, webFrame, remote} from 'electron';
-import log from 'electron-log';
 
 const UNREAD_COUNT_INTERVAL = 1000;
 const CLEAR_CACHE_INTERVAL = 6 * 60 * 60 * 1000; // 6 hours

--- a/src/browser/webview/mattermost.js
+++ b/src/browser/webview/mattermost.js
@@ -6,6 +6,7 @@
 /* eslint-disable no-magic-numbers */
 
 import {ipcRenderer, webFrame, remote} from 'electron';
+import log from 'electron-log';
 
 const UNREAD_COUNT_INTERVAL = 1000;
 const CLEAR_CACHE_INTERVAL = 6 * 60 * 60 * 1000; // 6 hours
@@ -242,7 +243,7 @@ ipcRenderer.on('user-activity-update', (event, {userIsActive, isSystemEvent}) =>
 
 // exit fullscreen embedded elements like youtube - https://mattermost.atlassian.net/browse/MM-19226
 ipcRenderer.on('exit-fullscreen', () => {
-  if (document.fullscreenElement) {
+  if (document.fullscreenElement && document.fullscreenElement.nodeName.toLowerCase() === 'iframe') {
     document.exitFullscreen();
   }
 });

--- a/src/main.js
+++ b/src/main.js
@@ -449,6 +449,13 @@ function handleAppWebContentsCreated(dc, contents) {
   // implemented to temporarily help solve for https://community-daily.mattermost.com/core/pl/b95bi44r4bbnueqzjjxsi46qiw
   contents.on('before-input-event', (event, input) => {
     if (!input.shift && !input.control && !input.alt && !input.meta) {
+      // hacky fix for https://mattermost.atlassian.net/browse/MM-19226
+      if ((input.key === 'Escape' || input.key === 'f') && input.type === 'keyDown') {
+        // only do this when in fullscreen on a mac
+        if (mainWindow.isFullScreen() && process.platform === 'darwin') {
+          mainWindow.webContents.send('exit-fullscreen');
+        }
+      }
       return;
     }
 


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
When the Mac Desktop app is in macOS fullscreen, engaging html fullscreen on an inline Youtube video gets stuck in html fullscreen mode. The `Escape` key, the `f` key shortcut and the fullscreen button don't do anything.

This PR listens for the `Escape` and `f` keys from the main process to manually tell the webview in the renderer process to exit html fullscreen if engaged.

This PR doesn't fix the fullscreen button, as due to `contextIsolation` the desktop app can't control the contents of the Webapp.

**Issue link**
https://mattermost.atlassian.net/browse/MM-19226