### PR TITLE
[MM-34645] Align App Options header and save indicator using display: inline-block instead of float: left

### DIFF
--- a/src/renderer/components/SettingsPage.jsx
+++ b/src/renderer/components/SettingsPage.jsx
@@ -335,7 +335,7 @@ export default class SettingsPage extends React.PureComponent {
                 fontSize: '20px',
                 margin: '0',
                 padding: '1em 0',
-                float: 'left',
+                display: 'inline-block',
             },
             sectionHeadingLink: {
                 marginTop: '24px',

--- a/src/renderer/css/settings.css
+++ b/src/renderer/css/settings.css
@@ -3,7 +3,7 @@
 }
 
 .IndicatorContainer {
-  float: left;
+  display: inline-block;
   padding: 1em;
 }
 


### PR DESCRIPTION
**Summary**
On the Settings page, if the window is large enough the first setting would sit next to the header and save indicator.
This was caused by setting `float: left` on those elements.

This PR changes the elements to use `display: inline-block` so that the header and save indicator are next to each other while each subsequent `div` is correctly stacked.

**Issue link**
https://mattermost.atlassian.net/browse/MM-34645
