### PR TITLE
[MM-33373] Trigger the smaller font for 99+ mentions

### DIFF
--- a/src/main/badge.js
+++ b/src/main/badge.js
@@ -23,7 +23,7 @@ function showBadgeWindows(sessionExpired, showUnreadBadge, mentionCount) {
         text = '•';
         description = 'You have unread channels';
     }
-    WindowManager.setOverlayIcon(text, description);
+    WindowManager.setOverlayIcon(text, description, mentionCount > 99);
 }
 
 function showBadgeOSX(sessionExpired, showUnreadBadge, mentionCount) {

--- a/src/main/windows/windowManager.js
+++ b/src/main/windows/windowManager.js
@@ -221,12 +221,12 @@ function createDataURL(text, small) {
     return win.webContents.executeJavaScript(code);
 }
 
-export async function setOverlayIcon(badgeText, description) {
+export async function setOverlayIcon(badgeText, description, small) {
     if (process.platform === 'win32') {
         let overlay = null;
         if (status.mainWindow && badgeText) {
             try {
-                const dataUrl = await createDataURL(badgeText);
+                const dataUrl = await createDataURL(badgeText, small);
                 overlay = nativeImage.createFromDataURL(dataUrl);
             } catch (err) {
                 log.error(`Couldn't generate a badge: ${err}`);


### PR DESCRIPTION
**Summary**
We were missing using the smaller font for when the mention count was over 99, which is needed to make the badge look nice. This PR restores that in `browser-view`.

**Issue link**
https://mattermost.atlassian.net/browse/MM-33373
