### PR TITLE
[MM-22558] Fix 3rd party login detection

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -476,12 +476,13 @@ function handleAppWebContentsCreated(dc, contents) {
   contents.on('did-start-navigation', (event, url) => {
     const contentID = event.sender.id;
     const parsedURL = Utils.parseURL(url);
+    const server = Utils.getServer(parsedURL, config.teams);
 
     if (!isTrustedURL(parsedURL)) {
       return;
     }
 
-    if (isCustomLoginURL(parsedURL)) {
+    if (isCustomLoginURL(parsedURL, server)) {
       customLogins[contentID].inProgress = true;
     } else if (customLogins[contentID].inProgress) {
       customLogins[contentID].inProgress = false;


### PR DESCRIPTION
**Summary**
The recent update to fix support for MM subpaths missed updating the section of code that determines if a 3rd party login process has begun or is ending. This PR updates that section of code to now allow proper 3rd party authentication to work with subpaths.

**Issue link**
https://mattermost.atlassian.net/browse/MM-22558