### PR TITLE
[MM-20227][MM-31388] move to roles and fix focus

### DIFF
--- a/src/main/MattermostView.js
+++ b/src/main/MattermostView.js
@@ -110,6 +110,9 @@ export class MattermostView extends EventEmitter {
     if (request && !this.isVisible) {
       this.window.addBrowserView(this.view);
       this.setBounds(getWindowBoundaries(this.window));
+      if (this.status === READY) {
+        this.focus();
+      }
     } else if (!request && this.isVisible) {
       this.window.removeBrowserView(this.view);
     }

--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -7,8 +7,6 @@ import {app, Menu, session, shell, webContents} from 'electron';
 
 import * as WindowManager from '../windows/windowManager';
 
-const ZOOM_DIFFERENTIAL = 0.5;
-
 function createTemplate(config) {
   const separatorItem = {
     type: 'separator',
@@ -63,10 +61,6 @@ function createTemplate(config) {
     platformAppMenu = platformAppMenu.concat([
       separatorItem, {
         role: 'quit',
-        accelerator: 'CmdOrCtrl+Q',
-        click() {
-          app.quit();
-        },
       }]);
   }
 
@@ -79,48 +73,17 @@ function createTemplate(config) {
   template.push({
     label: '&Edit',
     submenu: [{
-      label: 'Undo',
-      accelerator: 'CmdOrCtrl+Z',
-      click() {
-        const focused = webContents.getFocusedWebContents();
-        focused.undo();
-      },
+      role: 'undo',
     }, {
-      label: 'Redo',
-      accelerator: 'CmdOrCtrl+SHIFT+Z',
-      click() {
-        const focused = webContents.getFocusedWebContents();
-        focused.redo();
-      },
+      role: 'Redo',
     }, separatorItem, {
-      label: 'Cut',
-      accelerator: 'CmdOrCtrl+X',
-      click() {
-        const focused = webContents.getFocusedWebContents();
-        focused.cut();
-      },
+      role: 'cut',
     }, {
-      label: 'Copy',
-      accelerator: 'CmdOrCtrl+C',
-      click() {
-        const focused = webContents.getFocusedWebContents();
-        focused.copy();
-      },
+      role: 'copy'
     }, {
-      label: 'Paste',
-      accelerator: 'CmdOrCtrl+V',
-      click() {
-        const focused = webContents.getFocusedWebContents();
-        focused.paste();
-      },
+      role: 'paste',
     }, {
-      label: 'Paste and Match Style',
-      accelerator: 'CmdOrCtrl+SHIFT+V',
-      visible: process.platform === 'darwin',
-      click() {
-        const focused = webContents.getFocusedWebContents();
-        focused.pasteAndMatchStyle();
-      },
+      role: 'pasteAndMatchStyle',
     }, {
       role: 'selectall',
       accelerator: 'CmdOrCtrl+A',
@@ -158,31 +121,11 @@ function createTemplate(config) {
     accelerator: process.platform === 'darwin' ? 'Ctrl+Cmd+F' : 'F11',
   }, separatorItem, {
     label: 'Actual Size',
-    accelerator: 'CmdOrCtrl+0',
-    click() {
-      const focused = webContents.getFocusedWebContents();
-      focused.setZoomLevel(1);
-    },
+    role: 'resetZoom',
   }, {
-    label: 'Zoom In',
-    accelerator: 'CmdOrCtrl+SHIFT+=',
-    click() {
-      const focused = webContents.getFocusedWebContents();
-      const level = focused.getZoomLevel();
-      if (level <= 3) {
-        focused.setZoomLevel(level + ZOOM_DIFFERENTIAL);
-      }
-    },
+    role: 'zoomIn',
   }, {
-    label: 'Zoom Out',
-    accelerator: 'CmdOrCtrl+-',
-    click() {
-      const focused = webContents.getFocusedWebContents();
-      const level = focused.getZoomLevel();
-      if (level >= 0) {
-        focused.setZoomLevel(level - ZOOM_DIFFERENTIAL);
-      }
-    },
+    role: 'zoomOut',
   }, separatorItem, {
     label: 'Developer Tools for Application Wrapper',
     accelerator: (() => {

--- a/src/main/windows/mainWindow.js
+++ b/src/main/windows/mainWindow.js
@@ -107,7 +107,6 @@ function createMainWindow(config, options) {
   // Ideally, app should detect that OS is shutting down.
   mainWindow.on('blur', () => {
     saveWindowState(boundsInfoPath, mainWindow);
-    mainWindow.blurWebView();
   });
 
   mainWindow.on('close', (event) => {

--- a/src/main/windows/windowManager.js
+++ b/src/main/windows/windowManager.js
@@ -90,6 +90,7 @@ export function showMainWindow() {
     status.mainWindow.on('maximize', handleMaximizeMainWindow);
     status.mainWindow.on('unmaximize', handleUnmaximizeMainWindow);
     status.mainWindow.on('will-resize', handleResizeMainWindow);
+    status.mainWindow.on('focus', this.focusBrowserView);
   }
   initializeViewManager();
 }


### PR DESCRIPTION
**Summary**

Copying anything from the about window was crashing and the only way to make it work is to use the role instead of a custom function. I tried to use commands while focusing on the renderer but seems I can't copy anything from the tabs or zoom in there (which is the expected and desirable) so I moved some commands to use roles, and removed any click function that was already with a role property (it gets ignored)

additionally it fixes focus issues when starting or alt-tabbing

**Issue link**

[MM-20227](https://mattermost.atlassian.net/browse/MM-20227)
[MM-31388](https://mattermost.atlassian.net/browse/MM-31388)

