### PR TITLE
Change dev server port

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -532,7 +532,7 @@ function handleAppWebContentsCreated(dc, contents) {
       return;
     }
     const mode = Utils.runMode();
-    if ((mode === DEV_SERVER && parsedURL.origin === 'http://localhost:9000') ||
+    if ((mode === DEV_SERVER && parsedURL.origin === 'http://localhost:9001') ||
         ((mode === DEVELOPMENT || mode === PRODUCTION) &&
           (parsedURL.path === 'renderer/index.html' || parsedURL.path === 'renderer/settings.html'))) {
       log.info('loading settings page');

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -49,7 +49,7 @@ export function getLocalURL(urlPath, query, isMain) {
     log.info('detected webserver');
     protocol = 'http';
     hostname = 'localhost';
-    port = ':9000'; // TODO: find out how to get the devserver port
+    port = ':9001'; // TODO: find out how to get the devserver port
     pathname = `${processPath}/${urlPath}`;
   } else {
     protocol = 'file';

--- a/webpack.config.renderer.js
+++ b/webpack.config.renderer.js
@@ -14,7 +14,7 @@ const CopyPlugin = require('copy-webpack-plugin');
 
 const base = require('./webpack.config.base');
 
-const WEBSERVER_PORT = 9000;
+const WEBSERVER_PORT = 9001;
 
 module.exports = merge(base, {
   entry: {


### PR DESCRIPTION
**Summary**
Changing the dev server port to 9001, as using 9000 conflicts running a local `mattermost-server` instance as the `mattermost-minio` container defaults to using port 9000.
