### PR TITLE
[MM-23153] Fixed the issue where back/forward navigation not in the main window causes the app to crash

### DIFF
--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -214,7 +214,7 @@ function createTemplate(mainWindow, config, isDev) {
         if (focusedWindow === mainWindow) {
           mainWindow.webContents.send('go-back');
         } else if (focusedWindow.webContents.canGoBack()) {
-          focusedWindow.goBack();
+          focusedWindow.webContents.goBack();
         }
       },
     }, {
@@ -224,7 +224,7 @@ function createTemplate(mainWindow, config, isDev) {
         if (focusedWindow === mainWindow) {
           mainWindow.webContents.send('go-forward');
         } else if (focusedWindow.webContents.canGoForward()) {
-          focusedWindow.goForward();
+          focusedWindow.webContents.goForward();
         }
       },
     }],

--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -210,22 +210,14 @@ function createTemplate(mainWindow, config, isDev) {
     submenu: [{
       label: 'Back',
       accelerator: process.platform === 'darwin' ? 'Cmd+[' : 'Alt+Left',
-      click: (item, focusedWindow) => {
-        if (focusedWindow === mainWindow) {
-          mainWindow.webContents.send('go-back');
-        } else if (focusedWindow.webContents.canGoBack()) {
-          focusedWindow.goBack();
-        }
+      click: () => {
+        mainWindow.webContents.send('go-back');
       },
     }, {
       label: 'Forward',
       accelerator: process.platform === 'darwin' ? 'Cmd+]' : 'Alt+Right',
-      click: (item, focusedWindow) => {
-        if (focusedWindow === mainWindow) {
-          mainWindow.webContents.send('go-forward');
-        } else if (focusedWindow.webContents.canGoForward()) {
-          focusedWindow.goForward();
-        }
+      click: () => {
+        mainWindow.webContents.send('go-forward');
       },
     }],
   });

--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -210,14 +210,22 @@ function createTemplate(mainWindow, config, isDev) {
     submenu: [{
       label: 'Back',
       accelerator: process.platform === 'darwin' ? 'Cmd+[' : 'Alt+Left',
-      click: () => {
-        mainWindow.webContents.send('go-back');
+      click: (item, focusedWindow) => {
+        if (focusedWindow === mainWindow) {
+          mainWindow.webContents.send('go-back');
+        } else if (focusedWindow.webContents.canGoBack()) {
+          focusedWindow.goBack();
+        }
       },
     }, {
       label: 'Forward',
       accelerator: process.platform === 'darwin' ? 'Cmd+]' : 'Alt+Right',
-      click: () => {
-        mainWindow.webContents.send('go-forward');
+      click: (item, focusedWindow) => {
+        if (focusedWindow === mainWindow) {
+          mainWindow.webContents.send('go-forward');
+        } else if (focusedWindow.webContents.canGoForward()) {
+          focusedWindow.goForward();
+        }
       },
     }],
   });


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
This PR stops the crash that happens when you try to navigate back/forward with an OAuth window open, now the back/forward buttons will correctly work with the focused window.

**Issue link**
https://mattermost.atlassian.net/browse/MM-23153
