### PR TITLE
[MM-14135] allow negative window app positions

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -997,23 +997,22 @@ function clearAppCache() {
   }
 }
 
-function getValidWindowPosition(state, screen) {
+function isWithinDisplay(state, display) {
+  // given a display, check if window is within it
+  return (state.x > display.maxX || state.y > display.maxY || state.x < display.minX || state.y < display.minY);
+}
+
+function getValidWindowPosition(state) {
   // Check if the previous position is out of the viewable area
   // (e.g. because the screen has been plugged off)
-  const displays = screen.getAllDisplays();
-  let minX = 0;
-  let maxX = 0;
-  let minY = 0;
-  let maxY = 0;
-  for (let i = 0; i < displays.length; i++) {
-    const display = displays[i];
-    maxX = Math.max(maxX, display.bounds.x + display.bounds.width);
-    maxY = Math.max(maxY, display.bounds.y + display.bounds.height);
-    minX = Math.min(minX, display.bounds.x);
-    minY = Math.min(minY, display.bounds.y);
-  }
+  const boundaries = Utils.getDisplayBoundaries();
+  const isDisplayed = boundaries.reduce(
+    (prev, display) => {
+      return prev || isWithinDisplay(state, display);
+    },
+    false);
 
-  if (state.x > maxX || state.y > maxY || state.x < minX || state.y < minY) {
+  if (isDisplayed) {
     Reflect.deleteProperty(state, 'x');
     Reflect.deleteProperty(state, 'y');
     Reflect.deleteProperty(state, 'width');
@@ -1024,15 +1023,20 @@ function getValidWindowPosition(state, screen) {
 }
 
 function resizeScreen(screen, browserWindow) {
+  console.log('resize screen called!');
   function handle() {
+    console.log('handle resize called!');
     const position = browserWindow.getPosition();
+    console.log(position);
     const size = browserWindow.getSize();
+    console.log(size);
     const validPosition = getValidWindowPosition({
       x: position[0],
       y: position[1],
       width: size[0],
       height: size[1],
-    }, screen);
+    });
+    console.log(`moving window to: ${validPosition.x}:${validPosition.y}`);
     browserWindow.setPosition(validPosition.x || 0, validPosition.y || 0);
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -1023,20 +1023,15 @@ function getValidWindowPosition(state) {
 }
 
 function resizeScreen(screen, browserWindow) {
-  console.log('resize screen called!');
   function handle() {
-    console.log('handle resize called!');
     const position = browserWindow.getPosition();
-    console.log(position);
     const size = browserWindow.getSize();
-    console.log(size);
     const validPosition = getValidWindowPosition({
       x: position[0],
       y: position[1],
       width: size[0],
       height: size[1],
     });
-    console.log(`moving window to: ${validPosition.x}:${validPosition.y}`);
     browserWindow.setPosition(validPosition.x || 0, validPosition.y || 0);
   }
 

--- a/src/main/Validator.js
+++ b/src/main/Validator.js
@@ -7,9 +7,6 @@ import Utils from '../utils/util';
 const defaultOptions = {
   stripUnknown: true,
 };
-
-const defaultMinWindowXPos = -100;
-const defaultMinWindowYPos = -100;
 const defaultWindowWidth = 1000;
 const defaultWindowHeight = 700;
 const minWindowWidth = 400;
@@ -25,8 +22,8 @@ const argsSchema = Joi.object({
 });
 
 const boundsInfoSchema = Joi.object({
-  x: Joi.number().integer().min(defaultMinWindowXPos).default(0),
-  y: Joi.number().integer().min(defaultMinWindowYPos).default(0),
+  x: Joi.number().integer().default(0),
+  y: Joi.number().integer().default(0),
   width: Joi.number().integer().min(minWindowWidth).required().default(defaultWindowWidth),
   height: Joi.number().integer().min(minWindowHeight).required().default(defaultWindowHeight),
   maximized: Joi.boolean().default(false),

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -3,6 +3,7 @@
 // See LICENSE.txt for license information.
 import url from 'url';
 
+import electron from 'electron';
 import {isUri, isHttpUri, isHttpsUri} from 'valid-url';
 
 function getDomain(inputURL) {
@@ -33,9 +34,27 @@ function isInternalURL(targetURL, currentURL, basename = '/') {
   return true;
 }
 
+function getDisplayBoundaries() {
+  const {screen} = electron;
+
+  const displays = screen.getAllDisplays();
+
+  return displays.map((display) => {
+    return {
+      maxX: display.workArea.x + display.workArea.width,
+      maxY: display.workArea.y + display.workArea.height,
+      minX: display.workArea.x,
+      minY: display.workArea.y,
+      maxWidth: display.workArea.width,
+      maxHeight: display.workArea.height,
+    };
+  });
+}
+
 export default {
   getDomain,
   isValidURL,
   isValidURI,
   isInternalURL,
+  getDisplayBoundaries,
 };


### PR DESCRIPTION
**Summary**
Allow for negative window position, so the app can be set to a monitor to the left or on top of the primary display

**Issue link**
[MM-14135](https://mattermost.atlassian.net/browse/MM-14135)

**Test Cases**

*** Case 1 ***
On a multimonitor setup, set as main display the rightest monitor (or the bottom one if they are stacked)
open mattermost
move the window to any monitor not on the main display
quit the app
reopen

expected: window position is as we left it. Notice that if we leave the window partially outside of the screen it might reposition on reopen.

*** Case 2 ***
Same as on Case 1, but disconnect the extra display before launching
expected: window goes to main display.