### PR TITLE
[MM-20156] Added '99+' message badge for Windows when over 99 mentions are on the badge

### DIFF
--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -69,7 +69,7 @@ function showBadgeWindows(sessionExpired, unreadCount, mentionCount) {
     const dataURL = createBadgeDataURL('•');
     sendBadge(dataURL, 'Session Expired: Please sign in to continue receiving notifications.');
   } else if (mentionCount > 0) {
-    const dataURL = createBadgeDataURL(mentionCount.toString());
+    const dataURL = createBadgeDataURL((mentionCount > 99) ? '99+' : mentionCount.toString(), mentionCount > 99);
     sendBadge(dataURL, 'You have unread mentions (' + mentionCount + ')');
   } else if (unreadCount > 0 && config.showUnreadBadge) {
     const dataURL = createBadgeDataURL('•');

--- a/src/browser/js/badge.js
+++ b/src/browser/js/badge.js
@@ -3,9 +3,9 @@
 // See LICENSE.txt for license information.
 'use strict';
 
-export function createDataURL(text) {
+export function createDataURL(text, small) {
   const scale = 2; // should rely display dpi
-  const size = 16 * scale;
+  const size = (small ? 20 : 16) * scale;
   const canvas = document.createElement('canvas');
   canvas.setAttribute('width', size);
   canvas.setAttribute('height', size);


### PR DESCRIPTION
Please provide the following information:

**Summary**
When a user has over 99 mentions, the text expands too large to fit the badge, creating a poor UX. This PR forces that over 99 mentions will show as "99+".

**Issue link**
https://mattermost.atlassian.net/browse/MM-20156
