### PR TITLE
[MM-22585] Ctrl/Cmd+<num> now switches to tabs based on order

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -153,7 +153,8 @@ export default class MainPage extends React.Component {
 
     // can't switch tabs sequentially for some reason...
     ipcRenderer.on('switch-tab', (event, key) => {
-      this.handleSelect(key);
+      const nextIndex = this.props.teams.findIndex((team) => team.order === key);
+      this.handleSelect(nextIndex);
     });
     ipcRenderer.on('select-next-tab', () => {
       const currentOrder = this.props.teams[this.state.key].order;

--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -34,7 +34,7 @@ export default class MainPage extends React.Component {
   constructor(props) {
     super(props);
 
-    let key = this.props.initialIndex;
+    let key = this.props.teams.findIndex((team) => team.order === this.props.initialIndex);
     if (this.props.deeplinkingUrl !== null) {
       const parsedDeeplink = this.parseDeeplinkURL(this.props.deeplinkingUrl);
       if (parsedDeeplink) {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
When switching the order of the tabs, and using `Ctrl+i` or `Cmd+i`, where `i` is the 1-based order of the tab to switch to, the app was opening the wrong tab if the order of the tabs did not match the storage order.

This PR now makes sure that the hotkey switches to the correct tab.

**Issue link**
https://mattermost.atlassian.net/browse/MM-22585
