### PR TITLE
add own branch for testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,6 +305,17 @@ jobs:
           path: ./dist
           destination: packages
 
+  share_to_channel:
+    executor: wine-chrome
+    steps:
+      - attach_workspace:
+          at: ./dist
+      - run: mkdir -p ./links
+      - run:
+          name: "Get urls for sharing"
+          command: |
+            curl -H "Circle-Token: $CIRCLE_TOKEN" https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/artifacts \
+            | grep -o 'https://[^"]*' > ./links/linklist.txt
   upload_to_s3:
     executor: aws
     steps:
@@ -481,3 +492,29 @@ workflows:
                 # release-XX.YY.ZZ
                 # release-XX.YY.ZZ-rc-something
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
+  nightly_browser_view:
+    triggers:
+      - schedule:
+          cron: "0 4 * * 0-5"
+          filters:
+            branches:
+              only:
+                - browser-view
+                - BV_pipeline #remove this one before merging
+    jobs:
+      - build-linux
+      - build-win-no-installer:
+          context: windows-codesign
+      - mac_installer:
+          context: codesign-certificates
+      - store_artifacts:
+          # for master/PR builds
+          requires:
+            - build-linux
+            - build-win-no-installer
+            - mac_installer
+      - share_to_channel:
+          context: desktop_browserview
+          requires:
+            - store_artifacts
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,16 +320,16 @@ jobs:
       - run:
           name: "Get urls for sharing"
           command: |
-            artifacts=$(curl -H "Circle-Token: $CIRCLE_TOKEN" -H "Accept: application/json" -X GET "https://circleci.com/api/v2/project/github/mattermost/desktop/$CIRCLE_PREVIOUS_BUILD_NUM/artifacts")
-            header="Links for $(date +"%b-%d-%Y")"
-            processed=echo $artifacts | jq '.items[].url'
-            echo "export ARTIFACT_RESPONSE=$(echo "$header\n$processed") >> $BASH_ENV
+            echo "Links for $(date +"%b-%d-%Y")" > ./links/linklist.txt
+            curl -H "Circle-Token: $CIRCLE_TOKEN" -H "Accept: application/json" -X GET "https://circleci.com/api/v2/project/github/mattermost/desktop/$CIRCLE_PREVIOUS_BUILD_NUM/artifacts" | jq -r '.items[].url' >> ./links/linklist.txt
+            echo "Retrieved links for job #${CIRCLE_PREVIOUS_BUILD_NUM}"
       - run: 
           command: |
+            linklist=$(<./links/linklist.txt);
             echo '{}' | jq "{
               \"username\": \"NightBuilder\",
               \"icon_url\": \"https://upload.wikimedia.org/wikipedia/commons/1/17/Luna_symbol.png\",
-              \"text\": \"${ARTIFACT_RESPONSE}\"
+              \"text\": \"${linklist}\"
             }" >> /tmp/webhook-data.json
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,7 +333,7 @@ jobs:
             }" >> /tmp/webhook-data.json
       - run:
           command: |
-            curl -i -X POST -d @/tmp/webhook-data.json $MM_TOKEN || echo "NOFICATION FAILED! check logs as this will succeed intentionally"
+            curl -i -X POST -H "Content-Type: application/json" -d @/tmp/webhook-data.json $MM_TOKEN || echo "NOFICATION FAILED! check logs as this will succeed intentionally"
 
   upload_to_s3:
     executor: aws

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,11 +311,25 @@ jobs:
       - attach_workspace:
           at: ./dist
       - run: mkdir -p ./links
+      - run: echo "### Nightly builds:\n" > ./links/linklist.txt
       - run:
           name: "Get urls for sharing"
           command: |
             curl -H "Circle-Token: $CIRCLE_TOKEN" https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/artifacts \
-            | grep -o 'https://[^"]*' > ./links/linklist.txt
+            | grep -o 'https://[^"]*' >> ./links/linklist.txt
+      - run: 
+          command: |
+            linklist=$(<./links/linklist.txt);
+            echo "payload=" > /tmp/webhook-data.json;
+            echo '{}' | jq "{
+              \"username\": \"NightBuilder\",
+              \"icon_url\": \"https://upload.wikimedia.org/wikipedia/commons/1/17/Luna_symbol.png\",
+              \"text\": "${linklist@Q}"
+            }" >> /tmp/webhook-data.json
+      - run:
+          command: |
+            curl -i -X POST -d @/tmp/webhook-data.json $MM_TOKEN || echo "NOFICATION FAILED! check logs as this will succeed intentionally"
+
   upload_to_s3:
     executor: aws
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,7 +330,7 @@ jobs:
             echo '{}' | jq "{
               \"username\": \"NightBuilder\",
               \"icon_url\": \"https://upload.wikimedia.org/wikipedia/commons/1/17/Luna_symbol.png\",
