### PR TITLE
[MM-22229] migrate some operations to promises

### DIFF
--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -250,9 +250,7 @@ export default class MattermostView extends React.Component {
       errorInfo: null,
     });
     const webContents = this.webviewRef.current.getWebContents();
-    webContents.session.clearCache(() => {
-      webContents.reload();
-    });
+    webContents.session.clearCache().then(webContents.reload);
   }
 
   focusOnWebView = () => {

--- a/src/main.js
+++ b/src/main.js
@@ -1096,10 +1096,7 @@ function wasUpdated(lastAppVersion) {
 function clearAppCache() {
   if (mainWindow) {
     console.log('Clear cache after update');
-    mainWindow.webContents.session.clearCache(() => {
-      //Restart after cache clear
-      mainWindow.reload();
-    });
+    mainWindow.webContents.session.clearCache().then(mainWindow.reload);
   } else {
     //Wait for mainWindow
     setTimeout(clearAppCache, 100);

--- a/src/main/cookieManager.js
+++ b/src/main/cookieManager.js
@@ -4,10 +4,8 @@
 import {app} from 'electron';
 
 function flushCookiesStore(session) {
-  session.cookies.flushStore((err) => {
-    if (err) {
-      console.log(err);
-    }
+  session.cookies.flushStore().catch((err) => {
+    console.log(`There was a problem flushing cookies:\n${err}`);
   });
 }
 

--- a/src/main/downloadURL.js
+++ b/src/main/downloadURL.js
@@ -17,10 +17,18 @@ export default function downloadURL(browserWindow, URL, callback) {
     const dialogOptions = {
       defaultPath: path.join(app.getPath('downloads'), file),
     };
-    dialog.showSaveDialog(browserWindow, dialogOptions, (filename) => {
-      if (filename) {
-        saveResponseBody(response, filename, callback);
+    dialog.showSaveDialog(
+      browserWindow,
+      dialogOptions
+    ).then(
+      (filename) => {
+        if (filename) {
+          saveResponseBody(response, filename, callback);
+        }
       }
+    ).catch((err) => {
+      console.log(`there was an error trying to save a file: ${err}`);
+      callback();
     });
   }).on('error', callback);
   request.end();

--- a/src/main/downloadURL.js
+++ b/src/main/downloadURL.js
@@ -27,8 +27,7 @@ export default function downloadURL(browserWindow, URL, callback) {
         }
       }
     ).catch((err) => {
-      console.log(`there was an error trying to save a file: ${err}`);
-      callback();
+      callback(err);
     });
   }).on('error', callback);
   request.end();

--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -144,9 +144,7 @@ function createTemplate(mainWindow, config, isDev) {
         if (focusedWindow === mainWindow) {
           mainWindow.webContents.send('clear-cache-and-reload-tab');
         } else {
-          focusedWindow.webContents.session.clearCache(() => {
-            focusedWindow.reload();
-          });
+          focusedWindow.webContents.session.clearCache().then(focusedWindow.reload);
         }
       }
     },


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
with the move to electron 6 some functions are now returning promises, this pr addresses that

**Issue link**
[MM-22231](https://mattermost.atlassian.net/browse/MM-22231)
[MM-22229](https://mattermost.atlassian.net/browse/MM-22229)
[MM-22232](https://mattermost.atlassian.net/browse/MM-22232)

**Test Cases**
for download: download a file from the proxy, on error it shouldn't crash.
for cache: use menu for clear cache and reload, after a while it should show the channel again (not get stuck in a white page)
for cookies: not really sure how to make this check, it should handle any error while flushing the cookie store and print an error on console, but I don't know what can make this fail.

