### PR TITLE
[MM-32424] fix server devtools being hidden by browserview

### DIFF
--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -195,9 +195,9 @@ function createTemplate(config) {
       if (focusedWindow) {
         // toggledevtools opens it in the last known position, so sometimes it goes below the browserview
         if (focusedWindow.isDevToolsOpened()) {
-          focusedWindow.openDevTools({mode: 'detach'});
-        } else {
           focusedWindow.closeDevTools();
+        } else {
+          focusedWindow.openDevTools({mode: 'detach'});
         }
       }
     },

--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -193,7 +193,12 @@ function createTemplate(config) {
     })(),
     click(item, focusedWindow) {
       if (focusedWindow) {
-        focusedWindow.toggleDevTools({mode: 'detach'});
+        // toggledevtools opens it in the last known position, so sometimes it goes below the browserview
+        if (focusedWindow.isDevToolsOpened()) {
+          focusedWindow.openDevTools({mode: 'detach'});
+        } else {
+          focusedWindow.closeDevTools();
+        }
       }
     },
   }, {


### PR DESCRIPTION
**Summary**

toggle devtools tries to restore to the last known position of the devtools, so it might end below the browserview, checking and using open with detach mode prevents this from happening. Also removes the option to reattaching the window.

**Issue link**

[MM-32424](https://mattermost.atlassian.net/browse/MM-32424)