### PR TITLE
Use ‘isTrustedURL’ function to validate url

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -769,12 +769,8 @@ function initializeAfterAppReady() {
     // get the requesting webContents url
     const requestingURL = webContents.getURL();
 
-    // is the target url trusted?
-    const matchingTeamIndex = config.teams.findIndex((team) => {
-      return requestingURL.startsWith(team.url);
-    });
-
-    callback(matchingTeamIndex >= 0);
+    // is the requesting url trusted?
+    callback(isTrustedURL(requestingURL));
   });
 }
 


### PR DESCRIPTION
**Summary**
Trusted URL validation when a browser permission request comes through could be bypassed. This PR updates the validation to use the newer isTrustedURL() function to perform the url validation instead.

**Issue link**
[MM-20188](https://mattermost.atlassian.net/browse/MM-20188)
