### PR TITLE
[MM-23215] prevent mouse event to go through and click on window

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -520,17 +520,20 @@ export default class MainPage extends React.Component {
     }
   }
 
-  handleClose = () => {
+  handleClose = (e) => {
+    e.stopPropagation(); // since it is our button, the event goes into MainPage's onclick event, getting focus back.
     const win = remote.getCurrentWindow();
     win.close();
   }
 
-  handleMinimize = () => {
+  handleMinimize = (e) => {
+    e.stopPropagation();
     const win = remote.getCurrentWindow();
     win.minimize();
   }
 
-  handleMaximize = () => {
+  handleMaximize = (e) => {
+    e.stopPropagation();
     const win = remote.getCurrentWindow();
     win.maximize();
   }


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
when clicking on the close button with the new tabbar, on windows (not sure why only this one) it goes through and prevents the app from losing focus, which the webapp interprets as having the window visible

**Issue link**
[MM-23215](https://mattermost.atlassian.net/browse/MM-23215)

**Test Cases**
have two users on the same channel, one on the app and another somewhere else
close the app 
mention the user on the app from the other one
expected: notification appears
**Additional Notes**
