### PR TITLE
[MM-34201] fix non-links crashing the app

### DIFF
--- a/src/main/views/webContentEvents.js
+++ b/src/main/views/webContentEvents.js
@@ -97,6 +97,12 @@ const generateDidStartNavigation = (getServersFunction) => {
 const generateNewWindowListener = (getServersFunction, spellcheck) => {
     return (event, url) => {
         const parsedURL = urlUtils.parseURL(url);
+        if (!parsedURL) {
+            event.preventDefault();
+            log.warn(`Ignoring non-url ${url}`);
+            return;
+        }
+
         const configServers = getServersFunction();
 
         // Dev tools case


### PR DESCRIPTION
Please provide the following information:

**Summary**

If a url doesn't parse it shouldn't crash the app

**Issue link**

[MM-34201](https://mattermost.atlassian.net/browse/MM-34201)

**Test Cases**
create a group link (like `@appsteam`) and click on it
