### PR TITLE
[MM-21869] handle downloading in a new way to adapt to electron v6

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -695,17 +695,11 @@ function initializeAfterAppReady() {
       name: 'All files',
       extensions: ['*'],
     });
-    const savePath = dialog.showSaveDialog({
+    item.setSaveDialogOptions({
       title: filename,
       defaultPath: os.homedir() + '/Downloads/' + filename,
       filters,
     });
-
-    if (savePath) {
-      item.setSavePath(savePath);
-    } else {
-      item.cancel();
-    }
   });
 
   ipcMain.emit('update-menu', true, config.data);


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**

electron is moving towards using promises in its api, this caused our downloads to stop working. having an asynchronous download also showed browser's file dialog (thus duplicating it)

this pr adresses those issues by using another mechanism to download.

**Issue link**
[MM-21869](https://mattermost.atlassian.net/browse/MM-21869)

**Test Cases**

1. upload file
2. from the desktop download it

expected:
- only 1 dialog
- extension set to the right one (e.g.: pdf for pdf files)
- file downloads
- app doesn't crash

**Additional Notes**
tested on osx
