### PR TITLE
[MM-34461] Restore Find menu item

### DIFF
--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -100,6 +100,12 @@ function createTemplate(config) {
     });
 
     const viewSubMenu = [{
+        label: 'Find..',
+        accelerator: 'CmdOrCtrl+F',
+        click() {
+            WindowManager.sendToFind();
+        },
+    }, {
         label: 'Reload',
         accelerator: 'CmdOrCtrl+R',
         click() {

--- a/src/main/windows/windowManager.js
+++ b/src/main/windows/windowManager.js
@@ -381,6 +381,13 @@ export function reload() {
     }
 }
 
+export function sendToFind() {
+    const currentView = status.viewManager.getCurrentView();
+    if (currentView) {
+        currentView.view.webContents.sendInputEvent({type: 'keyDown', keyCode: 'F', modifiers: ['CmdOrCtrl', 'Shift']});
+    }
+}
+
 export function handleHistory(event, offset) {
     if (status.viewManager) {
         const activeView = status.viewManager.getCurrentView();


### PR DESCRIPTION
**Summary**
When we switched over to the new method for finding messages in the desktop app, we removed the menu item.

This PR restores the menu item and forwards the keyboard shortcut to the webapp.

**Issue link**
https://mattermost.atlassian.net/browse/MM-34461
