### PR TITLE
[MM022677] fix focus on new server modal

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -55,6 +55,7 @@ export default class MainPage extends React.Component {
       targetURL: '',
       certificateRequests: [],
       maximized: false,
+      showNewTeamModal: false,
     };
   }
 
@@ -181,8 +182,12 @@ export default class MainPage extends React.Component {
     });
 
     function focusListener() {
-      self.handleOnTeamFocused(self.state.key);
-      self.refs[`mattermostView${self.state.key}`].focusOnWebView();
+      if (this.state.showNewTeamModal && this.inputRef) {
+        this.inputRef.current().focus();
+      } else {
+        self.handleOnTeamFocused(self.state.key);
+        self.refs[`mattermostView${self.state.key}`].focusOnWebView();
+      }
       self.setState({unfocused: false});
     }
 
@@ -603,6 +608,9 @@ export default class MainPage extends React.Component {
       isDarkMode: this.props.setDarkMode(),
     });
   }
+  setInputRef = (ref) => {
+    this.inputRef = ref;
+  }
 
   render() {
     const self = this;
@@ -763,6 +771,7 @@ export default class MainPage extends React.Component {
         currentOrder={this.props.teams.length}
         show={this.state.showNewTeamModal}
         restoreFocus={false}
+        setInputRef={this.setInputRef}
         onClose={() => {
           this.setState({
             showNewTeamModal: false,

--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -138,6 +138,7 @@ export default class NewTeamModal extends React.Component {
         className='NewTeamModal'
         show={this.props.show}
         id='newServerModal'
+        enforceFocus={true}
         onEntered={() => this.teamNameInputRef.focus()}
         onHide={this.props.onClose}
         container={this.props.modalContainer}
@@ -175,6 +176,9 @@ export default class NewTeamModal extends React.Component {
                 onChange={this.handleTeamNameChange}
                 inputRef={(ref) => {
                   this.teamNameInputRef = ref;
+                  if (this.props.setInputRef) {
+                    this.props.setInputRef(ref);
+                  }
                 }}
                 onClick={(e) => {
                   e.stopPropagation();
@@ -238,4 +242,5 @@ NewTeamModal.propTypes = {
   modalContainer: PropTypes.object,
   restoreFocus: PropTypes.bool,
   currentOrder: PropTypes.number,
+  setInputRef: PropTypes.ref,
 };


### PR DESCRIPTION
Before submitting, please confirm you've
 - [ ] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**

Focus was lost when having the new server modal and switched applications. This patch will return focus to the name input.

**Issue link**

[MM-22677](https://mattermost.atlassian.net/browse/MM-22677)

**Test Cases**
- open new server modal
- check that focus is on the name input
- alt+tab to another app and alt+tab back
- focus should be on the name input

**Additional Notes**
