### PR TITLE
[MM-22434] update joi, convert to json before validating

### DIFF
--- a/src/main/Validator.js
+++ b/src/main/Validator.js
@@ -158,7 +158,8 @@ export function validateV2ConfigData(data) {
 
 // validate certificate.json
 export function validateCertificateStore(data) {
-  return validateAgainstSchema(data, certificateStoreSchema);
+  const jsonData = (typeof data === 'object' ? data : JSON.parse(data));
+  return validateAgainstSchema(jsonData, certificateStoreSchema);
 }
 
 // validate allowedProtocols.json
@@ -167,11 +168,17 @@ export function validateAllowedProtocols(data) {
 }
 
 function validateAgainstSchema(data, schema) {
-  if (typeof data !== 'object' || !schema) {
+  if (typeof data !== 'object') {
+    console.error(`Input 'data' is not an object we can validate: ${typeof data}`);
     return false;
   }
-  const {error, value} = Joi.validate(data, schema, defaultOptions);
+  if (!schema) {
+    console.error('No schema provided to validate');
+    return false;
+  }
+  const {error, value} = schema.validate(data, defaultOptions);
   if (error) {
+    console.error(`Validation failed due to: ${error}`);
     return false;
   }
   return value;

--- a/src/main/certificateStore.js
+++ b/src/main/certificateStore.js
@@ -32,18 +32,16 @@ function getHost(targetURL) {
 function CertificateStore(storeFile) {
   this.storeFile = storeFile;
   let storeStr;
-  let jsonStore;
   try {
     storeStr = fs.readFileSync(storeFile, 'utf-8');
-    jsonStore = JSON.parse(storeStr);
-    const result = Validator.validateCertificateStore(jsonStore);
+    const result = Validator.validateCertificateStore(storeStr);
     if (!result) {
       throw new Error('Provided certificate store file does not validate, using defaults instead.');
     }
+    this.data = result;
   } catch (e) {
-    jsonStore = {};
+    this.data = {};
   }
-  this.data = jsonStore;
 }
 
 CertificateStore.prototype.save = function save() {

--- a/src/main/certificateStore.js
+++ b/src/main/certificateStore.js
@@ -4,7 +4,6 @@
 'use strict';
 
 import fs from 'fs';
-import url from 'url';
 
 import * as Validator from './Validator';
 
@@ -26,27 +25,25 @@ function areEqual(certificate0, certificate1) {
 }
 
 function getHost(targetURL) {
-  return url.parse(targetURL).host;
+  const parsedURL = new URL(targetURL);
+  return parsedURL.origin;
 }
 
 function CertificateStore(storeFile) {
   this.storeFile = storeFile;
   let storeStr;
+  let jsonStore;
   try {
     storeStr = fs.readFileSync(storeFile, 'utf-8');
-    storeStr = Validator.validateCertificateStore(storeStr);
-    if (!storeStr) {
+    jsonStore = JSON.parse(storeStr);
+    const result = Validator.validateCertificateStore(jsonStore);
+    if (!result) {
       throw new Error('Provided certificate store file does not validate, using defaults instead.');
     }
   } catch (e) {
-    storeStr = '{}';
+    jsonStore = {};
   }
-  try {
-    this.data = JSON.parse(storeStr);
-  } catch (e) {
-    console.log('Error when parsing', storeFile, ':', e);
-    this.data = {};
-  }
+  this.data = jsonStore;
 }
 
 CertificateStore.prototype.save = function save() {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -27,44 +27,43 @@
       }
     },
     "@hapi/address": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
-      "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw=="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
+      "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
+    },
+    "@hapi/formula": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
+      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
     },
     "@hapi/hoek": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
-      "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A=="
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
     },
     "@hapi/joi": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.0.tgz",
-      "integrity": "sha512-n6kaRQO8S+kepUTbXL9O/UOL788Odqs38/VOfoCrATDtTvyfiO3fgjlSRaNkHabpTLgM7qru9ifqXlXbXk8SeQ==",
+      "version": "16.1.8",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+      "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
       "requires": {
-        "@hapi/address": "2.x.x",
-        "@hapi/hoek": "6.x.x",
-        "@hapi/marker": "1.x.x",
-        "@hapi/topo": "3.x.x"
+        "@hapi/address": "^2.1.2",
+        "@hapi/formula": "^1.2.0",
+        "@hapi/hoek": "^8.2.4",
+        "@hapi/pinpoint": "^1.0.2",
+        "@hapi/topo": "^3.1.3"
       }
     },
-    "@hapi/marker": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/marker/-/marker-1.0.0.tgz",
-      "integrity": "sha512-JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA=="
+    "@hapi/pinpoint": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
+      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ=="
     },
     "@hapi/topo": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.2.tgz",
-      "integrity": "sha512-r+aumOqJ5QbD6aLPJWqVjMAPsx5pZKz+F5yPqXZ/WWG9JTtHbQqlzrJoknJ0iJxLj9vlXtmpSdjlkszseeG8OA==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
       "requires": {
-        "@hapi/hoek": "8.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.0.2.tgz",
-          "integrity": "sha512-O6o6mrV4P65vVccxymuruucb+GhP2zl9NLCG8OdoFRS8BEGw3vwpPp20wpAtpbQQxz1CEUtmxJGgWhjq1XA3qw=="
-        }
+        "@hapi/hoek": "^8.3.0"
       }
     },
     "ansi-regex": {

--- a/src/package.json
+++ b/src/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://about.mattermost.com",
   "license": "Apache-2.0",
   "dependencies": {
-    "@hapi/joi": "^15.1.0",
+    "@hapi/joi": "^16.1.8",
     "auto-launch": "^5.0.5",
     "bootstrap": "^3.3.7",
     "electron-context-menu": "^0.15.0",


### PR DESCRIPTION
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**

When loading the certificate.json file, it was failing validation, this was due to several parts, one it was missing the protocol on it to validate as uri. also it wasn't loaded as an object, so i couldn't load.

Improved code and upgraded joi to next version.

**Issue link**

[MM-22434](https://mattermost.atlassian.net/browse/MM-22434)

**Test Cases**

with a server with an untrusted certificate, go throught the dialog and save the connection as valid. upon restart, no dialog should appear.
