### PR TITLE
[MM-21341] Changed keyboard shortcut logic to pull focused web contents if an explicitly focused tab is not found

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -77,10 +77,6 @@ export default class MainPage extends React.Component {
 
   getTabWebContents(index = this.state.key || 0, teams = this.props.teams) {
     const allWebContents = remote.webContents.getAllWebContents();
-    const openDevTools = allWebContents.find((webContents) => webContents.getURL().includes('chrome-devtools') && webContents.isFocused());
-    if (openDevTools) {
-      return openDevTools;
-    }
 
     if (this.state.showNewTeamModal) {
       const indexURL = '/browser/index.html';
@@ -94,7 +90,8 @@ export default class MainPage extends React.Component {
     if (!tabURL) {
       return null;
     }
-    return allWebContents.find((webContents) => webContents.getURL().includes(tabURL) || webContents.getURL().includes(this.refs[`mattermostView${index}`].getSrc()));
+    const tab = allWebContents.find((webContents) => webContents.isFocused() && webContents.getURL().includes(this.refs[`mattermostView${index}`].getSrc()));
+    return tab || remote.webContents.getFocusedWebContents();
   }
 
   componentDidMount() {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
When using the JIRA plugin connect functionality, the desktop app will open a new window for sign-in. The copy/paste shortcuts weren't working due to the logic grabbing the Mattermost tab that opened the window rather than the window itself.

This PR changes the logic to ensure the Mattermost tab is focused, otherwise it should grab whatever web contents are focused and send the command there.

**Issue link**
https://mattermost.atlassian.net/browse/MM-21341