### PR TITLE
[MM-34890][MM-34897] Fix some fullscreen issues

### DIFF
--- a/src/common/communication.js
+++ b/src/common/communication.js
@@ -45,6 +45,7 @@ export const WINDOW_CLOSE = 'window_close';
 export const WINDOW_MINIMIZE = 'window_minimize';
 export const WINDOW_MAXIMIZE = 'window_maximize';
 export const WINDOW_RESTORE = 'window_restore';
+export const GET_FULL_SCREEN_STATUS = 'get-full-screen-status';
 
 export const UPDATE_TARGET_URL = 'update_target_url';
 

--- a/src/main/windows/mainWindow.js
+++ b/src/main/windows/mainWindow.js
@@ -6,10 +6,10 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 
-import {app, BrowserWindow} from 'electron';
+import {app, BrowserWindow, ipcMain} from 'electron';
 import log from 'electron-log';
 
-import {SELECT_NEXT_TAB, SELECT_PREVIOUS_TAB} from 'common/communication';
+import {SELECT_NEXT_TAB, SELECT_PREVIOUS_TAB, GET_FULL_SCREEN_STATUS} from 'common/communication';
 
 import * as Validator from '../Validator';
 import ContextMenu from '../contextMenu';
@@ -52,6 +52,7 @@ function createMainWindow(config, options) {
     }
 
     const {maximized: windowIsMaximized} = windowOptions;
+    const fullscreen = process.platform === 'darwin' && windowIsMaximized && windowOptions.x === 0 && windowOptions.y === 0;
 
     const spellcheck = (typeof config.useSpellChecker === 'undefined' ? true : config.useSpellChecker);
 
@@ -66,7 +67,7 @@ function createMainWindow(config, options) {
         minWidth: minimumWindowWidth,
         minHeight: minimumWindowHeight,
         frame: !isFramelessWindow(),
-        fullscreen: false,
+        fullscreen,
         titleBarStyle: 'hidden',
         trafficLightPosition: {x: 12, y: 24},
         backgroundColor: '#fff', // prevents blurry text: https://electronjs.org/docs/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do
@@ -82,6 +83,8 @@ function createMainWindow(config, options) {
 
     const mainWindow = new BrowserWindow(windowOptions);
     mainWindow.setMenuBarVisibility(false);
+
+    ipcMain.handle(GET_FULL_SCREEN_STATUS, () => mainWindow.isFullScreen());
 
     const localURL = getLocalURLString('index.html');
     mainWindow.loadURL(localURL).catch(

--- a/src/main/windows/mainWindow.js
+++ b/src/main/windows/mainWindow.js
@@ -18,6 +18,7 @@ import {getLocalPreload, getLocalURLString} from '../utils';
 function saveWindowState(file, window) {
     const windowState = window.getBounds();
     windowState.maximized = window.isMaximized();
+    windowState.fullscreen = window.isFullScreen();
     try {
         fs.writeFileSync(file, JSON.stringify(windowState));
     } catch (e) {
@@ -52,7 +53,6 @@ function createMainWindow(config, options) {
     }
 
     const {maximized: windowIsMaximized} = windowOptions;
-    const fullscreen = process.platform === 'darwin' && windowIsMaximized && windowOptions.x === 0 && windowOptions.y === 0;
 
     const spellcheck = (typeof config.useSpellChecker === 'undefined' ? true : config.useSpellChecker);
 
@@ -67,7 +67,7 @@ function createMainWindow(config, options) {
         minWidth: minimumWindowWidth,
         minHeight: minimumWindowHeight,
         frame: !isFramelessWindow(),
-        fullscreen,
+        fullscreen: windowOptions.fullscreen,
         titleBarStyle: 'hidden',
         trafficLightPosition: {x: 12, y: 24},
         backgroundColor: '#fff', // prevents blurry text: https://electronjs.org/docs/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do

--- a/src/main/windows/settingsWindow.js
+++ b/src/main/windows/settingsWindow.js
@@ -14,6 +14,7 @@ export function createSettingsWindow(mainWindow, config, withDevTools) {
         ...config.data,
         parent: mainWindow,
         title: 'Desktop App Settings',
+        fullscreen: false,
         webPreferences: {
             nodeIntegration: false,
             contextIsolation: true,

--- a/src/renderer/components/MainPage.jsx
+++ b/src/renderer/components/MainPage.jsx
@@ -32,6 +32,7 @@ import {
     SELECT_PREVIOUS_TAB,
     ADD_SERVER,
     FOCUS_THREE_DOT_MENU,
+    GET_FULL_SCREEN_STATUS,
 } from 'common/communication';
 
 import restoreButton from '../../assets/titlebar/chrome-restore.svg';
@@ -149,6 +150,8 @@ export default class MainPage extends React.PureComponent {
 
         window.ipcRenderer.on('enter-full-screen', () => this.handleFullScreenState(true));
         window.ipcRenderer.on('leave-full-screen', () => this.handleFullScreenState(false));
+
+        window.ipcRenderer.invoke(GET_FULL_SCREEN_STATUS).then((fullScreenStatus) => this.handleFullScreenState(fullScreenStatus));
 
         window.ipcRenderer.on(ADD_SERVER, () => {
             this.addServer();


### PR DESCRIPTION
**Summary**
Fix 2 full-screen issues:
- Fullscreen status wouldn't restore when the app was restarted
- When opening the settings window in fullscreen mode, the window would get stuck in fullscreen and there was no way of getting out of it, so I've prevented the window from full-screening at all on opening.

**Issue link**
https://mattermost.atlassian.net/browse/MM-34890
https://mattermost.atlassian.net/browse/MM-34897
