### PR TITLE
[MM-32392] prevent crash when checking a URL

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -548,7 +548,7 @@ function handleAppWebContentsCreated(dc, contents) {
       log.info(`${url} is a known team, preventing to open a new window`);
       return;
     }
-    if (Utils.isAdminUrl(server.url, parsedURL)) {
+    if (urlUtils.isAdminUrl(server.url, parsedURL)) {
       log.info(`${url} is an admin console page, preventing to open a new window`);
       return;
     }


### PR DESCRIPTION
**Summary**
Prevent a crash when checking a URL

**Issue link**
[MM-29748](https://mattermost.atlassian.net/browse/MM-32392)

**Test Cases**

upload a file
open preview page and instead of using the download button, use the preview icon
expected: no crash

**Additional notes**
this doesn't fix that the download starts when using the icon.