### PR TITLE
[MM-23228] warn when setting tray icon on linux

### DIFF
--- a/src/browser/components/DestructiveConfirmModal.jsx
+++ b/src/browser/components/DestructiveConfirmModal.jsx
@@ -19,7 +19,9 @@ export default function DestructiveConfirmationModal(props) {
       <Modal.Header closeButton={true}>
         <Modal.Title>{title}</Modal.Title>
       </Modal.Header>
-      {body}
+      <Modal.Body>
+        {body}
+      </Modal.Body>
       <Modal.Footer>
         <Button
           bsStyle='link'

--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -79,7 +79,6 @@ export default class MattermostView extends React.Component {
     // Open link in browserWindow. for example, attached files.
     webview.addEventListener('new-window', (e) => {
       if (!Utils.isValidURI(e.url)) {
-        console.log(`${e.url} is not a valid url, discarding.`);
         return;
       }
       const currentURL = url.parse(webview.getURL());

--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -79,6 +79,7 @@ export default class MattermostView extends React.Component {
     // Open link in browserWindow. for example, attached files.
     webview.addEventListener('new-window', (e) => {
       if (!Utils.isValidURI(e.url)) {
+        console.log(`${e.url} is not a valid url, discarding.`);
         return;
       }
       const currentURL = url.parse(webview.getURL());

--- a/src/browser/components/RemoveServerModal.jsx
+++ b/src/browser/components/RemoveServerModal.jsx
@@ -16,7 +16,7 @@ export default function RemoveServerModal(props) {
       acceptLabel='Remove'
       cancelLabel='Cancel'
       body={(
-        <Modal.Body>
+        <React.Fragment>
           <p>
             {'This will remove the server from your Desktop App but will not delete any of its data' +
           ' - you can add the server back to the app at any time.'}
@@ -24,7 +24,7 @@ export default function RemoveServerModal(props) {
           <p>
             {'Confirm you wish to remove the '}<strong>{serverName}</strong>{' server?'}
           </p>
-        </Modal.Body>
+        </React.Fragment>
       )}
     />
   );

--- a/src/browser/components/RemoveServerModal.jsx
+++ b/src/browser/components/RemoveServerModal.jsx
@@ -3,7 +3,6 @@
 // See LICENSE.txt for license information.
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Modal} from 'react-bootstrap';
 
 import DestructiveConfirmationModal from './DestructiveConfirmModal.jsx';
 

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -912,15 +912,15 @@ export default class SettingsPage extends React.Component {
 
     const linuxTrayWarning = (
       <DestructiveConfirmationModal
-        title='Please read carefully before turning this on'
+        title='Please read carefully before turning this option on'
         body={
           <React.Fragment>
-            <span>{
+            <p>{
               `There is a known issue on linux distributions with old versions of libappnotify. 
               Please read the following information in order to know if it's safe to turn on or possible workarounds.`
             }
-            </span>
-            <ExternalLink href={'https://mattermost.atlassian.net/browse/MM-23228'}>{'More Information.'}</ExternalLink>
+            </p>
+            <p><ExternalLink href={'https://mattermost.atlassian.net/browse/MM-23228'}>{'More Information.'}</ExternalLink></p>
           </React.Fragment>
         }
         acceptLabel='Continue'

--- a/src/browser/components/externalLink.jsx
+++ b/src/browser/components/externalLink.jsx
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {ipcRenderer} from 'electron';
+
+// this component is used to override some checks from the UI, leaving only to trust the protocol in case it wasn't http/s
+// it is used the same as an `a` JSX tag
+export default function ExternalLink(props) {
+  const click = (e) => {
+    e.preventDefault();
+    let parseUrl;
+    try {
+      parseUrl = new URL(props.href);
+      ipcRenderer.send('confirm-protocol', parseUrl.protocol, props.href);
+    } catch (err) {
+      console.error(`invalid url ${props.href} supplied to externallink: ${err}`);
+    }
+  };
+  const options = {
+    onClick: click,
+    ...props,
+  };
+  return (
+    <a {...options}/>
+  );
+}
+
+ExternalLink.propTypes = {
+  href: PropTypes.string.isRequired,
+};


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
On linux, there is a known problem which crashes the desktop. Since it is an upstream problem in the library and a fix is already provided on some modern distros, we are warning that this might be the case and providing a link to useful information for users to try and overcome the limitation.

**Issue link**

[MM-23228](https://mattermost.atlassian.net/browse/MM-23228)

**Test Cases**

Open settings on linux: when trying to turn the `minimize to tray option` on, a warning should appear with a link to a documentation page.

This should not happen if platform is other than linux or while turning it off.

**Additional Notes**
I created a component to override security on UI-based links to go to external sites.

It currently is missing the actual desktop channel post, as I want to have a first review on functionality, as the post can be edited later on. It is linking to the jira ticket for now.

**Screenshots**
<img width="1311" alt="Screenshot 2020-05-12 at 14 48 18" src="https://user-images.githubusercontent.com/1515906/81693067-ab011400-945f-11ea-8808-d9f30e75537d.png">
