### PR TITLE
Add Swedish sv-SE (already in simple-spellchecker)

### DIFF
--- a/src/browser/js/contextMenu.js
+++ b/src/browser/js/contextMenu.js
@@ -35,6 +35,7 @@ function getSpellCheckerLocaleMenus(onSelectSpellCheckerLocale) {
     {language: 'Ukrainian', locale: 'uk-UA'},
     {language: 'Spanish (ES)', locale: 'es-ES'},
     {language: 'Spanish (MX)', locale: 'es-MX'},
+    {language: 'Swedish', locale: 'sv-SE'},
     {language: 'Dutch', locale: 'nl-NL'},
     {language: 'Italian', locale: 'it-IT'},
   ];

--- a/src/main/SpellChecker.js
+++ b/src/main/SpellChecker.js
@@ -119,6 +119,9 @@ SpellChecker.getSpellCheckerLocale = (electronLocale) => {
   if (electronLocale.match(/^ru-?/)) {
     return 'ru-RU';
   }
+  if (electronLocale.match(/^sv-?/)) {
+    return 'sv-SE';
+  }
   if (electronLocale.match(/^uk-?/)) {
     return 'uk-UA';
   }

--- a/test/specs/spellchecker_test.js
+++ b/test/specs/spellchecker_test.js
@@ -36,10 +36,10 @@ describe('main/Spellchecker.js', function() {
 
       SpellChecker.getSpellCheckerLocale('ru').should.equal('ru-RU');
       SpellChecker.getSpellCheckerLocale('ru-RU').should.equal('ru-RU');
-      
+
       SpellChecker.getSpellCheckerLocale('sv').should.equal('sv-SE');
       SpellChecker.getSpellCheckerLocale('sv-SE').should.equal('sv-SE');
-      
+
       SpellChecker.getSpellCheckerLocale('uk').should.equal('uk-UA');
       SpellChecker.getSpellCheckerLocale('uk-UA').should.equal('uk-UA');
     });

--- a/test/specs/spellchecker_test.js
+++ b/test/specs/spellchecker_test.js
@@ -36,7 +36,10 @@ describe('main/Spellchecker.js', function() {
 
       SpellChecker.getSpellCheckerLocale('ru').should.equal('ru-RU');
       SpellChecker.getSpellCheckerLocale('ru-RU').should.equal('ru-RU');
-
+      
+      SpellChecker.getSpellCheckerLocale('sv').should.equal('sv-SE');
+      SpellChecker.getSpellCheckerLocale('sv-SE').should.equal('sv-SE');
+      
       SpellChecker.getSpellCheckerLocale('uk').should.equal('uk-UA');
       SpellChecker.getSpellCheckerLocale('uk-UA').should.equal('uk-UA');
     });

--- a/test/specs/spellchecker_test.js
+++ b/test/specs/spellchecker_test.js
@@ -140,6 +140,26 @@ describe('main/Spellchecker.js', function() {
     });
   });
 
+  describe('sv-SE', function() {
+    let spellchecker = null;
+
+    before(function(done) {
+      spellchecker = new SpellChecker(
+        'sv-SE',
+        path.resolve(__dirname, '../../src/node_modules/simple-spellchecker/dict'),
+        done
+      );
+    });
+
+    it('should spellcheck', function() {
+      spellchecker.spellCheck('ändamålslös').should.equal(true);
+      spellchecker.spellCheck('ändamålslos').should.equal(false);
+    });
+    it('should give suggestions', function() {
+      spellchecker.getSuggestions('ändamålslos', 1).length.should.be.equal(1);
+    });
+  });
+
   describe('uk-UA', function() {
     let spellchecker = null;
 


### PR DESCRIPTION
Before submitting, please confirm you've
 - [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
 - [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
 - [x] executed `npm run lint:js` for proper code formatting

Please provide the following information:

**Summary**
Add swedish sv-SE already in simple-spellchecker

