### PR TITLE
[MM-24286] - Fix save image functionality of context menu

### DIFF
--- a/src/browser/js/contextMenu.js
+++ b/src/browser/js/contextMenu.js
@@ -53,7 +53,7 @@ export default {
     };
     const actualOptions = Object.assign({}, defaultOptions, options);
     electronContextMenu({
-      window: win,
+      window: win.webContents ? win : {...win, webContents: win.getWebContents()},
       prepend(_defaultActions, params) {
         if (actualOptions.useSpellChecker) {
           const prependMenuItems = [];


### PR DESCRIPTION
**Summary**
The issue is that in the context of the setup here webContents aren't passed to webview. What I did fixes the issue but there might be a better solution. Suggestions? 
 
**Issue link**
https://mattermost.atlassian.net/browse/MM-24286

Fix versions
v4.5 Desktop App