### PR TITLE
[MM-23082] Fixes whitescreen issue on app upgrade / GPO / whitelabeled app deployments

### DIFF
--- a/src/common/config/buildConfig.js
+++ b/src/common/config/buildConfig.js
@@ -25,7 +25,7 @@ const buildConfig = {
     }
   */],
   helpLink: 'https://about.mattermost.com/default-desktop-app-documentation/',
-  enableServerManagement: false,
+  enableServerManagement: true,
   enableAutoUpdater: true,
 };
 

--- a/src/common/config/buildConfig.js
+++ b/src/common/config/buildConfig.js
@@ -20,8 +20,7 @@ const buildConfig = {
   defaultTeams: [/*
     {
       name: 'example',
-      url: 'https://example.com',
-      order: 0
+      url: 'https://example.com'
     }
   */],
   helpLink: 'https://about.mattermost.com/default-desktop-app-documentation/',

--- a/src/common/config/buildConfig.js
+++ b/src/common/config/buildConfig.js
@@ -9,6 +9,7 @@
  * @prop {Object[]} defaultTeams
  * @prop {string} defaultTeams[].name - The tab name for default team.
  * @prop {string} defaultTeams[].url - The URL for default team.
+ * @prop {string} defaultTeams[].order - Sort order for team tabs (0, 1, 2)
  * @prop {string} helpLink - The URL for "Help->Learn More..." menu item.
  *                           If null is specified, the menu disappears.
  * @prop {boolean} enableServerManagement - Whether users can edit servers configuration.
@@ -19,11 +20,12 @@ const buildConfig = {
   defaultTeams: [/*
     {
       name: 'example',
-      url: 'https://example.com'
-    }*/
-  ],
+      url: 'https://example.com',
+      order: 0
+    }
+  */],
   helpLink: 'https://about.mattermost.com/default-desktop-app-documentation/',
-  enableServerManagement: true,
+  enableServerManagement: false,
   enableAutoUpdater: true,
 };
 

--- a/src/common/config/index.js
+++ b/src/common/config/index.js
@@ -341,6 +341,7 @@ export default class Config extends EventEmitter {
       if (y.order == null) {
         y.order = 0;
       }
+
       // once we ensured `order` exists, we can sort numerically
       return x.order - y.order;
     });

--- a/src/common/config/index.js
+++ b/src/common/config/index.js
@@ -289,8 +289,8 @@ export default class Config extends EventEmitter {
       combinedTeams.push(...this.localConfigData.teams);
     }
 
-    combinedTeams = this.filterOutDuplicateTeams(combinedTeams)
-    combinedTeams = this.sortUnorderedTeams(combinedTeams)
+    combinedTeams = this.filterOutDuplicateTeams(combinedTeams);
+    combinedTeams = this.sortUnorderedTeams(combinedTeams);
 
     this.combinedData.teams = combinedTeams;
     this.combinedData.localTeams = this.localConfigData.teams;
@@ -336,7 +336,11 @@ export default class Config extends EventEmitter {
     let i = 0;
 
     newTeams = newTeams.filter((newTeam) => {
-      if (!newTeam.order || newTeam.order < 0) { newTeam.order = i++; } return newTeam; // eslint-disable-line max-nested-callbacks
+      if (!newTeam.order || newTeam.order < 0) {
+        newTeam.order = i++;
+      }
+
+      return newTeam; // eslint-disable-line max-nested-callbacks
     });
     return newTeams;
   }

