### PR TITLE
[MM-33032] Use `hidden` titleBarStyle value to fix macOS Catalina click issue

### DIFF
--- a/src/main/windows/mainWindow.js
+++ b/src/main/windows/mainWindow.js
@@ -64,7 +64,8 @@ function createMainWindow(config, options) {
         minHeight: minimumWindowHeight,
         frame: !isFramelessWindow(),
         fullscreen: false,
-        titleBarStyle: 'hiddenInset',
+        titleBarStyle: 'hidden',
+        trafficLightPosition: {x: 12, y: 24},
         backgroundColor: '#fff', // prevents blurry text: https://electronjs.org/docs/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do
         webPreferences: {
             nodeIntegration: true,


### PR DESCRIPTION
**Summary**
If you have a tab near the center of the tab bar on macOS, and try to click on the top-most portion of it, the tab would not register a click event and thus not respond.

This is due to the way that Electron was insetting the traffic light buttons, causing some kind of overlap over the tabs. This PR changes the `titleBarStyle` to `hidden` and manually sets the inset, which seems to solve the issue.

**Issue link**
https://mattermost.atlassian.net/browse/MM-33032
