### PR TITLE
[MM-33238] Check for admin URL when toggling back bar

### DIFF
--- a/src/main/MattermostView.js
+++ b/src/main/MattermostView.js
@@ -132,7 +132,7 @@ export class MattermostView extends EventEmitter {
         const request = typeof requestedVisibility === 'undefined' ? true : requestedVisibility;
         if (request && !this.isVisible) {
             this.window.addBrowserView(this.view);
-            this.setBounds(getWindowBoundaries(this.window, !urlUtils.isTeamUrl(this.server.url, this.view.webContents.getURL())));
+            this.setBounds(getWindowBoundaries(this.window, !(urlUtils.isTeamUrl(this.server.url, this.view.webContents.getURL()) || urlUtils.isAdminUrl(this.server.url, this.view.webContents.getURL()))));
             if (this.status === READY) {
                 this.focus();
             }
@@ -189,7 +189,7 @@ export class MattermostView extends EventEmitter {
     }
 
     handleDidNavigate = (event, url) => {
-        const isUrlTeamUrl = urlUtils.isTeamUrl(this.server.url, url);
+        const isUrlTeamUrl = urlUtils.isTeamUrl(this.server.url, url) || urlUtils.isAdminUrl(this.server.url, url);
         if (isUrlTeamUrl) {
             this.setBounds(getWindowBoundaries(this.window));
             WindowManager.sendToRenderer(TOGGLE_BACK_BUTTON, false);


### PR DESCRIPTION
**Summary**
When switching between tabs, we check if the back bar should be displayed. Unfortunately, we didn't account for the `admin_console` route and you would see the back displayed when switching back to a tab on the `admin_console`.

Now we check for the `admin_console` route specifically.
NOTE: Are there any other routes we should be checking for that don't need the back button?

**Issue link**
https://mattermost.atlassian.net/browse/MM-33238
