### PR TITLE
[MM-27331] only show the picker if there is more than 1 cert

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -332,12 +332,16 @@ function handleAppBeforeQuit() {
 }
 
 function handleSelectCertificate(event, webContents, url, list, callback) {
-  event.preventDefault(); // prevent the app from getting the first certificate available
-  // store callback so it can be called with selected certificate
-  certificateRequests.set(url, callback);
+  if (list.length > 1) {
+    event.preventDefault(); // prevent the app from getting the first certificate available
+    // store callback so it can be called with selected certificate
+    certificateRequests.set(url, callback);
 
-  // open modal for selecting certificate
-  mainWindow.webContents.send('select-user-certificate', url, list);
+    // open modal for selecting certificate
+    mainWindow.webContents.send('select-user-certificate', url, list);
+  } else {
+    log.info(`There were ${list.length} candidate certificates. Skipping certificate selection`);
+  }
 }
 
 function handleSelectedCertificate(event, server, cert) {


### PR DESCRIPTION
**Summary**

Prevents showing the certificate modal if there is only one option to manage a certificate login. Will still be shown if there is more than one that suits.

**Additional Notes**
Fixes https://github.com/mattermost/desktop/issues/1328

[MM-27331](https://mattermost.atlassian.net/browse/MM-27331)
