### PR TITLE
[MM-22494] Fixed misuse of config.set

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -768,13 +768,13 @@ export default class MainPage extends React.Component {
           });
         }}
         onSave={(newTeam) => {
-          this.props.teams.push(newTeam);
-          this.setState({
-            showNewTeamModal: false,
-            key: this.props.teams.length - 1,
+          this.props.localTeams.push(newTeam);
+          this.props.onTeamConfigChange(this.props.localTeams, () => {
+            self.setState({
+              showNewTeamModal: false,
+              key: this.props.teams.length - 1,
+            });
           });
-          this.render();
-          this.props.onTeamConfigChange(this.props.teams);
         }}
       />
     );
@@ -833,6 +833,7 @@ export default class MainPage extends React.Component {
 MainPage.propTypes = {
   onBadgeChange: PropTypes.func.isRequired,
   teams: PropTypes.array.isRequired,
+  localTeams: PropTypes.array.isRequired,
   onTeamConfigChange: PropTypes.func.isRequired,
   initialIndex: PropTypes.number.isRequired,
   useSpellChecker: PropTypes.bool.isRequired,

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -26,14 +26,6 @@ const config = new Config(remote.app.getPath('userData') + '/config.json', remot
 
 const teams = config.teams;
 
-// Make sure teams have an order
-if (teams.every((team) => !team.order)) {
-  teams.forEach((team, index) => {
-    team.order = index;
-  });
-  teamConfigChange(teams);
-}
-
 remote.getCurrentWindow().removeAllListeners('focus');
 
 if (teams.length === 0) {
@@ -140,8 +132,11 @@ function showBadge(sessionExpired, unreadCount, mentionCount) {
   }
 }
 
-function teamConfigChange(updatedTeams) {
+function teamConfigChange(updatedTeams, callback) {
   config.set('teams', updatedTeams);
+  if (callback) {
+    config.once('update', callback);
+  }
 }
 
 function handleSelectSpellCheckerLocale(locale) {
@@ -196,6 +191,7 @@ function openMenu() {
 ReactDOM.render(
   <MainPage
     teams={teams}
+    localTeams={config.localTeams}
     initialIndex={initialIndex}
     onBadgeChange={showBadge}
     onTeamConfigChange={teamConfigChange}


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
On apps using GPO configurations, when launching the app for the first time, or when adding a new team using the + button, GPO teams would sometimes be duplicated. This was caused by running `config.set('teams', <some array>)` with the GPO teams in the array, thus setting them as local teams as well.

This PR ensures that all uses of `config.set('teams', <some array>)` do not include the GPO teams.

**Issue link**
https://mattermost.atlassian.net/browse/MM-22494
https://github.com/mattermost/desktop/issues/1189