### PR TITLE
fix branch releasing

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -146,7 +146,7 @@ case "${1}" in
                 exit 3
             fi
 
-            new_pkg_version="${new_branch_version}.0-rc0"
+            new_pkg_version="${new_branch_version}.0-rc1"
             git checkout -b "${new_branch_name}"
             write_package_version "${new_pkg_version}"
             tag "${new_pkg_version}" "Quality branch"
@@ -163,7 +163,7 @@ case "${1}" in
             fi
             new_branch_version="${major}.${minor}"
             new_branch_name="release-${new_branch_version}"
-            new_pkg_version="${new_branch_version}.0-rc0"
+            new_pkg_version="${new_branch_version}.0-rc1"
             master_pkg_version="${major}.$(( minor + 1 )).0-develop"
             print_info "Creating a new features branch: ${new_branch_name}"
 


### PR DESCRIPTION
release process is creating rc0 for new feature branches, which might be confusing for users.

no qa needed