### PR TITLE
[MM-31342] fix "save image as" context menu crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7970,13 +7970,13 @@
       }
     },
     "electron-context-menu": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/electron-context-menu/-/electron-context-menu-2.4.0.tgz",
-      "integrity": "sha512-6HRAEeFoMoBZyQ69FBGNQIVVDRBw8nYmvMPaV+CfRDa/spreHsjMD+XesJ/2/lMSAAMDTCgFCC24167Uer2cZw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/electron-context-menu/-/electron-context-menu-2.5.0.tgz",
+      "integrity": "sha512-kzvp8XUmbp2TG2hELJUl7Yjlq4Ag549JQu/C8mxvy1CmAU15UFmPC3bPdXMGE/e3xbi97shgxfttxeQ/6h4MoQ==",
       "requires": {
-        "cli-truncate": "^2.0.0",
-        "electron-dl": "^3.0.0",
-        "electron-is-dev": "^1.0.1"
+        "cli-truncate": "^2.1.0",
+        "electron-dl": "^3.1.0",
+        "electron-is-dev": "^1.2.0"
       }
     },
     "electron-devtools-installer": {
@@ -8005,9 +8005,9 @@
       }
     },
     "electron-dl": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/electron-dl/-/electron-dl-3.0.2.tgz",
-      "integrity": "sha512-pRgE9Jbhoo5z6Vk3qi+vIrfpMDlCp2oB1UeR96SMnsfz073jj0AZGQwp69EdIcEvlUlwBSGyJK8Jt6OB6JLn+g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/electron-dl/-/electron-dl-3.1.0.tgz",
+      "integrity": "sha512-nY3vvxX5w11+cFT6JkJwMHtH6dk5sPtjRtzjaj4NrS9CyYF3atvVt8yMfZtXruULU1JAuxEEf2B8O6YgXs9xsQ==",
       "requires": {
         "ext-name": "^5.0.0",
         "pupa": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "auto-launch": "^5.0.5",
     "bootstrap": "^3.3.7",
     "brace-expansion": "^2.0.0",
-    "electron-context-menu": "^2.4.0",
+    "electron-context-menu": "^2.5.0",
     "electron-devtools-installer": "^3.1.1",
     "electron-is-dev": "^1.0.1",
     "electron-log": "^4.1.3",


### PR DESCRIPTION
**Summary**

upgrade electron-context-menu so it upgrades electron-dl which was causing the crash.

**Issue link**
[MM-31342](https://mattermost.atlassian.net/browse/MM-31342)
**Test Cases**

click on a profile picture and use `save image` or `save image` as context menu options
