### PR TITLE
[MM-32570] Use OpenSans as the font for the URL preview modal

### DIFF
--- a/src/renderer/css/components/HoveringURL.css
+++ b/src/renderer/css/components/HoveringURL.css
@@ -24,6 +24,7 @@
 .HoveringURL p {
   margin: 0;
   font-size: small;
+  font-family: "Open Sans", sans-serif;
   padding-left: 4px;
   padding-right: 4px;
 }

--- a/src/renderer/modals/urlView/urlView.jsx
+++ b/src/renderer/modals/urlView/urlView.jsx
@@ -1,6 +1,8 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import 'bootstrap/dist/css/bootstrap.min.css';
+import 'renderer/css/modals.css';
 import 'renderer/css/components/HoveringURL.css';
 
 const queryString = window.location.search;

--- a/src/renderer/modals/urlView/urlView.jsx
+++ b/src/renderer/modals/urlView/urlView.jsx
@@ -1,8 +1,6 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import 'bootstrap/dist/css/bootstrap.min.css';
-import 'renderer/css/modals.css';
 import 'renderer/css/components/HoveringURL.css';
 
 const queryString = window.location.search;


### PR DESCRIPTION
**Summary**
Most of our app uses the Open Sans font, so this PR brings the URL preview modal in-line with that.

**Issue link**
https://mattermost.atlassian.net/browse/MM-32570
