### PR TITLE
Replace npm install with npm ci on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ commands:
         default: ""
     steps:
       - run: apt-get update && apt-get -y install << parameters.apt_opts >>
-      - run: npm install
+      - run: npm ci
 
   win_make:
     description: "Run mattermost's makefile.ps1 on ./scripts/"
@@ -289,7 +289,7 @@ jobs:
           at: ./dist
       - run:
           name: Installing npm dependencies
-          command: npm install
+          command: npm ci
       - build:
           os: mac
           path: ./dist/macos-release

--- a/scripts/Makefile.ps1
+++ b/scripts/Makefile.ps1
@@ -244,8 +244,8 @@ function Run-BuildChangelog {
 }
 
 function Run-BuildElectron {
-    Print-Info "Installing nodejs/electron dependencies (running npm install)..."
-    npm install
+    Print-Info "Installing nodejs/electron dependencies (running npm ci)..."
+    npm ci
     #npm install --prefix="$(Get-RootDir)" "$(Get-RootDir)"
     Print-Info "Building nodejs/electron code (running npm run build)..."
     npm run build


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [ ] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Builds on CircleCI currently use `npm install` for dependencies, when they should be using `npm ci`. That way `package-lock.json` does not get modified during build and we can be sure of the versions we ship. This PR fixes that.

**Issue link**

**Test Cases**

**Additional Notes**
Not sure if this actually works or if there's some reason we actually have to use `npm install`, but I guess we'll see when the checks run. Also not sure how to test the PowerShell change without cutting a release.