### PR TITLE
[MM-31467] Move protocol handling over from original MattermostView into web contents handler

### DIFF
--- a/src/main/MattermostView.js
+++ b/src/main/MattermostView.js
@@ -1,16 +1,19 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {BrowserView, app} from 'electron';
+import {BrowserView, app, shell, dialog} from 'electron';
 import log from 'electron-log';
-import path from 'path';
 
 import {EventEmitter} from 'events';
 
 import {RELOAD_INTERVAL, MAX_SERVER_RETRIES, SECOND} from 'common/utils/constants';
 import urlUtils from 'common/utils/url';
 import {LOAD_RETRY, LOAD_SUCCESS, LOAD_FAILED, UPDATE_TARGET_URL} from 'common/communication';
+import {protocols} from '../../electron-builder.json';
+const scheme = protocols[0].schemes[0];
 
+import allowProtocolDialog from './allowProtocolDialog';
+import downloadURL from './downloadURL';
 import {getWindowBoundaries, getLocalPreload} from './utils';
 import * as WindowManager from './windows/windowManager';
 
@@ -57,6 +60,7 @@ export class MattermostView extends EventEmitter {
   setReadyCallback = (func) => {
     this.readyCallBack = func;
     this.view.webContents.on('update-target-url', this.handleUpdateTarget);
+    //this.view.webContents.on('new-window', this.handleNewWindow);
   }
 
   load = (someURL) => {
@@ -166,6 +170,67 @@ export class MattermostView extends EventEmitter {
   handleUpdateTarget = (e, url) => {
     if (!this.server.sameOrigin(url)) {
       this.emit(UPDATE_TARGET_URL, url);
+    }
+  }
+
+  handleNewWindow = (e, url) => {
+    // Check for valid URL
+    if (!urlUtils.isValidURI(url)) {
+      e.preventDefault();
+      return;
+    }
+
+    // Parse current and destination URLs
+    const currentURL = urlUtils.parseURL(this.view.webContents.getURL());
+    const destURL = urlUtils.parseURL(url);
+
+    // Check for custom protocol
+    if (destURL.protocol !== 'http:' && destURL.protocol !== 'https:' && destURL.protocol !== `${scheme}:`) {
+      e.preventDefault();
+      allowProtocolDialog.handleDialogEvent(destURL.protocol, url);
+      return;
+    }
+
+    if (urlUtils.isInternalURL(destURL, currentURL, this.state.basename)) {
+      // Download file case
+      if (destURL.path.match(/^\/api\/v[3-4]\/public\/files\//)) {
+        downloadURL(url, (err) => {
+          if (err) {
+            dialog.showMessageBox(WindowManager.getMainWindow(), {
+              type: 'error',
+              message: err.toString(),
+            });
+            log.error(err);
+          }
+        });
+      } else if (destURL.path.match(/^\/help\//)) {
+        // Help links case
+        // continue to open special case internal urls in default browser
+        shell.openExternal(url);
+      } else if (urlUtils.isTeamUrl(this.props.src, url, true) || urlUtils.isAdminUrl(this.props.src, url)) {
+        // Normal in-app behaviour case
+        e.preventDefault();
+        this.webviewRef.current.loadURL(url);
+      } else if (urlUtils.isPluginUrl(this.props.src, url)) {
+        // Plugin case
+        // New window should disable nodeIntegration.
+        window.open(url, app.name, 'nodeIntegration=no, contextIsolation=yes, show=yes');
+      } else if (urlUtils.isManagedResource(this.props.src, url)) {
+        // 'Trusted' URL case
+        e.preventDefault();
+      } else {
+        e.preventDefault();
+        shell.openExternal(url);
+      }
+    } else {
+      const parsedURL = urlUtils.parseURL(url);
+      const serverURL = urlUtils.getServer(parsedURL, this.props.teams);
+      if (serverURL !== null && urlUtils.isTeamUrl(serverURL.url, parsedURL)) {
+        this.props.handleInterTeamLink(parsedURL);
+      } else {
+        // if the link is external, use default os' application.
+        allowProtocolDialog.handleDialogEvent(destURL.protocol, url);
+      }
     }
   }
 }

--- a/src/main/MattermostView.js
+++ b/src/main/MattermostView.js
@@ -184,13 +184,6 @@ export class MattermostView extends EventEmitter {
     const currentURL = urlUtils.parseURL(this.view.webContents.getURL());
     const destURL = urlUtils.parseURL(url);
 
-    // Check for custom protocol
-    if (destURL.protocol !== 'http:' && destURL.protocol !== 'https:' && destURL.protocol !== `${scheme}:`) {
-      e.preventDefault();
-      allowProtocolDialog.handleDialogEvent(destURL.protocol, url);
-      return;
-    }
-
     if (urlUtils.isInternalURL(destURL, currentURL, this.state.basename)) {
       // Download file case
       if (destURL.path.match(/^\/api\/v[3-4]\/public\/files\//)) {

--- a/src/main/downloadURL.js
+++ b/src/main/downloadURL.js
@@ -49,7 +49,6 @@ function getAttachmentName(headers) {
 }
 
 function saveResponseBody(response, filename, callback) {
-  console.log(filename);
   const output = fs.createWriteStream(filename);
   output.on('close', callback);
   switch (response.headers['content-encoding']) {

--- a/src/main/downloadURL.js
+++ b/src/main/downloadURL.js
@@ -49,6 +49,7 @@ function getAttachmentName(headers) {
 }
 
 function saveResponseBody(response, filename, callback) {
+  console.log(filename);
   const output = fs.createWriteStream(filename);
   output.on('close', callback);
   switch (response.headers['content-encoding']) {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -35,6 +35,7 @@ import UserActivityMonitor from './UserActivityMonitor';
 import * as WindowManager from './windows/windowManager';
 import {showBadge} from './badge';
 import {displayMention, displayDownloadCompleted} from './notifications';
+import downloadURL from './downloadURL';
 
 import parseArgs from './ParseArgs';
 import {addModal} from './modalManager';
@@ -597,6 +598,11 @@ function handleAppWebContentsCreated(dc, contents) {
     }
     event.preventDefault();
 
+    // Check for valid URL
+    if (!urlUtils.isValidURI(url)) {
+      return;
+    }
+
     // Check for custom protocol
     if (parsedURL.protocol !== 'http:' && parsedURL.protocol !== 'https:' && parsedURL.protocol !== `${scheme}:`) {
       allowProtocolDialog.handleDialogEvent(parsedURL.protocol, url);
@@ -609,6 +615,29 @@ function handleAppWebContentsCreated(dc, contents) {
       shell.openExternal(url);
       return;
     }
+
+    // Public download links case
+    // TODO: This doesn't work correctly right now, needs to be refactored
+    // if (parsedURL.pathname.match(/^(\/api\/v[3-4]\/public)*\/files\//)) {
+    //   downloadURL(url, (err) => {
+    //     if (err) {
+    //       dialog.showMessageBox(WindowManager.getMainWindow(), {
+    //         type: 'error',
+    //         message: err.toString(),
+    //       });
+    //       log.error(err);
+    //     }
+    //   });
+    //   return;
+    // }
+
+    if (parsedURL.pathname.match(/^\/help\//)) {
+      // Help links case
+      // continue to open special case internal urls in default browser
+      shell.openExternal(url);
+      return;
+    }
+
     if (urlUtils.isTeamUrl(server.url, parsedURL, true)) {
       log.info(`${url} is a known team, preventing to open a new window`);
       return;


### PR DESCRIPTION
**Summary**
Protocol handling wasn't migrated over from the original `MattermostView`, so I've done that and made it work with the `webContents` object rather than `webview`.
