### PR TITLE
[MM-20796] Removed visibility: hidden from MM view when error page was showing

### DIFF
--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -323,7 +323,7 @@ export default class MattermostView extends React.Component {
     if (this.props.withTab) {
       classNames.push('mattermostView-with-tab');
     }
-    if (!this.props.active || this.state.errorInfo) {
+    if (!this.props.active) {
       classNames.push('mattermostView-hidden');
     }
 


### PR DESCRIPTION
**Summary**
When using Ctrl (or Cmd) + Tab to navigate tabs, if you tried to tab through a tab with an error screen, the event would be suppressed, since the `webview` was focused, but still hidden. This PR removes the `visibility: hidden` descriptor from the `webview` when the error page is showing, such that keyboard shortcuts still work as normal.

**Issue link**
https://mattermost.atlassian.net/browse/MM-20796

