### PR TITLE
[MM-23057] add different useragent for popup windows

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -86,6 +86,18 @@ const customLoginRegexPaths = [
 // tracking in progress custom logins
 const customLogins = {};
 
+const nixUA = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome Safari/537.36';
+
+const popupUserAgent = {
+  darwin: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome Safari/537.36',
+  win32: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome Safari/537.36',
+  aix: nixUA,
+  freebsd: nixUA,
+  linux: nixUA,
+  openbsd: nixUA,
+  sunos: nixUA,
+};
+
 /**
  * Main entry point for the application, ensures that everything initializes in the proper order
  */
@@ -525,7 +537,12 @@ function handleAppWebContentsCreated(dc, contents) {
           popupWindow = null;
         });
       }
-      popupWindow.loadURL(url);
+
+      // currently changing the userAgent for popup windows to allow plugins to go through google's oAuth
+      // should be removed once a proper oAuth2 implementation is setup.
+      popupWindow.loadURL(url, {
+        userAgent: popupUserAgent[process.platform],
+      });
     }
   });
 


### PR DESCRIPTION
Before submitting, please confirm you've
 - [X] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
As discussed, this will change user agent when navigating through a popup window to allow for finishing google's oauth

**Issue link**

[MM-23057](https://mattermost.atlassian.net/browse/MM-23057)

**Test Cases**
 on a test server with a zoom plugin that supports oauth (ask me for one if you don't want to set it up yourself) try to start a zoom videocall.

tested on osx catalina, win10 and ubuntu 18.04
**Additional Notes**
this is a temporary fix until a proper oauth2 handshake is implemented.