### PR TITLE
[MM-28595] Open team links within the app

### DIFF
--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -94,7 +94,10 @@ export default class MattermostView extends React.Component {
         } else if (destURL.path.match(/^\/help\//)) {
           // continue to open special case internal urls in default browser
           shell.openExternal(e.url);
-        } else if (Utils.isTeamUrl(this.props.src, e.url, true) || Utils.isPluginUrl(this.props.src, e.url)) {
+        } else if (Utils.isTeamUrl(this.props.src, e.url, true)) {
+          e.preventDefault();
+          this.webviewRef.current.loadURL(e.url);
+        } else if (Utils.isPluginUrl(this.props.src, e.url)) {
           // New window should disable nodeIntegration.
           window.open(e.url, remote.app.name, 'nodeIntegration=no, contextIsolation=yes, show=yes');
         } else if (Utils.isManagedResource(this.props.src, e.url)) {


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**

Team links were not opening when setting the help link as it was trying to open in a new window and we don't allow new windows for server links unless they are popups 

**Issue link**

[MM-28595](https://mattermost.atlassian.net/browse/MM-28595)

**Test Cases**

Change the help link to a channel or some other page that it is within the server's teams. App should reload to it.
Change the help link to a page not belonging to a team (like https://google.com). A new browser tab with the page is loaded.