### PR TITLE
add PR/Issue template and release notes section in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,63 @@
+<!-- Thank you for contributing a pull request! Here are a few tips to help you:
+
+1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
+2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
+3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
+-->
+
+#### Summary
+<!--
+A brief description of what this pull request does.
+-->
+
+#### Ticket Link
+<!--
+If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.
+
+  Fixes https://github.com/mattermost/desktop/issues/XXXXX
+
+Otherwise, link the JIRA ticket.
+-->
+
+#### Checklist
+<!--
+Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
+-->
+- [ ] Added or updated unit tests (required for all new features)
+- [ ] Has UI changes
+- [ ] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
+- [ ] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
+- [ ] executed `npm run lint:js` for proper code formatting
+
+#### Device Information
+This PR was tested on: <!-- Device name(s), OS version(s) -->
+
+#### Screenshots
+<!--
+If the PR includes UI changes, include screenshots/GIFs.
+-->
+
+#### Release Note
+<!--
+Add a release note for each of the following conditions:
+
+* New features and improvements, including behavioural changes, UI changes
+* Bug fixes and fixes of previous known issues
+* Deprecation warnings, breaking changes, or compatibility notes
+
+If no release notes are required write NONE. Use past-tense. Newlines are stripped.
+
+Examples:
+
+```release-note
+Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
+```
+
+```release-note
+NONE
+```
+-->
+
+```release-note
+
+```


### PR DESCRIPTION
#### Summary
Add a release not section in the PR template to facilitate the release note process.

After this PR get approval, I will setup the webhook

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/DOPS-371

#### Checklist

- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [ ] executed `npm run lint:js` for proper code formatting

#### Device Information
This PR was tested on: N/A
#### Screenshots
N/A

#### Release Note

```release-note
NONE
```