### PR TITLE
[MM 19649] Fix blank window when auto-starting the app on login

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -535,6 +535,7 @@ function initializeAfterAppReady() {
 
   mainWindow = createMainWindow(config.data, {
     hideOnStartup,
+    trayIconShown: process.platform === 'win32' || config.showTrayIcon,
     linuxAppIcon: path.join(assetsDir, 'appicon.png'),
     deeplinkingUrl,
   });

--- a/src/main/Validator.js
+++ b/src/main/Validator.js
@@ -8,6 +8,8 @@ const defaultOptions = {
   stripUnknown: true,
 };
 
+const defaultMinWindowXPos = -100;
+const defaultMinWindowYPos = -100;
 const defaultWindowWidth = 1000;
 const defaultWindowHeight = 700;
 const minWindowWidth = 400;
@@ -23,8 +25,8 @@ const argsSchema = Joi.object({
 });
 
 const boundsInfoSchema = Joi.object({
-  x: Joi.number().integer().min(0),
-  y: Joi.number().integer().min(0),
+  x: Joi.number().integer().min(defaultMinWindowXPos).default(0),
+  y: Joi.number().integer().min(defaultMinWindowYPos).default(0),
   width: Joi.number().integer().min(minWindowWidth).required().default(defaultWindowWidth),
   height: Joi.number().integer().min(minWindowHeight).required().default(defaultWindowHeight),
   maximized: Joi.boolean().default(false),

--- a/src/main/mainWindow.js
+++ b/src/main/mainWindow.js
@@ -68,6 +68,10 @@ function createMainWindow(config, options) {
 
   mainWindow.once('ready-to-show', () => {
     mainWindow.webContents.setZoomLevel(0);
+
+    // handle the initial state of the app on launch
+    // 1. When not configured to hide on startup, immediately show contents and optionally maximize as needed
+    // 2. When configured to hide on startup and there is no tray icon, show contents and minimize to the app icon
     if (!hideOnStartup) {
       mainWindow.show();
       if (windowIsMaximized) {
@@ -75,17 +79,24 @@ function createMainWindow(config, options) {
       }
     } else if (hideOnStartup && !trayIconShown) {
       mainWindow.show();
+
+      // NOTE: minimized here instead of right after creating the window as .show() seems to 'un-minimize' but not show contents
       mainWindow.minimize();
     }
   });
 
   mainWindow.once('show', () => {
+    // handle showing the window when hidden to the tray icon on launch
+    // - optionally maximize the window as needed
     if (hideOnStartup && windowIsMaximized) {
       mainWindow.maximize();
     }
   });
 
   mainWindow.once('restore', () => {
+    // handle restoring the window when minimized to the app icon on launch
+    // 1. show the window contents
+    // 2. optionally maximize the window as needed
     if (hideOnStartup) {
       mainWindow.show();
       if (windowIsMaximized) {

--- a/src/main/mainWindow.js
+++ b/src/main/mainWindow.js
@@ -48,7 +48,7 @@ function createMainWindow(config, options) {
   Object.assign(windowOptions, {
     title: app.getName(),
     fullscreenable: true,
-    show: hideOnStartup,
+    show: hideOnStartup || false,
     minWidth: minimumWindowWidth,
     minHeight: minimumWindowHeight,
     fullscreen: false,

--- a/src/main/mainWindow.js
+++ b/src/main/mainWindow.js
@@ -79,6 +79,12 @@ function createMainWindow(config, options) {
     }
   });
 
+  mainWindow.once('show', () => {
+    if (hideOnStartup && windowIsMaximized) {
+      mainWindow.maximize();
+    }
+  });
+
   mainWindow.once('restore', () => {
     if (hideOnStartup) {
       mainWindow.show();

--- a/src/main/mainWindow.js
+++ b/src/main/mainWindow.js
@@ -79,7 +79,7 @@ function createMainWindow(config, options) {
     mainWindow.webContents.setZoomLevel(0);
 
     // handle showing the window when not launched by auto-start
-    //- when not configured to hide on startup, immediately show contents and optionally maximize as needed
+    // - when not configured to auto-start, immediately show contents and optionally maximize as needed
     if (!hideOnStartup) {
       mainWindow.show();
       if (windowIsMaximized) {


### PR DESCRIPTION
**Summary**
Prior to the upgrade to Electron v5 (from v2), the app would immediately minimize the app window once created. It would then wait for the window's 'ready-to-show' event fired and call the `.show()` method to show the UI in the window while the window remained minimized. Following the upgrade of Electron, calling the `.show()` method un-minimizes the Window, but the UI doesn't get shown resulting in a blank window (I suspect this has something to do with not being told the Window is visible and/or not getting a resize event to re-render the UI). Although the below ticket only refers to Windows, the reality is that it can be repro'd on other OS's by using the supported `--hidden` flag when starting the app from command line.

This PR sets the initial `show` option when creating the window based on whether the auto-launch setting is configured or not, i.e. the app UI is not hidden by default when the app is started by auto-launch since the entire window is not visible. This avoids the blank screen when the app is auto launched (or started with the `--hidden` flag as the UI is never hidden to begin with.

The PR also tweaks the code that restores the window when a user clicks on the tray and/or running app icon.

Updated non-macOS app behaviour – when the app is auto-launched:

1. if the app is configured to show a tray icon, upon login only the tray icon is shown. The user can click on the tray icon to reveal the window. Note: in Windows, the tray icon will always be shown, i.e. there is no setting to turn the tray icon off in Windows
2. if the app is configured to NOT show a tray icon, upon login the app window is immediately minimized into the running app icon. The user can click on the running app icon to reveal the window.

Updated macOS app behaviour – when the app is auto-launched, it will always minimize into the app icon whether there is a tray icon present or not.

Note: in all cases, if the app was maximized when it was last quit, it will be automatically be maximized again when the user clicks the tray icon or app icon after auto-start.

**Issue link**
https://mattermost.atlassian.net/browse/MM-19649
