### PR TITLE
prevent eager filtering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,7 @@ jobs:
             echo $(pwd)
             ls .
             curl -H "Circle-Token: $CIRCLE_TOKEN" -H "Accept: application/json" -X GET "https://circleci.com/api/v2/project/github/mattermost/desktop/$CIRCLE_BUILD_NUM/artifacts" | jq -r '.items[].url' >> ./dist/artifactlist.txt
-            grep -v ".yml" ./dist/artifactlist.txt | grep -v "._" > ./templist.txt
+            grep -v ".yml" ./dist/artifactlist.txt | grep -v "\._" > ./templist.txt
             echo "##### :tux: Linux" > ./dist/linklist.txt
             grep "linux" ./templist.txt | awk -F/ '{print "- ["$NF"]("$0")"}' >> ./dist/linklist.txt
             echo "##### :apple_logo: macOS" >> ./dist/linklist.txt


### PR DESCRIPTION
**Summary**

grep -v seems to be using a regex to filter, this should prevent treating `.` as a wildcard

