### PR TITLE
[MM-34564] Set max-width on the server tabs to 224px

### DIFF
--- a/src/renderer/css/components/TabBar.css
+++ b/src/renderer/css/components/TabBar.css
@@ -17,7 +17,6 @@
   flex: 0 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 200px;
   white-space: nowrap;
   text-align: center;
 }
@@ -26,6 +25,7 @@
   -webkit-app-region: no-drag;
   -webkit-user-select: none;
   min-width: 48px;
+  max-width: 224px;
 }
 
 .TabBar>li>a {


### PR DESCRIPTION
**Summary**
Set `max-width` on the server tabs to 224px, using the entire wrapped `div` instead of the inner label `span`

**Issue link**
https://mattermost.atlassian.net/browse/MM-34564
