### PR TITLE
[MM-19205] Allow the use of v2 configs by v1 config desktop apps

### DIFF
--- a/src/common/config/index.js
+++ b/src/common/config/index.js
@@ -209,11 +209,9 @@ export default class Config extends EventEmitter {
       configData = this.readFileSync(this.configFilePath);
 
       // validate based on config file version
-      switch (configData.version) {
-      case 1:
+      if (configData.version > 0) {
         configData = Validator.validateV1ConfigData(configData);
-        break;
-      default:
+      } else {
         configData = Validator.validateV0ConfigData(configData);
       }
       if (!configData) {


### PR DESCRIPTION
**Summary**
This PR changes the config to allow newer versions of the config to attempt to use the version of the config currently supported by the version of the app being used (ie. if you have a v2 config, the app will try to treat it as a v1 config)

**Issue link**
https://mattermost.atlassian.net/browse/MM-19205
