### PR TITLE
[MM-22007] Fix MSI download from S3, don't run when not an RC/release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,10 +243,12 @@ jobs:
       - checkout
       - attach_workspace:
           at: ./dist
-      - run: |
-        if [ -z `git tag -l --points-at master` ]; then
-          circleci-agent step halt
-        fi  
+      - run:
+          name: "Don't upload if it's not on a tag"
+          command: |
+            if [ -z `git tag -l --points-at master` ]; then
+              circleci-agent step halt
+            fi  
       - run:
           name: "Setup files for ghr"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,6 +228,12 @@ jobs:
       - attach_workspace:
           at: ./dist
       - run:
+          name: "Don't upload if it's not on a tag"
+          command: |
+            if [ -z `git tag -l --points-at master` ]; then
+              circleci-agent step halt
+            fi  
+      - run:
           name: "Setup files for aws-s3"
           command: |
             mkdir -p ./aws-s3-dist
@@ -287,7 +293,6 @@ workflows:
             branches:
               ignore:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
-                - test-ci
 
       - build-mac-no-dmg:
           requires:
@@ -296,7 +301,6 @@ workflows:
             branches:
               ignore:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
-                - test-ci
 
       - msi_installer:
           requires:
@@ -309,7 +313,6 @@ workflows:
                 # release-XX.YY.ZZ
                 # release-XX.YY.ZZ-rc-something
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
-                - test-ci
 
       - mac_installer:
           requires:
@@ -319,7 +322,6 @@ workflows:
             branches:
               only:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
-                - test-ci
 
       - store_artifacts:
           # for master/PR builds
@@ -331,7 +333,6 @@ workflows:
             branches:
               ignore:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
-                - test-ci
 
       - upload_to_s3:
           # for release builds
@@ -355,4 +356,3 @@ workflows:
             branches:
               only:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
-                - test-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,6 +243,10 @@ jobs:
       - checkout
       - attach_workspace:
           at: ./dist
+      - run: |
+        if [ -z `git tag -l --points-at master` ]; then
+          circleci-agent step halt
+        fi  
       - run:
           name: "Setup files for ghr"
           command: |
@@ -273,13 +277,7 @@ workflows:
       - build-linux:
           requires:
             - check
-          filters:
-            branches:
-              only:
-                - /.*/
-            tags:
-              ignore:
-                - /.*/
+
       - build-win-no-installer:
           requires:
             - check
@@ -287,6 +285,8 @@ workflows:
             branches:
               ignore:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
+                - test-ci
+
       - build-mac-no-dmg:
           requires:
             - check
@@ -294,6 +294,8 @@ workflows:
             branches:
               ignore:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
+                - test-ci
+
       - msi_installer:
           requires:
             - check
@@ -305,6 +307,8 @@ workflows:
                 # release-XX.YY.ZZ
                 # release-XX.YY.ZZ-rc-something
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
+                - test-ci
+
       - mac_installer:
           requires:
             - check
@@ -313,6 +317,8 @@ workflows:
             branches:
               only:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
+                - test-ci
+
       - store_artifacts:
           # for master/PR builds
           requires:
@@ -323,6 +329,8 @@ workflows:
             branches:
               ignore:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
+                - test-ci
+
       - upload_to_s3:
           # for release builds
           requires:
@@ -345,3 +353,4 @@ workflows:
             branches:
               only:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
+                - test-ci

--- a/scripts/generate_release_markdown.sh
+++ b/scripts/generate_release_markdown.sh
@@ -22,8 +22,8 @@ Release notes can be found here: https://docs.mattermost.com/help/apps/desktop-c
 The download links can be found below.
 
 #### Windows - msi files (beta)
-$(print_link "${BASE_URL}/mattermost-desktop-v${VERSION}-x64.msi")
-$(print_link "${BASE_URL}/mattermost-desktop-v${VERSION}-x86.msi")
+$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-x64.msi")
+$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-x86.msi")
 
 #### Windows - setup exe files
 $(print_link "${BASE_URL}/mattermost-desktop-setup-${VERSION}-win.exe")


### PR DESCRIPTION
**Summary**
 - Prevent circle from publishing a new release if it's not an RC or final
 - Fix naming on MSI

**Issue link**
[MM-22007](https://mattermost.atlassian.net/browse/MM-22007)

**Additional Notes**
Successfull test for github: https://app.circleci.com/github/mattermost/desktop/pipelines/faaa2eb9-c5b3-4a2b-8272-037a69d1f8b3/workflows/51853392-0006-42bb-b038-0ccfbe6eab82