### PR TITLE
[MM-20796] Un-reverted the Ctrl+Tab fix and also made sure the tabs go in the right order

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -157,23 +157,18 @@ export default class MainPage extends React.Component {
     });
     ipcRenderer.on('select-next-tab', () => {
       const currentOrder = this.props.teams[this.state.key].order;
-      const nextIndex = this.props.teams.map((team, index) => {
-        return {
-          index,
-          order: team.order - (currentOrder + 1),
-        };
-      }).find((team) => team.order === 0 || Math.abs(team.order) === this.props.teams.length);
-      this.handleSelect(nextIndex.index);
+      const nextOrder = ((currentOrder + 1) % this.props.teams.length);
+      const nextIndex = this.props.teams.findIndex((team) => team.order === nextOrder);
+      this.handleSelect(nextIndex);
     });
+
     ipcRenderer.on('select-previous-tab', () => {
       const currentOrder = this.props.teams[this.state.key].order;
-      const nextIndex = this.props.teams.map((team, index) => {
-        return {
-          index,
-          order: team.order - (currentOrder + 1),
-        };
-      }).find((team) => team.order === 0 || Math.abs(team.order) === this.props.teams.length);
-      this.handleSelect(nextIndex.index);
+
+      // js modulo operator returns a negative number if result is negative, so we have to ensure it's positive
+      const nextOrder = ((this.props.teams.length + (currentOrder - 1)) % this.props.teams.length);
+      const nextIndex = this.props.teams.findIndex((team) => team.order === nextOrder);
+      this.handleSelect(nextIndex);
     });
 
     // reload the activated tab

--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -160,7 +160,7 @@ export default class MainPage extends React.Component {
       const nextIndex = this.props.teams.map((team, index) => {
         return {
           index,
-          order: team.order - (currentOrder - 1),
+          order: team.order - (currentOrder + 1),
         };
       }).find((team) => team.order === 0 || Math.abs(team.order) === this.props.teams.length);
       this.handleSelect(nextIndex.index);

--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -160,7 +160,7 @@ export default class MainPage extends React.Component {
       const nextIndex = this.props.teams.map((team, index) => {
         return {
           index,
-          order: (team.order - currentOrder) - 1,
+          order: team.order - (currentOrder - 1),
         };
       }).find((team) => team.order === 0 || Math.abs(team.order) === this.props.teams.length);
       this.handleSelect(nextIndex.index);
@@ -170,7 +170,7 @@ export default class MainPage extends React.Component {
       const nextIndex = this.props.teams.map((team, index) => {
         return {
           index,
-          order: (team.order - currentOrder) + 1,
+          order: team.order - (currentOrder + 1),
         };
       }).find((team) => team.order === 0 || Math.abs(team.order) === this.props.teams.length);
       this.handleSelect(nextIndex.index);

--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -156,10 +156,24 @@ export default class MainPage extends React.Component {
       this.handleSelect(key);
     });
     ipcRenderer.on('select-next-tab', () => {
-      this.handleSelect(this.state.key + 1);
+      const currentOrder = this.props.teams[this.state.key].order;
+      const nextIndex = this.props.teams.map((team, index) => {
+        return {
+          index,
+          order: (team.order - currentOrder) - 1,
+        };
+      }).find((team) => team.order === 0 || Math.abs(team.order) === this.props.teams.length);
+      this.handleSelect(nextIndex.index);
     });
     ipcRenderer.on('select-previous-tab', () => {
-      this.handleSelect(this.state.key - 1);
+      const currentOrder = this.props.teams[this.state.key].order;
+      const nextIndex = this.props.teams.map((team, index) => {
+        return {
+          index,
+          order: (team.order - currentOrder) + 1,
+        };
+      }).find((team) => team.order === 0 || Math.abs(team.order) === this.props.teams.length);
+      this.handleSelect(nextIndex.index);
     });
 
     // reload the activated tab

--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -335,7 +335,7 @@ export default class MattermostView extends React.Component {
     if (this.props.withTab) {
       classNames.push('mattermostView-with-tab');
     }
-    if (!this.props.active || this.state.errorInfo) {
+    if (!this.props.active) {
       classNames.push('mattermostView-hidden');
     }
 


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
The fix in this PR: https://github.com/mattermost/desktop/pull/1127
Was overwritten by this PR: https://github.com/mattermost/desktop/pull/1056
This PR puts the fix back.

Also found a bug where tabbing through when you've re-ordered the tabs would tab through in the wrong order, also fixed.

**Issue link**
https://mattermost.atlassian.net/browse/MM-20796
