### PR TITLE
[MM-29677] fix download complete notification not appearing

### DIFF
--- a/src/browser/components/MainPage.jsx
+++ b/src/browser/components/MainPage.jsx
@@ -632,7 +632,7 @@ export default class MainPage extends React.Component {
     const title = process.platform === 'win32' ? item.serverInfo.name : 'Download Complete';
     const notificationBody = process.platform === 'win32' ? `Download Complete \n ${item.fileName}` : item.fileName;
 
-    await Utils.dispatchNotification(title, notificationBody, false, () => {
+    await Utils.dispatchNotification(title, notificationBody, false, {}, () => {
       shell.showItemInFolder(item.path.normalize());
     });
   }


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
fix 4.6-rc1 regression. notification of download complete was not appearing.

bug introduced in https://github.com/mattermost/desktop/pull/1351

**Issue link**
[MM-29677](https://mattermost.atlassian.net/browse/MM-29676)

**Test Cases**
upload a file to a post.
download it

Expected: notification appears announcing that the download is complete

**Additional Notes**
known issue: there is no custom sound for this notification.