### PR TITLE
[MM-31266] fix access url when it's not a mm server

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -518,7 +518,7 @@ function handleAppWebContentsCreated(dc, contents) {
     const parsedURL = urlUtils.parseURL(url);
     const server = urlUtils.getServer(parsedURL, config.teams);
 
-    if ((server !== null && urlUtils.isTeamUrl(server.url, parsedURL)) || urlUtils.isAdminUrl(server.url, parsedURL) || isTrustedPopupWindow(event.sender)) {
+    if (server && (urlUtils.isTeamUrl(server.url, parsedURL) || urlUtils.isAdminUrl(server.url, parsedURL) || isTrustedPopupWindow(event.sender))) {
       return;
     }
 


### PR DESCRIPTION
**Summary**

fix checking server's url param when it is not a team url during attempt to navigate in the main window.

**Issue link**
[MM-31266](https://mattermost.atlassian.net/browse/MM-31266)

**Test Cases**

login via OneLogin or gitlab shouldn't crash the app