### PR TITLE
[MM-22082] - Add focus to server name field in new server modal

### DIFF
--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -138,6 +138,7 @@ export default class NewTeamModal extends React.Component {
         className='NewTeamModal'
         show={this.props.show}
         id='newServerModal'
+        onEntered={() => this.teamNameInputRef.focus()}
         onHide={this.props.onClose}
         container={this.props.modalContainer}
         restoreFocus={this.props.restoreFocus}
@@ -173,9 +174,7 @@ export default class NewTeamModal extends React.Component {
                 placeholder='Server Name'
                 onChange={this.handleTeamNameChange}
                 inputRef={(ref) => {
-                  if (ref) {
-                    ref.focus();
-                  }
+                  this.teamNameInputRef = ref;
                 }}
                 onClick={(e) => {
                   e.stopPropagation();

--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -175,7 +175,7 @@ export default class NewTeamModal extends React.Component {
                 onClick={(e) => {
                   e.stopPropagation();
                 }}
-                autoFocus={true}
+                autofocus='true'
               />
               <FormControl.Feedback/>
               <HelpBlock>{'The name of the server displayed on your desktop app tab bar.'}</HelpBlock>

--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -172,6 +172,11 @@ export default class NewTeamModal extends React.Component {
                 value={this.state.teamName}
                 placeholder='Server Name'
                 onChange={this.handleTeamNameChange}
+                inputRef={(ref) => {
+                  if (ref) {
+                    ref.focus();
+                  }
+                }}
                 onClick={(e) => {
                   e.stopPropagation();
                 }}


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
By changing the autoFocus to an html property it seems to fix the issue!

**Issue link**
https://mattermost.atlassian.net/browse/MM-22082

