### PR TITLE
[MM-33577] Workaround for Linux minimizing/maximizing issue

### DIFF
--- a/src/main/windows/windowManager.js
+++ b/src/main/windows/windowManager.js
@@ -120,10 +120,26 @@ function handleMainWindowWebContentsCrashed() {
 
 function handleMaximizeMainWindow() {
     sendToRenderer(MAXIMIZE_CHANGE, true);
+
+    // Workaround as part of https://mattermost.atlassian.net/browse/MM-33577
+    // Linux (or GNOME at least) seems to have issues with Electron and getting the size correctly when minimizing/maximizing
+    // So we need to manually force the browser view to resize after a small interval to get the size correct
+    // Please remove this once this issue has been resolved by Electron
+    if (process.platform === 'linux') {
+        setTimeout(setBoundsForCurrentView, 10);
+    }
 }
 
 function handleUnmaximizeMainWindow() {
     sendToRenderer(MAXIMIZE_CHANGE, false);
+
+    // Workaround as part of https://mattermost.atlassian.net/browse/MM-33577
+    // Linux (or GNOME at least) seems to have issues with Electron and getting the size correctly when minimizing/maximizing
+    // So we need to manually force the browser view to resize after a small interval to get the size correct
+    // Please remove this once this issue has been resolved by Electron
+    if (process.platform === 'linux') {
+        setTimeout(setBoundsForCurrentView, 10);
+    }
 }
 
 function handleResizeMainWindow(event, newBounds) {


### PR DESCRIPTION
**Summary**
This is a workaround for the maximizing issue on Linux, by using `setTimeout` to run the resize code for BrowserViews a short time after the initial maximize event has run.

**Issue link**
https://mattermost.atlassian.net/browse/MM-33577