-              \"text\": "${linklist@Q}"
+              \"text\": \"${linklist@Q}\"
             }" >> /tmp/webhook-data.json
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,6 @@ commands:
       - run: 
           command: |
             export VERSION=$(jq -r .version package.json)
-            echo "payload=" > /tmp/webhook-data.json;
             echo '{}' | jq "{
               \"username\": \"<< parameters.username >>\",
               \"icon_url\": \"<< parameters.icon >>\",
@@ -56,7 +55,7 @@ commands:
             }" >> /tmp/webhook-data.json
       - run:
           command: |
-            curl -i -X POST -d @/tmp/webhook-data.json $MATTERMOST_RELEASE_WEBHOOK_URL_DESKTOP || echo "NOFICATION FAILED! check logs as this will succeed intentionally"
+            curl -i -H "Content-Type: application/json" -X POST -d @/tmp/webhook-data.json $MATTERMOST_RELEASE_WEBHOOK_URL_DESKTOP || echo "NOFICATION FAILED! check logs as this will succeed intentionally"
 
   update_image:
     description: "Update base image"
@@ -321,16 +320,14 @@ jobs:
       - run:
           name: "Get urls for sharing"
           command: |
-            curl -H "Circle-Token: $CIRCLE_TOKEN" https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/artifacts \
-            | grep -o 'https://[^"]*' >> ./links/linklist.txt
+            artifacts=$(curl -H "Circle-Token: $CIRCLE_TOKEN" -H "Accept: application/json" -X GET "https://circleci.com/api/v2/project/github/mattermost/desktop/$CIRCLE_BUILD_NUM/artifacts")
+            echo "export ARTIFACT_RESPONSE=$artifacts" >> $BASH_ENV
       - run: 
           command: |
-            linklist=$(<./links/linklist.txt);
-            echo "payload=" > /tmp/webhook-data.json;
             echo '{}' | jq "{
               \"username\": \"NightBuilder\",
               \"icon_url\": \"https://upload.wikimedia.org/wikipedia/commons/1/17/Luna_symbol.png\",
-              \"text\": \"${linklist@Q}\"
+              \"text\": \"${ARTIFACT_RESPONSE}\"
             }" >> /tmp/webhook-data.json
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -503,8 +503,7 @@ workflows:
                 - BV_pipeline #remove this one before merging
     jobs:
       - build-linux
-      - build-win-no-installer:
-          context: windows-codesign
+      - build-win-no-installer
       - mac_installer:
           context: codesign-certificates
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,8 @@
 version: 2.1
+parameters:
+  run_nightly:
+    default: false
+    type: boolean
 orbs:
   win: circleci/windows@1.0.0
   aws-s3: circleci/aws-s3@1.0.11
@@ -310,6 +314,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ./dist
+      - run: wget -qO - https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/Release.key | apt-key add -
+      - run: apt-get update && apt-get -y install jq
       - run: mkdir -p ./links
       - run: echo "### Nightly builds:\n" > ./links/linklist.txt
       - run:
@@ -507,14 +513,7 @@ workflows:
                 # release-XX.YY.ZZ-rc-something
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
   nightly_browser_view:
-    triggers:
-      - schedule:
-          cron: "0 4 * * 0-5"
-          filters:
-            branches:
-              only:
-                - browser-view
-                - BV_pipeline #remove this one before merging
+    when: << pipeline.parameters.run_nightly >>
     jobs:
       - build-linux
       - build-win-no-installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,8 +320,10 @@ jobs:
       - run:
           name: "Get urls for sharing"
           command: |
-            artifacts=$(curl -H "Circle-Token: $CIRCLE_TOKEN" -H "Accept: application/json" -X GET "https://circleci.com/api/v2/project/github/mattermost/desktop/$CIRCLE_BUILD_NUM/artifacts")
-            echo "export ARTIFACT_RESPONSE=$artifacts" >> $BASH_ENV
+            artifacts=$(curl -H "Circle-Token: $CIRCLE_TOKEN" -H "Accept: application/json" -X GET "https://circleci.com/api/v2/project/github/mattermost/desktop/$CIRCLE_PREVIOUS_BUILD_NUM/artifacts")
+            header="Links for $(date +"%b-%d-%Y")"
+            processed=echo $artifacts | jq '.items[].url'
+            echo "export ARTIFACT_RESPONSE=$(echo "$header\n$processed") >> $BASH_ENV
       - run: 
           command: |
             echo '{}' | jq "{


### PR DESCRIPTION
**Summary**

Add a workflow for CircleCI that will generate nightly builds for the browser-view branch so people can test the latests changes

**Issue link**

[MM-32108](https://mattermost.atlassian.net/browse/MM-32108)

