### PR TITLE
[MM-26017] add menu to all windows

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -16,6 +16,7 @@ import DotsVerticalIcon from 'mdi-react/DotsVerticalIcon';
 import {ipcRenderer, remote, shell} from 'electron';
 
 import Utils from '../../utils/util';
+import contextmenu from '../js/contextMenu';
 
 import restoreButton from '../../assets/titlebar/chrome-restore.svg';
 import maximizeButton from '../../assets/titlebar/chrome-maximize.svg';
@@ -61,6 +62,14 @@ export default class MainPage extends React.Component {
       focusFinder: false,
       finderVisible: false,
     };
+    contextmenu.setup({
+      useSpellChecker: this.props.useSpellChecker,
+      onSelectSpellCheckerLocale: (locale) => {
+        if (this.props.onSelectSpellCheckerLocale) {
+          this.props.onSelectSpellCheckerLocale(locale);
+        }
+      },
+    });
   }
 
   parseDeeplinkURL(deeplink, teams = this.props.teams) {

--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -126,7 +126,8 @@ export default class MattermostView extends React.Component {
         webview.focus();
       }
       if (!this.state.isContextMenuAdded) {
-        contextMenu.setup(webview, {
+        contextMenu.setup({
+          window: webview,
           useSpellChecker: this.props.useSpellChecker,
           onSelectSpellCheckerLocale: (locale) => {
             if (this.props.onSelectSpellCheckerLocale) {

--- a/src/browser/js/contextMenu.js
+++ b/src/browser/js/contextMenu.js
@@ -46,14 +46,18 @@ function getSpellCheckerLocaleMenus(onSelectSpellCheckerLocale) {
 }
 
 export default {
-  setup(win, options) {
+  setup(options) {
     const defaultOptions = {
       useSpellChecker: false,
       onSelectSpellCheckerLocale: null,
+      shouldShowMenu: (e, p) => {
+        const isInternalLink = p.linkURL.endsWith('#') && p.linkURL.slice(0, -1) === p.pageURL;
+        return p.isEditable || p.hasImageContents || (p.linkURL !== '' && !isInternalLink) || p.mediaType !== 'none' || p.misspelledWord !== '' || p.selectionText !== '';
+      }
     };
     const actualOptions = Object.assign({}, defaultOptions, options);
+
     electronContextMenu({
-      window: win.webContents ? win : {...win, webContents: win.getWebContents()},
       prepend(_defaultActions, params) {
         if (actualOptions.useSpellChecker) {
           const prependMenuItems = [];
@@ -70,6 +74,7 @@ export default {
         }
         return [];
       },
+      ...actualOptions,
     });
   },
 };

--- a/src/browser/js/contextMenu.js
+++ b/src/browser/js/contextMenu.js
@@ -53,7 +53,16 @@ export default {
       onSelectSpellCheckerLocale: null,
       shouldShowMenu: (e, p) => {
         const isInternalLink = p.linkURL.endsWith('#') && p.linkURL.slice(0, -1) === p.pageURL;
-        return p.isEditable || p.hasImageContents || (p.linkURL !== '' && !isInternalLink) || p.mediaType !== 'none' || p.misspelledWord !== '' || p.selectionText !== '';
+        let isInternalSrc;
+        try {
+          const srcurl = new URL(p.srcURL);
+          isInternalSrc = srcurl.protocol === 'file:';
+          console.log(`srcrurl protocol: ${srcurl.protocol}`);
+        } catch (err) {
+          console.log(`ups: ${err}`);
+          isInternalSrc = false;
+        }
+        return p.isEditable || (p.mediaType !== 'none' && !isInternalSrc) || (p.linkURL !== '' && !isInternalLink) || p.misspelledWord !== '' || p.selectionText !== '';
       }
     };
     const actualOptions = Object.assign({}, defaultOptions, options);

--- a/src/browser/js/contextMenu.js
+++ b/src/browser/js/contextMenu.js
@@ -1,16 +1,17 @@
 // Copyright (c) 2015-2016 Yuya Ochiai
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import {ipcRenderer} from 'electron';
+import {ipcRenderer, remote} from 'electron';
 import electronContextMenu from 'electron-context-menu';
 
-function getSuggestionsMenus(win, suggestions) {
+function getSuggestionsMenus(webcontents, suggestions) {
   if (suggestions.length === 0) {
     return [{
       label: 'No Suggestions',
       enabled: false,
     }];
   }
+  const win = webcontents || remote.getCurrentWindow();
   return suggestions.map((s) => ({
     label: s,
     click() {
@@ -63,7 +64,7 @@ export default {
           const prependMenuItems = [];
           if (params.isEditable && params.misspelledWord !== '') {
             const suggestions = ipcRenderer.sendSync('get-spelling-suggestions', params.misspelledWord);
-            prependMenuItems.push(...getSuggestionsMenus(win, suggestions));
+            prependMenuItems.push(...getSuggestionsMenus(options.window, suggestions));
           }
           if (params.isEditable) {
             prependMenuItems.push(

--- a/src/browser/settings.jsx
+++ b/src/browser/settings.jsx
@@ -15,7 +15,7 @@ import Config from '../common/config';
 import SettingsPage from './components/SettingsPage.jsx';
 import contextMenu from './js/contextMenu';
 
-contextMenu.setup(remote.getCurrentWindow());
+contextMenu.setup();
 
 const config = new Config(remote.app.getPath('userData') + '/config.json', remote.getCurrentWindow().registryConfigData);
 


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Provide context menu globally across electron. This means, we now have context menu on:
- add server modal (previously it only had it if it was started from the settings page) [MM-26017](https://mattermost.atlassian.net/browse/MM-26017)
- any other modal
- popup windows [MM-26076](https://mattermost.atlassian.net/browse/MM-26076)
- developer tools

**Issue link**
[MM-26017](https://mattermost.atlassian.net/browse/MM-26017)
[MM-26076](https://mattermost.atlassian.net/browse/MM-26076)

**Test Cases**
see above tickets
Additionally:
1. open webtools
2. go to network tab (or any other)
3. right click on an item, menu should appear (if it appears in chrome as well ;) )

clicking on tabs shouldn't show menus

@esethna would you mind to review, since we are adding menus all over the place I hopefully avoided any unexpected places.

**Screenshots**
<img width="1032" alt="Screenshot 2020-06-17 at 14 50 57" src="https://user-images.githubusercontent.com/1515906/84903785-d0acb900-b0ae-11ea-8bc7-7a116be11b96.png">

<img width="999" alt="Screenshot 2020-06-17 at 14 53 06" src="https://user-images.githubusercontent.com/1515906/84903752-c68aba80-b0ae-11ea-8fce-166142be9e44.png">
