### PR TITLE
[MM-23663] Fixed z-index ordering of webview vs. error page

### DIFF
--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -315,6 +315,9 @@ export default class MattermostView extends React.Component {
     if (!this.props.active) {
       classNames.push('mattermostView-hidden');
     }
+    if (this.state.errorInfo) {
+      classNames.push('mattermostView-error');
+    }
     if (this.props.allowExtraBar) {
       classNames.push('allow-extra-bar');
     }

--- a/src/browser/css/components/MattermostView.css
+++ b/src/browser/css/components/MattermostView.css
@@ -19,6 +19,10 @@
   z-index: -1;
 }
 
+.mattermostView-error webview {
+  z-index: -1;
+}
+
 .mattermostView-loadingScreen {
   vertical-align: middle;
   background: white;


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
We had removed the `mattermostView-hidden` class from the error state since it was causing issues with the Ctrl+Tab shortcut. Unfortunately, it meant that the `webview` was sitting on top on of the error page, making the error page not usable. This PR forces the `z-index` of the `webview` in the error state to sit below the error page itself, allowing for shortcuts to function while not displaying overtop of the error page.

**Issue link**
https://mattermost.atlassian.net/browse/MM-23663
