### PR TITLE
[MM-34494] Encapsulate context menu in a class object and add it to each view as necessary

### DIFF
--- a/src/main/views/MattermostView.js
+++ b/src/main/views/MattermostView.js
@@ -11,6 +11,7 @@ import {RELOAD_INTERVAL, MAX_SERVER_RETRIES, SECOND} from 'common/utils/constant
 import urlUtils from 'common/utils/url';
 import {LOAD_RETRY, LOAD_SUCCESS, LOAD_FAILED, UPDATE_TARGET_URL, IS_UNREAD, UNREAD_RESULT, TOGGLE_BACK_BUTTON, SET_SERVER_NAME} from 'common/communication';
 
+import ContextMenu from '../contextMenu';
 import {getWindowBoundaries, getLocalPreload} from '../utils';
 import * as WindowManager from '../windows/windowManager';
 import * as appState from '../appState';
@@ -70,6 +71,8 @@ export class MattermostView extends EventEmitter {
             this.altLastPressed = false;
             this.view.webContents.on('before-input-event', this.handleInputEvents);
         }
+
+        this.contextMenu = new ContextMenu({}, this.view);
     }
 
     // use the same name as the server

--- a/src/main/views/modalView.js
+++ b/src/main/views/modalView.js
@@ -4,6 +4,7 @@
 import {BrowserView} from 'electron';
 import log from 'electron-log';
 
+import ContextMenu from '../contextMenu';
 import {getWindowBoundaries} from '../utils';
 
 const ACTIVE = 'active';
@@ -33,6 +34,8 @@ export class ModalView {
             log.error('there was an error loading the modal:');
             log.error(e);
         }
+
+        this.contextMenu = new ContextMenu({}, this.view);
     }
 
     show = (win, withDevTools) => {

--- a/src/main/views/viewManager.js
+++ b/src/main/views/viewManager.js
@@ -7,7 +7,6 @@ import {SECOND} from 'common/utils/constants';
 import {UPDATE_TARGET_URL, SET_SERVER_KEY, LOAD_SUCCESS, LOAD_FAILED, TOGGLE_LOADING_SCREEN_VISIBILITY, GET_LOADING_SCREEN_DATA} from 'common/communication';
 import urlUtils from 'common/utils/url';
 
-import contextMenu from '../contextMenu';
 import {MattermostServer} from '../MattermostServer';
 import {getLocalURLString, getLocalPreload, getWindowBoundaries} from '../utils';
 
@@ -116,7 +115,6 @@ export class ViewManager {
                 } else {
                     this.fadeLoadingScreen();
                 }
-                contextMenu.reload(newView.getWebContents());
             } else {
                 log.warn(`couldn't show ${name}, not ready`);
             }

--- a/src/main/windows/mainWindow.js
+++ b/src/main/windows/mainWindow.js
@@ -12,7 +12,7 @@ import log from 'electron-log';
 import {SELECT_NEXT_TAB, SELECT_PREVIOUS_TAB} from 'common/communication';
 
 import * as Validator from '../Validator';
-import contextMenu from '../contextMenu';
+import ContextMenu from '../contextMenu';
 import {getLocalPreload, getLocalURLString} from '../utils';
 
 function saveWindowState(file, window) {
@@ -165,7 +165,9 @@ function createMainWindow(config, options) {
         }
     });
 
-    contextMenu.setup({useSpellChecker: config.useSpellChecker});
+    const contextMenu = new ContextMenu({}, mainWindow);
+    contextMenu.reload();
+
     return mainWindow;
 }
 

--- a/src/main/windows/settingsWindow.js
+++ b/src/main/windows/settingsWindow.js
@@ -4,6 +4,7 @@
 import {BrowserWindow} from 'electron';
 import log from 'electron-log';
 
+import ContextMenu from '../contextMenu';
 import {getLocalPreload, getLocalURLString} from '../utils';
 
 export function createSettingsWindow(mainWindow, config, withDevTools) {
@@ -20,6 +21,10 @@ export function createSettingsWindow(mainWindow, config, withDevTools) {
             spellcheck,
             enableRemoteModule: process.env.NODE_ENV === 'test',
         }});
+
+    const contextMenu = new ContextMenu({}, settingsWindow);
+    contextMenu.reload();
+
     const localURL = getLocalURLString('settings.html');
     settingsWindow.setMenuBarVisibility(false);
     settingsWindow.loadURL(localURL).catch(


### PR DESCRIPTION
**Summary**
Instead of using one context menu object and re-assigning it based on active view, we now create a new `electronContextMenu` object for each view so that the views are able to manage their own menus and each one will have one.

**Issue link**
https://mattermost.atlassian.net/browse/MM-34494
