### PR TITLE
[MM-31554] Add listener for config synchronization on the settings window

### DIFF
--- a/src/main/windows/windowManager.js
+++ b/src/main/windows/windowManager.js
@@ -138,6 +138,9 @@ export function sendToRenderer(channel, ...args) {
     showMainWindow();
   }
   status.mainWindow.webContents.send(channel, ...args);
+  if (status.settingsWindow && status.settingsWindow.isVisible()) {
+    status.settingsWindow.webContents.send(channel, ...args);
+  }
 }
 
 export function sendToAll(channel, ...args) {

--- a/src/renderer/components/SettingsPage.jsx
+++ b/src/renderer/components/SettingsPage.jsx
@@ -40,10 +40,7 @@ export default class SettingsPage extends React.Component {
       userOpenedDownloadDialog: false,
     };
 
-    ipcRenderer.invoke(GET_LOCAL_CONFIGURATION).then((config) => {
-      this.state = this.convertConfigDataToState(config);
-      this.setState({ready: true, maximized: false, ...this.state});
-    });
+    this.getConfig();
     this.trayIconThemeRef = React.createRef();
     this.downloadLocationRef = React.createRef();
 
@@ -59,6 +56,13 @@ export default class SettingsPage extends React.Component {
 
     ipcRenderer.on('reload-config', () => {
       this.updateSaveState();
+      this.getConfig();
+    });
+  }
+
+  getConfig = () => {
+    ipcRenderer.invoke(GET_LOCAL_CONFIGURATION).then((config) => {
+      this.setState({ready: true, maximized: false, ...this.convertConfigDataToState(config)});
     });
   }
 

--- a/src/renderer/components/SettingsPage.jsx
+++ b/src/renderer/components/SettingsPage.jsx
@@ -56,6 +56,10 @@ export default class SettingsPage extends React.Component {
         showAddTeamForm: true,
       });
     });
+
+    ipcRenderer.on('reload-config', () => {
+      this.updateSaveState();
+    });
   }
 
   convertConfigDataToState = (configData, currentState = {}) => {


### PR DESCRIPTION
**Summary**
When updating the config from the settings window, we weren't sending the call to synchronize the config back to the settings window, only the main window. Now we are able to update the config outside of the settings window as well and have those changes reflected in the settings window.

**Issue link**
https://mattermost.atlassian.net/browse/MM-31554
