### PR TITLE
[MM-9922] Hide tooltip for internal links (channels, timestamps, etc.)

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -526,7 +526,7 @@ export default class MainPage extends React.Component {
 
   handleTargetURLChange = (targetURL) => {
     clearTimeout(this.targetURLDisappearTimeout);
-    if (targetURL === '') {
+    if (targetURL === '' || this.parseDeeplinkURL(targetURL)) { // Do not show URL for internal links
       // set delay to avoid momentary disappearance when hovering over multiple links
       this.targetURLDisappearTimeout = setTimeout(() => {
         this.setState({targetURL: ''});


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
When setting the URL to show in the status bar / tooltip, this PR now checks to see if it is an internal link. When hovering over external links provided in chat messages, the tooltip still appears.

**Issue link**
https://github.com/mattermost/desktop/issues/909
https://mattermost.atlassian.net/browse/MM-9922

**Test Cases**
No test cases added; I apologize if they are necessary, but I am not familiar enough with the environment to write one.

**Additional Notes**
Tested on:
- macOS 10.15.7
- Mattermost Team Server 5.26.2