### PR TITLE
[MM-22193] Workaround for app hang on Windows 10 dark mode

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@
 
 import os from 'os';
 import path from 'path';
+import fs from 'fs';
 
 import electron from 'electron';
 import isDev from 'electron-is-dev';
@@ -599,6 +600,20 @@ function initializeAfterAppReady() {
     installExtension(REACT_DEVELOPER_TOOLS).
       then((name) => console.log(`Added Extension:  ${name}`)).
       catch((err) => console.log('An error occurred: ', err));
+  }
+
+  // Workaround for MM-22193
+  // From this post: https://github.com/electron/electron/issues/19468#issuecomment-549593139
+  // Electron 6 has a bug that affects users on Windows 10 using dark mode, causing the app to hang
+  // This workaround deletes a file that stops that from happening
+  if (process.platform === 'win32') {
+    const appUserDataPath = app.getPath('userData');
+    const devToolsExtensionsPath = path.join(appUserDataPath, 'DevTools Extensions');
+    try {
+      fs.unlinkSync(devToolsExtensionsPath);
+    } catch (_) {
+      // don't complain if the file doesn't exist
+    }
   }
 
   // Protocol handler for win32


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
As per this issue: https://github.com/electron/electron/issues/19468
On desktop app v4.4, the app will hang if you are running Windows 10 dark mode.
This PR adds a workaround to fix that hang as per this workaround: https://github.com/electron/electron/issues/19468#issuecomment-549593139

**Issue link**
https://mattermost.atlassian.net/browse/MM-22193

**Test Cases**
See ticket description.
Should ensure that the app does indeed hang on v4.4-rc1 before testing this fix.
