### PR TITLE
[MM-34527] fix reload and long names

### DIFF
--- a/src/common/utils/util.js
+++ b/src/common/utils/util.js
@@ -44,8 +44,19 @@ function browserWindowFromWebContents(content) {
     return window;
 }
 
+const DEFAULT_MAX = 20;
+
+function shorten(string, max) {
+    const maxLength = (max && max >= 4) ? max : DEFAULT_MAX;
+    if (string.length >= maxLength) {
+        return `${string.slice(0, maxLength - 3)}...`;
+    }
+    return string;
+}
+
 export default {
     getDisplayBoundaries,
     runMode,
     browserWindowFromWebContents,
+    shorten,
 };

--- a/src/main/views/MattermostView.js
+++ b/src/main/views/MattermostView.js
@@ -6,6 +6,7 @@ import log from 'electron-log';
 
 import {EventEmitter} from 'events';
 
+import Util from 'common/utils/util';
 import {RELOAD_INTERVAL, MAX_SERVER_RETRIES, SECOND} from 'common/utils/constants';
 import urlUtils from 'common/utils/url';
 import {LOAD_RETRY, LOAD_SUCCESS, LOAD_FAILED, UPDATE_TARGET_URL, IS_UNREAD, UNREAD_RESULT, TOGGLE_BACK_BUTTON, SET_SERVER_NAME} from 'common/communication';
@@ -87,7 +88,7 @@ export class MattermostView extends EventEmitter {
 
     load = (someURL) => {
         const loadURL = (typeof someURL === 'undefined') ? `${this.server.url.toString()}` : urlUtils.parseURL(someURL).toString();
-        log.info(`[${this.server.name}] Loading ${loadURL}`);
+        log.info(`[${Util.shorten(this.server.name)}] Loading ${loadURL}`);
         const loading = this.view.webContents.loadURL(loadURL, {userAgent});
         loading.then(this.loadSuccess(loadURL)).catch((err) => {
             this.loadRetry(loadURL, err);
@@ -107,7 +108,7 @@ export class MattermostView extends EventEmitter {
                 } else {
                     WindowManager.sendToRenderer(LOAD_FAILED, this.server.name, err.toString(), loadURL.toString());
                     this.emit(LOAD_FAILED, this.server.name, err.toString(), loadURL.toString());
-                    log.info(`[${this.server.name}] Couldn't stablish a connection with ${loadURL}: ${err}.`);
+                    log.info(`[${Util.shorten(this.server.name)}] Couldn't stablish a connection with ${loadURL}: ${err}.`);
                     this.status = ERROR;
                 }
             });
@@ -117,12 +118,12 @@ export class MattermostView extends EventEmitter {
     loadRetry = (loadURL, err) => {
         this.retryLoad = setTimeout(this.retry(loadURL), RELOAD_INTERVAL);
         WindowManager.sendToRenderer(LOAD_RETRY, this.server.name, Date.now() + RELOAD_INTERVAL, err.toString(), loadURL.toString());
-        log.info(`[${this.server.name}] failed loading ${loadURL}: ${err}, retrying in ${RELOAD_INTERVAL / SECOND} seconds`);
+        log.info(`[${Util.shorten(this.server.name)}] failed loading ${loadURL}: ${err}, retrying in ${RELOAD_INTERVAL / SECOND} seconds`);
     }
 
     loadSuccess = (loadURL) => {
         return () => {
-            log.info(`[${this.server.name}] finished loading ${loadURL}`);
+            log.info(`[${Util.shorten(this.server.name)}] finished loading ${loadURL}`);
             WindowManager.sendToRenderer(LOAD_SUCCESS, this.server.name);
             this.maxRetries = MAX_SERVER_RETRIES;
             if (this.status === LOADING) {

--- a/src/main/views/webContentEvents.js
+++ b/src/main/views/webContentEvents.js
@@ -210,6 +210,7 @@ export const addWebContentsEventListeners = (mmview, getServersFunction) => {
     if (listeners[contents.id]) {
         removeWebContentsListeners(contents.id);
     }
+
     const willNavigate = generateWillNavigate(getServersFunction);
     contents.on('will-navigate', willNavigate);
 
@@ -228,7 +229,6 @@ export const addWebContentsEventListeners = (mmview, getServersFunction) => {
     contents.on('page-title-updated', mmview.handleTitleUpdate);
     contents.on('page-favicon-updated', mmview.handleFaviconUpdate);
     contents.on('update-target-url', mmview.handleUpdateTarget);
-    contents.on(FOUND_IN_PAGE, mmview.handleFoundInPage);
     contents.on('did-navigate', mmview.handleDidNavigate);
 
     const removeListeners = () => {
@@ -239,7 +239,6 @@ export const addWebContentsEventListeners = (mmview, getServersFunction) => {
             contents.removeListener('page-title-updated', mmview.handleTitleUpdate);
             contents.removeListener('page-favicon-updated', mmview.handleFaviconUpdate);
             contents.removeListener('update-target-url', mmview.handleUpdateTarget);
-            contents.removeListener(FOUND_IN_PAGE, mmview.handleFoundInPage);
             contents.removeListener('did-navigate', mmview.handleDidNavigate);
         } catch (e) {
             log.error(`Error while trying to detach listeners, this might be ok if the process crashed: ${e}`);

--- a/src/main/views/webContentEvents.js
+++ b/src/main/views/webContentEvents.js
@@ -7,7 +7,6 @@ import log from 'electron-log';
 import {DEVELOPMENT, PRODUCTION} from 'common/utils/constants';
 import urlUtils from 'common/utils/url';
 import Utils from 'common/utils/util';
-import {FOUND_IN_PAGE} from 'common/communication';
 
 import * as WindowManager from '../windows/windowManager';
 

--- a/src/renderer/css/components/TabBar.css
+++ b/src/renderer/css/components/TabBar.css
@@ -16,6 +16,8 @@
 .TabBar .teamTabItem span {
   flex: 0 1 auto;
   overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 200px;
   white-space: nowrap;
   text-align: center;
 }

--- a/src/renderer/css/settings.css
+++ b/src/renderer/css/settings.css
@@ -18,8 +18,13 @@
 }
 
 .TeamListItem p {
-  overflow-wrap: break-word;
+    overflow-wrap: break-word;
 }
+
+.TeamListItem h4 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+};
 
 .checkbox > label {
   width: 100%;


### PR DESCRIPTION
Please provide the following information:

**Summary**

Pages were reloading after loading for the first time due to an exception being raised, which was treated as a load failure.
Also fixed long names getting in the way in several places.

**Issue link**

[MM-34527](https://mattermost.atlassian.net/browse/MM-34527)

**Screenshots**
<img width="1643" alt="Screen Shot 2021-03-30 at 17 25 38" src="https://user-images.githubusercontent.com/1515906/113153932-d2a7c900-9237-11eb-9434-0f0a4fbc70fa.png">

<img width="884" alt="Screen Shot 2021-03-31 at 15 42 27" src="https://user-images.githubusercontent.com/1515906/113153768-b4da6400-9237-11eb-9a5b-e25b0b9ebe92.png">
