### PR TITLE
[MM-20350] Block Basic auth for non trusted URLs

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -352,6 +352,9 @@ function handleAppGPUProcessCrashed(event, killed) {
 
 function handleAppLogin(event, webContents, request, authInfo, callback) {
   event.preventDefault();
+  if (!isTrustedURL(request.url)) {
+    return;
+  }
   loginCallbackMap.set(JSON.stringify(request), callback);
   mainWindow.webContents.send('login-request', request, authInfo);
 }


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
This PR fixes an issue where Basic Authentication challenges can be fired from the Mattermost app from arbitrary domains. This fix locks down the domains to only trusted URLS (ie. the URLs used by the Mattermost servers you have configured).

**Issue link**
https://mattermost.atlassian.net/browse/MM-20350
