### PR TITLE
[MM-32809] Remove Toggle Dark Mode menu item for Windows, enable toggling on Linux

### DIFF
--- a/src/common/config/index.js
+++ b/src/common/config/index.js
@@ -458,4 +458,13 @@ export default class Config extends EventEmitter {
             this.emit('darkModeChange', this.combinedData.darkMode);
         }
     }
+
+    /**
+     * Manually toggles dark mode for OSes that don't have a native dark mode setting
+     * @emits 'darkModeChange'
+     */
+    toggleDarkModeManually = () => {
+        this.set('darkMode', !this.combinedData.darkMode);
+        this.emit('darkModeChange', this.combinedData.darkMode);
+    }
 }

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -693,7 +693,7 @@ function initializeAfterAppReady() {
         });
     });
 
-    ipcMain.emit('update-menu', true, config.data);
+    ipcMain.emit('update-menu', true, config);
 
     ipcMain.emit('update-dict');
 
@@ -754,16 +754,16 @@ function handleCloseAppMenu() {
     WindowManager.focusBrowserView();
 }
 
-function handleUpdateMenuEvent(event, configData) {
+function handleUpdateMenuEvent(event, config) {
     // TODO: this might make sense to move to window manager? so it updates the window referenced if needed.
     const mainWindow = WindowManager.getMainWindow();
-    const aMenu = appMenu.createMenu(configData);
+    const aMenu = appMenu.createMenu(config);
     Menu.setApplicationMenu(aMenu);
     aMenu.addListener('menu-will-close', handleCloseAppMenu);
 
     // set up context menu for tray icon
     if (shouldShowTrayIcon()) {
-        const tMenu = trayMenu.createMenu(configData);
+        const tMenu = trayMenu.createMenu(config.data);
         setTrayMenu(tMenu, mainWindow);
     }
 }

--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -3,7 +3,7 @@
 // See LICENSE.txt for license information.
 'use strict';
 
-import {app, Menu, session, shell, webContents} from 'electron';
+import {app, ipcMain, Menu, session, shell, webContents} from 'electron';
 
 import * as WindowManager from '../windows/windowManager';
 
@@ -37,7 +37,7 @@ function createTemplate(config) {
         },
     });
 
-    if (config.enableServerManagement === true) {
+    if (config.data.enableServerManagement === true) {
         platformAppMenu.push({
             label: 'Sign in to Another Server',
             click() {
@@ -151,8 +151,7 @@ function createTemplate(config) {
         viewSubMenu.push({
             label: 'Toggle Dark Mode',
             click() {
-                // TODO: review what to do with this one
-                WindowManager.sendToRenderer('set-dark-mode');
+                config.toggleDarkModeManually();
             },
         });
     }
@@ -184,7 +183,7 @@ function createTemplate(config) {
         }],
     });
 
-    const teams = config.teams || [];
+    const teams = config.data.teams || [];
     const windowMenu = {
         label: '&Window',
         submenu: [{
@@ -221,11 +220,11 @@ function createTemplate(config) {
     };
     template.push(windowMenu);
     const submenu = [];
-    if (config.helpLink) {
+    if (config.data.MenuhelpLink) {
         submenu.push({
             label: 'Learn More...',
             click() {
-                shell.openExternal(config.helpLink);
+                shell.openExternal(config.data.helpLink);
             },
         });
         submenu.push(separatorItem);

--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -146,6 +146,17 @@ function createTemplate(config) {
         },
     }];
 
+    if (process.platform !== 'darwin' && process.platform !== 'win32') {
+        viewSubMenu.push(separatorItem);
+        viewSubMenu.push({
+            label: 'Toggle Dark Mode',
+            click() {
+                // TODO: review what to do with this one
+                WindowManager.sendToRenderer('set-dark-mode');
+            },
+        });
+    }
+
     template.push({
         label: '&View',
         submenu: viewSubMenu,

--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -146,17 +146,6 @@ function createTemplate(config) {
         },
     }];
 
-    if (process.platform !== 'darwin') {
-        viewSubMenu.push(separatorItem);
-        viewSubMenu.push({
-            label: 'Toggle Dark Mode',
-            click() {
-                // TODO: review what to do with this one
-                WindowManager.sendToRenderer('set-dark-mode');
-            },
-        });
-    }
-
     template.push({
         label: '&View',
         submenu: viewSubMenu,


### PR DESCRIPTION
**Summary**
@Willyfrog has already done the work to use the native dark mode option provided by Electron, so I'm just cleaning up by removing the menu item for Windows.

EDIT: The toggle wasn't working for non-Windows/macOS machines so I've enabled that as well.

**Issue link**
https://mattermost.atlassian.net/browse/MM-32809
