### PR TITLE
Make plugins oauth and oauth2 urls to be considered outside links

### DIFF
--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -118,7 +118,7 @@ export default class MattermostView extends React.Component {
         } else if (destURL.path.match(/^\/help\//)) {
           // continue to open special case internal urls in default browser
           shell.openExternal(e.url);
-        } else if (Utils.isTeamUrl(this.props.src, e.url, true) || Utils.isPluginUrl(this.props.src, e.url)) {
+        } else if (Utils.isTeamUrl(this.props.src, e.url, true) || (Utils.isPluginUrl(this.props.src, e.url) && !Utils.isPluginOAuth(e.url))) {
           // New window should disable nodeIntegration.
           window.open(e.url, remote.app.getName(), 'nodeIntegration=no, contextIsolation=yes, show=yes');
         } else {

--- a/src/main.js
+++ b/src/main.js
@@ -482,7 +482,7 @@ function handleAppWebContentsCreated(dc, contents) {
       log.info(`Popup window already open at provided url: ${url}`);
       return;
     }
-    if (Utils.isPluginUrl(server.url, parsedURL)) {
+    if (Utils.isPluginUrl(server.url, parsedURL) && !Utils.isPluginOAuth(parsedURL)) {
       if (!popupWindow || popupWindow.closed) {
         popupWindow = new BrowserWindow({
           backgroundColor: '#fff', // prevents blurry text: https://electronjs.org/docs/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -84,9 +84,9 @@ function isPluginUrl(serverUrl, inputURL) {
 
 function isPluginOAuth(inputURL) {
   const parsedURL = parseURL(inputURL);
-  const pluginOauthRegexes = /^\/plugins\/[\w.-]+\/oauth[2]?\//i;
+  const regex = /^\/plugins\/[\w.-]+\/oauth[2]?\//i;
 
-  return pluginOauthRegexes.test(parsedURL.pathname)
+  return regex.test(parsedURL.pathname)
 }
 
 function getServer(inputURL, teams) {

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -85,8 +85,8 @@ function isPluginUrl(serverUrl, inputURL) {
 function isPluginOAuth(inputURL) {
   const parsedURL = parseURL(inputURL);
   const pluginOauthRegexes = [
-    /^\/plugins\/[A-Za-z0-9\.]+\/oauth\//i,
-    /^\/plugins\/[A-Za-z0-9\.]+\/oauth2\//i,
+    /^\/plugins\/[A-Za-z0-9.]+\/oauth\//i,
+    /^\/plugins\/[A-Za-z0-9.]+\/oauth2\//i,
   ];
 
   for (const regexPath of pluginOauthRegexes) {

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -84,18 +84,9 @@ function isPluginUrl(serverUrl, inputURL) {
 
 function isPluginOAuth(inputURL) {
   const parsedURL = parseURL(inputURL);
-  const pluginOauthRegexes = [
-    /^\/plugins\/[A-Za-z0-9.]+\/oauth\//i,
-    /^\/plugins\/[A-Za-z0-9.]+\/oauth2\//i,
-  ];
+  const pluginOauthRegexes = /^\/plugins\/[\w.-]+\/oauth[2]?\//i;
 
-  for (const regexPath of pluginOauthRegexes) {
-    if (parsedURL.pathname.match(regexPath)) {
-      return true;
-    }
-  }
-
-  return false;
+  return pluginOauthRegexes.test(parsedURL.pathname)
 }
 
 function getServer(inputURL, teams) {

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -86,7 +86,7 @@ function isPluginOAuth(inputURL) {
   const parsedURL = parseURL(inputURL);
   const regex = /^\/plugins\/[\w.-]+\/oauth[2]?\//i;
 
-  return regex.test(parsedURL.pathname)
+  return regex.test(parsedURL.pathname);
 }
 
 function getServer(inputURL, teams) {

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -82,6 +82,22 @@ function isPluginUrl(serverUrl, inputURL) {
   return server.origin === parsedURL.origin && parsedURL.pathname.toLowerCase().startsWith(`${server.subpath}plugins/`);
 }
 
+function isPluginOAuth(inputURL) {
+  const parsedURL = parseURL(inputURL);
+  const pluginOauthRegexes = [
+    /^\/plugins\/[A-Za-z0-9\.]+\/oauth\//i,
+    /^\/plugins\/[A-Za-z0-9\.]+\/oauth2\//i,
+  ];
+
+  for (const regexPath of pluginOauthRegexes) {
+    if (parsedURL.pathname.match(regexPath)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function getServer(inputURL, teams) {
   const parsedURL = parseURL(inputURL);
   if (!parsedURL) {
@@ -125,5 +141,6 @@ export default {
   getServer,
   isTeamUrl,
   isPluginUrl,
+  isPluginOAuth,
   getDisplayBoundaries,
 };


### PR DESCRIPTION
**Summary**
Make plugins oauth and oauth2 urls to be considered outside links. This is to permit plugins to authenticate on a browser, and avoid [Google restrictions on log-in](https://security.googleblog.com/2019/04/better-protection-against-man-in-middle.html).
**Issue link**
https://mattermost.atlassian.net/browse/MM-22113
