### PR TITLE
Improve release

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -85,7 +85,7 @@ case "${1}" in
                 rc="${pkg_version#*-rc}"
             else
                 print_warning "No release candidate on the version, assuming 0"
-                rc=0
+                rc=1
             fi
             case "${rc}" in
                 ''|*[!0-9]*) 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -84,12 +84,12 @@ case "${1}" in
             if [[ "${pkg_version}" =~ "-rc" ]]; then
                 rc="${pkg_version#*-rc}"
             else
-                print_warning "No release candidate on the version, assuming 0"
+                print_warning "No release candidate on the version, assuming 1"
                 rc=1
             fi
             case "${rc}" in
                 ''|*[!0-9]*) 
-                    print_warning "Can't guess release candidate from version, assuming 0"
+                    print_warning "Can't guess release candidate from version, assuming 1"
                     rc=1
                 ;;
                 *)
@@ -123,7 +123,7 @@ case "${1}" in
     ;;
     "patch")
         if [[ "${branch_name}" =~ "release-" ]]; then
-            new_pkg_version="${major}.${minor}.$(( micro + 1 ))"
+            new_pkg_version="${major}.${minor}.$(( micro + 1 ))-rc1"
             print_info "Releasing v${new_pkg_version}"
             write_package_version "${new_pkg_version}"
             tag "${new_pkg_version}" "Released on $(date -u)"


### PR DESCRIPTION
it was bothering me to have to do this every time I make a new patch version.

rc now starts at 1
issuing release patch will create a new micro-version with -rc1 suffix

no QA should be needed as this only affects the release cut process