### PR TITLE
Prevent adding arbitrary websites as new servers

### DIFF
--- a/test/specs/browser/settings_test.js
+++ b/test/specs/browser/settings_test.js
@@ -79,7 +79,7 @@ describe('browser/settings.html', function desc() {
         waitForVisible('#newServerModal').
         setValue('#teamNameInput', 'TestTeam').
         pause(100).
-        setValue('#teamUrlInput', 'http://example.org').
+        setValue('#teamUrlInput', 'https://demo.mattermost.com/').
         click('#saveNewServerModal').
         waitForVisible('#newServerModal', true).
         waitForVisible('#serversSaveIndicator').
@@ -466,7 +466,7 @@ describe('browser/settings.html', function desc() {
     describe('Valid server url', () => {
       beforeEach(() => {
         return this.app.client.
-          setValue('#teamUrlInput', 'http://example.org').
+          setValue('#teamUrlInput', 'https://demo.mattermost.com/').
           click('#saveNewServerModal');
       });
 
@@ -498,7 +498,7 @@ describe('browser/settings.html', function desc() {
     describe('Valid Team Settings', () => {
       beforeEach(() => {
         return this.app.client.
-          setValue('#teamUrlInput', 'http://example.org').
+          setValue('#teamUrlInput', 'https://demo.mattermost.com/').
           setValue('#teamNameInput', 'TestTeam');
       });
 
@@ -520,7 +520,7 @@ describe('browser/settings.html', function desc() {
         const savedConfig = JSON.parse(fs.readFileSync(env.configFilePath, 'utf8'));
         savedConfig.teams.should.deep.contain({
           name: 'TestTeam',
-          url: 'http://example.org',
+          url: 'https://demo.mattermost.com/',
           order: 2,
         });
       });


### PR DESCRIPTION
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

**Summary**

This change prevents users from adding servers with URLs that are not Mattermost servers.

The implementation is perhaps a bit rough, so refactoring advice would be welcome, but it works. I figured it was best to get a fix up quickly rather than try to make it perfect because allowing arbitrary websites to run inside an Electron shell is a security issue. This doesn't fully plug the hole (any website with "Mattermost" in its `<title>` tag will pass the test) but it will screen out the majority of the risk.

**Issue link**

Closes https://github.com/mattermost/desktop/issues/1320