### PR TITLE
[MM-22618] Clicking on setting team links to proper tab

### DIFF
--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -631,7 +631,7 @@ export default class SettingsPage extends React.Component {
             addServer={this.addServer}
             allowTeamEdit={this.state.enableTeamModification}
             onTeamClick={(index) => {
-              backToIndex(index + this.state.buildTeams.length + this.state.registryTeams.length);
+              backToIndex(this.state.localTeams[index].order + this.state.buildTeams.length + this.state.registryTeams.length);
             }}
             modalContainer={this}
           />


### PR DESCRIPTION
**Summary**
When clicking on a server on the settings page to open that server's tab, if tabs were manually reordered, the proper incorrect tab can load. This PR takes into account the manual tab order to ensure that clicking on a server on the settings page will load the correct tab.

**Issue link**
https://mattermost.atlassian.net/browse/MM-22618
