### PR TITLE
Fix draw badge

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/mattermost/desktop.git"
   },
   "config": {
-    "target": "10.1.3",
+    "target": "10.3.1",
     "arch": "x64",
     "target_arch": "x64",
     "disturl": "https://electronjs.org/headers",

--- a/src/main/badge.js
+++ b/src/main/badge.js
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
@@ -37,18 +36,18 @@ function createDataURL(text, small) {
 
 function showBadgeWindows(sessionExpired, showUnreadBadge, mentionCount) {
   let description = 'You have no unread messages';
-  let dataURL = null;
+  let text;
   if (sessionExpired) {
-    dataURL = createDataURL('•');
+    text = '•';
     description = 'Session Expired: Please sign in to continue receiving notifications.';
   } else if (mentionCount > 0) {
-    dataURL = createDataURL((mentionCount > MAX_WIN_COUNT) ? `${MAX_WIN_COUNT}+` : mentionCount.toString(), mentionCount > MAX_WIN_COUNT);
+    text = (mentionCount > MAX_WIN_COUNT) ? `${MAX_WIN_COUNT}+` : mentionCount.toString();
     description = `You have unread mentions (${mentionCount})`;
   } else if (showUnreadBadge) {
-    dataURL = createDataURL('•');
+    text = '•';
     description = 'You have unread channels';
   }
-  WindowManager.setOverlayIcon(dataURL, description);
+  WindowManager.setOverlayIcon(text, description);
 }
 
 function showBadgeOSX(sessionExpired, showUnreadBadge, mentionCount) {

--- a/src/main/badge.js
+++ b/src/main/badge.js
@@ -10,30 +10,6 @@ import * as AppState from './appState';
 
 const MAX_WIN_COUNT = 99;
 
-function createDataURL(text, small) {
-  const scale = 2; // should rely display dpi
-  const size = (small ? 20 : 16) * scale;
-  const canvas = document.createElement('canvas');
-  canvas.setAttribute('width', size);
-  canvas.setAttribute('height', size);
-  const ctx = canvas.getContext('2d');
-
-  // circle
-  ctx.fillStyle = '#FF1744'; // Material Red A400
-  ctx.beginPath();
-  ctx.arc(size / 2, size / 2, size / 2, 0, Math.PI * 2);
-  ctx.fill();
-
-  // text
-  ctx.fillStyle = '#ffffff';
-  ctx.textAlign = 'center';
-  ctx.textBaseline = 'middle';
-  ctx.font = (11 * scale) + 'px sans-serif';
-  ctx.fillText(text, size / 2, size / 2, size);
-
-  return canvas.toDataURL();
-}
-
 function showBadgeWindows(sessionExpired, showUnreadBadge, mentionCount) {
   let description = 'You have no unread messages';
   let text;

--- a/src/main/windows/windowManager.js
+++ b/src/main/windows/windowManager.js
@@ -207,17 +207,17 @@ function createDataURL(text, small) {
   if (!win) {
     return null;
   }
+
   // since we don't have a document/canvas object in the main process, we use the webcontents from the window to draw.
   return win.webContents.executeJavascript(`
   window.drawBadge = fucntion ${drawBadge};
   window.drawBadge(${text}, ${small});
   `);
-
 }
 
 export function setOverlayIcon(badgeText, description) {
   if (process.platform === 'win32') {
-    const overlay = overlayDataURL ? nativeImage.createFromDataURL(overlayDataURL) : null;
+    const overlay = badgeText ? nativeImage.createFromDataURL(createDataURL(badgeText)) : null;
     if (status.mainWindow) {
       status.mainWindow.setOverlayIcon(overlay, description);
     }

--- a/src/main/windows/windowManager.js
+++ b/src/main/windows/windowManager.js
@@ -178,7 +178,44 @@ export function flashFrame(flash) {
   }
 }
 
-export function setOverlayIcon(overlayDataURL, description) {
+function drawBadge(text, small) {
+  const scale = 2; // should rely display dpi
+  const size = (small ? 20 : 16) * scale;
+  const canvas = document.createElement('canvas');
+  canvas.setAttribute('width', size);
+  canvas.setAttribute('height', size);
+  const ctx = canvas.getContext('2d');
+
+  // circle
+  ctx.fillStyle = '#FF1744'; // Material Red A400
+  ctx.beginPath();
+  ctx.arc(size / 2, size / 2, size / 2, 0, Math.PI * 2);
+  ctx.fill();
+
+  // text
+  ctx.fillStyle = '#ffffff';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.font = (11 * scale) + 'px sans-serif';
+  ctx.fillText(text, size / 2, size / 2, size);
+
+  return canvas.toDataURL();
+}
+
+function createDataURL(text, small) {
+  const win = status.mainWindow;
+  if (!win) {
+    return null;
+  }
+  // since we don't have a document/canvas object in the main process, we use the webcontents from the window to draw.
+  return win.webContents.executeJavascript(`
+  window.drawBadge = fucntion ${drawBadge};
+  window.drawBadge(${text}, ${small});
+  `);
+
+}
+
+export function setOverlayIcon(badgeText, description) {
   if (process.platform === 'win32') {
     const overlay = overlayDataURL ? nativeImage.createFromDataURL(overlayDataURL) : null;
     if (status.mainWindow) {


### PR DESCRIPTION
**Summary**
on windows, the badge code is no longer in the renderer process and it doesn't have direct access to the document to draw in a canvas.  To fix that we reach out to the webcontents of the main window and use it to get a canvas to draw.

@jupenur since we inject code into the webcontents, I wonder if that might be exploitable.