### PR TITLE
[MM-34594] Only show dock badge when the setting is enabled

### DIFF
--- a/src/main/appState.js
+++ b/src/main/appState.js
@@ -32,7 +32,7 @@ const emitBadge = (expired, mentions, unreads) => {
     status.emitter.emit(UPDATE_BADGE, expired, mentions, unreads);
 };
 
-const emitStatus = () => {
+export const emitStatus = () => {
     const expired = anyExpired();
     const mentions = totalMentions();
     const unreads = anyUnreads();

--- a/src/main/badge.js
+++ b/src/main/badge.js
@@ -10,6 +10,8 @@ import * as AppState from './appState';
 
 const MAX_WIN_COUNT = 99;
 
+let showUnreadBadgeSetting;
+
 function showBadgeWindows(sessionExpired, showUnreadBadge, mentionCount) {
     let description = 'You have no unread messages';
     let text;
@@ -19,7 +21,7 @@ function showBadgeWindows(sessionExpired, showUnreadBadge, mentionCount) {
     } else if (mentionCount > 0) {
         text = (mentionCount > MAX_WIN_COUNT) ? `${MAX_WIN_COUNT}+` : mentionCount.toString();
         description = `You have unread mentions (${mentionCount})`;
-    } else if (showUnreadBadge) {
+    } else if (showUnreadBadge && showUnreadBadgeSetting) {
         text = '•';
         description = 'You have unread channels';
     }
@@ -32,7 +34,7 @@ function showBadgeOSX(sessionExpired, showUnreadBadge, mentionCount) {
         badge = '•';
     } else if (mentionCount > 0) {
         badge = mentionCount.toString();
-    } else if (showUnreadBadge) {
+    } else if (showUnreadBadge && showUnreadBadgeSetting) {
         badge = '•';
     }
     app.dock.setBadge(badge);
@@ -57,6 +59,11 @@ function showBadge(sessionExpired, mentionCount, showUnreadBadge) {
         showBadgeLinux(sessionExpired, showUnreadBadge, mentionCount);
         break;
     }
+}
+
+export function setUnreadBadgeSetting(showUnreadBadge) {
+    showUnreadBadgeSetting = showUnreadBadge;
+    AppState.emitStatus();
 }
 
 export function setupBadge() {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -247,7 +247,7 @@ function handleConfigUpdate(newConfig) {
             log.error('error:', err);
         });
         WindowManager.setConfig(newConfig.data);
-        setUnreadBadgeSetting(newConfig.data.showUnreadBadge);
+        setUnreadBadgeSetting(newConfig.data && newConfig.data.showUnreadBadge);
     }
 
     ipcMain.emit('update-menu', true, config);

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -55,7 +55,7 @@ import {getLocalURLString, getLocalPreload} from './utils';
 import {destroyTray, refreshTrayImages, setTrayMenu, setupTray} from './tray/tray';
 import {AuthManager} from './authManager';
 import {CertificateManager} from './certificateManager';
-import {setupBadge} from './badge';
+import {setupBadge, setUnreadBadgeSetting} from './badge';
 
 if (process.env.NODE_ENV !== 'production' && module.hot) {
     module.hot.accept();
@@ -247,6 +247,7 @@ function handleConfigUpdate(newConfig) {
             log.error('error:', err);
         });
         WindowManager.setConfig(newConfig.data);
+        setUnreadBadgeSetting(newConfig.data.showUnreadBadge);
     }
 
     ipcMain.emit('update-menu', true, config);
@@ -255,6 +256,7 @@ function handleConfigUpdate(newConfig) {
 function handleConfigSynchronize() {
     // TODO: send this to server manager
     WindowManager.setConfig(config.data);
+    setUnreadBadgeSetting(config.data.showUnreadBadge);
     if (app.isReady()) {
         WindowManager.sendToRenderer(RELOAD_CONFIGURATION);
     }
@@ -514,7 +516,7 @@ function initializeAfterAppReady() {
     if (shouldShowTrayIcon()) {
         setupTray(config.trayIconTheme);
     }
-    setupBadge();
+    setupBadge(config.showUnreadBadge);
 
     session.defaultSession.on('will-download', (event, item, webContents) => {
         const filename = item.getFilename();


### PR DESCRIPTION
**Summary**
The `showUnreadBadge` setting was not being observed when setting the badge. This PR adds a variable for the setting and an updater such that the badge will turn on and off when the setting is toggled.

**Issue link**
https://mattermost.atlassian.net/browse/MM-34594
