### PR TITLE
[MM-19963] set working directory on start

### DIFF
--- a/scripts/Makefile.ps1
+++ b/scripts/Makefile.ps1
@@ -439,7 +439,7 @@ function Get-Cert {
 }
 
 function Remove-Cert {
-    if (Test-Path $env:PFX) {
+    if (Test-Path 'env:PFX') {
         Print-Info "Removing windows certificate"
         Remove-Item -path "./mattermost-desktop-windows.pfx"
     }

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -14,7 +14,10 @@ exports.default = async function notarizing(context) {
   }
 
   const appName = context.packager.appInfo.productFilename;
-
+  if (typeof process.env.APPLEID === 'undefined') {
+    console.log('skipping notarization, remember to setup environment variables for APPLEID and APPLEIDPASS if you want to notarize');
+    return;
+  }
   await notarize({
 
     // should we change it to appBundleId: 'com.mattermost.desktop',

--- a/src/main.js
+++ b/src/main.js
@@ -89,11 +89,14 @@ const customLogins = {};
  */
 async function initialize() {
   process.on('uncaughtException', criticalErrorHandler.processUncaughtExceptionHandler.bind(criticalErrorHandler));
+  global.willAppQuit = false;
 
   // prevent using a different working directory, which happens on windows running after installation.
-  process.chdir(path.dirname(process.execPath));
-
-  global.willAppQuit = false;
+  const expectedPath = path.dirname(process.execPath);
+  if (process.cwd() !== expectedPath && !isDev) {
+    console.warn(`Current working directory is ${process.cwd()}, changing into ${expectedPath}`);
+    process.chdir(expectedPath);
+  }
 
   // initialization that can run before the app is ready
   initializeArgs();

--- a/src/main.js
+++ b/src/main.js
@@ -90,6 +90,9 @@ const customLogins = {};
 async function initialize() {
   process.on('uncaughtException', criticalErrorHandler.processUncaughtExceptionHandler.bind(criticalErrorHandler));
 
+  // prevent using a different working directory, which happens on windows running after installation.
+  process.chdir(path.dirname(process.execPath));
+
   global.willAppQuit = false;
 
   // initialization that can run before the app is ready

--- a/src/main.js
+++ b/src/main.js
@@ -91,13 +91,6 @@ async function initialize() {
   process.on('uncaughtException', criticalErrorHandler.processUncaughtExceptionHandler.bind(criticalErrorHandler));
   global.willAppQuit = false;
 
-  // prevent using a different working directory, which happens on windows running after installation.
-  const expectedPath = path.dirname(process.execPath);
-  if (process.cwd() !== expectedPath && !isDev) {
-    console.warn(`Current working directory is ${process.cwd()}, changing into ${expectedPath}`);
-    process.chdir(expectedPath);
-  }
-
   // initialization that can run before the app is ready
   initializeArgs();
   initializeConfig();
@@ -172,6 +165,13 @@ function initializeAppEventListeners() {
 
 function initializeBeforeAppReady() {
   certificateStore = CertificateStore.load(path.resolve(app.getPath('userData'), 'certificate.json'));
+
+  // prevent using a different working directory, which happens on windows running after installation.
+  const expectedPath = path.dirname(process.execPath);
+  if (process.cwd() !== expectedPath && !isDev) {
+    console.warn(`Current working directory is ${process.cwd()}, changing into ${expectedPath}`);
+    process.chdir(expectedPath);
+  }
 
   // can only call this before the app is ready
   if (config.enableHardwareAcceleration === false) {


### PR DESCRIPTION
**Summary**
Ensure working directory is set to where the executable is to prevent problems

**Issue link**
[MM-19963](https://mattermost.atlassian.net/browse/MM-19963)
**Test Cases**
run from the command line from a directory different from where it is installed
use procmon or some other process monitoring tool that can provide information of the working directory and check that is properly set.

<img width="863" alt="Screenshot 2019-11-13 at 12 41 16" src="https://user-images.githubusercontent.com/1515906/68761149-c35cb700-0613-11ea-82b9-acd7e1fcb08f.png">
