### PR TITLE
[MM-20794] change suggestion on spellchecker locale change

### DIFF
--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -133,6 +133,7 @@ function teamConfigChange(updatedTeams) {
 
 function handleSelectSpellCheckerLocale(locale) {
   config.set('spellCheckerLocale', locale);
+  ipcRenderer.send('update-dict', locale);
 }
 
 ReactDOM.render(

--- a/src/main.js
+++ b/src/main.js
@@ -772,10 +772,12 @@ function handleUpdateMenuEvent(event, configData) {
   }
 }
 
-function handleUpdateDictionaryEvent() {
+// localeSelected might be null, if that's the case, use config's locale
+function handleUpdateDictionaryEvent(_, localeSelected) {
   if (config.useSpellChecker) {
+    const locale = localeSelected || config.spellCheckerLocale;
     spellChecker = new SpellChecker(
-      config.spellCheckerLocale,
+      locale,
       path.resolve(app.getAppPath(), 'node_modules/simple-spellchecker/dict'),
       (err) => {
         if (err) {

--- a/src/main.js
+++ b/src/main.js
@@ -776,14 +776,18 @@ function handleUpdateMenuEvent(event, configData) {
 function handleUpdateDictionaryEvent(_, localeSelected) {
   if (config.useSpellChecker) {
     const locale = localeSelected || config.spellCheckerLocale;
-    spellChecker = new SpellChecker(
-      locale,
-      path.resolve(app.getAppPath(), 'node_modules/simple-spellchecker/dict'),
-      (err) => {
-        if (err) {
-          console.error(err);
-        }
-      });
+    try {
+      spellChecker = new SpellChecker(
+        locale,
+        path.resolve(app.getAppPath(), 'node_modules/simple-spellchecker/dict'),
+        (err) => {
+          if (err) {
+            console.error(err);
+          }
+        });
+    } catch (e) {
+      console.error('couldn\'t load a spellchecker for locale');
+    }
   }
 }
 


### PR DESCRIPTION
**Summary**
when user selects a new locale, spellchecker should update its suggestions to match

**Issue link**
[MM-20794](https://mattermost.atlassian.net/browse/MM-20794)

**Test Cases**
1. misspell word
1. right click on a misspelled word
1. check suggestions
1. click on Spelling Languages and select a different one.
1. right click on the same misspelled word
1. suggestions should be different
