### PR TITLE
[MM-22960] - Keep desktop app pinned to task bar when the app upgrades

### DIFF
--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -124,6 +124,8 @@
       <ComponentRef Id="GPOUSEnglishFiles" />
     </Feature>
     <InstallExecuteSequence>
+      <RemoveShortcuts>Installed AND NOT UPGRADINGPRODUCTCODE</RemoveShortcuts>
+
       <Custom Action="KillApp" Before="InstallValidate" />
       <Custom Action="LaunchApp" After="InstallFinalize">Installed</Custom>
     </InstallExecuteSequence>


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Add setting to disable standard RemoveShortcuts action and keep icon pinned to taskbar on upgrade.

**Issue link**
https://mattermost.atlassian.net/browse/MM-22960
