### PR TITLE
[MM-18007] macOS app reopens closed window on Cmd+Tab

### DIFF
--- a/src/main/mainWindow.js
+++ b/src/main/mainWindow.js
@@ -124,11 +124,11 @@ function createMainWindow(config, options) {
         // need to leave fullscreen first, then hide the window
         if (mainWindow.isFullScreen()) {
           mainWindow.once('leave-full-screen', () => {
-            hideWindow(mainWindow);
+            app.hide();
           });
           mainWindow.setFullScreen(false);
         } else {
-          hideWindow(mainWindow);
+          app.hide();
         }
         break;
       default:

--- a/test/specs/app_test.js
+++ b/test/specs/app_test.js
@@ -34,6 +34,20 @@ describe('application', function desc() {
     visible.should.be.true;
   });
 
+  if (process.platform === 'darwin') {
+    it.skip('should show closed window with cmd+tab', async () => {
+      // Unable to utilize Command key press due to: https://bugs.chromium.org/p/chromedriver/issues/detail?id=3023#c2
+      await this.app.client.waitUntilWindowLoaded();
+      await this.app.client.keys(['Meta', 'w']);
+      let visible = await this.app.browserWindow.isVisible();
+      visible.should.be.false;
+
+      this.app.client.keys(['Meta', 'Tab']);
+      visible = await this.app.browserWindow.isVisible();
+      visible.should.be.true;
+    });
+  }
+
   it.skip('should restore window bounds', async () => {
     // bounds seems to be incorrectly calculated in some environments
     // - Windows 10: OK


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
<!--
Write a short (one line) summary that describes the changes in this pull request for inclusion in the changelog
-->
On macOS, closed window reopens on Cmd+Tab

**Issue link**
<!--
Please include a link to the GitHub issue this pull request addresses, if applicable.
-->
Fixes https://github.com/mattermost/desktop/issues/1068

**Test Cases**
Unfortunately, my test case is skipped until Chromedriver on Mac issue is addressed: https://bugs.chromium.org/p/chromedriver/issues/detail?id=3023#c2
Maybe I'm mistaken though, please advise if there's an alternative.
Possibly able to run this kind of test using TestCafe.

**Additional Notes**
For changelog message, do I need conventional commit format? Such as `FEAT:`, `FIX:`?
