### PR TITLE
[MM-21075] Prevent known teams to open in a new app window

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -432,6 +432,10 @@ function handleAppWebContentsCreated(dc, contents) {
       log.info(`Untrusted popup window blocked: ${url}`);
       return;
     }
+    if (isTrustedTeam(url)) {
+      log.info('this is a known team, preventing to open a new window');
+      return;
+    }
     if (popupWindow && popupWindow.getURL() === url) {
       log.info(`Popup window already open at provided url: ${url}`);
       return;
@@ -852,7 +856,7 @@ function parseURL(url) {
   }
 }
 
-function isTrustedURL(url) {
+function isTrustedTeam(url) {
   const parsedURL = parseURL(url);
   if (!parsedURL) {
     return false;
@@ -870,6 +874,14 @@ function isTrustedURL(url) {
     }
   }
   return false;
+}
+
+function isTrustedURL(url) {
+  const parsedURL = parseURL(url);
+  if (!parsedURL) {
+    return false;
+  }
+  return isTrustedTeam(parsedURL);
 }
 
 function isTrustedPopupWindow(webContents) {

--- a/src/main.js
+++ b/src/main.js
@@ -432,8 +432,8 @@ function handleAppWebContentsCreated(dc, contents) {
       log.info(`Untrusted popup window blocked: ${url}`);
       return;
     }
-    if (isKnownTeam(url)) {
-      log.info('this is a known team, preventing to open a new window');
+    if (isTeamUrl(url) === true) {
+      log.info(`${url} is a known team, preventing to open a new window`);
       return;
     }
     if (popupWindow && popupWindow.getURL() === url) {
@@ -856,7 +856,19 @@ function parseURL(url) {
   }
 }
 
-function isKnownTeam(url) {
+function isTeamUrl(url) {
+  const parsedURL = parseURL(url);
+  if (!parsedURL) {
+    return null;
+  }
+  if (isCustomLoginURL(parsedURL)) {
+    return false;
+  }
+  const nonTeamUrlPaths = ['plugins', 'signup', 'login', 'admin', 'channel', 'post', 'api', 'oauth'];
+  return !(nonTeamUrlPaths.some((testPath) => parsedURL.pathname.toLowerCase().startsWith(`/${testPath}/`)));
+}
+
+function isTrustedURL(url) {
   const parsedURL = parseURL(url);
   if (!parsedURL) {
     return false;
@@ -874,14 +886,6 @@ function isKnownTeam(url) {
     }
   }
   return false;
-}
-
-function isTrustedURL(url) {
-  const parsedURL = parseURL(url);
-  if (!parsedURL) {
-    return false;
-  }
-  return isKnownTeam(parsedURL);
 }
 
 function isTrustedPopupWindow(webContents) {

--- a/src/main.js
+++ b/src/main.js
@@ -432,7 +432,7 @@ function handleAppWebContentsCreated(dc, contents) {
       log.info(`Untrusted popup window blocked: ${url}`);
       return;
     }
-    if (isTrustedTeam(url)) {
+    if (isKnownTeam(url)) {
       log.info('this is a known team, preventing to open a new window');
       return;
     }
@@ -856,7 +856,7 @@ function parseURL(url) {
   }
 }
 
-function isTrustedTeam(url) {
+function isKnownTeam(url) {
   const parsedURL = parseURL(url);
   if (!parsedURL) {
     return false;
@@ -881,7 +881,7 @@ function isTrustedURL(url) {
   if (!parsedURL) {
     return false;
   }
-  return isTrustedTeam(parsedURL);
+  return isKnownTeam(parsedURL);
 }
 
 function isTrustedPopupWindow(webContents) {


### PR DESCRIPTION
**Summary**
When a link to a team is posted and the user has that server on the list of tabs on the desktop app, it should only open in the browser, it shouldn't open a new desktop window with the server

**Issue link**

[MM-21075](https://mattermost.atlassian.net/browse/MM-21075)

**Test Cases**

Repro steps:
  1) Add mysql.test.mattermost.com as a server on the desktop app as well as another server
  2) On the other server, post a link to https://mysql.test.mattermost.com/
  3) Click on that link

Observed: A new desktop app window opens to mysql.test and a browser tab for mysql.test also opens

Expected: Nothing should open another desktop app window. Current expected is that it opens in browser tab.

**Additional Notes**
It is not expected to change tabs within the app