### PR TITLE
[MM-22558] fix loginurls on subpath and server's with team in the url

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -453,6 +453,7 @@ function handleAppWebContentsCreated(dc, contents) {
     if ((server !== null && Utils.isTeamUrl(server.url, parsedURL)) || isTrustedPopupWindow(event.sender)) {
       return;
     }
+
     if (isCustomLoginURL(parsedURL, server)) {
       return;
     }
@@ -986,17 +987,20 @@ function isCustomLoginURL(url, server) {
   if (!isTrustedURL(parsedURL)) {
     return false;
   }
-  let urlPath = parsedURL.pathname;
-  if (subpath !== '' && urlPath.startsWith(subpath)) {
+  const urlPath = parsedURL.pathname;
+  if ((subpath !== '' || subpath !== '/') && urlPath.startsWith(subpath)) {
     const replacement = subpath.endsWith('/') ? '/' : '';
-    console.log(`urlpath was ${urlPath}`);
-    urlPath = urlPath.replace(subpath, replacement);
-    console.log(`urlpath now is ${urlPath}`);
+    const replacedPath = urlPath.replace(subpath, replacement);
+    for (const regexPath of customLoginRegexPaths) {
+      if (replacedPath.match(regexPath)) {
+        return true;
+      }
+    }
   }
+
+  // if there is no subpath, or we are adding the team and got redirected to the real server it'll be caught here
   for (const regexPath of customLoginRegexPaths) {
-    console.log(`testing ${regexPath}`);
     if (urlPath.match(regexPath)) {
-      console.log('match found');
       return true;
     }
   }

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -63,7 +63,7 @@ function getServerInfo(serverUrl) {
 function isTeamUrl(serverUrl, inputUrl, withApi) {
   const parsedURL = parseURL(inputUrl);
   const server = getServerInfo(serverUrl);
-  if (!parsedURL || !server || (!testUrlsIgnoringSubpath(server, parsedURL))) {
+  if (!parsedURL || !server || (!equalUrlsIgnoringSubpath(server, parsedURL))) {
     return null;
   }
 
@@ -83,7 +83,7 @@ function isPluginUrl(serverUrl, inputURL) {
     return false;
   }
   return (
-    testUrlsIgnoringSubpath(server, parsedURL) &&
+    equalUrlsIgnoringSubpath(server, parsedURL) &&
     (parsedURL.pathname.toLowerCase().startsWith(`${server.subpath}plugins/`) ||
       parsedURL.pathname.toLowerCase().startsWith('/plugins/')));
 }
@@ -94,23 +94,23 @@ function getServer(inputURL, teams) {
     return null;
   }
   let parsedServerUrl;
-  let secondoption = null;
+  let secondOption = null;
   for (let i = 0; i < teams.length; i++) {
     parsedServerUrl = parseURL(teams[i].url);
 
     // check server and subpath matches (without subpath pathname is \ so it always matches)
-    if (testUrlsWithSubpath(parsedServerUrl, parsedURL)) {
+    if (equalUrlsWithSubpath(parsedServerUrl, parsedURL)) {
       return {name: teams[i].name, url: parsedServerUrl, index: i};
     }
-    if (testUrlsIgnoringSubpath(parsedServerUrl, parsedURL)) {
+    if (equalUrlsIgnoringSubpath(parsedServerUrl, parsedURL)) {
       // in case the user added something on the path that doesn't really belong to the server
       // there might be more than one that matches, but we can't differentiate, so last one
-      // is as good as any other.
+      // is as good as any other in case there is no better match (e.g.: two subpath servers with the same origin)
       // e.g.: https://community.mattermost.com/core
-      secondoption = {name: teams[i].name, url: parsedServerUrl, index: i};
+      secondOption = {name: teams[i].name, url: parsedServerUrl, index: i};
     }
   }
-  return secondoption;
+  return secondOption;
 }
 
 function getDisplayBoundaries() {
@@ -131,11 +131,11 @@ function getDisplayBoundaries() {
 }
 
 // next two functions are defined to clarify intent
-function testUrlsWithSubpath(url1, url2) {
+function equalUrlsWithSubpath(url1, url2) {
   return url1.origin === url2.origin && url2.pathname.toLowerCase().startsWith(url1.pathname.toLowerCase());
 }
 
-function testUrlsIgnoringSubpath(url1, url2) {
+function equalUrlsIgnoringSubpath(url1, url2) {
   return url1.origin.toLowerCase() === url2.origin.toLowerCase();
 }
 

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -63,14 +63,17 @@ function getServerInfo(serverUrl) {
 function isTeamUrl(serverUrl, inputUrl, withApi) {
   const parsedURL = parseURL(inputUrl);
   const server = getServerInfo(serverUrl);
-  if (!parsedURL || !server) {
+  if (!parsedURL || !server || (!testUrlsIgnoringSubpath(server, parsedURL))) {
     return null;
   }
+
   const nonTeamUrlPaths = ['plugins', 'signup', 'login', 'admin', 'channel', 'post', 'oauth', 'admin_console'];
   if (withApi) {
     nonTeamUrlPaths.push('api');
   }
-  return !(nonTeamUrlPaths.some((testPath) => parsedURL.pathname.toLowerCase().startsWith(`${server.subpath}${testPath}/`)));
+  return !(nonTeamUrlPaths.some((testPath) => (
+    parsedURL.pathname.toLowerCase().startsWith(`${server.subpath}${testPath}/`) ||
+    parsedURL.pathname.toLowerCase().startsWith(`/${testPath}/`))));
 }
 
 function isPluginUrl(serverUrl, inputURL) {
@@ -79,7 +82,10 @@ function isPluginUrl(serverUrl, inputURL) {
   if (!parsedURL || !server) {
     return false;
   }
-  return server.origin === parsedURL.origin && parsedURL.pathname.toLowerCase().startsWith(`${server.subpath}plugins/`);
+  return (
+    testUrlsIgnoringSubpath(server, parsedURL) &&
+    (parsedURL.pathname.toLowerCase().startsWith(`${server.subpath}plugins/`) ||
+      parsedURL.pathname.toLowerCase().startsWith('/plugins/')));
 }
 
 function getServer(inputURL, teams) {
@@ -88,15 +94,23 @@ function getServer(inputURL, teams) {
     return null;
   }
   let parsedServerUrl;
+  let secondoption = null;
   for (let i = 0; i < teams.length; i++) {
     parsedServerUrl = parseURL(teams[i].url);
 
     // check server and subpath matches (without subpath pathname is \ so it always matches)
-    if (parsedServerUrl.origin === parsedURL.origin && parsedURL.pathname.startsWith(parsedServerUrl.pathname)) {
+    if (testUrlsWithSubpath(parsedServerUrl, parsedURL)) {
       return {name: teams[i].name, url: parsedServerUrl, index: i};
     }
+    if (testUrlsIgnoringSubpath(parsedServerUrl, parsedURL)) {
+      // in case the user added something on the path that doesn't really belong to the server
+      // there might be more than one that matches, but we can't differentiate, so last one
+      // is as good as any other.
+      // e.g.: https://community.mattermost.com/core
+      secondoption = {name: teams[i].name, url: parsedServerUrl, index: i};
+    }
   }
-  return null;
+  return secondoption;
 }
 
 function getDisplayBoundaries() {
@@ -114,6 +128,15 @@ function getDisplayBoundaries() {
       maxHeight: display.workArea.height,
     };
   });
+}
+
+// next two functions are defined to clarify intent
+function testUrlsWithSubpath(url1, url2) {
+  return url1.origin === url2.origin && url2.pathname.toLowerCase().startsWith(url1.pathname.toLowerCase());
+}
+
+function testUrlsIgnoringSubpath(url1, url2) {
+  return url1.origin.toLowerCase() === url2.origin.toLowerCase();
 }
 
 export default {


### PR DESCRIPTION
Before submitting, please confirm you've

 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**

custom logins weren't accounting for any path on the server configuration (subpath/team), this PR adds that option.

**Issue link**

[MM-22558](https://mattermost.atlassian.net/browse/MM-22558)

**Test Cases**
on the desktop add servers with either subpath or team configured (e.g.: https://community.mattermost.com/core)
using onelogin SSO should work properly

