### PR TITLE
[MM-20645] fix spellchecker

### DIFF
--- a/src/browser/js/contextMenu.js
+++ b/src/browser/js/contextMenu.js
@@ -52,7 +52,7 @@ export default {
     const actualOptions = Object.assign({}, defaultOptions, options);
     electronContextMenu({
       window: win,
-      prepend(params) {
+      prepend(_defaultActions, params) {
         if (actualOptions.useSpellChecker) {
           const prependMenuItems = [];
           if (params.isEditable && params.misspelledWord !== '') {


### PR DESCRIPTION
**Summary**
on [electron-context-menu v0.12](https://github.com/sindresorhus/electron-context-menu/releases/tag/v0.12.0) they released a breaking change, we need to adapt to it to allow the spellchecker to show.

**Issue link**
[MM-20645](https://mattermost.atlassian.net/browse/MM-20645)
**Test Cases**
- on the imput line type "helo my friend"
- "helo" should show with a red underline
- right click on it to correct

Expected:
- suggestion of "hello" appears
- clicking on suggestion substitutes the word.
