### PR TITLE
[MM-20660] set white background for OSs which have turned off subpixel aliasing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -438,6 +438,7 @@ function handleAppWebContentsCreated(dc, contents) {
     }
     if (!popupWindow) {
       popupWindow = new BrowserWindow({
+        backgroundColor: '#fff', // prevents blurry text: https://electronjs.org/docs/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do
         parent: mainWindow,
         show: false,
         webPreferences: {

--- a/src/main/autoUpdater.js
+++ b/src/main/autoUpdater.js
@@ -39,6 +39,7 @@ function createUpdaterModal(parentWindow, options) {
     height: windowHeight,
     resizable: false,
     autoHideMenuBar: true,
+    backgroundColor: '#fff', // prevents blurry text: https://electronjs.org/docs/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do
   };
   if (process.platform === 'linux') {
     windowOptions.icon = options.linuxAppIcon;

--- a/src/main/mainWindow.js
+++ b/src/main/mainWindow.js
@@ -52,6 +52,7 @@ function createMainWindow(config, options) {
     minWidth: minimumWindowWidth,
     minHeight: minimumWindowHeight,
     fullscreen: false,
+    backgroundColor: '#fff', // prevents blurry text: https://electronjs.org/docs/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: false,


### PR DESCRIPTION
**Summary**
set up a white bg for browser windows so fonts without subpixel aliasing are rendered properly
**Issue link**
[MM-20660](https://mattermost.atlassian.net/browse/MM-20660)
