### PR TITLE
remove dev_web_server

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "clean": "rm -rf release/ node_modules/ dist/ && find src -name '*_bundle.js' | xargs rm",
     "clean-install": "npm run clean && npm install",
     "clean-dist": "rm -rf dist/",
-    "watch": "cross-env-shell WEBPACK_DEV_SERVER=1 run-p watch:*",
+    "watch": "run-p watch:*",
     "watch:main": "node scripts/watch_main_and_preload.js",
     "watch:renderer": "webpack-dev-server --config webpack.config.renderer.js",
     "test": "npm-run-all lint:js test:*",

--- a/src/common/utils/constants.js
+++ b/src/common/utils/constants.js
@@ -1,7 +1,6 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-export const DEV_SERVER = 'dev_server';
 export const PRODUCTION = 'production';
 export const DEVELOPMENT = 'development';
 

--- a/src/common/utils/util.js
+++ b/src/common/utils/util.js
@@ -4,7 +4,7 @@
 
 import electron from 'electron';
 
-import {DEVELOPMENT, DEV_SERVER, PRODUCTION} from './constants';
+import {DEVELOPMENT, PRODUCTION} from './constants';
 
 function getDisplayBoundaries() {
   const {screen} = electron;
@@ -24,13 +24,7 @@ function getDisplayBoundaries() {
 }
 
 function runMode() {
-  let mode = DEVELOPMENT;
-  if (process.env.WEBPACK_DEV_SERVER) {
-    mode = DEV_SERVER;
-  } else if (process.env.NODE_ENV === PRODUCTION) {
-    mode = PRODUCTION;
-  }
-  return mode;
+  return process.env.NODE_ENV === PRODUCTION ? PRODUCTION : DEVELOPMENT;
 }
 
 export default {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -14,7 +14,7 @@ import 'airbnb-js-shims/target/es2015';
 import Utils from 'common/utils/util';
 import urlUtils from 'common/utils/url';
 
-import {DEV_SERVER, DEVELOPMENT, PRODUCTION, SECOND} from 'common/utils/constants';
+import {DEVELOPMENT, PRODUCTION, SECOND} from 'common/utils/constants';
 import {SWITCH_SERVER, FOCUS_BROWSERVIEW, QUIT, DARK_MODE_CHANGE, DOUBLE_CLICK_ON_WINDOW, WINDOW_CLOSE, WINDOW_MAXIMIZE, WINDOW_MINIMIZE, WINDOW_RESTORE, NOTIFY_MENTION, GET_DOWNLOAD_LOCATION} from 'common/communication';
 import {REQUEST_PERMISSION_CHANNEL, GRANT_PERMISSION_CHANNEL, DENY_PERMISSION_CHANNEL, BASIC_AUTH_PERMISSION} from 'common/permissions';
 import Config from 'common/config';
@@ -532,8 +532,7 @@ function handleAppWebContentsCreated(dc, contents) {
       return;
     }
     const mode = Utils.runMode();
-    if ((mode === DEV_SERVER && parsedURL.origin === 'http://localhost:9001') ||
-        ((mode === DEVELOPMENT || mode === PRODUCTION) &&
+    if (((mode === DEVELOPMENT || mode === PRODUCTION) &&
           (parsedURL.path === 'renderer/index.html' || parsedURL.path === 'renderer/settings.html'))) {
       log.info('loading settings page');
       return;

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -4,9 +4,8 @@
 
 import electron, {app} from 'electron';
 import path from 'path';
-import log from 'electron-log';
 
-import {DEV_SERVER, PRODUCTION} from 'common/utils/constants';
+import {PRODUCTION} from 'common/utils/constants';
 import Utils from 'common/utils/util';
 
 const TAB_BAR_HEIGHT = 38;
@@ -39,27 +38,16 @@ export function getLocalURLString(urlPath, query, isMain) {
 }
 
 export function getLocalURL(urlPath, query, isMain) {
-  let protocol;
-  let hostname;
-  let port;
   let pathname;
   const processPath = isMain ? '' : '/renderer';
   const mode = Utils.runMode();
-  if (mode === DEV_SERVER) {
-    log.info('detected webserver');
-    protocol = 'http';
-    hostname = 'localhost';
-    port = ':9001'; // TODO: find out how to get the devserver port
-    pathname = `${processPath}/${urlPath}`;
+  const protocol = 'file';
+  const hostname = '';
+  const port = '';
+  if (mode === PRODUCTION) {
+    pathname = path.join(electron.app.getAppPath(), `dist/${processPath}/${urlPath}`);
   } else {
-    protocol = 'file';
-    hostname = '';
-    port = '';
-    if (mode === PRODUCTION) {
-      pathname = path.join(electron.app.getAppPath(), `dist/${processPath}/${urlPath}`);
-    } else {
-      pathname = path.resolve(__dirname, `../../dist/${processPath}/${urlPath}`); // TODO: find a better way to work with webpack on this
-    }
+    pathname = path.resolve(__dirname, `../../dist/${processPath}/${urlPath}`); // TODO: find a better way to work with webpack on this
   }
   const localUrl = new URL(`${protocol}://${hostname}${port}`);
   localUrl.pathname = pathname;


### PR DESCRIPTION
**Summary**

differentiating between webserver and development is no longer needed and it fixes the url view not being shown when using `npm run watch`

**Test Cases**

- `npm run watch`
- create a post with a non-team related url like `[google](https://google.com)`
- hover the url with the mouse

Expected: on the bottom left you can see the google.com url with a grey background

