### PR TITLE
[MM-21195] add file extension on download

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -645,9 +645,18 @@ function initializeAfterAppReady() {
   if (process.platform === 'darwin') {
     session.defaultSession.on('will-download', (event, item) => {
       const filename = item.getFilename();
+      const fileElements = filename.split('.');
+      let filter = null;
+      if (fileElements.length > 1) {
+        filter = {
+          name: fileElements[fileElements.length - 1],
+          extensions: [fileElements[fileElements.length - 1]],
+        };
+      }
       const savePath = dialog.showSaveDialog({
         title: filename,
         defaultPath: os.homedir() + '/Downloads/' + filename,
+        filter,
       });
 
       if (savePath) {

--- a/src/main.js
+++ b/src/main.js
@@ -642,21 +642,28 @@ function initializeAfterAppReady() {
     });
   }
 
-  if (process.platform === 'darwin') {
+  //if (process.platform === 'darwin') {
+    console.log('registering will-download event ilstener');
     session.defaultSession.on('will-download', (event, item) => {
+      console.log(`downloading file: ${item.getFilename()}`);
       const filename = item.getFilename();
       const fileElements = filename.split('.');
-      let filter = null;
+      const filters = [];
       if (fileElements.length > 1) {
-        filter = {
-          name: fileElements[fileElements.length - 1],
+        filters.push({
+          name: `${fileElements[fileElements.length - 1]} files`,
           extensions: [fileElements[fileElements.length - 1]],
-        };
+        });
       }
+      filters.push({
+        name: 'All files',
+        extensions: ['*'],
+      });
+      console.log(`fiiiiiiiiilllllllter is: ${filters}`);
       const savePath = dialog.showSaveDialog({
         title: filename,
         defaultPath: os.homedir() + '/Downloads/' + filename,
-        filter,
+        filters,
       });
 
       if (savePath) {
@@ -665,7 +672,7 @@ function initializeAfterAppReady() {
         item.cancel();
       }
     });
-  }
+  //}
 
   ipcMain.emit('update-menu', true, config.data);
 

--- a/src/main.js
+++ b/src/main.js
@@ -642,37 +642,34 @@ function initializeAfterAppReady() {
     });
   }
 
-  //if (process.platform === 'darwin') {
-    console.log('registering will-download event ilstener');
-    session.defaultSession.on('will-download', (event, item) => {
-      console.log(`downloading file: ${item.getFilename()}`);
-      const filename = item.getFilename();
-      const fileElements = filename.split('.');
-      const filters = [];
-      if (fileElements.length > 1) {
-        filters.push({
-          name: `${fileElements[fileElements.length - 1]} files`,
-          extensions: [fileElements[fileElements.length - 1]],
-        });
-      }
+  session.defaultSession.on('will-download', (event, item) => {
+    const filename = item.getFilename();
+    const fileElements = filename.split('.');
+    const filters = [];
+    if (fileElements.length > 1) {
       filters.push({
-        name: 'All files',
-        extensions: ['*'],
+        name: `${fileElements[fileElements.length - 1]} files`,
+        extensions: [fileElements[fileElements.length - 1]],
       });
-      console.log(`fiiiiiiiiilllllllter is: ${filters}`);
-      const savePath = dialog.showSaveDialog({
-        title: filename,
-        defaultPath: os.homedir() + '/Downloads/' + filename,
-        filters,
-      });
+    }
 
-      if (savePath) {
-        item.setSavePath(savePath);
-      } else {
-        item.cancel();
-      }
+    // add default filter
+    filters.push({
+      name: 'All files',
+      extensions: ['*'],
     });
-  //}
+    const savePath = dialog.showSaveDialog({
+      title: filename,
+      defaultPath: os.homedir() + '/Downloads/' + filename,
+      filters,
+    });
+
+    if (savePath) {
+      item.setSavePath(savePath);
+    } else {
+      item.cancel();
+    }
+  });
 
   ipcMain.emit('update-menu', true, config.data);
 


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**

when downloading on windows, we need to add the file extension filter to ensure it uses the same extension so it doesn't overwrite it on name change.

**Issue link**
<!--
Please include a link to the GitHub issue this pull request addresses, if applicable.
-->
[MM-21195](https://mattermost.atlassian.net/browse/MM-21195)

**Test Cases**
1. upload a file to a channel
2. on a win machine, download it
3. dialog should show up matching the extension of the file, as well as `*.*`
4. when downloading try to change the name of the file
5. save it
expected: extension is preserved unless we select the filter `*.*`


**Additional Notes**
