### PR TITLE
[MM-22004] Add dragability to the title bar buttons area for macOS

### DIFF
--- a/src/browser/css/index.css
+++ b/src/browser/css/index.css
@@ -107,6 +107,7 @@ body {
 
 .topBar.macOS .three-dot-menu {
   flex-basis: 80px;
+  -webkit-app-region: drag;
 }
 
 .topBar.macOS.fullScreen .three-dot-menu {


### PR DESCRIPTION
**Summary**
When trying to drag the title bar near the title bar buttons on macOS, dragging would not work. This PR enables dragging for that area for macOS.

**Issue link**
https://mattermost.atlassian.net/browse/MM-22004
