### PR TITLE
[MM-34459] Fix config key to show 'learn more'

### DIFF
--- a/src/main/menus/app.js
+++ b/src/main/menus/app.js
@@ -230,7 +230,7 @@ function createTemplate(config) {
     };
     template.push(windowMenu);
     const submenu = [];
-    if (config.data.MenuhelpLink) {
+    if (config.data.helpLink) {
         submenu.push({
             label: 'Learn More...',
             click() {


### PR DESCRIPTION
**Summary**

During the refactor the key to learn more url was inadvertently edited which prevented showing the menu item. This pr corrects the key.

**Issue link**
[MM-34459](https://mattermost.atlassian.net/browse/MM-34459)

**Screenshots**
<img width="219" alt="Screen Shot 2021-04-08 at 12 53 49" src="https://user-images.githubusercontent.com/1515906/114015252-c6d88a00-9869-11eb-94b1-aa0995d88c47.png">

