### PR TITLE
[MM-26832] don't show the window until it is ready

### DIFF
--- a/src/main/mainWindow.js
+++ b/src/main/mainWindow.js
@@ -44,7 +44,7 @@ function createMainWindow(config, options) {
     windowOptions = {width: defaultWindowWidth, height: defaultWindowHeight};
   }
 
-  const {hideOnStartup, trayIconShown} = options;
+  const {hideOnStartup} = options;
   const {maximized: windowIsMaximized} = windowOptions;
 
   if (process.platform === 'linux') {
@@ -54,6 +54,7 @@ function createMainWindow(config, options) {
     title: app.name,
     fullscreenable: true,
     show: false, // don't start the window until it is ready and only if it isn't hidden
+    paintWhenInitiallyHidden: hideOnStartup, // if initially hidden, we want it to start painting to get info from the webapp
     minWidth: minimumWindowWidth,
     minHeight: minimumWindowHeight,
     frame: !isFramelessWindow(),
@@ -74,15 +75,6 @@ function createMainWindow(config, options) {
 
   const indexURL = global.isDev ? 'http://localhost:8080/browser/index.html' : `file://${app.getAppPath()}/browser/index.html`;
   mainWindow.loadURL(indexURL);
-
-  // handle hiding the app when launched by auto-start
-  if (hideOnStartup) {
-    if (trayIconShown && process.platform !== 'darwin') {
-      mainWindow.hide();
-    } else {
-      mainWindow.minimize();
-    }
-  }
 
   mainWindow.once('ready-to-show', () => {
     mainWindow.webContents.zoomLevel = 0;

--- a/src/main/mainWindow.js
+++ b/src/main/mainWindow.js
@@ -53,7 +53,7 @@ function createMainWindow(config, options) {
   Object.assign(windowOptions, {
     title: app.name,
     fullscreenable: true,
-    show: hideOnStartup || false,
+    show: false, // don't start the window until it is ready and only if it isn't hidden
     minWidth: minimumWindowWidth,
     minHeight: minimumWindowHeight,
     frame: !isFramelessWindow(),

--- a/src/main/mainWindow.js
+++ b/src/main/mainWindow.js
@@ -54,7 +54,7 @@ function createMainWindow(config, options) {
     title: app.name,
     fullscreenable: true,
     show: false, // don't start the window until it is ready and only if it isn't hidden
-    paintWhenInitiallyHidden: hideOnStartup, // if initially hidden, we want it to start painting to get info from the webapp
+    paintWhenInitiallyHidden: true, // we want it to start painting to get info from the webapp
     minWidth: minimumWindowWidth,
     minHeight: minimumWindowHeight,
     frame: !isFramelessWindow(),


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Additional Notes**
I've yet to test on windows and ubuntu 20.20 so I'm setting the wip flag until then. but feel free to review in the meantime, it won't take long 😄 

**Summary**

Fixes a race condition when using the `--hidden` flag in the cli (or from using autolaunch) that was causing it will try to show and hide the window.

**Issue link**

[MM-26832](https://mattermost.atlassian.net/browse/MM-26832)

**Test Cases**
Two possibilities for testing the same

1. Autostart:
  - set autostart on login from the preferences
  - restart OS

2. Terminal
- launch the app from the command line with the `--hidden` flag

Expected:
- app should show minimized

