### PR TITLE
[MM-25355] Throttle notifications for Windows by channel id

### DIFF
--- a/src/main/notifications/Mention.js
+++ b/src/main/notifications/Mention.js
@@ -1,26 +1,24 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {Notification} from 'electron';
+import {app, Notification, nativeImage} from 'electron';
 
 import osVersion from 'common/osVersion';
 
-const appIconURL = 'file://assets/appicon_48.png';
+const appIconURL = `file:///${app.getAppPath()}/assets/appicon_48.png`;
 
 const defaultOptions = {
     title: 'Someone mentioned you',
     silent: false,
-    icon: appIconURL,
+    icon: nativeImage.createFromDataURL(appIconURL),
     urgency: 'normal',
 };
 export const DEFAULT_WIN7 = 'Ding';
 
 export class Mention extends Notification {
-    constructor(customOptions) {
+    constructor(customOptions, channel) {
         const options = {...defaultOptions, ...customOptions};
-        if (process.platform === 'win32') {
-            options.icon = appIconURL;
-        } else if (process.platform === 'darwin') { // TODO: review
+        if (process.platform === 'darwin') { // TODO: review
             // Notification Center shows app's icon, so there were two icons on the notification.
             Reflect.deleteProperty(options, 'icon');
         }
@@ -31,6 +29,7 @@ export class Mention extends Notification {
         }
         super(options);
         this.customSound = customSound;
+        this.channel = channel;
     }
 
     getNotificationSound = () => {

--- a/src/main/notifications/Mention.js
+++ b/src/main/notifications/Mention.js
@@ -16,7 +16,7 @@ const defaultOptions = {
 export const DEFAULT_WIN7 = 'Ding';
 
 export class Mention extends Notification {
-    constructor(customOptions, channel) {
+    constructor(customOptions, channel, teamId) {
         const options = {...defaultOptions, ...customOptions};
         if (process.platform === 'darwin') { // TODO: review
             // Notification Center shows app's icon, so there were two icons on the notification.
@@ -30,6 +30,7 @@ export class Mention extends Notification {
         super(options);
         this.customSound = customSound;
         this.channel = channel;
+        this.teamId = teamId;
     }
 
     getNotificationSound = () => {

--- a/src/main/notifications/Mention.js
+++ b/src/main/notifications/Mention.js
@@ -12,7 +12,7 @@ const appIconURL = path.resolve(assetsDir, 'appicon_48.png');
 const defaultOptions = {
     title: 'Someone mentioned you',
     silent: false,
-    icon: nativeImage.createFromDataURL(appIconURL),
+    icon: appIconURL,
     urgency: 'normal',
 };
 export const DEFAULT_WIN7 = 'Ding';

--- a/src/main/notifications/index.js
+++ b/src/main/notifications/index.js
@@ -27,13 +27,13 @@ export function displayMention(title, body, channel, teamId, silent, webcontents
         data,
     };
 
-    const mention = new Mention(options, channel);
+    const mention = new Mention(options, channel, teamId);
 
     mention.on('show', () => {
         // On Windows, manually dismiss notifications from the same channel and only show the latest one
         if (process.platform === 'win32') {
             for (const notification of currentNotifications.values()) {
-                if (notification.channel.id === mention.channel.id) {
+                if (notification.channel.id === mention.channel.id && notification.teamId === mention.teamId) {
                     notification.close();
                     currentNotifications.delete(notification);
                 }


### PR DESCRIPTION
**Summary**
On Windows, when receiving multiple notifications sequentially, the application would show them in order but there would be a delay between each notification and if there was a large number of notifications, the application would spam the user.

This PR stops the spam of notifications by only storing the last notification from each channel id in the Notifications Center and auto-dismissing all previous notifications.

**Issue link**
https://mattermost.atlassian.net/browse/MM-25355
