### PR TITLE
[MM-33247] Have the app handle links to other teams as a deep link

### DIFF
--- a/src/main/views/webContentEvents.js
+++ b/src/main/views/webContentEvents.js
@@ -9,6 +9,8 @@ import urlUtils from 'common/utils/url';
 import Utils from 'common/utils/util';
 import {FOUND_IN_PAGE} from 'common/communication';
 
+import * as WindowManager from '../windows/windowManager';
+
 import {protocols} from '../../../electron-builder.json';
 
 import allowProtocolDialog from '../allowProtocolDialog';
@@ -137,7 +139,7 @@ const generateNewWindowListener = (getServersFunction, spellcheck) => {
         }
 
         if (urlUtils.isTeamUrl(server.url, parsedURL, true)) {
-            log.info(`${url} is a known team, preventing to open a new window`);
+            WindowManager.showMainWindow(parsedURL);
             return;
         }
         if (urlUtils.isAdminUrl(server.url, parsedURL)) {


### PR DESCRIPTION
**Summary**
Previously, we had a `webview` handler deal with linking between different servers, but since that's gone, we were only using the `webContents` handler, which was missing any way of linking between servers.

This PR leverages the deeplinking mechanism (which is similar to what we were doing previously) to allow inter-server links to be opened within the app.

**Issue link**
https://mattermost.atlassian.net/browse/MM-33247
