### PR TITLE
[MM-34067] Explicitly destroy web contents in non-permanent BrowserViews

### DIFF
--- a/src/main/views/MattermostView.js
+++ b/src/main/views/MattermostView.js
@@ -171,6 +171,7 @@ export class MattermostView extends EventEmitter {
         if (this.window) {
             this.window.removeBrowserView(this.view);
         }
+        this.view.webContents.destroy();
         this.window = null;
         this.server = null;
         this.isVisible = false;

--- a/src/main/views/MattermostView.js
+++ b/src/main/views/MattermostView.js
@@ -171,7 +171,11 @@ export class MattermostView extends EventEmitter {
         if (this.window) {
             this.window.removeBrowserView(this.view);
         }
+
+        // workaround to eliminate zombie processes
+        // https://github.com/mattermost/desktop/pull/1519
         this.view.webContents.destroy();
+
         this.window = null;
         this.server = null;
         this.isVisible = false;

--- a/src/main/views/modalView.js
+++ b/src/main/views/modalView.js
@@ -70,9 +70,12 @@ export class ModalView {
             if (this.view.webContents.isDevToolsOpened()) {
                 this.view.webContents.closeDevTools();
             }
-
             this.windowAttached.removeBrowserView(this.view);
+
+            // workaround to eliminate zombie processes
+            // https://github.com/mattermost/desktop/pull/1519
             this.view.webContents.destroy();
+
             this.windowAttached = null;
             this.status = ACTIVE;
         }

--- a/src/main/views/modalView.js
+++ b/src/main/views/modalView.js
@@ -72,6 +72,7 @@ export class ModalView {
             }
 
             this.windowAttached.removeBrowserView(this.view);
+            this.view.webContents.destroy();
             this.windowAttached = null;
             this.status = ACTIVE;
         }

--- a/src/main/views/viewManager.js
+++ b/src/main/views/viewManager.js
@@ -203,6 +203,9 @@ export class ViewManager {
             const hideView = () => {
                 this.urlViewCancel = null;
                 currentWindow.removeBrowserView(urlView);
+
+                // workaround to eliminate zombie processes
+                // https://github.com/mattermost/desktop/pull/1519
                 urlView.webContents.destroy();
             };
 

--- a/src/main/views/viewManager.js
+++ b/src/main/views/viewManager.js
@@ -203,6 +203,7 @@ export class ViewManager {
             const hideView = () => {
                 this.urlViewCancel = null;
                 currentWindow.removeBrowserView(urlView);
+                urlView.webContents.destroy();
             };
 
             const timeout = setTimeout(hideView,


### PR DESCRIPTION
**Summary**
When we upgraded to Electron v11, `BrowserView.destroy()` was removed, with Electron electing to have Node manage the objects once removed. However, as indicated by this post: https://github.com/electron/electron/pull/23578#issuecomment-742150830, if you don't explicitly destroy the `webContents` object inside, a zombie will persist.

This was causing issues when hovering links or opening modals, as we would create the BrowserView and then simply set its reference to null. Doing this multiple times would result in a lot of zombies.

This PR explicitly destroys the `webContents` object on each `BrowserView` destroy to avoid this issue.

**Issue link**
https://mattermost.atlassian.net/browse/MM-34067
