### PR TITLE
[MM-19636] make file names consistent

### DIFF
--- a/scripts/Makefile.ps1
+++ b/scripts/Makefile.ps1
@@ -219,7 +219,8 @@ function Run-BuildId {
     $msiDescriptorFileName = "scripts\msi_installer.wxs"
     $msiDescriptor = [xml](Get-Content $msiDescriptorFileName)
     $msiDescriptor.Wix.Product.Version = [string]$env:COM_MATTERMOST_MAKEFILE_BUILD_ID_MSI
-    $ComponentDownload = $msiDescriptor.CreateElement("Property", "https://releases.mattermost.com/desktop/$version/mattermost-desktop-$version-`$(var.Platform).msi")
+    $ComponentDownload = $msiDescriptor.CreateElement("Property")
+    $ComponentDownload.InnerText = "https://releases.mattermost.com/desktop/$version/mattermost-desktop-$version-`$(var.Platform).msi"
     $ComponentDownload.SetAttribute("Id", "ComponentDownload")
     $msiDescriptor.Wix.Product.AppendChild($ComponentDownload)
     $msiDescriptor.Save($msiDescriptorFileName)

--- a/scripts/Makefile.ps1
+++ b/scripts/Makefile.ps1
@@ -219,7 +219,7 @@ function Run-BuildId {
     $msiDescriptorFileName = "scripts\msi_installer.wxs"
     $msiDescriptor = [xml](Get-Content $msiDescriptorFileName)
     $msiDescriptor.Wix.Product.Version = [string]$env:COM_MATTERMOST_MAKEFILE_BUILD_ID_MSI
-    $ComponentDownload = $msiDescriptor.CreateElement("Property")
+    $ComponentDownload = $msiDescriptor.CreateElement("Property", "http://schemas.microsoft.com/wix/2006/wi")
     $ComponentDownload.InnerText = "https://releases.mattermost.com/desktop/$version/mattermost-desktop-$version-`$(var.Platform).msi"
     $ComponentDownload.SetAttribute("Id", "ComponentDownload")
     $msiDescriptor.Wix.Product.AppendChild($ComponentDownload)

--- a/scripts/Makefile.ps1
+++ b/scripts/Makefile.ps1
@@ -187,10 +187,11 @@ function Run-BuildId {
     
     Print-Info "Checking build id tag..."    
     if ($env:APPVEYOR_REPO_TAG -eq $true) {
-        $version = "$env:APPVEYOR_REPO_TAG_NAME"
+        $tagversion = "$env:APPVEYOR_REPO_TAG_NAME"
     } else {
-        $version = "$(git describe --tags $(git rev-list --tags --max-count=1))"
+        $tagversion = "$(git describe --tags $(git rev-list --tags --max-count=1))"
     }
+    $version = "$(jq -r '.version' package.json)"
 
     Print-Info "Checking build id tag validity... [$version]"
     [version]$appVersion = New-Object -TypeName System.Version

--- a/scripts/Makefile.ps1
+++ b/scripts/Makefile.ps1
@@ -204,7 +204,7 @@ function Run-BuildId {
     }
 
     Print-Info -NoNewLine "Getting build id version..."
-    $env:COM_MATTERMOST_MAKEFILE_BUILD_ID = "v$version"
+    $env:COM_MATTERMOST_MAKEFILE_BUILD_ID = "$version"
     Print " [$env:COM_MATTERMOST_MAKEFILE_BUILD_ID]"
 
     Print-Info -NoNewLine "Getting build id version for msi..."

--- a/scripts/Makefile.ps1
+++ b/scripts/Makefile.ps1
@@ -219,8 +219,11 @@ function Run-BuildId {
     $msiDescriptorFileName = "scripts\msi_installer.wxs"
     $msiDescriptor = [xml](Get-Content $msiDescriptorFileName)
     $msiDescriptor.Wix.Product.Version = [string]$env:COM_MATTERMOST_MAKEFILE_BUILD_ID_MSI
-    $msiDescriptor.Wix.Product.ComponentDownload = "https://releases.mattermost.com/desktop/$version/mattermost-desktop-$version-`$(var.Platform).msi"
+    $ComponentDownload = $msiDescriptor.CreateElement("Property", "https://releases.mattermost.com/desktop/$version/mattermost-desktop-$version-`$(var.Platform).msi")
+    $ComponentDownload.SetAttribute("Id", "ComponentDownload")
+    $msiDescriptor.Wix.Product.AppendChild($ComponentDownload)
     $msiDescriptor.Save($msiDescriptorFileName)
+    Print-Info "Modified Wix XML"
 }
 
 function Run-BuildChangelog {

--- a/scripts/dependencies.ps1
+++ b/scripts/dependencies.ps1
@@ -64,6 +64,7 @@ function Check-Deps {
         if ($verbose) { Print-Error "signtool dependency missing." }
         $missing += "signtool"
     }
+    if ($verbose) { Print-Info "Checking jq dependency..." }
     if (!(Check-Command "jq")) {
         if ($verbose) { Print-Error "jq dependency missing." }
         $missing += "jq"

--- a/scripts/dependencies.ps1
+++ b/scripts/dependencies.ps1
@@ -64,6 +64,10 @@ function Check-Deps {
         if ($verbose) { Print-Error "signtool dependency missing." }
         $missing += "signtool"
     }
+    if (!(Check-Command "jq")) {
+        if ($verbose) { Print-Error "jq dependency missing." }
+        $missing += "jq"
+    }
 
     if ($throwable -and $missing.Count -gt 0) {
         throw "com.mattermost.makefile.deps.missing"
@@ -126,6 +130,11 @@ function Install-Deps {
             "npm" {
                 Print-Info "Installing nodejs-lts (with npm)..."
                 choco install nodejs-lts --yes
+                break;
+            }
+            "jq" {
+                Print-Info "Installing jq"
+                choco install jq --yes
                 break;
             }
         }

--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -35,7 +35,7 @@
   - there are any changes in the feature hierarchy (child
     feature moving out of a parent, or a parent feature getting a new child).
   -->
-  <Product Id="*" UpgradeCode="8523DAF0-699D-4CC7-9A65-C5E696A9DE6D" Name="Mattermost" Manufacturer="Mattermost, Inc." Language="1033" Codepage="1252" Version="4.1.2">
+  <Product Id="*" UpgradeCode="8523DAF0-699D-4CC7-9A65-C5E696A9DE6D" Name="Mattermost" Manufacturer="Mattermost, Inc." Language="1033" Codepage="1252" Version="0.0.0">
     <!--
     perMachine installs the app system wide (ALLUSERS is set to 1)
     src.: https://www.joyofsetup.com/2008/04/01/new-wix-feature-setting-package-installation-scope/
@@ -134,7 +134,7 @@
     <Property Id="ARPCONTACT">https://pre-release.mattermost.com</Property>
     <Property Id="ARPHELPLINK">https://docs.mattermost.com/</Property>
     <Property Id="ARPURLINFOABOUT">https://mattermost.com/</Property>
-    <Property Id="ComponentDownload"><![CDATA[https://releases.mattermost.com/desktop/4.1.2/mattermost-setup-4.1.2-win64.msi]]></Property>
+    <Property Id="ComponentDownload">https://releases.mattermost.com/desktop/0.0.0/mattermost-desktop-0.0.0-$(var.Platform).msi</Property>
     <Property Id="ADDDESKTOPSHORTCUT">true</Property>
     <Property Id="ADDSTARTMENUSHORTCUT">true</Property>
     <UI>

--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -134,7 +134,10 @@
     <Property Id="ARPCONTACT">https://pre-release.mattermost.com</Property>
     <Property Id="ARPHELPLINK">https://docs.mattermost.com/</Property>
     <Property Id="ARPURLINFOABOUT">https://mattermost.com/</Property>
-    <Property Id="ComponentDownload">https://releases.mattermost.com/desktop/0.0.0/mattermost-desktop-0.0.0-$(var.Platform).msi</Property>
+    <!--
+      Next line will be added by `Makefile.ps1`, leaving it here for reference, as it will be added before constructing the MSI
+      <Property Id="ComponentDownload">https://releases.mattermost.com/desktop/0.0.0/mattermost-desktop-0.0.0-$(var.Platform).msi</Property> 
+    -->
     <Property Id="ADDDESKTOPSHORTCUT">true</Property>
     <Property Id="ADDSTARTMENUSHORTCUT">true</Property>
     <UI>

--- a/scripts/tools.ps1
+++ b/scripts/tools.ps1
@@ -158,6 +158,11 @@ function Get-NpmDir {
     if ([System.IO.File]::Exists("$npmDir\npm.cmd")) {
         return $npmDir
     }
+    $progFile = ${env:ProgramW6432}
+    $npmDir = Join-Path -Path "$progFile" -ChildPath "nodejs"
+    if ([System.IO.File]::Exists("$npmDir\npm.cmd")) {
+        return $npmDir
+    }
     return $null
 }
 


### PR DESCRIPTION
**Summary**
Some filenames for windows added a `v` in front of the version name, this is removed now
removed fixed versions from xml file
get release version from package.json instead of tag

**Issue link**
[MM-19636](https://mattermost.atlassian.net/browse/MM-19636)

**Additional Notes**
for -develop versions, it'll add the number of commits to the build version.
