### PR TITLE
[MM-19919] Allow links to other servers to go directly to that server in the app

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -15,6 +15,8 @@ import DotsVerticalIcon from 'mdi-react/DotsVerticalIcon';
 
 import {ipcRenderer, remote} from 'electron';
 
+import Utils from '../../utils/util';
+
 import restoreButton from '../../assets/titlebar/chrome-restore.svg';
 import maximizeButton from '../../assets/titlebar/chrome-maximize.svg';
 import minimizeButton from '../../assets/titlebar/chrome-minimize.svg';
@@ -370,15 +372,7 @@ export default class MainPage extends React.Component {
   };
 
   handleInterTeamLink = (linkUrl) => {
-    let selectedTeam;
-    this.props.teams.forEach((team, index) => {
-      if (linkUrl.href.startsWith(team.url)) {
-        selectedTeam = {
-          team,
-          index,
-        };
-      }
-    });
+    const selectedTeam = Utils.getServer(linkUrl, this.props.teams);
     if (!selectedTeam) {
       return;
     }

--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -369,6 +369,23 @@ export default class MainPage extends React.Component {
     this.handleSelect(key);
   };
 
+  handleInterTeamLink = (linkUrl) => {
+    let selectedTeam;
+    this.props.teams.forEach((team, index) => {
+      if (linkUrl.href.startsWith(team.url)) {
+        selectedTeam = {
+          team,
+          index,
+        };
+      }
+    });
+    if (!selectedTeam) {
+      return;
+    }
+    this.refs[`mattermostView${selectedTeam.index}`].handleDeepLink(linkUrl.href);
+    this.setState({key: selectedTeam.index});
+  }
+
   handleMaximizeState = () => {
     const win = remote.getCurrentWindow();
     this.setState({maximized: win.isMaximized()});
@@ -713,7 +730,7 @@ export default class MainPage extends React.Component {
         <MattermostView
           key={id}
           id={id}
-
+          teams={this.props.teams}
           useSpellChecker={this.props.useSpellChecker}
           onSelectSpellCheckerLocale={this.props.onSelectSpellCheckerLocale}
           src={teamUrl}
@@ -721,6 +738,7 @@ export default class MainPage extends React.Component {
           onTargetURLChange={self.handleTargetURLChange}
           onBadgeChange={handleBadgeChange}
           onNotificationClick={handleNotificationClick}
+          handleInterTeamLink={self.handleInterTeamLink}
           ref={id}
           active={isActive}
         />);

--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -126,8 +126,14 @@ export default class MattermostView extends React.Component {
           shell.openExternal(e.url);
         }
       } else {
-        // if the link is external, use default os' application.
-        ipcRenderer.send('confirm-protocol', destURL.protocol, e.url);
+        const parsedURL = Utils.parseURL(e.url);
+        const serverURL = Utils.getServer(parsedURL, this.props.teams);
+        if (serverURL !== null && Utils.isTeamUrl(serverURL.url, parsedURL)) {
+          this.props.handleInterTeamLink(parsedURL);
+        } else {
+          // if the link is external, use default os' application.
+          ipcRenderer.send('confirm-protocol', destURL.protocol, e.url);
+        }
       }
     });
 
@@ -362,6 +368,7 @@ export default class MattermostView extends React.Component {
 MattermostView.propTypes = {
   name: PropTypes.string,
   id: PropTypes.string,
+  teams: PropTypes.array.isRequired,
   withTab: PropTypes.bool,
   onTargetURLChange: PropTypes.func,
   onBadgeChange: PropTypes.func,
@@ -369,6 +376,7 @@ MattermostView.propTypes = {
   active: PropTypes.bool,
   useSpellChecker: PropTypes.bool,
   onSelectSpellCheckerLocale: PropTypes.func,
+  handleInterTeamLink: PropTypes.func,
 };
 
 /* eslint-enable react/no-set-state */

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -93,7 +93,7 @@ function getServer(inputURL, teams) {
 
     // check server and subpath matches (without subpath pathname is \ so it always matches)
     if (parsedServerUrl.origin === parsedURL.origin && parsedURL.pathname.startsWith(parsedServerUrl.pathname)) {
-      return {name: teams[i].name, url: parsedServerUrl};
+      return {name: teams[i].name, url: parsedServerUrl, index: i};
     }
   }
   return null;


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

**Summary**
When clicking a link from Server A that links to Server B, even if you have Server B configured, it would open the link in your browser. This PR allows those links to be opened directly in the tab for that server.

**Issue link**
https://mattermost.atlassian.net/browse/MM-19919
