### PR TITLE
[MM-25122] Use modded version of winreg that supports UTF-8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19960,6 +19960,11 @@
       "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.4.tgz",
       "integrity": "sha1-ugZWKbepJRMOFXeRCM9UCZDpjRs="
     },
+    "winreg-utf8": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/winreg-utf8/-/winreg-utf8-0.1.1.tgz",
+      "integrity": "sha512-A4tBCO0bx3FCA/s8RowK40h3BQhKOWRFmsn6gYrXj6WjRAbOGnNJkTOpVmtA82UeGNMtpn3Wr0TWb742C1AS+g=="
+    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "semver": "^5.5.0",
     "underscore": "^1.9.1",
     "valid-url": "^1.0.9",
-    "winreg": "^1.2.4",
+    "winreg-utf8": "^0.1.1",
     "yargs": "^15.3.1"
   }
 }

--- a/src/common/config/RegistryConfig.js
+++ b/src/common/config/RegistryConfig.js
@@ -4,7 +4,7 @@
 
 import {EventEmitter} from 'events';
 import log from 'electron-log';
-import WindowsRegistry from 'winreg';
+import WindowsRegistry from 'winreg-utf8';
 
 const REGISTRY_HIVE_LIST = [WindowsRegistry.HKLM, WindowsRegistry.HKCU];
 const BASE_REGISTRY_KEY_PATH = '\\Software\\Policies\\Mattermost';
@@ -122,7 +122,7 @@ export default class RegistryConfig extends EventEmitter {
    * @param {string} name Name of the specific entry to retrieve (optional)
    */
     getRegistryEntryValues(hive, key, name) {
-        const registry = new WindowsRegistry({hive, key});
+        const registry = new WindowsRegistry({hive, key, utf8: true});
         return new Promise((resolve, reject) => {
             try {
                 registry.values((error, results) => {


### PR DESCRIPTION
**Summary**
I found a modded version of `node-winreg` that actually supports UTF-8 correctly by changing the code page of the console when the call to `reg.exe` is executed. This allows special characters to work correctly with GPO servers.

**Issue link**
https://mattermost.atlassian.net/browse/MM-25122
