### PR TITLE
[MM-31383] Make no the default when asking to add a protocol

### DIFF
--- a/src/main/allowProtocolDialog.js
+++ b/src/main/allowProtocolDialog.js
@@ -49,6 +49,7 @@ function handleDialogEvent(protocol, URL) {
     title: 'Non http(s) protocol',
     message: `${protocol} link requires an external application.`,
     detail: `The requested link is ${URL} . Do you want to continue?`,
+    defaultId: 2,
     type: 'warning',
     buttons: [
       'Yes',


### PR DESCRIPTION
**Summary**
Make `No` the default choice when asking if a protocol should be added

**Issue link**

[MM-31383](https://mattermost.atlassian.net/browse/MM-31383

**Additional Notes**
<img width="270" alt="Screen Shot 2021-02-17 at 14 24 38" src="https://user-images.githubusercontent.com/1515906/108210812-4c727000-712c-11eb-8675-6f92b46416f4.png">
)


