### PR TITLE
[MM-31215][MM-31387] Fixes for bad tab navigation and dragging

### DIFF
--- a/src/common/communication.js
+++ b/src/common/communication.js
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 export const SWITCH_SERVER = 'switch-server';
+export const SET_SERVER_KEY = 'set-server-key';
 export const MARK_READ = 'mark-read';
 export const FOCUS_BROWSERVIEW = 'focus-browserview';
 export const ZOOM = 'zoom';

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -445,8 +445,8 @@ function handleAppWillFinishLaunching() {
   });
 }
 
-function handleSwitchServer(event, serverName, notifyRenderer) {
-  WindowManager.switchServer(serverName, notifyRenderer);
+function handleSwitchServer(event, serverName) {
+  WindowManager.switchServer(serverName);
 }
 
 function handleNewServerModal() {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -445,8 +445,8 @@ function handleAppWillFinishLaunching() {
   });
 }
 
-function handleSwitchServer(event, serverName) {
-  WindowManager.switchServer(serverName);
+function handleSwitchServer(event, serverName, notifyRenderer) {
+  WindowManager.switchServer(serverName, notifyRenderer);
 }
 
 function handleNewServerModal() {

--- a/src/main/viewManager.js
+++ b/src/main/viewManager.js
@@ -51,7 +51,7 @@ export class ViewManager {
       if (recycle && recycle.isVisible) {
         setFocus = recycle.name;
       }
-      if (recycle && urlUtils.parseURL(recycle.server.url).toString() === urlUtils.parseURL(server.url).toString()) {
+      if (recycle && recycle.server.url === urlUtils.parseURL(server.url)) {
         oldviews.delete(recycle.name);
         this.views.set(recycle.name, recycle);
       } else {

--- a/src/main/viewManager.js
+++ b/src/main/viewManager.js
@@ -4,7 +4,7 @@ import log from 'electron-log';
 import {BrowserView} from 'electron';
 
 import {SECOND} from 'common/utils/constants';
-import {UPDATE_TARGET_URL} from 'common/communication';
+import {UPDATE_TARGET_URL, SET_SERVER_KEY} from 'common/communication';
 
 import contextMenu from './contextMenu';
 import {MattermostServer} from './MattermostServer';
@@ -96,6 +96,8 @@ export class ViewManager {
       if (newView.isReady()) {
         // if view is not ready, the renderer will have something to display instead.
         newView.show();
+        const serverInfo = this.configServers.find((candidate) => candidate.name === newView.server.name);
+        newView.window.webContents.send(SET_SERVER_KEY, serverInfo.order);
         contextMenu.reload(newView.getWebContents());
       } else {
         console.log(`couldn't show ${name}, not ready`);

--- a/src/main/viewManager.js
+++ b/src/main/viewManager.js
@@ -4,6 +4,7 @@ import log from 'electron-log';
 import {BrowserView} from 'electron';
 
 import {SECOND} from 'common/utils/constants';
+import urlUtils from 'common/utils/url';
 import {UPDATE_TARGET_URL, SET_SERVER_KEY} from 'common/communication';
 
 import contextMenu from './contextMenu';
@@ -40,7 +41,7 @@ export class ViewManager {
   }
 
   reloadConfiguration = (configServers, mainWindow) => {
-    this.configServers = configServers;
+    this.configServers = configServers.concat();
     const oldviews = this.views;
     this.views = new Map();
     const sorted = this.configServers.sort((a, b) => a.order - b.order);
@@ -50,7 +51,7 @@ export class ViewManager {
       if (recycle && recycle.isVisible) {
         setFocus = recycle.name;
       }
-      if (recycle && recycle.server.url === server.url) {
+      if (recycle && urlUtils.parseURL(recycle.server.url).toString() === urlUtils.parseURL(server.url).toString()) {
         oldviews.delete(recycle.name);
         this.views.set(recycle.name, recycle);
       } else {
@@ -93,11 +94,11 @@ export class ViewManager {
       }
 
       this.currentView = name;
+      const serverInfo = this.configServers.find((candidate) => candidate.name === newView.server.name);
+      newView.window.webContents.send(SET_SERVER_KEY, serverInfo.order);
       if (newView.isReady()) {
         // if view is not ready, the renderer will have something to display instead.
         newView.show();
-        const serverInfo = this.configServers.find((candidate) => candidate.name === newView.server.name);
-        newView.window.webContents.send(SET_SERVER_KEY, serverInfo.order);
         contextMenu.reload(newView.getWebContents());
       } else {
         console.log(`couldn't show ${name}, not ready`);

--- a/src/main/windows/windowManager.js
+++ b/src/main/windows/windowManager.js
@@ -233,8 +233,6 @@ function initializeViewManager() {
 export function switchServer(serverName) {
   showMainWindow();
   status.viewManager.showByName(serverName);
-  const server = status.config.teams.find((candidate) => candidate.name === serverName);
-  sendToRenderer(SET_SERVER_KEY, server.order);
 }
 
 export function focusBrowserView() {

--- a/src/main/windows/windowManager.js
+++ b/src/main/windows/windowManager.js
@@ -5,7 +5,7 @@ import path from 'path';
 import {app, BrowserWindow, nativeImage, systemPreferences} from 'electron';
 import log from 'electron-log';
 
-import {MAXIMIZE_CHANGE, SET_SERVER_KEY} from 'common/communication';
+import {MAXIMIZE_CHANGE} from 'common/communication';
 
 import {getAdjustedWindowBoundaries} from '../utils';
 

--- a/src/main/windows/windowManager.js
+++ b/src/main/windows/windowManager.js
@@ -5,7 +5,7 @@ import path from 'path';
 import {app, BrowserWindow, nativeImage, systemPreferences} from 'electron';
 import log from 'electron-log';
 
-import {MAXIMIZE_CHANGE, SWITCH_SERVER} from 'common/communication';
+import {MAXIMIZE_CHANGE, SET_SERVER_KEY} from 'common/communication';
 
 import {getAdjustedWindowBoundaries} from '../utils';
 
@@ -230,13 +230,11 @@ function initializeViewManager() {
   }
 }
 
-export function switchServer(serverName, notifyRenderer) {
+export function switchServer(serverName) {
   showMainWindow();
   status.viewManager.showByName(serverName);
-  if (notifyRenderer) {
-    const server = status.config.teams.find((candidate) => candidate.name === serverName);
-    sendToRenderer(SWITCH_SERVER, server.order);
-  }
+  const server = status.config.teams.find((candidate) => candidate.name === serverName);
+  sendToRenderer(SET_SERVER_KEY, server.order);
 }
 
 export function focusBrowserView() {

--- a/src/renderer/components/MainPage.jsx
+++ b/src/renderer/components/MainPage.jsx
@@ -34,6 +34,7 @@ import {
   WINDOW_MAXIMIZE,
   DOUBLE_CLICK_ON_WINDOW,
   PLAY_SOUND,
+  SET_SERVER_KEY
 } from 'common/communication';
 
 import restoreButton from '../../assets/titlebar/chrome-restore.svg';
@@ -205,10 +206,9 @@ export default class MainPage extends React.Component {
     });
 
     // can't switch tabs sequentially for some reason...
-    ipcRenderer.on(SWITCH_SERVER, (event, key) => {
+    ipcRenderer.on(SET_SERVER_KEY, (event, key) => {
       const nextIndex = this.props.teams.findIndex((team) => team.order === key);
-      const team = this.props.teams[nextIndex];
-      this.handleSelect(team.name, nextIndex);
+      this.handleSetServerKey(nextIndex);
     });
     ipcRenderer.on('select-next-tab', () => {
       const currentOrder = this.props.teams[this.state.key].order;
@@ -420,14 +420,18 @@ export default class MainPage extends React.Component {
     this.setState({fullScreen: isFullScreen});
   }
 
-  handleSelect = (name, key) => {
-    ipcRenderer.send(SWITCH_SERVER, name);
+  handleSetServerKey = (key) => {
     const newKey = (this.props.teams.length + key) % this.props.teams.length;
     this.setState({
       key: newKey,
       finderVisible: false,
     });
     this.handleOnTeamFocused(newKey);
+  }
+
+  handleSelect = (name, key) => {
+    ipcRenderer.send(SWITCH_SERVER, name);
+    this.handleSetServerKey(key);
   }
 
   handleDragAndDrop = async (dropResult) => {

--- a/src/renderer/components/MainPage.jsx
+++ b/src/renderer/components/MainPage.jsx
@@ -421,7 +421,7 @@ export default class MainPage extends React.Component {
   }
 
   handleSelect = (name, key) => {
-    ipcRenderer.send('switch-server', name);
+    ipcRenderer.send(SWITCH_SERVER, name);
     const newKey = (this.props.teams.length + key) % this.props.teams.length;
     this.setState({
       key: newKey,

--- a/src/renderer/components/SettingsPage.jsx
+++ b/src/renderer/components/SettingsPage.jsx
@@ -22,7 +22,7 @@ const CONFIG_TYPE_SERVERS = 'servers';
 const CONFIG_TYPE_APP_OPTIONS = 'appOptions';
 
 function backToIndex(serverName) {
-  ipcRenderer.send(SWITCH_SERVER, serverName, true);
+  ipcRenderer.send(SWITCH_SERVER, serverName);
   window.close();
 }
 

--- a/src/renderer/components/SettingsPage.jsx
+++ b/src/renderer/components/SettingsPage.jsx
@@ -13,7 +13,7 @@ import {Checkbox, Col, FormGroup, Grid, HelpBlock, Navbar, Radio, Row, Button} f
 import {ipcRenderer} from 'electron';
 import {debounce} from 'underscore';
 
-import {GET_LOCAL_CONFIGURATION, UPDATE_CONFIGURATION, DOUBLE_CLICK_ON_WINDOW, GET_DOWNLOAD_LOCATION} from 'common/communication';
+import {GET_LOCAL_CONFIGURATION, UPDATE_CONFIGURATION, DOUBLE_CLICK_ON_WINDOW, GET_DOWNLOAD_LOCATION, SWITCH_SERVER} from 'common/communication';
 
 import TeamList from './TeamList.jsx';
 import AutoSaveIndicator from './AutoSaveIndicator.jsx';
@@ -22,7 +22,7 @@ const CONFIG_TYPE_SERVERS = 'servers';
 const CONFIG_TYPE_APP_OPTIONS = 'appOptions';
 
 function backToIndex(serverName) {
-  ipcRenderer.send('switch-server', serverName);
+  ipcRenderer.send(SWITCH_SERVER, serverName, true);
   window.close();
 }
 


### PR DESCRIPTION
**Summary**
I've reworked how we notify the front-end wrapper that the tabs have changed externally, and made a few fixes around making sure the right tabs are picked at any given time.

What should be working now:
- Tab navigation via keyboard shortcuts
- Clicking on a server in Settings and loading it correctly
- Seamless tab dragging without reloading any servers

**Issue link**
https://mattermost.atlassian.net/browse/MM-31215
https://mattermost.atlassian.net/browse/MM-31387
