### PR TITLE
[MM-31224] fix reloading servers and other tab issues

### DIFF
--- a/src/main/MattermostView.js
+++ b/src/main/MattermostView.js
@@ -134,6 +134,7 @@ export class MattermostView extends EventEmitter {
     this.window = null;
     this.server = null;
     this.isVisible = false;
+    clearTimeout(this.retryLoad);
   }
 
   focus = () => {

--- a/src/main/viewManager.js
+++ b/src/main/viewManager.js
@@ -46,12 +46,12 @@ export class ViewManager {
     let setFocus;
     sorted.forEach((server) => {
       const recycle = oldviews.get(server.name);
-      if (recycle) {
+      if (recycle && recycle.isVisible) {
+        setFocus = recycle.name;
+      }
+      if (recycle && recycle.server.url === server.url) {
         oldviews.delete(recycle.name);
         this.views.set(recycle.name, recycle);
-        if (recycle.isVisible) {
-          setFocus = recycle.name;
-        }
       } else {
         this.loadServer(server, mainWindow);
       }

--- a/src/renderer/components/MainPage.jsx
+++ b/src/renderer/components/MainPage.jsx
@@ -114,8 +114,12 @@ export default class MainPage extends React.Component {
 
   getTabStatus() {
     // TODO: should try to make this a bit safer in case we get into a weird situation
-    const tabname = this.props.teams[this.state.key].name;
-    return this.state.tabStatus.get(tabname);
+    const tab = this.props.teams[this.state.key];
+    if (tab) {
+      const tabname = tab.name;
+      return this.state.tabStatus.get(tabname);
+    }
+    return null;
   }
 
   componentDidMount() {
@@ -747,6 +751,15 @@ export default class MainPage extends React.Component {
 
       let component;
       const tabStatus = this.getTabStatus();
+      if (!tabStatus) {
+        const tab = this.props.teams[this.state.key];
+        if (tab) {
+          console.error(`Not tabStatus for ${this.props.teams[this.state.key].name}`);
+        } else {
+          console.error('No tab status, tab doesn\'t exist anymore');
+        }
+        return null;
+      }
       switch (tabStatus.status) {
       case RETRY:
       case FAILED:


### PR DESCRIPTION
**Summary**

Change server load, so it reuses browserviews, preventing white pages flashes 
Fixed some errors from the renderer that were turning the tabs white

what's not fixed:
- remove `saving...` label, when changing any settings the label remains. Created ticket [MM-31554](https://mattermost.atlassian.net/browse/MM-31554)
- Sometimes it doesn't update which tab is in focus.

**Issue link**

[MM-31224](https://mattermost.atlassian.net/browse/MM-31224)
