### PR TITLE
[MM-22479] Added aria-label to 3-dot menu on Windows

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -707,6 +707,7 @@ export default class MainPage extends React.Component {
             onClick={this.openMenu}
             tabIndex={0}
             ref={this.threeDotMenu}
+            aria-label='Context menu'
           >
             <DotsVerticalIcon/>
           </button>


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
ARIA label added to the 3-dot menu button, so now it will read 'Context menu button' instead of 'Unlabelled 0 button'.

**Issue link**
https://mattermost.atlassian.net/browse/MM-22479

**Test Cases**
1. Open Mattermost Desktop on Windows, and run JAWS screen reader
2. With the Mattermost window focused, press ALT
3. The 3-dot menu should receive focus and JAWS should read 'Context menu button'
