### PR TITLE
[MM-21400] Enable setuid on linux packaging

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -25,6 +25,7 @@
       ]
     }
   ],
+  "afterPack": "scripts/afterpack.js",
   "afterSign": "scripts/notarize.js",
   "deb": {
     "synopsis": "Mattermost"

--- a/scripts/afterpack.js
+++ b/scripts/afterpack.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-const {path} = require('path');
+const path = require('path');
 
 const {spawn} = require('electron-notarize');
 

--- a/scripts/afterpack.js
+++ b/scripts/afterpack.js
@@ -7,7 +7,7 @@ const {spawn} = require('electron-notarize');
 
 const SETUID_PERMISSIONS = '4755';
 
-async function afterPack(context) {
+exports.default = async function afterPack(context) {
   if (context.electronPlatformName === 'linux') {
     context.targets.forEach(async (target) => {
       if (!['appimage', 'snap'].includes(target.name.toLowerCase())) {
@@ -20,6 +20,4 @@ async function afterPack(context) {
       }
     });
   }
-}
-
-export default afterPack;
+};

--- a/scripts/afterpack.js
+++ b/scripts/afterpack.js
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import path from 'path';
+
+import spawn from 'electron-notarize';
+
+const SETUID_PERMISSIONS = '4755';
+
+async function afterPack(context) {
+  if (context.electronPlatformName === 'linux') {
+    context.targets.forEach(async (target) => {
+      if (!['appimage', 'snap'].includes(target.name.toLowerCase())) {
+        const result = await spawn('chmod', [SETUID_PERMISSIONS, path.join(context.appOutDir, 'chrome-sandbox')]);
+        if (result.code !== 0) {
+          throw new Error(
+            `Failed to set proper permissions for linux arch on ${target.name}`
+          );
+        }
+      }
+    });
+  }
+}
+
+export default afterPack;

--- a/scripts/afterpack.js
+++ b/scripts/afterpack.js
@@ -3,7 +3,7 @@
 
 const path = require('path');
 
-const {spawn} = require('electron-notarize');
+const {spawn} = require('electron-notarize/lib/spawn.js');
 
 const SETUID_PERMISSIONS = '4755';
 

--- a/scripts/afterpack.js
+++ b/scripts/afterpack.js
@@ -1,9 +1,9 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import path from 'path';
+const {path} = require('path');
 
-import spawn from 'electron-notarize';
+const {spawn} = require('electron-notarize');
 
 const SETUID_PERMISSIONS = '4755';
 


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**

Linux users can't get links to open due to not having the setuid bit active. This pr changes permissions on chrome so it can send links to the browser

**Issue link**
Github https://github.com/mattermost/desktop/issues/1101
Jira [MM-21400](https://mattermost.atlassian.net/browse/MM-21400)
**Test Cases**

on a linux machine, open the app and try to have a link opened on the browser.

**Additional Notes**
having `tail -f /var/log/syslog` should only show a message about blocking the URL (which is only preventing to open on the same electron window)
I've tested this on Ubuntu, we might want to test on other scenarios.