### PR TITLE
[MM-31233] Reverse maximize logic typo

### DIFF
--- a/src/main/windows/windowManager.js
+++ b/src/main/windows/windowManager.js
@@ -214,9 +214,9 @@ export function handleDoubleClick(e, windowType) {
   case 'Maximize':
   default:
     if (win.isMaximized()) {
-      win.maximize();
-    } else {
       win.unmaximize();
+    } else {
+      win.maximize();
     }
     break;
   }


### PR DESCRIPTION
**Summary**
Looks like the logic to minimize/maximize was reversed. Probably just a typo.

Fun fact: The reversed login worked fine on Windows 10, wonder if `maximize()`/`unmaximize()` are both just toggles in Windows.

**Issue link**
https://mattermost.atlassian.net/browse/MM-31233
