### PR TITLE
CircleCI config tweaks (#1116)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,6 @@ commands:
         type: string
         default: "./linux/"
     steps:
-      - run: npm run build
       - run: npm run package:<< parameters.os >>
       - run: mkdir -p << parameters.path >>
       - run: bash -x ./scripts/cp_artifacts.sh release << parameters.path >>
@@ -188,10 +187,9 @@ jobs:
       - win_make:
           operation: "build"
       - run: mkdir -p ./dist/win-release
-      #- run: cp -r release/*.exe ./dist/win-release
       - run: cp -r release/*.zip ./dist/win-release
       - run: cp -r release/*.msi ./dist/win-release
-      #- run: cp -r release/*.blockmap ./dist/win-release
+      - run: cp -r release/*.exe ./dist/win-release
 
       - persist_to_workspace:
           root: ./dist/
@@ -229,10 +227,16 @@ jobs:
       - checkout
       - attach_workspace:
           at: ./dist
+      - run:
+          name: "Setup files for aws-s3"
+          command: |
+            mkdir -p ./aws-s3-dist
+            cp ./dist/{macos-release,win-release,linux}/* ./aws-s3-dist
       - aws-s3/copy:
-          from: ./dist/
+          from: ./aws-s3-dist/
           to: s3://releases.mattermost.com/desktop/$(jq -r .version package.json)/
           arguments: --acl public-read --cache-control "no-cache" --recursive
+
   upload_to_github:
     executor: github
     steps:
@@ -249,12 +253,17 @@ jobs:
           command: |
             go get github.com/tcnksm/ghr
             VERSION=$(jq -r .version package.json)
-            RELEASE_TITLE="${VERSION} ($(date -u "+%Y-%m-%d"))"
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -draft \
+            RELEASE_TITLE="v${VERSION} ($(date -u "+%Y-%m-%d"))"
+            ghr \
+              -t ${GITHUB_TOKEN} \
+              -u ${CIRCLE_PROJECT_USERNAME} \
+              -draft \
               --body="$(./scripts/generate_release_markdown.sh $VERSION)" \
               --name="${RELEASE_TITLE}" $( [[ $VERSION =~ "-rc" ]] && printf %s "-prerelease") \
-              -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} \
-              -delete ${VERSION} ./ghr-dist
+              -r ${CIRCLE_PROJECT_REPONAME} \
+              -c ${CIRCLE_SHA1} \
+              -delete \
+              v${VERSION} ./ghr-dist
 
 workflows:
   version: 2
@@ -264,20 +273,27 @@ workflows:
       - build-linux:
           requires:
             - check
+          filters:
+            branches:
+              only:
+                - /.*/
+            tags:
+              ignore:
+                - /.*/
       - build-win-no-installer:
           requires:
             - check
           filters:
             branches:
               ignore:
-                - /^release-\d+\.\d+(\.\d+)?(-rc.*)?/
+                - /^release-\d+(\.\d+){1,2}(-rc.*)?/
       - build-mac-no-dmg:
           requires:
             - check
           filters:
             branches:
               ignore:
-                - /^release-\d+\.\d+(\.\d+)?(-rc.*)?/
+                - /^release-\d+(\.\d+){1,2}(-rc.*)?/
       - msi_installer:
           requires:
             - check
@@ -288,7 +304,7 @@ workflows:
                 # only for release and release candidates
                 # release-XX.YY.ZZ
                 # release-XX.YY.ZZ-rc-something
-                - /^release-\d+\.\d+(\.\d+)?(-rc.*)?/
+                - /^release-\d+(\.\d+){1,2}(-rc.*)?/
       - mac_installer:
           requires:
             - check
@@ -296,7 +312,7 @@ workflows:
           filters:
             branches:
               only:
-                - /^release-\d+\.\d+(\.\d+)?(-rc.*)?/
+                - /^release-\d+(\.\d+){1,2}(-rc.*)?/
       - store_artifacts:
           # for master/PR builds
           requires:
@@ -306,7 +322,7 @@ workflows:
           filters:
             branches:
               ignore:
-                - /^release-\d+\.\d+(\.\d+)?(-rc.*)?/
+                - /^release-\d+(\.\d+){1,2}(-rc.*)?/
       - upload_to_s3:
           # for release builds
           requires:
@@ -315,9 +331,10 @@ workflows:
             - build-linux
           context: mattermost-release-s3
           filters:
-            tags:
+            branches:
               only:
-                - /^v\d+\.\d+\.\d+?$/
+                - /^release-\d+(\.\d+){1,2}(-rc.*)?/
+
       - upload_to_github:
           requires:
             - msi_installer
@@ -327,4 +344,4 @@ workflows:
           filters:
             branches:
               only:
-                - /^release-\d+\.\d+(\.\d+)?(-rc.*)?/
+                - /^release-\d+(\.\d+){1,2}(-rc.*)?/

--- a/scripts/generate_release_markdown.sh
+++ b/scripts/generate_release_markdown.sh
@@ -15,7 +15,10 @@ VERSION="$1" # such as 3.7.1, 4.0.0-rc1
 BASE_URL="https://releases.mattermost.com/desktop/${VERSION}"
 
 cat <<-MD
-### Mattermost Desktop ${VERSION} has been cut!
+### Mattermost Desktop v${VERSION} has been cut!
+
+Release notes can be found here: https://docs.mattermost.com/help/apps/desktop-changelog.html
+
 The download links can be found below.
 
 #### Windows - msi files (beta)


### PR DESCRIPTION
* update ci files

* remove redundant build step

- npm run package:* also builds

* fix path to temp aws files

* include exe in windows build

* add release notes reference

* tweak ghr draft tag name

* remove test filtering

* ignore tags for build_linux

* don't try to use the tag

Co-authored-by: Guillermo Vayá <guivaya@gmail.com>

Manual cherry pick