### PR TITLE
[MM-33141] Fixed use of bad context in TeamList

### DIFF
--- a/src/renderer/components/TeamList.jsx
+++ b/src/renderer/components/TeamList.jsx
@@ -64,18 +64,6 @@ export default class TeamList extends React.PureComponent {
         this.props.onTeamsChange(teams);
     }
 
-    handleTeamEditing = (teamName, teamUrl, teamIndex, teamOrder) => {
-        this.setState({
-            showEditTeamForm: true,
-            team: {
-                url: teamUrl,
-                name: teamName,
-                index: teamIndex,
-                order: teamOrder,
-            },
-        });
-    }
-
     openServerRemoveModal = (indexForServer) => {
         this.setState({indexToRemoveServer: indexForServer});
     }
@@ -84,32 +72,39 @@ export default class TeamList extends React.PureComponent {
         this.setState({indexToRemoveServer: -1});
     }
 
+    handleTeamRemovePrompt = (index) => {
+        return () => {
+            document.activeElement.blur();
+            this.openServerRemoveModal(index);
+        };
+    }
+
+    handleTeamEditing = (team, index) => {
+        return () => {
+            document.activeElement.blur();
+            this.setState({
+                showEditTeamForm: true,
+                team: {
+                    url: team.url,
+                    name: team.name,
+                    index,
+                    order: team.order,
+                },
+            });
+        };
+    }
+
     render() {
-        const self = this;
         const teamNodes = this.props.teams.map((team, i) => {
-            function handleTeamRemove() {
-                document.activeElement.blur();
-                self.openServerRemoveModal(i);
-            }
-
-            function handleTeamEditing() {
-                document.activeElement.blur();
-                self.handleTeamEditing(team.name, team.url, i, team.order);
-            }
-
-            function handleTeamClick() {
-                self.props.onTeamClick(team.name);
-            }
-
             return (
                 <TeamListItem
                     index={i}
                     key={`teamListItem_${team.name}`}
                     name={team.name}
                     url={team.url}
-                    onTeamRemove={handleTeamRemove}
-                    onTeamEditing={handleTeamEditing}
-                    onTeamClick={handleTeamClick}
+                    onTeamRemove={this.handleTeamRemovePrompt(i)}
+                    onTeamEditing={this.handleTeamEditing(team, i)}
+                    onTeamClick={() => this.props.onTeamClick(team.name)}
                 />
             );
         });
@@ -183,6 +178,7 @@ export default class TeamList extends React.PureComponent {
 }
 
 TeamList.propTypes = {
+    onTeamClick: PropTypes.func,
     onTeamsChange: PropTypes.func,
     showAddTeamForm: PropTypes.bool,
     teams: PropTypes.array,

--- a/src/renderer/components/TeamList.jsx
+++ b/src/renderer/components/TeamList.jsx
@@ -89,16 +89,16 @@ export default class TeamList extends React.PureComponent {
         const teamNodes = this.props.teams.map((team, i) => {
             function handleTeamRemove() {
                 document.activeElement.blur();
-                this.openServerRemoveModal(i);
+                self.openServerRemoveModal(i);
             }
 
             function handleTeamEditing() {
                 document.activeElement.blur();
-                this.handleTeamEditing(team.name, team.url, i, team.order);
+                self.handleTeamEditing(team.name, team.url, i, team.order);
             }
 
             function handleTeamClick() {
-                this.props.onTeamClick(team.name);
+                self.props.onTeamClick(team.name);
             }
 
             return (

--- a/src/renderer/components/TeamList.jsx
+++ b/src/renderer/components/TeamList.jsx
@@ -98,7 +98,6 @@ export default class TeamList extends React.PureComponent {
         const teamNodes = this.props.teams.map((team, i) => {
             return (
                 <TeamListItem
-                    index={i}
                     key={`teamListItem_${team.name}`}
                     name={team.name}
                     url={team.url}


### PR DESCRIPTION
**Summary**
When I migrated over the ESLint configuration from the webapp, I had changed the use of `self` here to `this`. I thought I had tested it, but turns out that the context here wasn't the class, so I've reverted to `self`.

Funny enough, the ESLint warning seems to be gone anyhow...

**Issue link**
https://mattermost.atlassian.net/browse/MM-33141
