### PR TITLE
[MM-31923] Fix missing key on apt-get

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ commands:
         type: string
         default: ""
     steps:
+      - run: wget -qO - https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/Release.key | apt-key add -
       - run: apt-get update && apt-get -y install << parameters.apt_opts >>
       - run: npm ci
 


### PR DESCRIPTION
**Summary**

circle is failing due to some deps having its signing key updated


**Ticket**

[MM-31923](https://mattermost.atlassian.net/browse/MM-31923)