### PR TITLE
[MM-20832] prevent dialog stacking, move to promises

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -348,7 +348,7 @@ function handleAppCertificateError(event, webContents, url, error, certificate, 
 
     // update the callback
     const errorID = `${url}:${error}`;
-  
+
     // if we are already showing that error, don't add more dialogs
     if (certificateErrorCallbacks.has(errorID)) {
       console.log(`Ignoring already shown dialog for ${errorID}`);

--- a/src/main.js
+++ b/src/main.js
@@ -50,7 +50,7 @@ const assetsDir = path.resolve(app.getAppPath(), 'assets');
 const loginCallbackMap = new Map();
 const certificateRequests = new Map();
 const userActivityMonitor = new UserActivityMonitor();
-const certificateErrors = new Map();
+const certificateErrorCallbacks = new Map();
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -345,56 +345,54 @@ function handleAppCertificateError(event, webContents, url, error, certificate, 
     if (certificateStore.isExisting(url)) {
       detail = 'Certificate is different from previous one.\n\n' + detail;
     }
-    const errorID = `${url}:${error}`;
 
-    // if we are already showing that error, don't add more dialogs, but update the callback as the previous one might have expired
-    if ((typeof certificateErrors.get(errorID)) === 'undefined') {
-      certificateErrors.set(errorID, callback);
-      dialog.showMessageBox(mainWindow, {
-        title: 'Certificate Error',
-        message: 'There is a configuration issue with this Mattermost server, or someone is trying to intercept your connection. You also may need to sign into the Wi-Fi you are connected to using your web browser.',
-        type: 'error',
-        buttons: ['More Details', 'Cancel Connection'],
-        cancelId: 1,
-      }).then(
-        ({response}) => {
-          if (response === 0) {
-            dialog.showMessageBox(mainWindow, {
-              title: 'Certificate Not Trusted',
-              message: `Certificate from "${certificate.issuerName}" is not trusted.`,
-              detail,
-              type: 'error',
-              buttons: ['Trust Insecure Certificate', 'Cancel Connection'],
-              cancelId: 1,
-            }).then(({response: responseTwo}) => {
-              if (responseTwo === 0) {
-                certificateStore.add(url, certificate);
-                certificateStore.save();
-                certificateErrors.get(errorID)(true);
-                certificateErrors.delete(errorID);
-                webContents.loadURL(url);
-              } else {
-                certificateErrors.get(errorID)(false);
-                certificateErrors.delete(errorID);
-              }
-            }).catch((dialogError) => {
-              log.error(`There was an error with the dialog for trusting the certificate: ${dialogError}`);
-              certificateErrors.delete(errorID);
-            });
-          } else {
-            certificateErrors.get(errorID)(false);
-            certificateErrors.delete(errorID);
-          }
-        }
-      ).catch((dialogError) => {
-        log.error(`There was an error with the dialog: ${dialogError}`);
-        certificateErrors.delete(errorID);
-      });
-    } else {
-      // update the callback
-      console.log(`ignoring dialog for ${errorID}`);
-      certificateErrors.set(errorID, callback);
+    // update the callback
+    const errorID = `${url}:${error}`;
+    certificateErrorCallbacks.set(errorID, callback);
+
+    // if we are already showing that error, don't add more dialogs
+    if (certificateErrorCallbacks.has(errorID)) {
+      console.log(`Ignoring already shown dialog for ${errorID}`);
+      return;
     }
+
+    certificateErrorCallbacks.set(errorID, callback);
+    dialog.showMessageBox(mainWindow, {
+      title: 'Certificate Error',
+      message: 'There is a configuration issue with this Mattermost server, or someone is trying to intercept your connection. You also may need to sign into the Wi-Fi you are connected to using your web browser.',
+      type: 'error',
+      buttons: ['More Details', 'Cancel Connection'],
+      cancelId: 1,
+    }).then(
+      ({response}) => {
+        if (response === 0) {
+          return dialog.showMessageBox(mainWindow, {
+            title: 'Certificate Not Trusted',
+            message: `Certificate from "${certificate.issuerName}" is not trusted.`,
+            detail,
+            type: 'error',
+            buttons: ['Trust Insecure Certificate', 'Cancel Connection'],
+            cancelId: 1,
+          });
+        }
+        return {response};
+      }).then(
+      ({response: responseTwo}) => {
+        if (responseTwo === 0) {
+          certificateStore.add(url, certificate);
+          certificateStore.save();
+          certificateErrorCallbacks.get(errorID)(true);
+          certificateErrorCallbacks.delete(errorID);
+          webContents.loadURL(url);
+        } else {
+          certificateErrorCallbacks.get(errorID)(false);
+          certificateErrorCallbacks.delete(errorID);
+        }
+      }).catch(
+      (dialogError) => {
+        log.error(`There was an error with the Certificate Error dialog: ${dialogError}`);
+        certificateErrorCallbacks.delete(errorID);
+      });
   }
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -348,6 +348,7 @@ function handleAppCertificateError(event, webContents, url, error, certificate, 
 
     // update the callback
     const errorID = `${url}:${error}`;
+  
     // if we are already showing that error, don't add more dialogs
     if (certificateErrorCallbacks.has(errorID)) {
       console.log(`Ignoring already shown dialog for ${errorID}`);

--- a/src/main.js
+++ b/src/main.js
@@ -341,11 +341,6 @@ function handleAppCertificateError(event, webContents, url, error, certificate, 
     event.preventDefault();
     callback(true);
   } else {
-    let detail = `URL: ${url}\nError: ${error}`;
-    if (certificateStore.isExisting(url)) {
-      detail = 'Certificate is different from previous one.\n\n' + detail;
-    }
-
     // update the callback
     const errorID = `${url}:${error}`;
 
@@ -355,12 +350,15 @@ function handleAppCertificateError(event, webContents, url, error, certificate, 
       certificateErrorCallbacks.set(errorID, callback);
       return;
     }
+    const extraDetail = certificateStore.isExisting(url) ? 'Certificate is different from previous one.\n\n' : '';
+    const detail = `${extraDetail}URL: ${url}\nError: ${error}`;
 
     certificateErrorCallbacks.set(errorID, callback);
     dialog.showMessageBox(mainWindow, {
       title: 'Certificate Error',
       message: 'There is a configuration issue with this Mattermost server, or someone is trying to intercept your connection. You also may need to sign into the Wi-Fi you are connected to using your web browser.',
       type: 'error',
+      detail,
       buttons: ['More Details', 'Cancel Connection'],
       cancelId: 1,
     }).then(
@@ -369,7 +367,7 @@ function handleAppCertificateError(event, webContents, url, error, certificate, 
           return dialog.showMessageBox(mainWindow, {
             title: 'Certificate Not Trusted',
             message: `Certificate from "${certificate.issuerName}" is not trusted.`,
-            detail,
+            detail: extraDetail,
             type: 'error',
             buttons: ['Trust Insecure Certificate', 'Cancel Connection'],
             cancelId: 1,

--- a/src/main.js
+++ b/src/main.js
@@ -348,11 +348,10 @@ function handleAppCertificateError(event, webContents, url, error, certificate, 
 
     // update the callback
     const errorID = `${url}:${error}`;
-    certificateErrorCallbacks.set(errorID, callback);
-
     // if we are already showing that error, don't add more dialogs
     if (certificateErrorCallbacks.has(errorID)) {
       console.log(`Ignoring already shown dialog for ${errorID}`);
+      certificateErrorCallbacks.set(errorID, callback);
       return;
     }
 


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
whenever there is no connection stablished, a new connection retry is launched every few seconds, if that fails a new dialog was being presented to the user, which might end up in a stack of errors. this PR only allows one dialog per instance and error-type.

Also, on electron6 the api for the dialog moved to promises, so I updated the code for that.

**Issue link**
[MM-20832](https://mattermost.atlassian.net/browse/MM-20832)
 
**Test Cases**
change the date on your machine to a year in the future, connect to community and the dialog should show up. waiting for several minutes shouldn't create new dialogs.

