### PR TITLE
[MM-24587] Added margin at top of draggable tab bar to facilitate resizing

### DIFF
--- a/src/browser/css/components/TabBar.css
+++ b/src/browser/css/components/TabBar.css
@@ -5,6 +5,8 @@
   display: flex !important;
   flex-wrap: nowrap;
   justify-content: flex-start;
+  -webkit-app-region: drag;
+  margin-top: 4px;
 }
 
 .TabBar.darkMode {
@@ -31,7 +33,6 @@
   max-height: 32px;
   line-height: 16px;
   margin-right: -1px;
-  margin-top: 4px;
   padding: 6px 0;
   color: rgba(61,60,64,0.7);
   font-family: Arial;

--- a/src/browser/css/index.css
+++ b/src/browser/css/index.css
@@ -79,13 +79,11 @@ body {
 
 .topBar {
   height: 40px;
-  -webkit-app-region: drag;
 }
 
 .topBar>.topBar-bg {
   display: flex;
   overflow: hidden;
-  -webkit-app-region: drag;
   height: 36px;
   background-color: rgba(0,0,0,0.1);
 }
@@ -246,6 +244,7 @@ body {
   z-index: 9;
   background: linear-gradient(90deg, rgba(0, 0, 0, 0) 0%, #e5e5e5 100%);
   -webkit-app-region: drag;
+  margin-top: 4px;
 }
 
 .topBar.darkMode .overlay-gradient {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
On Electron apps in Windows and Linux, a `--webkit-app-drag` draggable area cannot be used to resize the window, as per this issue: https://github.com/electron/electron/issues/3022

This PR adds a small margin to the draggable area so that the topmost part of the window can facilitate resizing and the rest of the top bar can be used to drag the window.

**Issue link**
https://mattermost.atlassian.net/browse/MM-24587
