### PR TITLE
[MM-32442] Fix event as content bound

### DIFF
--- a/src/main/windows/windowManager.js
+++ b/src/main/windows/windowManager.js
@@ -120,10 +120,10 @@ function handleUnmaximizeMainWindow() {
 }
 
 function handleResizeMainWindow(event, newBounds) {
-  setBoundsForCurrentView(newBounds);
+  setBoundsForCurrentView(event, newBounds);
 }
 
-function setBoundsForCurrentView(newBounds) {
+function setBoundsForCurrentView(event, newBounds) {
   const currentView = status.viewManager.getCurrentView();
   const bounds = newBounds || status.mainWindow.getContentBounds();
   if (currentView) {


### PR DESCRIPTION
**Summary**
fix to prevent some events being passed as content boundaries. on linux this caused a crash on start

**Issue link**
https://mattermost.atlassian.net/browse/MM-32442

**Test Cases**
resizing the window doesn't crash the app.

