### PR TITLE
[MM-22230] fix promises, reenable trust protocols, reenable capturing unhandled exceptions

### DIFF
--- a/src/main/CriticalErrorHandler.js
+++ b/src/main/CriticalErrorHandler.js
@@ -95,10 +95,9 @@ export default class CriticalErrorHandler {
           break;
         case buttons.indexOf(BUTTON_REOPEN):
           app.relaunch();
-          app.exit(-1);
           break;
         }
-        throw err;
+        app.exit(-1);
       });
     } else {
       log.err(`Window wasn't ready to handle the error: ${err}\ntrace: ${err.stack}`);

--- a/src/main/CriticalErrorHandler.js
+++ b/src/main/CriticalErrorHandler.js
@@ -32,13 +32,6 @@ function openDetachedExternal(url) {
   }
 }
 
-function bindWindowToShowMessageBox(win) {
-  if (win && win.isVisible()) {
-    return dialog.showMessageBox.bind(null, win);
-  }
-  return dialog.showMessageBox;
-}
-
 export default class CriticalErrorHandler {
   constructor() {
     this.mainWindow = null;
@@ -49,16 +42,17 @@ export default class CriticalErrorHandler {
   }
 
   windowUnresponsiveHandler() {
-    const result = dialog.showMessageBox(this.mainWindow, {
+    dialog.showMessageBox(this.mainWindow, {
       type: 'warning',
       title: app.name,
       message: 'The window is no longer responsive.\nDo you wait until the window becomes responsive again?',
       buttons: ['No', 'Yes'],
       defaultId: 0,
+    }).then((result) => {
+      if (result === 0) {
+        throw new Error('BrowserWindow \'unresponsive\' event has been emitted');
+      }
     });
-    if (result === 0) {
-      throw new Error('BrowserWindow \'unresponsive\' event has been emitted');
-    }
   }
 
   processUncaughtExceptionHandler(err) {
@@ -71,31 +65,37 @@ export default class CriticalErrorHandler {
       if (process.platform === 'darwin') {
         buttons.reverse();
       }
-      const showMessageBox = bindWindowToShowMessageBox(this.mainWindow);
-      const result = showMessageBox({
-        type: 'error',
-        title: app.name,
-        message: `The ${app.name} app quit unexpectedly. Click "Show Details" to learn more or "Reopen" to open the application again.\n\nInternal error: ${err.message}`,
-        buttons,
-        defaultId: buttons.indexOf(BUTTON_REOPEN),
-        noLink: true,
-      });
-      switch (result) {
-      case buttons.indexOf(BUTTON_SHOW_DETAILS):
+      const bindWindow = this.mainWindow && this.mainWindow.isVisible() ? this.mainWindow : null;
+      dialog.showMessageBox(
+        bindWindow,
         {
-          const child = openDetachedExternal(file);
+          type: 'error',
+          title: app.name,
+          message: `The ${app.name} app quit unexpectedly. Click "Show Details" to learn more or "Reopen" to open the application again.\n\nInternal error: ${err.message}`,
+          buttons,
+          defaultId: buttons.indexOf(BUTTON_REOPEN),
+          noLink: true,
+        }
+      ).then((result) => {
+        let child;
+        switch (result) {
+        case buttons.indexOf(BUTTON_SHOW_DETAILS):
+          child = openDetachedExternal(file);
           if (child) {
-            child.on('error', (spawnError) => {
-              console.log(spawnError);
-            });
+            child.on(
+              'error',
+              (spawnError) => {
+                console.log(spawnError);
+              }
+            );
             child.unref();
           }
+          break;
+        case buttons.indexOf(BUTTON_REOPEN):
+          app.relaunch();
+          break;
         }
-        break;
-      case buttons.indexOf(BUTTON_REOPEN):
-        app.relaunch();
-        break;
-      }
+      });
     }
     throw err;
   }

--- a/src/main/allowProtocolDialog.js
+++ b/src/main/allowProtocolDialog.js
@@ -57,7 +57,7 @@ function initDialogEvent(mainWindow) {
       ],
       cancelId: 2,
       noLink: true,
-    }).then((response) => {
+    }).then(({response}) => {
       switch (response) {
       case 1: {
         allowedProtocols.push(protocol);

--- a/src/main/allowProtocolDialog.js
+++ b/src/main/allowProtocolDialog.js
@@ -57,7 +57,7 @@ function initDialogEvent(mainWindow) {
       ],
       cancelId: 2,
       noLink: true,
-    }, (response) => {
+    }).then((response) => {
       switch (response) {
       case 1: {
         allowedProtocols.push(protocol);

--- a/src/main/autoUpdater.js
+++ b/src/main/autoUpdater.js
@@ -142,7 +142,7 @@ function initialize(appState, mainWindow, notifyOnly = false) {
         buttons: ['Close'],
         title: 'Your Desktop App is up to date',
         message: 'You have the latest version of the Mattermost Desktop App.',
-      }, () => {}); // eslint-disable-line no-empty-function
+      });
     }
     setTimeout(() => {
       autoUpdater.checkForUpdates();


### PR DESCRIPTION
Before submitting, please confirm you've

 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**

on electron v6 dialog module changed to promise based functions, so all of them would return a promise.

this fixes that, reenabling trusting protocols

also while working on this, I realised the unhandled exceptions dialog wasn't working properly, so fixed it as well.

**Issue link**

[MM-22230](https://mattermost.atlassian.net/browse/MM-22230)

**Test Cases**

for the protocol question:
1. ensure you don't have spotify in your `<configpath>/Mattermost/allowedProtocols.json` or dont have that file
1. post a link with spotify protocol like: `here is a protocol link [herbie hanckock](spotify:album:5fmIolILp5NAtNYiRPjhzA)`
1. dialog should appear. if hitting save it will add an entry to the above file, if hitting yes it wont but still open on spotify
1. if user chose save, the file must contain the entry and clicking again on the posted link should not raise the dialog again.

for testing the protocol, it might need to find a way to make the app crash, and a dialog should appear letting you have three choices:
- ignore it
- view details (a window with info should appear and close the app)
- relaunch (app should close and reopen)

I don't have an easy way for QA to test this. I tested it with an exception raised, but that was removed from code before pushing the PR
**Additional Notes**