--- a/src/common/config/index.js
+++ b/src/common/config/index.js
@@ -347,9 +347,8 @@ export default class Config extends EventEmitter {
     // Now re-number all items from 0 to (max), ensuring user's sort order is preserved. The
     // new tabbed interface requires an item with order:0 in order to raise the first tab.
     //
-    let i = 0;
-    newTeams.forEach((team) => {
-      team.order = i++;
+    newTeams.forEach((team, i) => {
+      team.order = i;
     });
 
     return newTeams;

--- a/src/common/config/index.js
+++ b/src/common/config/index.js
@@ -272,7 +272,7 @@ export default class Config extends EventEmitter {
     delete this.combinedData.defaultTeams;
 
     // IMPORTANT: properly combine teams from all sources
-    const combinedTeams = [];
+    let combinedTeams = [];
 
     // - start by adding default teams from buildConfig, if any
     if (this.buildConfigData.defaultTeams && this.buildConfigData.defaultTeams.length) {
@@ -288,6 +288,9 @@ export default class Config extends EventEmitter {
     if (this.enableServerManagement) {
       combinedTeams.push(...this.localConfigData.teams);
     }
+
+    combinedTeams = this.filterOutDuplicateTeams(combinedTeams)
+    combinedTeams = this.sortUnorderedTeams(combinedTeams)
 
     this.combinedData.teams = combinedTeams;
     this.combinedData.localTeams = this.localConfigData.teams;
@@ -321,6 +324,20 @@ export default class Config extends EventEmitter {
       return this.predefinedTeams.findIndex((existingTeam) => newTeam.url === existingTeam.url) === -1; // eslint-disable-line max-nested-callbacks
     });
 
+    return newTeams;
+  }
+
+  /**
+   * Apply a default sort order to the team list, if no order is specified.
+   * @param {array} teams to sort
+   */
+  sortUnorderedTeams(teams) {
+    let newTeams = teams;
+    let i = 0;
+
+    newTeams = newTeams.filter((newTeam) => {
+      if (!newTeam.order || newTeam.order < 0) { newTeam.order = i++; } return newTeam; // eslint-disable-line max-nested-callbacks
+    });
     return newTeams;
   }
 

--- a/src/common/config/index.js
+++ b/src/common/config/index.js
@@ -341,7 +341,8 @@ export default class Config extends EventEmitter {
       if (y.order == null) {
         y.order = 0;
       }
-      return (x.order === y.order) ? 0 : ((x.order > y.order) ? 1 : -1); // eslint-disable-line no-nested-ternary
+      // once we ensured `order` exists, we can sort numerically
+      return x.order - y.order;
     });
 
     // Now re-number all items from 0 to (max), ensuring user's sort order is preserved. The

--- a/src/common/config/index.js
+++ b/src/common/config/index.js
@@ -332,16 +332,26 @@ export default class Config extends EventEmitter {
    * @param {array} teams to sort
    */
   sortUnorderedTeams(teams) {
-    let newTeams = teams;
-    let i = 0;
-
-    newTeams = newTeams.filter((newTeam) => {
-      if (!newTeam.order || newTeam.order < 0) {
-        newTeam.order = i++;
+    // Make a best pass at interpreting sort order. If an order is not specified, assume it is 0.
+    //
+    const newTeams = teams.sort((x, y) => {
+      if (x.order == null) {
+        x.order = 0;
       }
-
-      return newTeam; // eslint-disable-line max-nested-callbacks
+      if (y.order == null) {
+        y.order = 0;
+      }
+      return (x.order === y.order) ? 0 : ((x.order > y.order) ? 1 : -1); // eslint-disable-line no-nested-ternary
     });
+
+    // Now re-number all items from 0 to (max), ensuring user's sort order is preserved. The
+    // new tabbed interface requires an item with order:0 in order to raise the first tab.
+    //
+    let i = 0;
+    newTeams.forEach((team) => {
+      team.order = i++;
+    });
+
     return newTeams;
   }
 


### PR DESCRIPTION
If sort order was not present in buildConfig.js (or previous configuration), we will assume reasonable defaults.

Before submitting, please confirm you've
 - [X] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [X] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [X] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
This fixes an issue where enterprises deploying with buildConfig.js or GPO settings were getting a white screen on app startup.  It might have also affected users that upgraded their application from previous releases due to a configuration file format change.

**Issue link**
https://github.com/mattermost/desktop/issues/1224

**Test Cases**
* Define default servers in src/common/config/buildConfig.js, but leave out the order:0 parameter
* Launch application
* Confirm that application loads and displays tab, as expected.

**Additional Notes**
