### PR TITLE
[MM-32333] Open public links in the user's default browser

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -550,19 +550,21 @@ function handleAppWebContentsCreated(dc, contents) {
     }
 
     // Public download links case
-    // TODO: This doesn't work correctly right now, needs to be refactored
-    // if (parsedURL.pathname.match(/^(\/api\/v[3-4]\/public)*\/files\//)) {
-    //   downloadURL(url, (err) => {
-    //     if (err) {
-    //       dialog.showMessageBox(WindowManager.getMainWindow(), {
-    //         type: 'error',
-    //         message: err.toString(),
-    //       });
-    //       log.error(err);
-    //     }
-    //   });
-    //   return;
-    // }
+    // TODO: We might be handling different types differently in the future, for now
+    // we are going to mimic the browser and just pop a new browser window for public links
+    if (parsedURL.pathname.match(/^(\/api\/v[3-4]\/public)*\/files\//)) {
+      // downloadURL(url, (err) => {
+      //   if (err) {
+      //     dialog.showMessageBox(WindowManager.getMainWindow(), {
+      //       type: 'error',
+      //       message: err.toString(),
+      //     });
+      //     log.error(err);
+      //   }
+      // });
+      shell.openExternal(url);
+      return;
+    }
 
     if (parsedURL.pathname.match(/^\/help\//)) {
       // Help links case

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -34,9 +34,6 @@ import UserActivityMonitor from './UserActivityMonitor';
 import * as WindowManager from './windows/windowManager';
 import {displayMention, displayDownloadCompleted} from './notifications';
 
-// see below
-// import downloadURL from './downloadURL';
-
 import parseArgs from './ParseArgs';
 import {addModal} from './modalManager';
 import {getLocalURLString, getLocalPreload} from './utils';
@@ -553,15 +550,6 @@ function handleAppWebContentsCreated(dc, contents) {
     // TODO: We might be handling different types differently in the future, for now
     // we are going to mimic the browser and just pop a new browser window for public links
     if (parsedURL.pathname.match(/^(\/api\/v[3-4]\/public)*\/files\//)) {
-      // downloadURL(url, (err) => {
-      //   if (err) {
-      //     dialog.showMessageBox(WindowManager.getMainWindow(), {
-      //       type: 'error',
-      //       message: err.toString(),
-      //     });
-      //     log.error(err);
-      //   }
-      // });
       shell.openExternal(url);
       return;
     }


### PR DESCRIPTION
**Summary**
We were currently handling public links by treating the `/files` route as another team, which was opening images in the BrowserView. This PR switches over to opening public links in the user's default browser so that all files can be handled correctly and the app will not get into a weird state.

**Issue link**
https://mattermost.atlassian.net/browse/MM-32333
