### PR TITLE
[MM-32382] Use resize event instead of will-resize for monitoring size of BV

### DIFF
--- a/src/main/windows/windowManager.js
+++ b/src/main/windows/windowManager.js
@@ -86,11 +86,9 @@ export function showMainWindow() {
       criticalErrorHandler.windowUnresponsiveHandler();
     });
     status.mainWindow.on('crashed', handleMainWindowWebContentsCrashed);
-    status.mainWindow.on('enter-full-screen', setBoundsForCurrentView);
-    status.mainWindow.on('leave-full-screen', setBoundsForCurrentView);
     status.mainWindow.on('maximize', handleMaximizeMainWindow);
     status.mainWindow.on('unmaximize', handleUnmaximizeMainWindow);
-    status.mainWindow.on('will-resize', handleResizeMainWindow);
+    status.mainWindow.on('resize', handleResizeMainWindow);
     status.mainWindow.on('focus', this.focusBrowserView);
   }
   initializeViewManager();
@@ -113,12 +111,10 @@ function handleMainWindowWebContentsCrashed() {
 
 function handleMaximizeMainWindow() {
   sendToRenderer(MAXIMIZE_CHANGE, true);
-  setBoundsForCurrentView();
 }
 
 function handleUnmaximizeMainWindow() {
   sendToRenderer(MAXIMIZE_CHANGE, false);
-  setBoundsForCurrentView();
 }
 
 function handleResizeMainWindow(event, newBounds) {


### PR DESCRIPTION
**Summary**
`will-resize` was not being called when the window moved back to its original monitor on replug on macOS.
`resize` seems to be a lot more reliable and smoother, also takes care of the maximize/minimize case.

**Issue link**
https://mattermost.atlassian.net/browse/MM-32382
