### PR TITLE
[MM-25522] Revert unnecessary fix for bad UX causing focus to not be restored correctly

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -805,7 +805,6 @@ export default class MainPage extends React.Component {
       <NewTeamModal
         currentOrder={this.props.teams.length}
         show={this.state.showNewTeamModal}
-        restoreFocus={false}
         setInputRef={this.setInputRef}
         onClose={() => {
           this.setState({


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
When Desktop Tabs were added a fix was made very early in the process to not restore focus to the app after the modal was closed. See here: https://github.com/mattermost/desktop/pull/1056/commits/f09ea8d2cc439b98940e2adaadb4fe1832a8d5fa

I'm not sure why this was done, as there is no PR feedback/no further comment from me, but it appears that this fix is no longer needed as restoring focus seems to work correctly. This PR will restore the ability of the modal to restore focus on close.

**Issue link**
https://mattermost.atlassian.net/browse/MM-25522
