### PR TITLE
[MM-23082] cherry pick of #1246

### DIFF
--- a/src/common/config/buildConfig.js
+++ b/src/common/config/buildConfig.js
@@ -9,6 +9,7 @@
  * @prop {Object[]} defaultTeams
  * @prop {string} defaultTeams[].name - The tab name for default team.
  * @prop {string} defaultTeams[].url - The URL for default team.
+ * @prop {string} defaultTeams[].order - Sort order for team tabs (0, 1, 2)
  * @prop {string} helpLink - The URL for "Help->Learn More..." menu item.
  *                           If null is specified, the menu disappears.
  * @prop {boolean} enableServerManagement - Whether users can edit servers configuration.
@@ -20,8 +21,8 @@ const buildConfig = {
     {
       name: 'example',
       url: 'https://example.com'
-    }*/
-  ],
+    }
+  */],
   helpLink: 'https://about.mattermost.com/default-desktop-app-documentation/',
   enableServerManagement: true,
   enableAutoUpdater: true,


### PR DESCRIPTION
Cherry pick #1246 

* Fixes whitescreen issue on app upgrade / GPO push / whitelabeled app deployments.  If sort order was not present in buildConfig.js (or previous configuration), we will assume reasonable defaults

* Fixing eslint bugs - with my apologies

* Removing order flag from sample configuration, but leaving it in the documentation.
BUGFIX: Accidentally left my custom enableServerManagement flag in place.  Reverted to default

* Making a more educated guess as to the user's desired sort order.

* Update src/common/config/index.js

Use forEach's index instead of an external one.

Co-Authored-By: Guillermo Vayá <guivaya@gmail.com>

* Update src/common/config/index.js

Let me test this, I'm not sure I understand how this logic works.  :)

Co-Authored-By: Guillermo Vayá <guivaya@gmail.com>

* Removed optional field

* Fixed broken lint:js with my apologies

Co-authored-by: Guillermo Vayá <guivaya@gmail.com>

Before submitting, please confirm you've
 - [ ] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [ ] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [ ] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
<!--
Write a short (one line) summary that describes the changes in this pull request for inclusion in the changelog
-->

**Issue link**
<!--
Please include a link to the GitHub issue this pull request addresses, if applicable.
-->

**Test Cases**

**Additional Notes**
