### PR TITLE
[MM-20742] Null checking on URL pathname when deep linking

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -70,8 +70,8 @@ export default class MainPage extends React.Component {
             teamURL,
             teamIndex: index,
             originalURL: deeplinkURL,
-            url: `${teamURL.protocol}//${teamURL.host}${deeplinkURL.pathname || ''}`,
-            path: deeplinkURL.pathname || '',
+            url: `${teamURL.protocol}//${teamURL.host}${deeplinkURL.pathname || '/'}`,
+            path: deeplinkURL.pathname || '/',
           };
         }
       });

--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -70,8 +70,8 @@ export default class MainPage extends React.Component {
             teamURL,
             teamIndex: index,
             originalURL: deeplinkURL,
-            url: `${teamURL.protocol}//${teamURL.host}${deeplinkURL.pathname}`,
-            path: deeplinkURL.pathname,
+            url: `${teamURL.protocol}//${teamURL.host}${deeplinkURL.pathname || ''}`,
+            path: deeplinkURL.pathname || '',
           };
         }
       });


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
When deep linking to the root of a server and the URL doesn't end with a `/`, the URL `pathname` would be `null` and would be converted to a string as such. This PR does a null check returning a blank string if `pathname` is `null`.

**Issue link**
https://mattermost.atlassian.net/browse/MM-20742

**Test Cases**
1. Open Mattermost Desktop and add the Community server
2. Go to your browser and enter `mattermost://community.mattermost.com`
3. Press Enter and allow to open in Mattermost
4. The deep link should pop the community server up, rather than generate a Channel Not Found error.
