### PR TITLE
[MM-28620] allow navigating links to admin_console

### DIFF
--- a/src/browser/components/MattermostView.jsx
+++ b/src/browser/components/MattermostView.jsx
@@ -94,7 +94,7 @@ export default class MattermostView extends React.Component {
         } else if (destURL.path.match(/^\/help\//)) {
           // continue to open special case internal urls in default browser
           shell.openExternal(e.url);
-        } else if (Utils.isTeamUrl(this.props.src, e.url, true)) {
+        } else if (Utils.isTeamUrl(this.props.src, e.url, true) || Utils.isAdminUrl(this.props.src, e.url)) {
           e.preventDefault();
           this.webviewRef.current.loadURL(e.url);
         } else if (Utils.isPluginUrl(this.props.src, e.url)) {

--- a/src/main.js
+++ b/src/main.js
@@ -487,7 +487,7 @@ function handleAppWebContentsCreated(dc, contents) {
     const parsedURL = Utils.parseURL(url);
     const server = Utils.getServer(parsedURL, config.teams);
 
-    if ((server !== null && Utils.isTeamUrl(server.url, parsedURL)) || isTrustedPopupWindow(event.sender)) {
+    if ((server !== null && Utils.isTeamUrl(server.url, parsedURL)) || isTrustedPopupWindow(event.sender) || Utils.isAdminUrl(server.url, parsedURL)) {
       return;
     }
 
@@ -536,8 +536,12 @@ function handleAppWebContentsCreated(dc, contents) {
       log.info(`Untrusted popup window blocked: ${url}`);
       return;
     }
-    if (Utils.isTeamUrl(server.url, parsedURL, true) === true) {
+    if (Utils.isTeamUrl(server.url, parsedURL, true)) {
       log.info(`${url} is a known team, preventing to open a new window`);
+      return;
+    }
+    if (Utils.isAdminUrl(server.url, parsedURL)) {
+      log.info(`${url} is an admin console page, preventing to open a new window`);
       return;
     }
     if (popupWindow && !popupWindow.closed && popupWindow.getURL() === url) {

--- a/src/main.js
+++ b/src/main.js
@@ -487,7 +487,8 @@ function handleAppWebContentsCreated(dc, contents) {
     const parsedURL = Utils.parseURL(url);
     const server = Utils.getServer(parsedURL, config.teams);
 
-    if ((server !== null && Utils.isTeamUrl(server.url, parsedURL)) || isTrustedPopupWindow(event.sender) || Utils.isAdminUrl(server.url, parsedURL)) {
+    if ((server !== null && (Utils.isTeamUrl(server.url, parsedURL) || Utils.isAdminUrl(server.url, parsedURL))) ||
+      isTrustedPopupWindow(event.sender)) {
       return;
     }
 

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -79,6 +79,16 @@ function getManagedResources() {
   return buildConfig.managedResources || [];
 }
 
+function isAdminUrl(serverUrl, inputUrl) {
+  const parsedURL = parseURL(inputUrl);
+  const server = getServerInfo(serverUrl);
+  if (!parsedURL || !server || (!equalUrlsIgnoringSubpath(server, parsedURL))) {
+    return null;
+  }
+  return (parsedURL.pathname.toLowerCase().startsWith(`${server.subpath}/admin_console/`) ||
+    parsedURL.pathname.toLowerCase().startsWith('/admin_console/'));
+}
+
 function isTeamUrl(serverUrl, inputUrl, withApi) {
   const parsedURL = parseURL(inputUrl);
   const server = getServerInfo(serverUrl);
@@ -225,6 +235,7 @@ export default {
   parseURL,
   getServer,
   getServerInfo,
+  isAdminUrl,
   isTeamUrl,
   isPluginUrl,
   isManagedResource,


### PR DESCRIPTION
**Summary**

Navigate to admin pages when the link clicked tries to open them in a new window.

**Issue link**
[MM-28620](https://mattermost.atlassian.net/browse/MM-28620)
**Test Cases**

Go to admin console, scroll down to `Custom Terms of Service (beta)` and click on `go to Site Configuration > Customization.`

Expected: app loads the page.

**Additional Notes**

since we are stopping window creation and loading a new page, it is expected to have a loading flash.