### PR TITLE
[MM-33902] connection issues, add server through command line, non-mattermost servers

### DIFF
--- a/src/common/communication.js
+++ b/src/common/communication.js
@@ -38,6 +38,7 @@ export const MODAL_INFO = 'modal-info';
 export const MODAL_CANCEL = 'modal-cancel';
 export const MODAL_RESULT = 'modal-result';
 export const MODAL_SEND_IPC_MESSAGE = 'modal-send-ipc-message';
+export const MODAL_INVOKE_IPC_MESSAGE = 'modal-invoke-ipc-message';
 export const MODAL_OPEN = 'modal-open';
 export const MODAL_CLOSE = 'modal-close';
 export const NOTIFY_MENTION = 'notify_mention';
@@ -75,3 +76,5 @@ export const SELECT_NEXT_TAB = 'select-next-tab';
 export const SELECT_PREVIOUS_TAB = 'select-previous-tab';
 export const ADD_SERVER = 'add-server';
 export const FOCUS_THREE_DOT_MENU = 'focus-three-dot-menu';
+
+export const TEST_SERVER = 'test-server';

--- a/src/common/config/buildConfig.js
+++ b/src/common/config/buildConfig.js
@@ -21,7 +21,8 @@ const buildConfig = {
     defaultTeams: [/*
     {
       name: 'example',
-      url: 'https://example.com'
+      url: 'https://example.com',
+      isNonMattermost: false
     }
   */],
     helpLink: 'https://about.mattermost.com/default-desktop-app-documentation/',

--- a/src/common/utils/constants.js
+++ b/src/common/utils/constants.js
@@ -7,4 +7,6 @@ export const DEVELOPMENT = 'development';
 export const SECOND = 1000;
 export const RELOAD_INTERVAL = 5 * SECOND;
 
-export const MAX_SERVER_RETRIES = 5;
+export const MAX_SERVER_RETRIES = 3;
+
+export const MAX_LOADING_SCREEN_SECONDS = 20;

--- a/src/common/utils/constants.js
+++ b/src/common/utils/constants.js
@@ -5,6 +5,6 @@ export const PRODUCTION = 'production';
 export const DEVELOPMENT = 'development';
 
 export const SECOND = 1000;
-export const RELOAD_INTERVAL = 10 * SECOND;
+export const RELOAD_INTERVAL = 5 * SECOND;
 
 export const MAX_SERVER_RETRIES = 5;

--- a/src/main/MattermostServer.js
+++ b/src/main/MattermostServer.js
@@ -4,9 +4,10 @@
 import urlUtils from 'common/utils/url';
 
 export class MattermostServer {
-    constructor(name, serverUrl) {
-        this.name = name;
-        this.url = urlUtils.parseURL(serverUrl);
+    constructor(configServer) {
+        this.name = configServer.name;
+        this.url = urlUtils.parseURL(configServer.url);
+        this.isNonMattermost = configServer.isNonMattermost;
         if (!this.url) {
             throw new Error('Invalid url for creating a server');
         }

--- a/src/main/ParseArgs.js
+++ b/src/main/ParseArgs.js
@@ -1,7 +1,10 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import log from 'electron-log';
 import yargs from 'yargs';
+
+import urlUtils from 'common/utils/url';
 
 import {protocols} from '../../electron-builder.json';
 
@@ -15,7 +18,10 @@ function triageArgs(args) {
     // ensure any args following a possible deeplink are discarded
     if (protocols && protocols[0] && protocols[0].schemes && protocols[0].schemes[0]) {
         const scheme = protocols[0].schemes[0].toLowerCase();
-        const deeplinkIndex = args.findIndex((arg) => arg.toLowerCase().includes(`${scheme}:`));
+        const deeplinkIndex = args.findIndex((arg) => {
+            const url = arg.toLowerCase();
+            return url.startsWith(`${scheme}:`) || url.startsWith('http:') || url.startsWith('https:');
+        });
         if (deeplinkIndex !== -1) {
             return args.slice(0, deeplinkIndex + 1);
         }
@@ -28,10 +34,42 @@ function parseArgs(args) {
         alias('dataDir', 'd').string('dataDir').describe('dataDir', 'Set the path to where user data is stored.').
         alias('disableDevMode', 'p').boolean('disableDevMode').describe('disableDevMode', 'Disable development mode. Allows for testing as if it was Production.').
         alias('version', 'v').boolean('version').describe('version', 'Prints the application version.').
+        alias('serverName', 's').string('serverName').describe('serverName', 'Add url a new mattermost server to the configuration').
+        alias('otherServerName', 'S').string('otherServerName').describe('otherServerName', 'Add a server that might not be a Mattermost one, this feature is unsupported and you might experience unexpected behaviour.').
         help('help').
         parse(args);
 }
 
 function validateArgs(args) {
     return Validator.validateArgs(args) || {};
+}
+
+export function getDeeplinkingURL(args, scheme) {
+    if (Array.isArray(args) && args.length) {
+    // deeplink urls should always be the last argument, but may not be the first (i.e. Windows with the app already running)
+        const url = args[args.length - 1];
+        if (url && scheme && url.startsWith(scheme) && urlUtils.isValidURI(url)) {
+            return url;
+        }
+    }
+    return null;
+}
+
+export function getServerURL(args, scheme) {
+    if (Array.isArray(args) && args.length) {
+    // deeplink urls should always be the last argument, but may not be the first (i.e. Windows with the app already running)
+        const url = args[args.length - 1];
+        if (!url) {
+            return null;
+        }
+        if (scheme && url.startsWith(scheme) && urlUtils.isValidURI(url)) {
+            log.warn('Found a deeplinking url, will assume https but this might not be right. Please review your configuration');
+            const host = url.split(':', 2);
+            return `https:${host[1]}`;
+        }
+        if (url.startsWith('http:') || url.startsWith('https:')) {
+            return url;
+        }
+    }
+    return null;
 }

--- a/src/main/ParseArgs.js
+++ b/src/main/ParseArgs.js
@@ -10,34 +10,34 @@ import {protocols} from '../../electron-builder.json';
 
 import * as Validator from './Validator';
 
-export default function parse(args) {
-    return validateArgs(parseArgs(triageArgs(args)));
+export default function parse() {
+    return validateArgs(triageArgs(parseArgs()));
 }
 
 function triageArgs(args) {
     // ensure any args following a possible deeplink are discarded
     if (protocols && protocols[0] && protocols[0].schemes && protocols[0].schemes[0]) {
         const scheme = protocols[0].schemes[0].toLowerCase();
-        const deeplinkIndex = args.findIndex((arg) => {
+        const deeplinkIndex = args._.findIndex((arg) => {
             const url = arg.toLowerCase();
             return url.startsWith(`${scheme}:`) || url.startsWith('http:') || url.startsWith('https:');
         });
         if (deeplinkIndex !== -1) {
-            return args.slice(0, deeplinkIndex + 1);
+            args._ = args._.slice(0, deeplinkIndex + 1);
         }
     }
     return args;
 }
 
-function parseArgs(args) {
-    return yargs.
+function parseArgs() {
+    yargs.
         alias('dataDir', 'd').string('dataDir').describe('dataDir', 'Set the path to where user data is stored.').
         alias('disableDevMode', 'p').boolean('disableDevMode').describe('disableDevMode', 'Disable development mode. Allows for testing as if it was Production.').
         alias('version', 'v').boolean('version').describe('version', 'Prints the application version.').
         alias('serverName', 's').string('serverName').describe('serverName', 'Add url a new mattermost server to the configuration').
         alias('otherServerName', 'S').string('otherServerName').describe('otherServerName', 'Add a server that might not be a Mattermost one, this feature is unsupported and you might experience unexpected behaviour.').
-        help('help').
-        parse(args);
+        help('help');
+    return yargs.argv;
 }
 
 function validateArgs(args) {
@@ -56,20 +56,20 @@ export function getDeeplinkingURL(args, scheme) {
 }
 
 export function getServerURL(args, scheme) {
-    if (Array.isArray(args) && args.length) {
-    // deeplink urls should always be the last argument, but may not be the first (i.e. Windows with the app already running)
-        const url = args[args.length - 1];
-        if (!url) {
-            return null;
-        }
-        if (scheme && url.startsWith(scheme) && urlUtils.isValidURI(url)) {
-            log.warn('Found a deeplinking url, will assume https but this might not be right. Please review your configuration');
-            const host = url.split(':', 2);
-            return `https:${host[1]}`;
-        }
-        if (url.startsWith('http:') || url.startsWith('https:')) {
-            return url;
-        }
+    if (args._.length === 0) {
+        return null;
+    }
+    const url = args._[args._.length - 1]; // should be the last one
+    if (!url) {
+        return null;
+    }
+    if (scheme && url.startsWith(scheme) && urlUtils.isValidURI(url)) {
+        log.warn('Found a deeplinking url, will assume https but this might not be right. Please review your configuration');
+        const host = url.split(':', 2);
+        return `https:${host[1]}`;
+    }
+    if (url.startsWith('http:') || url.startsWith('https:')) {
+        return url;
     }
     return null;
 }

--- a/src/main/Validator.js
+++ b/src/main/Validator.js
@@ -21,6 +21,7 @@ const argsSchema = Joi.object({
     version: Joi.boolean(),
     serverName: Joi.string(),
     otherServerName: Joi.string(),
+    _: Joi.any(),
 });
 
 const boundsInfoSchema = Joi.object({

--- a/src/main/Validator.js
+++ b/src/main/Validator.js
@@ -19,6 +19,8 @@ const argsSchema = Joi.object({
     disableDevMode: Joi.boolean(),
     dataDir: Joi.string(),
     version: Joi.boolean(),
+    serverName: Joi.string(),
+    otherServerName: Joi.string(),
 });
 
 const boundsInfoSchema = Joi.object({
@@ -67,6 +69,7 @@ const configDataSchemaV2 = Joi.object({
         name: Joi.string().required(),
         url: Joi.string().required(),
         order: Joi.number().integer().min(0),
+        isNonMattermost: Joi.boolean().default(false),
     })).default([]),
     showTrayIcon: Joi.boolean().default(false),
     trayIconTheme: Joi.any().allow('').valid('light', 'dark').default('light'),
@@ -151,12 +154,12 @@ export function validateV1ConfigData(data) {
 export function validateV2ConfigData(data) {
     if (Array.isArray(data.teams) && data.teams.length) {
     // first replace possible backslashes with forward slashes
-        let teams = data.teams.map(({name, url, order}) => {
+        let teams = data.teams.map(({name, url, order, isNonMattermost}) => {
             let updatedURL = url;
             if (updatedURL.includes('\\')) {
                 updatedURL = updatedURL.toLowerCase().replace(/\\/gi, '/');
             }
-            return {name, url: updatedURL, order};
+            return {name, url: updatedURL, order, isNonMattermost: Boolean(isNonMattermost)};
         });
 
         // next filter out urls that are still invalid so all is not lost

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -30,6 +30,7 @@ import {
     SHOW_SETTINGS_WINDOW,
     RELOAD_CONFIGURATION,
     USER_ACTIVITY_UPDATE,
+    TEST_SERVER,
 } from 'common/communication';
 import Config from 'common/config';
 
@@ -228,6 +229,7 @@ function initializeInterCommunicationEventListeners() {
     ipcMain.handle('get-app-version', handleAppVersion);
     ipcMain.on('update-menu', handleUpdateMenuEvent);
     ipcMain.on(FOCUS_BROWSERVIEW, WindowManager.focusBrowserView);
+    ipcMain.handle(TEST_SERVER, urlUtils.testServerUrl);
 
     if (process.platform !== 'darwin') {
         ipcMain.on('open-app-menu', handleOpenAppMenu);

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -124,7 +124,7 @@ try {
 //
 
 function initializeArgs() {
-    global.args = parseArgs(process.argv.slice(1));
+    global.args = parseArgs();
 
     // output the application version via cli when requested (-v or --version)
     if (global.args.version) {

--- a/src/main/preload/modalPreload.js
+++ b/src/main/preload/modalPreload.js
@@ -6,7 +6,7 @@
 
 import {ipcRenderer} from 'electron';
 
-import {MODAL_CANCEL, MODAL_RESULT, MODAL_INFO, RETRIEVE_MODAL_INFO, MODAL_SEND_IPC_MESSAGE} from 'common/communication';
+import {MODAL_CANCEL, MODAL_RESULT, MODAL_INFO, RETRIEVE_MODAL_INFO, MODAL_SEND_IPC_MESSAGE, MODAL_INVOKE_IPC_MESSAGE} from 'common/communication';
 
 console.log('preloaded for the modal!');
 
@@ -29,6 +29,9 @@ window.addEventListener('message', async (event) => {
     case MODAL_SEND_IPC_MESSAGE:
         console.log('sending custom ipc message');
         ipcRenderer.send(event.data.data.type, ...event.data.data.args);
+        break;
+    case MODAL_INVOKE_IPC_MESSAGE:
+        window.postMessage({type: event.data.data.type, data: ipcRenderer.invoke(event.data.data.type, ...event.data.data.args)}, window.location.href);
         break;
     default:
         console.log(`got a message: ${event}`);

--- a/src/main/views/MattermostView.js
+++ b/src/main/views/MattermostView.js
@@ -106,9 +106,9 @@ export class MattermostView extends EventEmitter {
                     this.loadRetry(loadURL, err);
                 } else {
                     WindowManager.sendToRenderer(LOAD_FAILED, this.server.name, err.toString(), loadURL.toString());
-                    this.emit(LOAD_FAILED, this.server.name, err.toString(), loadURL.toString());
                     log.info(`[${this.server.name}] Couldn't stablish a connection with ${loadURL}: ${err}.`);
                     this.status = ERROR;
+                    this.emit(LOAD_FAILED, this.server.name, err.toString(), loadURL.toString());
                 }
             });
         };
@@ -191,7 +191,7 @@ export class MattermostView extends EventEmitter {
     }
 
     isReady = () => {
-        return this.status === READY;
+        return this.status !== LOADING;
     }
 
     needsLoadingScreen = () => {

--- a/src/main/views/viewManager.js
+++ b/src/main/views/viewManager.js
@@ -37,7 +37,7 @@ export class ViewManager {
     }
 
     loadServer = (server) => {
-        const srv = new MattermostServer(server.name, server.url);
+        const srv = new MattermostServer(server);
         const view = new MattermostView(srv, this.mainWindow, this.viewOptions);
         this.views.set(server.name, view);
         if (!this.loadingScreen) {

--- a/src/main/views/viewManager.js
+++ b/src/main/views/viewManager.js
@@ -44,6 +44,7 @@ export class ViewManager {
             this.createLoadingScreen();
         }
         view.once(LOAD_SUCCESS, this.activateView);
+        view.once(LOAD_FAILED, this.failView);
         view.load();
         view.on(UPDATE_TARGET_URL, this.showURLView);
     }
@@ -137,12 +138,22 @@ export class ViewManager {
             view.focus();
         }
     }
+
     activateView = (viewName) => {
         if (this.currentView === viewName) {
             this.showByName(this.currentView);
         }
         const view = this.views.get(viewName);
+        view.removeListener(LOAD_FAILED, this.failView);
         addWebContentsEventListeners(view, this.getServers);
+    }
+
+    failView = (viewName) => {
+        if (this.currentView === viewName) {
+            this.showByName(this.currentView);
+        }
+        const view = this.views.get(viewName);
+        view.removeListener(LOAD_SUCCESS, this.activateView);
     }
 
     getCurrentView() {


### PR DESCRIPTION
**Summary**

Make animation finish when it is an error, or on anything other that is not a mattermostt server if it is configured as such
Added two new flags to add a server from the comman line. one adds a regular mattermost server, the other adds a non-mattermost server.

current `--help` looks like:

```shell
$ mattermost --help
Options:
  --version, -v          Prints the application version.               [boolean]
  --dataDir, -d          Set the path to where user data is stored.     [string]
  --disableDevMode, -p   Disable development mode. Allows for testing as if it
                         was Production.                               [boolean]
  --serverName, -s       Add url a new mattermost server to the configuration
                                                                        [string]
  --otherServerName, -S  Add a server that might not be a Mattermost one, this
                         feature is unsupported and you might experience
                         unexpected behaviour.                          [string]
  --help                 Show help                                     [boolean]
```

**Issue link**
[MM-33902](https://mattermost.atlassian.net/browse/MM-33902)

**Test Cases**

***Fail to connect***

1. add a server that doesn't respond
2. wait a few seconds (15s) until the 3 retries fail
expected an error page should show

***Add a mattermost server***

1. on the command line, launch the app with the following flags `-s <name of the server> <url of the server>`
given that name is unique and server url is unique, it will be added to the list of tabs and it will persist after quiting the app

Expected: server tab appears with the provided name, restarting the app persists.

***Add a non-mattermost server***

1. on the command line, launch the app with the following flags `-S <name of the server> <url of the server>` (notice this is a capital S)

given that name is unique and server url is unique, it will be added to the list of tabs and it will persist after quiting the app

Expected: server tab appears with the provided name, restarting the app persists. if it is not a mattermost server it will show once it's loaded.

Another way to test this is to add the key `isNonMattermost` to `true` to any server configured in `config.json`

**Additional Notes**

@esethna @lieut-data one of the problems with the new loading screen was that it waits until the webapp says it's ready. this helps hide the webapp loading (the user would be experiencing two load screens which is not nice), so I took the opportunitty to add the flag we mentioned offline to detect wether the server is a supported mattermost server or any other page.

We also need to do a PR to docs/release notes to try and clarify this feature as not officially supported, as it might have unexpected consecuences.