### PR TITLE
[MM-22617] Force wrap long server urls in setting page

### DIFF
--- a/src/browser/css/settings.css
+++ b/src/browser/css/settings.css
@@ -17,6 +17,10 @@
   transition: opacity 1s cubic-bezier(0.19, 1, 0.22, 1);
 }
 
+.TeamListItem p {
+  overflow-wrap: break-word;
+}
+
 .checkbox > label {
   width: 100%;
 }


### PR DESCRIPTION
**Summary**
By default, long strings like URLs containing no breaking spaces will push past the end of their containers instead of breaking. This PR forces long non-breaking strings to wrap at the end of their container.

**Issue link**
https://mattermost.atlassian.net/browse/MM-22617
