### PR TITLE
[MM-22618] Reorder tab menu items to match tab order

### DIFF
--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -241,7 +241,7 @@ function createTemplate(mainWindow, config, isDev) {
     }, {
       role: 'close',
       accelerator: 'CmdOrCtrl+W',
-    }, separatorItem, ...teams.slice(0, 9).map((team, i) => {
+    }, separatorItem, ...teams.slice(0, 9).sort((teamA, teamB) => teamA.order - teamB.order).map((team, i) => {
       return {
         label: team.name,
         accelerator: `CmdOrCtrl+${i + 1}`,

--- a/src/main/menus/tray.js
+++ b/src/main/menus/tray.js
@@ -9,7 +9,7 @@ function createTemplate(mainWindow, config, isDev) {
   const settingsURL = isDev ? 'http://localhost:8080/browser/settings.html' : `file://${app.getAppPath()}/browser/settings.html`;
   const teams = config.teams;
   const template = [
-    ...teams.slice(0, 9).map((team, i) => {
+    ...teams.slice(0, 9).sort((teamA, teamB) => teamA.order - teamB.order).map((team, i) => {
       return {
         label: team.name,
         click: () => {


### PR DESCRIPTION
**Summary**
Window menu items for tabs were not reordering with the tabs. This PR reorders the menu items when tabs are manually reordered.

**Issue link**
https://mattermost.atlassian.net/browse/MM-22618

