### PR TITLE
Fixes MM-22411 : Have the same default protocols as the server in the autolink plugin #1273

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -26,9 +26,9 @@
         "mattermost",
         "http",
         "https",
+        "ftp",
         "mailto",
-        "tel",
-        "ftp"
+        "tel"
       ]
     }
   ],

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -23,7 +23,12 @@
     {
       "name": "Mattermost",
       "schemes": [
-        "mattermost"
+        "mattermost",
+        "http",
+        "https",
+        "mailto",
+        "tel",
+        "ftp"
       ]
     }
   ],


### PR DESCRIPTION
Before submitting, please confirm you've
 - [X] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [X] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [X] executed `npm run lint:js` for proper code formatting


Please provide the following information:

**Summary**
<!--
Write a short (one line) summary that describes the changes in this pull request for inclusion in the changelog
-->
- Adds the missing web links protocol to desktop. 

**Issue link**
<!--
Please include a link to the GitHub issue this pull request addresses, if applicable.
-->
JIRA: https://mattermost.atlassian.net/browse/MM-22411
Github : https://github.com/mattermost/desktop/issues/1273

**Test Cases**

**Additional Notes**
