### PR TITLE
[MM-31261] Use manual resizing of BrowserViews on resize, maximize and full-screen

### DIFF
--- a/src/main/MattermostView.js
+++ b/src/main/MattermostView.js
@@ -122,12 +122,6 @@ export class MattermostView extends EventEmitter {
   setBounds = (boundaries) => {
     // todo: review this, as it might not work properly with devtools/minimizing/resizing
     this.view.setBounds(boundaries);
-    this.view.setAutoResize({
-      height: true,
-      width: true,
-      horizontal: true,
-      vertical: true,
-    });
   }
 
   destroy = () => {

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -8,7 +8,7 @@ import path from 'path';
 import {PRODUCTION} from 'common/utils/constants';
 import Utils from 'common/utils/util';
 
-const TAB_BAR_HEIGHT = 38;
+const TAB_BAR_HEIGHT = 40;
 
 export function shouldBeHiddenOnStartup(parsedArgv) {
   if (parsedArgv.hidden) {
@@ -24,6 +24,10 @@ export function shouldBeHiddenOnStartup(parsedArgv) {
 
 export function getWindowBoundaries(win) {
   const {width, height} = win.getContentBounds();
+  return getAdjustedWindowBoundaries(width, height);
+}
+
+export function getAdjustedWindowBoundaries(width, height) {
   return {
     x: 0,
     y: TAB_BAR_HEIGHT,

--- a/src/main/windows/windowManager.js
+++ b/src/main/windows/windowManager.js
@@ -7,6 +7,8 @@ import log from 'electron-log';
 
 import {MAXIMIZE_CHANGE, SWITCH_SERVER} from 'common/communication';
 
+import {getAdjustedWindowBoundaries} from '../utils';
+
 import {ViewManager} from '../viewManager';
 import {CriticalErrorHandler} from '../CriticalErrorHandler';
 
@@ -83,8 +85,11 @@ export function showMainWindow() {
       criticalErrorHandler.windowUnresponsiveHandler();
     });
     status.mainWindow.on('crashed', handleMainWindowWebContentsCrashed);
-    status.mainWindow.on('maximize', () => this.sendToRenderer(MAXIMIZE_CHANGE, true));
-    status.mainWindow.on('unmaximize', () => this.sendToRenderer(MAXIMIZE_CHANGE, false));
+    status.mainWindow.on('enter-full-screen', () => setBoundsForCurrentView());
+    status.mainWindow.on('leave-full-screen', () => setBoundsForCurrentView());
+    status.mainWindow.on('maximize', handleMaximizeMainWindow);
+    status.mainWindow.on('unmaximize', handleUnmaximizeMainWindow);
+    status.mainWindow.on('will-resize', handleResizeMainWindow);
   }
   initializeViewManager();
 }
@@ -102,6 +107,28 @@ export function on(event, listener) {
 
 function handleMainWindowWebContentsCrashed() {
   throw new Error('webContents \'crashed\' event has been emitted');
+}
+
+function handleMaximizeMainWindow() {
+  sendToRenderer(MAXIMIZE_CHANGE, true);
+  setBoundsForCurrentView();
+}
+
+function handleUnmaximizeMainWindow() {
+  sendToRenderer(MAXIMIZE_CHANGE, false);
+  setBoundsForCurrentView();
+}
+
+function handleResizeMainWindow(event, newBounds) {
+  setBoundsForCurrentView(newBounds);
+}
+
+function setBoundsForCurrentView(newBounds) {
+  const currentView = status.viewManager.getCurrentView();
+  const bounds = newBounds || status.mainWindow.getContentBounds();
+  if (currentView) {
+    currentView.setBounds(getAdjustedWindowBoundaries(bounds.width, bounds.height));
+  }
 }
 
 export function sendToRenderer(channel, ...args) {

--- a/src/main/windows/windowManager.js
+++ b/src/main/windows/windowManager.js
@@ -85,8 +85,8 @@ export function showMainWindow() {
       criticalErrorHandler.windowUnresponsiveHandler();
     });
     status.mainWindow.on('crashed', handleMainWindowWebContentsCrashed);
-    status.mainWindow.on('enter-full-screen', () => setBoundsForCurrentView());
-    status.mainWindow.on('leave-full-screen', () => setBoundsForCurrentView());
+    status.mainWindow.on('enter-full-screen', setBoundsForCurrentView);
+    status.mainWindow.on('leave-full-screen', setBoundsForCurrentView);
     status.mainWindow.on('maximize', handleMaximizeMainWindow);
     status.mainWindow.on('unmaximize', handleUnmaximizeMainWindow);
     status.mainWindow.on('will-resize', handleResizeMainWindow);


### PR DESCRIPTION
**Summary**
There's an issue with auto resizing the `BrowserView` elements, documented here: https://github.com/electron/electron/issues/13468

This PR will resize the active `BrowserView` on the `will-resize`, `maximize`, `unmaximize`, `enter-full-screen` and `leave-full-screen` events such that the BrowserView is always in its correct place.

**Issue link**
https://mattermost.atlassian.net/browse/MM-31261
