### PR TITLE
change certificate store key to webcontents id

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -142,9 +142,10 @@ export default class MainPage extends React.Component {
       this.loginRequest(event, request, authInfo);
     });
 
-    ipcRenderer.on('select-user-certificate', (_, origin, certificateList) => {
+    ipcRenderer.on('select-user-certificate', (_, id, origin, certificateList) => {
       const certificateRequests = self.state.certificateRequests;
       certificateRequests.push({
+        id,
         server: origin,
         certificateList,
       });
@@ -613,7 +614,7 @@ export default class MainPage extends React.Component {
     const certificateRequests = this.state.certificateRequests;
     const current = certificateRequests.shift();
     this.setState({certificateRequests});
-    ipcRenderer.send('selected-client-certificate', current.server, certificate);
+    ipcRenderer.send('selected-client-certificate', current.id, certificate);
     if (certificateRequests.length > 0) {
       this.switchToTabForCertificateRequest(certificateRequests[0].server);
     }
@@ -622,7 +623,7 @@ export default class MainPage extends React.Component {
     const certificateRequests = this.state.certificateRequests;
     const current = certificateRequests.shift();
     this.setState({certificateRequests});
-    ipcRenderer.send('selected-client-certificate', current.server);
+    ipcRenderer.send('selected-client-certificate', current.id);
     if (certificateRequests.length > 0) {
       this.switchToTabForCertificateRequest(certificateRequests[0].server);
     }

--- a/src/main.js
+++ b/src/main.js
@@ -334,23 +334,35 @@ function handleAppBeforeQuit() {
 function handleSelectCertificate(event, webContents, url, list, callback) {
   event.preventDefault(); // prevent the app from getting the first certificate available
   // store callback so it can be called with selected certificate
-  certificateRequests.set(url, callback);
+  log.info('******* Certificate webcontents url *******');
+  log.info(webContents.getURL());
+  log.info('******* Certificate webcontents id *******');
+  log.info(webContents.id);
+  log.info('******* url *******');
+  log.info(url);
+  certificateRequests.set(webContents.id, callback);
 
   // open modal for selecting certificate
-  mainWindow.webContents.send('select-user-certificate', url, list);
+  mainWindow.webContents.send('select-user-certificate', webContents.id, url, list);
 }
 
-function handleSelectedCertificate(event, server, cert) {
-  const callback = certificateRequests.get(server);
+function handleSelectedCertificate(event, id, cert) {
+  log.info('******* Certificate selected *******');
+  log.info(cert);
+  log.info('******* webcontents id *******');
+  log.info(id);
+  const callback = certificateRequests.get(id);
   if (!callback) {
-    log.error(`there was no callback associated with: ${server}`);
+    log.error(`there was no callback associated with: ${id}`);
     return;
   }
   if (typeof cert === 'undefined') {
     log.info('user canceled certificate selection');
   } else {
     try {
-      callback(cert);
+      const result = callback(cert);
+      log.info('******* Result *******');
+      log.info(result);
     } catch (e) {
       log.error(`There was a problem using the selected certificate: ${e}`);
     }
@@ -358,6 +370,7 @@ function handleSelectedCertificate(event, server, cert) {
 }
 
 function handleAppCertificateError(event, webContents, url, error, certificate, callback) {
+  log.error(`Handling error due to certificate: ${error}`);
   const parsedURL = new URL(url);
   if (!parsedURL) {
     return;


### PR DESCRIPTION
**Note**: This is a test build for investigating some issues with certificates. but if changing the key actually fixes the problem it might be an actual PR, so keeping this around for context and ease of access.

Please provide the following information:

**Summary**
Adds logs to the select client certificate process
change key from using url to webcontents id, so having multiple server tabs requesting the same url for authentication doesn't cause any problems.

related issues:  #1328 