### PR TITLE
[MM-23784] Removed unnecessary code for focusing the mattermost view

### DIFF
--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -234,11 +234,7 @@ export default class MattermostView extends React.Component {
 
   focusOnWebView = () => {
     const webview = this.webviewRef.current;
-    const webContents = webview.getWebContents(); // webContents might not be created yet.
-    if (webContents) {
-      webview.focus();
-      webContents.focus();
-    }
+    webview.focus();
   }
 
   handleMouseMove = (event) => {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
On Windows, when creating a new server using the + button or the 'Sign into another Server' menu item, a second `webContents` would be created for that server and would cause some events to be received by the wrong `webContents`.

I'm not 100% sure why this is happening, but it would appear that while calling `focusOnWebView()` on the `MattermostView`, a call to `webview.getWebContents()` is made and removing that call causes this issue to disappear. It would appear that focusing is still working without this call, so I have removed it. My thoughts are that `getWebContents` is returning a new `WebContents` object other than the one created, but I cannot confirm for sure. This feels like an Electron issue that we've happened to stumble across.

Tested on Windows 10 and macOS Catalina.

**Issue link**
https://mattermost.atlassian.net/browse/MM-23784

**Test Cases**
1. Open Mattermost Desktop on Windows, and make sure some text is on your clipboard
2. Press the '+' tab to create a new server
3. Fill out the details and press Add.
4. Ctrl+V to paste the text into the new server
5. The text should paste successfully.
