### PR TITLE
[MM-22751] Removed Windows 10 style border for non-Windows 10 clients

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -5,6 +5,7 @@
 // This files uses setState().
 /* eslint-disable react/no-set-state */
 
+import os from 'os';
 import url from 'url';
 
 import React, {Fragment} from 'react';
@@ -704,7 +705,7 @@ export default class MainPage extends React.Component {
     }
 
     let titleBarButtons;
-    if (process.platform !== 'darwin') {
+    if (os.platform() === 'win32' && os.release().startsWith('10')) {
       titleBarButtons = (
         <span className='title-bar-btns'>
           <div

--- a/src/browser/components/SettingsPage.jsx
+++ b/src/browser/components/SettingsPage.jsx
@@ -5,6 +5,8 @@
 // This file uses setState().
 /* eslint-disable react/no-set-state */
 
+import os from 'os';
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Button, Checkbox, Col, FormGroup, Grid, HelpBlock, Navbar, Radio, Row} from 'react-bootstrap';
@@ -540,7 +542,7 @@ export default class SettingsPage extends React.Component {
     }
 
     let titleBarButtons;
-    if (process.platform !== 'darwin') {
+    if (os.platform() === 'win32' && os.release().startsWith('10')) {
       titleBarButtons = (
         <span className='title-bar-btns'>
           <div

--- a/src/main/mainWindow.js
+++ b/src/main/mainWindow.js
@@ -72,7 +72,6 @@ function createMainWindow(config, options) {
   mainWindow.deeplinkingUrl = options.deeplinkingUrl;
   mainWindow.setMenuBarVisibility(false);
 
-
   const indexURL = global.isDev ? 'http://localhost:8080/browser/index.html' : `file://${app.getAppPath()}/browser/index.html`;
   mainWindow.loadURL(indexURL);
 

--- a/src/main/mainWindow.js
+++ b/src/main/mainWindow.js
@@ -3,6 +3,7 @@
 // See LICENSE.txt for license information.
 import fs from 'fs';
 import path from 'path';
+import os from 'os';
 
 import {app, BrowserWindow} from 'electron';
 
@@ -17,6 +18,10 @@ function saveWindowState(file, window) {
     // [Linux] error happens only when the window state is changed before the config dir is created.
     console.log(e);
   }
+}
+
+function isFramelessWindow() {
+  return os.platform() === 'darwin' || (os.platform() === 'win32' && os.release().startsWith('10'));
 }
 
 function createMainWindow(config, options) {
@@ -51,7 +56,7 @@ function createMainWindow(config, options) {
     show: hideOnStartup || false,
     minWidth: minimumWindowWidth,
     minHeight: minimumWindowHeight,
-    frame: false,
+    frame: !isFramelessWindow(),
     fullscreen: false,
     titleBarStyle: 'hiddenInset',
     backgroundColor: '#fff', // prevents blurry text: https://electronjs.org/docs/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do
@@ -65,6 +70,8 @@ function createMainWindow(config, options) {
 
   const mainWindow = new BrowserWindow(windowOptions);
   mainWindow.deeplinkingUrl = options.deeplinkingUrl;
+  mainWindow.setMenuBarVisibility(false);
+
 
   const indexURL = global.isDev ? 'http://localhost:8080/browser/index.html' : `file://${app.getAppPath()}/browser/index.html`;
   mainWindow.loadURL(indexURL);


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
This PR adds the original window border for non-Mac, non-Windows 10 clients so that the window style more accurately fits the OS being used.

This has been tested on:
- Windows 7 SP1
- Ubuntu 20.04 LTS
- Fedora 31

More testing on other operating systems should happen before this is merged.

**Issue link**
https://mattermost.atlassian.net/browse/MM-22751