### PR TITLE
[MM-25671] fix invalid urls

### DIFF
--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -13,7 +13,7 @@ function getDomain(inputURL) {
 }
 
 function isValidURL(testURL) {
-  return Boolean(isHttpUri(testURL) || isHttpsUri(testURL));
+  return Boolean(isHttpUri(testURL) || isHttpsUri(testURL)) && parseURL(testURL) !== null;
 }
 
 function isValidURI(testURL) {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**

when adding/modifying a server, we weren't making enough tests for the url, making it crash later.

**Issue link**

[MM-25671](https://mattermost.atlassian.net/browse/MM-25671)

**Test Cases**

1. add
- click on `add a new server` (either + or settings)
- add a name for the server
- add an invalid url (like `https://comm]unity.mattermost.com` notice the `]`)
- save

2.modify
- open preferences
- edit a server
- change into an invalid url
- save

expected: raises an error of invalid url on both cases


**Additional Notes**
