### PR TITLE
[MM-33542] Trigger finder cleanup on pressing close or Escape

### DIFF
--- a/src/renderer/modals/finder/finder.jsx
+++ b/src/renderer/modals/finder/finder.jsx
@@ -72,6 +72,11 @@ export default class Finder extends React.PureComponent {
         }
     }
 
+    close = () => {
+        this.props.stopFindInPage('clearSelection');
+        this.props.close();
+    }
+
     render() {
         return (
             <div
@@ -133,7 +138,7 @@ export default class Finder extends React.PureComponent {
                     </button>
                     <button
                         className='finder-close'
-                        onClick={this.props.close}
+                        onClick={this.close}
                     >
                         <svg
                             xmlns='http://www.w3.org/2000/svg'

--- a/src/renderer/modals/finder/finder.jsx
+++ b/src/renderer/modals/finder/finder.jsx
@@ -21,11 +21,6 @@ export default class Finder extends React.PureComponent {
         this.searchInput.addEventListener('keyup', this.handleKeyEvent);
     }
 
-    componentWillUnmount() {
-        this.props.stopFindInPage('clearSelection');
-        this.searchInput.removeEventListener('keyup', this.handleKeyEvent);
-    }
-
     static getDerivedStateFromProps(props, state) {
         if (state.searchTxt) {
             return {
@@ -73,6 +68,7 @@ export default class Finder extends React.PureComponent {
     }
 
     close = () => {
+        this.searchInput.removeEventListener('keyup', this.handleKeyEvent);
         this.props.stopFindInPage('clearSelection');
         this.props.close();
     }

--- a/src/renderer/modals/finder/finder.jsx
+++ b/src/renderer/modals/finder/finder.jsx
@@ -61,7 +61,7 @@ export default class Finder extends React.PureComponent {
 
     handleKeyEvent = (event) => {
         if (event.code === 'Escape') {
-            this.props.close();
+            this.close();
         } else if (event.code === 'Enter') {
             this.findNext();
         }


### PR DESCRIPTION
**Summary**
The Finder used to perform its cleanup on `componentWillUnmount`, which will not run when destroying a `BrowserView`. This PR moves the cleanup to the `close()` function that runs on pressing Escape or clicking the 'x' button.

**Issue link**
https://mattermost.atlassian.net/browse/MM-33542
