### PR TITLE
[MM-25526] Removed fix for flaky test causing visual issues with Add New Server flow

### DIFF
--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -141,7 +141,6 @@ export default class NewTeamModal extends React.Component {
         enforceFocus={true}
         onEntered={() => this.teamNameInputRef.focus()}
         onHide={this.props.onClose}
-        container={this.props.modalContainer}
         restoreFocus={this.props.restoreFocus}
         onKeyDown={(e) => {
           switch (e.key) {
@@ -239,7 +238,6 @@ NewTeamModal.propTypes = {
   team: PropTypes.object,
   editMode: PropTypes.bool,
   show: PropTypes.bool,
-  modalContainer: PropTypes.object,
   restoreFocus: PropTypes.bool,
   currentOrder: PropTypes.number,
   setInputRef: PropTypes.func,

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -635,7 +635,6 @@ export default class SettingsPage extends React.Component {
             onTeamClick={(index) => {
               backToIndex(this.state.localTeams[index].order + this.state.buildTeams.length + this.state.registryTeams.length);
             }}
-            modalContainer={this}
           />
         </Col>
       </Row>

--- a/src/browser/components/TeamList.jsx
+++ b/src/browser/components/TeamList.jsx
@@ -155,7 +155,6 @@ export default class TeamList extends React.Component {
           this.props.setAddTeamFormVisibility(false);
         }}
         team={this.state.team}
-        modalContainer={this.props.modalContainer}
       />);
 
     const removeServer = this.props.teams[this.state.indexToRemoveServer];
@@ -169,7 +168,6 @@ export default class TeamList extends React.Component {
           this.handleTeamRemove(this.state.indexToRemoveServer);
           this.closeServerRemoveModal();
         }}
-        modalContainer={this.props.modalContainer}
       />
     );
 
@@ -192,5 +190,4 @@ TeamList.propTypes = {
   toggleAddTeamForm: PropTypes.func,
   setAddTeamFormVisibility: PropTypes.func,
   onTeamClick: PropTypes.func,
-  modalContainer: PropTypes.object,
 };


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
When I did the changes for the New Desktop Tabs, I introduced a change to fix a flaky test here: https://github.com/mattermost/desktop/pull/1056/commits/e8e15e3a3da71b8af0f07ac6de3ef6609928b1e3

Unfortunately, this caused some visual issues when opening the Add Server Modal on the Settings Page. It appears the flaky test has been fixed so I'm reverting this change.

**Issue link**
https://mattermost.atlassian.net/browse/MM-25526
