### PR TITLE
[MM-23082] get a default key if not pre-stablished

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -43,6 +43,9 @@ export default class MainPage extends React.Component {
       }
     }
 
+    // servers come from several places, in case we can't find the right one, pick the first one
+    key = key === -1 ? 0 : key;
+
     this.topBar = React.createRef();
 
     this.state = {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [ ] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [ ] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
when having multiple servers pre-configured via GPO or buildConfig, sometimes no server is chosen as the first one, ending in a blank page.

**Issue link**

[MM-23082](https://mattermost.atlassian.net/browse/MM-23082)

**Test Cases**
- on windows, add 2 or more servers with GPO, start the app, first server should be chosen
- on osx/linux build the app with buildConfig.js having 2 or more servers setup and no `order` field, first server should be chosen.
