### PR TITLE
[MM-20659] fixing upgrade

### DIFF
--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -136,7 +136,6 @@
     <InstallExecuteSequence>
       <Custom Action="KillApp" Before="InstallValidate" />
       <Custom Action="LaunchApp" After="InstallFinalize">Installed</Custom>
-      <!-- <RemoveExistingProducts After="InstallFinalize" /> -->
       <RemoveExistingProducts Before="InstallInitialize" /> 
     </InstallExecuteSequence>
     <CustomAction Id="LaunchApp" FileKey="MattermostDesktopEXE" ExeCommand="" Return="asyncNoWait" />

--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -53,18 +53,8 @@
     <?if $(var.Platform) != x64 ?>
     <Condition Message="!(loc.Requires32Bit)"><![CDATA[NOT VersionNT64]]></Condition>
     <?endif ?>
-    <!--<MajorUpgrade
-      DowngradeErrorMessage="A later version of [ProductName] is already installed. Setup will now exit." />-->
+    <MajorUpgrade AllowDowngrades="yes" />
     <!-- Retrieve previous installation path -->
-    <!-- from https://stackoverflow.com/questions/114165/how-to-implement-wix-installer-upgrade -->
-    <Property Id="PREVIOUSVERSIONSINSTALLED" Secure="yes" />
-    <Upgrade Id="8523DAF0-699D-4CC7-9A65-C5E696A9DE6D">  
-      <UpgradeVersion
-          OnlyDetect="no"
-          Minimum="4.3.0" Maximum="99.0.0"
-          Property="PREVIOUSVERSIONSINSTALLED"
-          IncludeMinimum="yes" IncludeMaximum="no" />
-    </Upgrade>
     <Property Id="INSTALLDIR">
       <RegistrySearch Id="DetermineInstallLocation" Type="raw" Root="HKLM" Key="Software\Mattermost\Desktop" Name="InstallLocation" Win64="$(var.Win64)" />
     </Property>
@@ -136,7 +126,6 @@
     <InstallExecuteSequence>
       <Custom Action="KillApp" Before="InstallValidate" />
       <Custom Action="LaunchApp" After="InstallFinalize">Installed</Custom>
-      <RemoveExistingProducts Before="InstallInitialize" /> 
     </InstallExecuteSequence>
     <CustomAction Id="LaunchApp" FileKey="MattermostDesktopEXE" ExeCommand="" Return="asyncNoWait" />
     <CustomAction Id="KillApp" Directory="INSTALLDIR" Return="ignore" ExeCommand="&quot;[SystemFolder]taskkill.exe&quot; /F /IM &quot;Mattermost.exe&quot;" />

--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -56,6 +56,15 @@
     <!--<MajorUpgrade
       DowngradeErrorMessage="A later version of [ProductName] is already installed. Setup will now exit." />-->
     <!-- Retrieve previous installation path -->
+    <!-- from https://stackoverflow.com/questions/114165/how-to-implement-wix-installer-upgrade -->
+    <Property Id="PREVIOUSVERSIONSINSTALLED" Secure="yes" />
+    <Upgrade Id="8523DAF0-699D-4CC7-9A65-C5E696A9DE6D">  
+      <UpgradeVersion
+          OnlyDetect="no"
+          Minimum="4.3.0" Maximum="99.0.0"
+          Property="PREVIOUSVERSIONSINSTALLED"
+          IncludeMinimum="yes" IncludeMaximum="no" />
+    </Upgrade>
     <Property Id="INSTALLDIR">
       <RegistrySearch Id="DetermineInstallLocation" Type="raw" Root="HKLM" Key="Software\Mattermost\Desktop" Name="InstallLocation" Win64="$(var.Win64)" />
     </Property>
@@ -127,7 +136,8 @@
     <InstallExecuteSequence>
       <Custom Action="KillApp" Before="InstallValidate" />
       <Custom Action="LaunchApp" After="InstallFinalize">Installed</Custom>
-      <RemoveExistingProducts After="InstallFinalize" />
+      <!-- <RemoveExistingProducts After="InstallFinalize" /> -->
+      <RemoveExistingProducts Before="InstallInitialize" /> 
     </InstallExecuteSequence>
     <CustomAction Id="LaunchApp" FileKey="MattermostDesktopEXE" ExeCommand="" Return="asyncNoWait" />
     <CustomAction Id="KillApp" Directory="INSTALLDIR" Return="ignore" ExeCommand="&quot;[SystemFolder]taskkill.exe&quot; /F /IM &quot;Mattermost.exe&quot;" />


### PR DESCRIPTION
**Summary**
Add code for removing any previously installed version, also changed to doing it before installing the new one.

**Issue link**
[MM-20659](https://mattermost.atlassian.net/browse/MM-20659)
[MM-20678](https://mattermost.atlassian.net/browse/MM-20678)

**Test Cases**
on windows, install version 4.3.1 and configure it with a server
run installer based on this version

Expected:
- previows version no longer displays on settings->apps
- if autostart after install is selected, it should open to the server tab (no blank screen)

**Additional Notes**
For testing, this **needs an msi installer**, so either QA has to wait for it (RC/final), or we can create one on demand.
There seems to be problems with 4.3.0, for some reason this version install to a different path (not in `program files` and it seems to cause troubles)