### PR TITLE
Fix hide/close behaviour on Windows, Linux and MacOS

### DIFF
--- a/src/main/mainWindow.js
+++ b/src/main/mainWindow.js
@@ -131,15 +131,22 @@ function createMainWindow(config, options) {
         window.blur(); // To move focus to the next top-level window in Windows
         window.hide();
       }
+      function closeWindow(window) {
+        window.close();
+      }
       switch (process.platform) {
       case 'win32':
-        hideWindow(mainWindow);
+        if (config.minimizeToTray) {
+          hideWindow(mainWindow);
+        } else {
+          closeWindow(mainWindow);
+        }
         break;
       case 'linux':
         if (config.minimizeToTray) {
           hideWindow(mainWindow);
         } else {
-          mainWindow.minimize();
+          closeWindow(mainWindow);
         }
         break;
       case 'darwin':
@@ -149,8 +156,10 @@ function createMainWindow(config, options) {
             app.hide();
           });
           mainWindow.setFullScreen(false);
-        } else {
+        } else if (config.minimizeToTray) {
           app.hide();
+        } else {
+          closeWindow(mainWindow);
         }
         break;
       default:


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**

This pull request fixes issue #90 on Windows 7, Windows 10, MacOS Mojave (don't have Catalina to test), and Arch Linux (GNOME + KDE both tested).

- [x] The commit respects `config.minimizeToTray`
- [x] Correct and user-expected behaviour that closes window when quitting the application, if `minimizeToTray` is `false`.

**Issue link**

https://github.com/mattermost/desktop/issues/90
