### PR TITLE
[MM-21835] Use URL instead of the url library

### DIFF
--- a/src/browser/components/NewTeamModal.jsx
+++ b/src/browser/components/NewTeamModal.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {Modal, Button, FormGroup, FormControl, ControlLabel, HelpBlock} from 'react-bootstrap';
 
-import Utils from '../../utils/util';
+import urlUtils from '../../utils/url';
 
 export default class NewTeamModal extends React.Component {
   static defaultProps = {
@@ -62,7 +62,7 @@ export default class NewTeamModal extends React.Component {
     if (!(/^https?:\/\/.*/).test(this.state.teamUrl.trim())) {
       return 'URL should start with http:// or https://.';
     }
-    if (!Utils.isValidURL(this.state.teamUrl.trim())) {
+    if (!urlUtils.isValidURL(this.state.teamUrl.trim())) {
       return 'URL is not formatted correctly.';
     }
     return null;

--- a/src/browser/components/externalLink.jsx
+++ b/src/browser/components/externalLink.jsx
@@ -5,6 +5,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {ipcRenderer} from 'electron';
 
+import urlUtils from '../../utils/url';
+
 // this component is used to override some checks from the UI, leaving only to trust the protocol in case it wasn't http/s
 // it is used the same as an `a` JSX tag
 export default function ExternalLink(props) {
@@ -12,7 +14,7 @@ export default function ExternalLink(props) {
     e.preventDefault();
     let parseUrl;
     try {
-      parseUrl = new URL(props.href);
+      parseUrl = urlUtils.parseURL(props.href);
       ipcRenderer.send('confirm-protocol', parseUrl.protocol, props.href);
     } catch (err) {
       console.error(`invalid url ${props.href} supplied to externallink: ${err}`);

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -8,11 +8,11 @@ window.eval = global.eval = () => { // eslint-disable-line no-multi-assign, no-e
   throw new Error('Sorry, Mattermost does not support window.eval() for security reasons.');
 };
 
-import url from 'url';
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {remote, ipcRenderer} from 'electron';
+
+import urlUtils from '../utils/url';
 
 import Config from '../common/config';
 
@@ -32,11 +32,12 @@ if (teams.length === 0) {
   remote.getCurrentWindow().loadFile('browser/settings.html');
 }
 
-const parsedURL = url.parse(window.location.href, true);
-const initialIndex = parsedURL.query.index ? parseInt(parsedURL.query.index, 10) : getInitialIndex();
+const parsedURLSearchParams = urlUtils.parseURL(window.location.href).searchParams;
+const parsedURLHasIndex = parsedURLSearchParams.has('index');
+const initialIndex = parsedURLHasIndex ? parseInt(parsedURLSearchParams.get('index'), 10) : getInitialIndex();
 
 let deeplinkingUrl = null;
-if (!parsedURL.query.index || parsedURL.query.index === null) {
+if (!parsedURLHasIndex) {
   deeplinkingUrl = remote.getCurrentWindow().deeplinkingUrl;
 }
 

--- a/src/browser/js/contextMenu.js
+++ b/src/browser/js/contextMenu.js
@@ -4,6 +4,8 @@
 import {ipcRenderer, remote} from 'electron';
 import electronContextMenu from 'electron-context-menu';
 
+import urlUtils from '../../utils/url';
+
 function getSuggestionsMenus(webcontents, suggestions) {
   if (suggestions.length === 0) {
     return [{
@@ -57,7 +59,7 @@ export default {
         const isInternalLink = p.linkURL.endsWith('#') && p.linkURL.slice(0, -1) === p.pageURL;
         let isInternalSrc;
         try {
-          const srcurl = new URL(p.srcURL);
+          const srcurl = urlUtils.parseURL(p.srcURL);
           isInternalSrc = srcurl.protocol === 'file:';
           console.log(`srcrurl protocol: ${srcurl.protocol}`);
         } catch (err) {

--- a/src/browser/updater.jsx
+++ b/src/browser/updater.jsx
@@ -1,17 +1,18 @@
 // Copyright (c) 2015-2016 Yuya Ochiai
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import url from 'url';
 
 import React from 'react';
 import ReactDOM from 'react-dom';
 import propTypes from 'prop-types';
 import {ipcRenderer, remote} from 'electron';
 
+import urlUtils from '../utils/url';
+
 import UpdaterPage from './components/UpdaterPage.jsx';
 
-const thisURL = url.parse(location.href, true);
-const notifyOnly = thisURL.query.notifyOnly === 'true';
+const thisURL = urlUtils.parseURL(location.href);
+const notifyOnly = thisURL.searchParams.get('notifyOnly') === 'true';
 
 class UpdaterPageContainer extends React.Component {
   constructor(props) {

--- a/src/common/permissions.js
+++ b/src/common/permissions.js
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 

--- a/src/main/Validator.js
+++ b/src/main/Validator.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 import Joi from '@hapi/joi';
 
-import Utils from '../utils/util';
+import urlUtils from '../utils/url';
 
 const defaultOptions = {
   stripUnknown: true,
@@ -137,7 +137,7 @@ export function validateV1ConfigData(data) {
     });
 
     // next filter out urls that are still invalid so all is not lost
-    teams = teams.filter(({url}) => Utils.isValidURL(url));
+    teams = teams.filter(({url}) => urlUtils.isValidURL(url));
 
     // replace original teams
     data.teams = teams;
@@ -157,7 +157,7 @@ export function validateV2ConfigData(data) {
     });
 
     // next filter out urls that are still invalid so all is not lost
-    teams = teams.filter(({url}) => Utils.isValidURL(url));
+    teams = teams.filter(({url}) => urlUtils.isValidURL(url));
 
     // replace original teams
     data.teams = teams;

--- a/src/main/certificateStore.js
+++ b/src/main/certificateStore.js
@@ -5,6 +5,8 @@
 
 import fs from 'fs';
 
+import urlUtils from '../utils/url';
+
 import * as Validator from './Validator';
 
 function comparableCertificate(certificate) {
@@ -22,11 +24,6 @@ function areEqual(certificate0, certificate1) {
     return false;
   }
   return true;
-}
-
-function getHost(targetURL) {
-  const parsedURL = new URL(targetURL);
-  return parsedURL.origin;
 }
 
 function CertificateStore(storeFile) {
@@ -49,15 +46,15 @@ CertificateStore.prototype.save = function save() {
 };
 
 CertificateStore.prototype.add = function add(targetURL, certificate) {
-  this.data[getHost(targetURL)] = comparableCertificate(certificate);
+  this.data[urlUtils.getHost(targetURL)] = comparableCertificate(certificate);
 };
 
 CertificateStore.prototype.isExisting = function isExisting(targetURL) {
-  return this.data.hasOwnProperty(getHost(targetURL));
+  return this.data.hasOwnProperty(urlUtils.getHost(targetURL));
 };
 
 CertificateStore.prototype.isTrusted = function isTrusted(targetURL, certificate) {
-  const host = getHost(targetURL);
+  const host = urlUtils.getHost(targetURL);
   if (!this.isExisting(targetURL)) {
     return false;
   }

--- a/src/main/trustedOrigins.js
+++ b/src/main/trustedOrigins.js
@@ -7,7 +7,7 @@ import fs from 'fs';
 
 import log from 'electron-log';
 
-import Utils from '../utils/util.js';
+import urlUtils from '../utils/url';
 
 import * as Validator from './Validator';
 
@@ -56,12 +56,12 @@ export default class TrustedOriginsStore {
     if (!validPermissions) {
       throw new Error(`Invalid permissions set for trusting ${targetURL}`);
     }
-    this.data.set(Utils.getHost(targetURL), validPermissions);
+    this.data.set(urlUtils.getHost(targetURL), validPermissions);
   };
 
   // enables usage of `targetURL` for `permission`
   addPermission = (targetURL, permission) => {
-    const origin = Utils.getHost(targetURL);
+    const origin = urlUtils.getHost(targetURL);
     const currentPermissions = this.data.get(origin) || {};
     currentPermissions[permission] = true;
     this.set(origin, currentPermissions);
@@ -70,7 +70,7 @@ export default class TrustedOriginsStore {
   delete = (targetURL) => {
     let host;
     try {
-      host = Utils.getHost(targetURL);
+      host = urlUtils.getHost(targetURL);
       this.data.delete(host);
     } catch {
       return false;
@@ -79,7 +79,7 @@ export default class TrustedOriginsStore {
   }
 
   isExisting = (targetURL) => {
-    return (typeof this.data.get(Utils.getHost(targetURL)) !== 'undefined');
+    return (typeof this.data.get(urlUtils.getHost(targetURL)) !== 'undefined');
   };
 
   // if user hasn't set his preferences, it will return null (falsy)
@@ -90,7 +90,7 @@ export default class TrustedOriginsStore {
     }
     let origin;
     try {
-      origin = Utils.getHost(targetURL);
+      origin = urlUtils.getHost(targetURL);
     } catch (e) {
       log.error(`invalid host to retrieve permissions: ${targetURL}: ${e}`);
       return null;

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -1,0 +1,190 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {isHttpsUri, isHttpUri, isUri} from 'valid-url';
+
+import buildConfig from '../common/config/buildConfig';
+
+function getDomain(inputURL) {
+  const parsedURL = parseURL(inputURL);
+  return parsedURL.origin;
+}
+
+function isValidURL(testURL) {
+  return Boolean(isHttpUri(testURL) || isHttpsUri(testURL)) && parseURL(testURL) !== null;
+}
+
+function isValidURI(testURL) {
+  return Boolean(isUri(testURL));
+}
+
+function parseURL(inputURL) {
+  if (!inputURL) {
+    return null;
+  }
+  if (inputURL instanceof URL) {
+    return inputURL;
+  }
+  try {
+    return new URL(inputURL);
+  } catch (e) {
+    return null;
+  }
+}
+
+function getHost(inputURL) {
+  const parsedURL = parseURL(inputURL);
+  if (parsedURL) {
+    return parsedURL.origin;
+  }
+  throw new Error(`Couldn't parse url: ${inputURL}`);
+}
+
+// isInternalURL determines if the target url is internal to the application.
+// - currentURL is the current url inside the webview
+// - basename is the global export from the Mattermost application defining the subpath, if any
+function isInternalURL(targetURL, currentURL, basename = '/') {
+  if (targetURL.host !== currentURL.host) {
+    return false;
+  }
+
+  if (!(targetURL.pathname || '/').startsWith(basename)) {
+    return false;
+  }
+
+  return true;
+}
+
+function getServerInfo(serverUrl) {
+  const parsedServer = parseURL(serverUrl);
+  if (!parsedServer) {
+    return null;
+  }
+
+  // does the server have a subpath?
+  const pn = parsedServer.pathname.toLowerCase();
+  const subpath = pn.endsWith('/') ? pn.toLowerCase() : `${pn}/`;
+  return {origin: parsedServer.origin, subpath, url: parsedServer};
+}
+
+function getManagedResources() {
+  if (!buildConfig) {
+    return [];
+  }
+
+  return buildConfig.managedResources || [];
+}
+
+function isAdminUrl(serverUrl, inputUrl) {
+  const parsedURL = parseURL(inputUrl);
+  const server = getServerInfo(serverUrl);
+  if (!parsedURL || !server || (!equalUrlsIgnoringSubpath(server, parsedURL))) {
+    return null;
+  }
+  return (parsedURL.pathname.toLowerCase().startsWith(`${server.subpath}/admin_console/`) ||
+    parsedURL.pathname.toLowerCase().startsWith('/admin_console/'));
+}
+
+function isTeamUrl(serverUrl, inputUrl, withApi) {
+  const parsedURL = parseURL(inputUrl);
+  const server = getServerInfo(serverUrl);
+  if (!parsedURL || !server || (!equalUrlsIgnoringSubpath(server, parsedURL))) {
+    return null;
+  }
+
+  // pre process nonTeamUrlPaths
+  let nonTeamUrlPaths = [
+    'plugins',
+    'signup',
+    'login',
+    'admin',
+    'channel',
+    'post',
+    'oauth',
+    'admin_console',
+  ];
+  const managedResources = getManagedResources();
+  nonTeamUrlPaths = nonTeamUrlPaths.concat(managedResources);
+
+  if (withApi) {
+    nonTeamUrlPaths.push('api');
+  }
+  return !(nonTeamUrlPaths.some((testPath) => (
+    parsedURL.pathname.toLowerCase().startsWith(`${server.subpath}${testPath}/`) ||
+    parsedURL.pathname.toLowerCase().startsWith(`/${testPath}/`))));
+}
+
+function isPluginUrl(serverUrl, inputURL) {
+  const server = getServerInfo(serverUrl);
+  const parsedURL = parseURL(inputURL);
+  if (!parsedURL || !server) {
+    return false;
+  }
+  return (
+    equalUrlsIgnoringSubpath(server, parsedURL) &&
+    (parsedURL.pathname.toLowerCase().startsWith(`${server.subpath}plugins/`) ||
+      parsedURL.pathname.toLowerCase().startsWith('/plugins/')));
+}
+
+function isManagedResource(serverUrl, inputURL) {
+  const server = getServerInfo(serverUrl);
+  const parsedURL = parseURL(inputURL);
+  if (!parsedURL || !server) {
+    return false;
+  }
+
+  const managedResources = getManagedResources();
+
+  return (
+    equalUrlsIgnoringSubpath(server, parsedURL) && managedResources && managedResources.length &&
+    managedResources.some((managedResource) => (parsedURL.pathname.toLowerCase().startsWith(`${server.subpath}${managedResource}/`) || parsedURL.pathname.toLowerCase().startsWith(`/${managedResource}/`))));
+}
+
+function getServer(inputURL, teams) {
+  const parsedURL = parseURL(inputURL);
+  if (!parsedURL) {
+    return null;
+  }
+  let parsedServerUrl;
+  let secondOption = null;
+  for (let i = 0; i < teams.length; i++) {
+    parsedServerUrl = parseURL(teams[i].url);
+
+    // check server and subpath matches (without subpath pathname is \ so it always matches)
+    if (equalUrlsWithSubpath(parsedServerUrl, parsedURL)) {
+      return {name: teams[i].name, url: parsedServerUrl, index: i};
+    }
+    if (equalUrlsIgnoringSubpath(parsedServerUrl, parsedURL)) {
+      // in case the user added something on the path that doesn't really belong to the server
+      // there might be more than one that matches, but we can't differentiate, so last one
+      // is as good as any other in case there is no better match (e.g.: two subpath servers with the same origin)
+      // e.g.: https://community.mattermost.com/core
+      secondOption = {name: teams[i].name, url: parsedServerUrl, index: i};
+    }
+  }
+  return secondOption;
+}
+
+// next two functions are defined to clarify intent
+function equalUrlsWithSubpath(url1, url2) {
+  return url1.origin === url2.origin && url2.pathname.toLowerCase().startsWith(url1.pathname.toLowerCase());
+}
+
+function equalUrlsIgnoringSubpath(url1, url2) {
+  return url1.origin.toLowerCase() === url2.origin.toLowerCase();
+}
+
+export default {
+  getDomain,
+  isValidURL,
+  isValidURI,
+  isInternalURL,
+  parseURL,
+  getServer,
+  getServerInfo,
+  isAdminUrl,
+  isTeamUrl,
+  isPluginUrl,
+  isManagedResource,
+  getHost,
+};

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -1,173 +1,9 @@
 // Copyright (c) 2015-2016 Yuya Ochiai
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import url from 'url';
 
 import electron, {remote} from 'electron';
 import log from 'electron-log';
-import {isUri, isHttpUri, isHttpsUri} from 'valid-url';
-
-import buildConfig from '../common/config/buildConfig';
-
-function getDomain(inputURL) {
-  const parsedURL = url.parse(inputURL);
-  return `${parsedURL.protocol}//${parsedURL.host}`;
-}
-
-function isValidURL(testURL) {
-  return Boolean(isHttpUri(testURL) || isHttpsUri(testURL)) && parseURL(testURL) !== null;
-}
-
-function isValidURI(testURL) {
-  return Boolean(isUri(testURL));
-}
-
-function parseURL(inputURL) {
-  if (!inputURL) {
-    return null;
-  }
-  if (inputURL instanceof URL) {
-    return inputURL;
-  }
-  try {
-    return new URL(inputURL);
-  } catch (e) {
-    return null;
-  }
-}
-
-function getHost(inputURL) {
-  const parsedURL = parseURL(inputURL);
-  if (parsedURL) {
-    return parsedURL.origin;
-  }
-  throw new Error(`Couldn't parse url: ${inputURL}`);
-}
-
-// isInternalURL determines if the target url is internal to the application.
-// - currentURL is the current url inside the webview
-// - basename is the global export from the Mattermost application defining the subpath, if any
-function isInternalURL(targetURL, currentURL, basename = '/') {
-  if (targetURL.host !== currentURL.host) {
-    return false;
-  }
-
-  if (!(targetURL.pathname || '/').startsWith(basename)) {
-    return false;
-  }
-
-  return true;
-}
-
-function getServerInfo(serverUrl) {
-  const parsedServer = parseURL(serverUrl);
-  if (!parsedServer) {
-    return null;
-  }
-
-  // does the server have a subpath?
-  const pn = parsedServer.pathname.toLowerCase();
-  const subpath = pn.endsWith('/') ? pn.toLowerCase() : `${pn}/`;
-  return {origin: parsedServer.origin, subpath, url: parsedServer};
-}
-
-function getManagedResources() {
-  if (!buildConfig) {
-    return [];
-  }
-
-  return buildConfig.managedResources || [];
-}
-
-function isAdminUrl(serverUrl, inputUrl) {
-  const parsedURL = parseURL(inputUrl);
-  const server = getServerInfo(serverUrl);
-  if (!parsedURL || !server || (!equalUrlsIgnoringSubpath(server, parsedURL))) {
-    return null;
-  }
-  return (parsedURL.pathname.toLowerCase().startsWith(`${server.subpath}/admin_console/`) ||
-    parsedURL.pathname.toLowerCase().startsWith('/admin_console/'));
-}
-
-function isTeamUrl(serverUrl, inputUrl, withApi) {
-  const parsedURL = parseURL(inputUrl);
-  const server = getServerInfo(serverUrl);
-  if (!parsedURL || !server || (!equalUrlsIgnoringSubpath(server, parsedURL))) {
-    return null;
-  }
-
-  // pre process nonTeamUrlPaths
-  let nonTeamUrlPaths = [
-    'plugins',
-    'signup',
-    'login',
-    'admin',
-    'channel',
-    'post',
-    'oauth',
-    'admin_console',
-  ];
-  const managedResources = getManagedResources();
-  nonTeamUrlPaths = nonTeamUrlPaths.concat(managedResources);
-
-  if (withApi) {
-    nonTeamUrlPaths.push('api');
-  }
-  return !(nonTeamUrlPaths.some((testPath) => (
-    parsedURL.pathname.toLowerCase().startsWith(`${server.subpath}${testPath}/`) ||
-    parsedURL.pathname.toLowerCase().startsWith(`/${testPath}/`))));
-}
-
-function isPluginUrl(serverUrl, inputURL) {
-  const server = getServerInfo(serverUrl);
-  const parsedURL = parseURL(inputURL);
-  if (!parsedURL || !server) {
-    return false;
-  }
-  return (
-    equalUrlsIgnoringSubpath(server, parsedURL) &&
-    (parsedURL.pathname.toLowerCase().startsWith(`${server.subpath}plugins/`) ||
-      parsedURL.pathname.toLowerCase().startsWith('/plugins/')));
-}
-
-function isManagedResource(serverUrl, inputURL) {
-  const server = getServerInfo(serverUrl);
-  const parsedURL = parseURL(inputURL);
-  if (!parsedURL || !server) {
-    return false;
-  }
-
-  const managedResources = getManagedResources();
-
-  return (
-    equalUrlsIgnoringSubpath(server, parsedURL) && managedResources && managedResources.length &&
-    managedResources.some((managedResource) => (parsedURL.pathname.toLowerCase().startsWith(`${server.subpath}${managedResource}/`) || parsedURL.pathname.toLowerCase().startsWith(`/${managedResource}/`))));
-}
-
-function getServer(inputURL, teams) {
-  const parsedURL = parseURL(inputURL);
-  if (!parsedURL) {
-    return null;
-  }
-  let parsedServerUrl;
-  let secondOption = null;
-  for (let i = 0; i < teams.length; i++) {
-    parsedServerUrl = parseURL(teams[i].url);
-
-    // check server and subpath matches (without subpath pathname is \ so it always matches)
-    if (equalUrlsWithSubpath(parsedServerUrl, parsedURL)) {
-      return {name: teams[i].name, url: parsedServerUrl, index: i};
-    }
-    if (equalUrlsIgnoringSubpath(parsedServerUrl, parsedURL)) {
-      // in case the user added something on the path that doesn't really belong to the server
-      // there might be more than one that matches, but we can't differentiate, so last one
-      // is as good as any other in case there is no better match (e.g.: two subpath servers with the same origin)
-      // e.g.: https://community.mattermost.com/core
-      secondOption = {name: teams[i].name, url: parsedServerUrl, index: i};
-    }
-  }
-  return secondOption;
-}
 
 function getDisplayBoundaries() {
   const {screen} = electron;
@@ -184,15 +20,6 @@ function getDisplayBoundaries() {
       maxHeight: display.workArea.height,
     };
   });
-}
-
-// next two functions are defined to clarify intent
-function equalUrlsWithSubpath(url1, url2) {
-  return url1.origin === url2.origin && url2.pathname.toLowerCase().startsWith(url1.pathname.toLowerCase());
-}
-
-function equalUrlsIgnoringSubpath(url1, url2) {
-  return url1.origin.toLowerCase() === url2.origin.toLowerCase();
 }
 
 const dispatchNotification = async (title, body, silent, data, handleClick) => {
@@ -228,18 +55,6 @@ const dispatchNotification = async (title, body, silent, data, handleClick) => {
 };
 
 export default {
-  getDomain,
-  isValidURL,
-  isValidURI,
-  isInternalURL,
-  parseURL,
-  getServer,
-  getServerInfo,
-  isAdminUrl,
-  isTeamUrl,
-  isPluginUrl,
-  isManagedResource,
   getDisplayBoundaries,
   dispatchNotification,
-  getHost,
 };

--- a/test/modules/utils.js
+++ b/test/modules/utils.js
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2015-2016 Yuya Ochiai
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.

--- a/test/specs/utils/url_test.js
+++ b/test/specs/utils/url_test.js
@@ -2,106 +2,105 @@
 // See LICENSE.txt for license information.
 'use strict';
 
-import url from 'url';
 import assert from 'assert';
 
-import Utils from '../../../src/utils/util';
+import urlUtils from '../../../src/utils/url';
 
-describe('Utils', () => {
+describe('url', () => {
   describe('isValidURL', () => {
     it('should be true for a valid web url', () => {
       const testURL = 'https://developers.mattermost.com/';
-      assert.equal(Utils.isValidURL(testURL), true);
+      assert.equal(urlUtils.isValidURL(testURL), true);
     });
     it('should be true for a valid, non-https web url', () => {
       const testURL = 'http://developers.mattermost.com/';
-      assert.equal(Utils.isValidURL(testURL), true);
+      assert.equal(urlUtils.isValidURL(testURL), true);
     });
     it('should be true for an invalid, self-defined, top-level domain', () => {
       const testURL = 'https://www.example.x';
-      assert.equal(Utils.isValidURL(testURL), true);
+      assert.equal(urlUtils.isValidURL(testURL), true);
     });
     it('should be true for a file download url', () => {
       const testURL = 'https://community.mattermost.com/api/v4/files/ka3xbfmb3ffnmgdmww8otkidfw?download=1';
-      assert.equal(Utils.isValidURL(testURL), true);
+      assert.equal(urlUtils.isValidURL(testURL), true);
     });
     it('should be true for a permalink url', () => {
       const testURL = 'https://community.mattermost.com/test-channel/pl/pdqowkij47rmbyk78m5hwc7r6r';
-      assert.equal(Utils.isValidURL(testURL), true);
+      assert.equal(urlUtils.isValidURL(testURL), true);
     });
     it('should be true for a valid, internal domain', () => {
       const testURL = 'https://mattermost.company-internal';
-      assert.equal(Utils.isValidURL(testURL), true);
+      assert.equal(urlUtils.isValidURL(testURL), true);
     });
     it('should be true for a second, valid internal domain', () => {
       const testURL = 'https://serverXY/mattermost';
-      assert.equal(Utils.isValidURL(testURL), true);
+      assert.equal(urlUtils.isValidURL(testURL), true);
     });
     it('should be true for a valid, non-https internal domain', () => {
       const testURL = 'http://mattermost.local';
-      assert.equal(Utils.isValidURL(testURL), true);
+      assert.equal(urlUtils.isValidURL(testURL), true);
     });
     it('should be true for a valid, non-https, ip address with port number', () => {
       const testURL = 'http://localhost:8065';
-      assert.equal(Utils.isValidURL(testURL), true);
+      assert.equal(urlUtils.isValidURL(testURL), true);
     });
   });
   describe('isValidURI', () => {
     it('should be true for a deeplink url', () => {
       const testURL = 'mattermost://community-release.mattermost.com/core/channels/developers';
-      assert.equal(Utils.isValidURI(testURL), true);
+      assert.equal(urlUtils.isValidURI(testURL), true);
     });
     it('should be false for a malicious url', () => {
       const testURL = String.raw`mattermost:///" --data-dir "\\deans-mbp\mattermost`;
-      assert.equal(Utils.isValidURI(testURL), false);
+      assert.equal(urlUtils.isValidURI(testURL), false);
     });
   });
   describe('isInternalURL', () => {
     it('should be false for different hosts', () => {
-      const currentURL = url.parse('http://localhost/team/channel1');
-      const targetURL = url.parse('http://example.com/team/channel2');
+      const currentURL = new URL('http://localhost/team/channel1');
+      const targetURL = new URL('http://example.com/team/channel2');
       const basename = '/';
-      assert.equal(Utils.isInternalURL(targetURL, currentURL, basename), false);
+      assert.equal(urlUtils.isInternalURL(targetURL, currentURL, basename), false);
     });
 
     it('should be false for same hosts, non-matching basename', () => {
-      const currentURL = url.parse('http://localhost/subpath/team/channel1');
-      const targetURL = url.parse('http://localhost/team/channel2');
+      const currentURL = new URL('http://localhost/subpath/team/channel1');
+      const targetURL = new URL('http://localhost/team/channel2');
       const basename = '/subpath';
-      assert.equal(Utils.isInternalURL(targetURL, currentURL, basename), false);
+      assert.equal(urlUtils.isInternalURL(targetURL, currentURL, basename), false);
     });
 
     it('should be true for same hosts, matching basename', () => {
-      const currentURL = url.parse('http://localhost/subpath/team/channel1');
-      const targetURL = url.parse('http://localhost/subpath/team/channel2');
+      const currentURL = new URL('http://localhost/subpath/team/channel1');
+      const targetURL = new URL('http://localhost/subpath/team/channel2');
       const basename = '/subpath';
-      assert.equal(Utils.isInternalURL(targetURL, currentURL, basename), true);
+      assert.equal(urlUtils.isInternalURL(targetURL, currentURL, basename), true);
     });
 
     it('should be true for same hosts, default basename', () => {
-      const currentURL = url.parse('http://localhost/team/channel1');
-      const targetURL = url.parse('http://localhost/team/channel2');
+      const currentURL = new URL('http://localhost/team/channel1');
+      const targetURL = new URL('http://localhost/team/channel2');
       const basename = '/';
-      assert.equal(Utils.isInternalURL(targetURL, currentURL, basename), true);
+      assert.equal(urlUtils.isInternalURL(targetURL, currentURL, basename), true);
     });
 
     it('should be true for same hosts, default basename, empty target path', () => {
-      const currentURL = url.parse('http://localhost/team/channel1');
-      const targetURL = url.parse('http://localhost/');
+      const currentURL = new URL('http://localhost/team/channel1');
+      const targetURL = new URL('http://localhost/');
       const basename = '/';
-      assert.equal(Utils.isInternalURL(targetURL, currentURL, basename), true);
+      assert.equal(urlUtils.isInternalURL(targetURL, currentURL, basename), true);
     });
   });
 
   describe('getHost', () => {
     it('should return the origin of a well formed url', () => {
       const myurl = 'https://mattermost.com/download';
-      assert.equal(Utils.getHost(myurl), 'https://mattermost.com');
+      assert.equal(urlUtils.getHost(myurl), 'https://mattermost.com');
     });
 
     it('shoud raise an error on malformed urls', () => {
       const myurl = 'http://example.com:-80/';
-      assert.throws(() => Utils.getHost(myurl), Error);
+      assert.throws(() => urlUtils.getHost(myurl), Error);
     });
   });
 });


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Use URL instead of the url library throughout the project. Additionally, move all of the URL related helper functions from `src/utils/utils.js` to the new `src/utils/url.js` file and migrate tests.

**Issue link**
Fixes https://github.com/mattermost/desktop/issues/1206

**Test Cases**

**Additional Notes**
This is my first contribution to this repository, so please let me know anything I may have done incorrectly! Thank you :)
