### PR TITLE
Fix msi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,7 +294,7 @@ jobs:
           name: "Setup files for aws-s3"
           command: |
             mkdir -p ./aws-s3-dist
-            cp ./dist/{macos-release,win-release,linux}/* ./aws-s3-dist
+            cp --backup=numbered ./dist/{macos-release,win-release,linux}/* ./aws-s3-dist
       - aws-s3/copy:
           from: ./aws-s3-dist/
           to: s3://releases.mattermost.com/desktop/$(jq -r .version package.json)/
@@ -331,7 +331,7 @@ jobs:
           name: "Setup files for ghr"
           command: |
             mkdir -p ./ghr-dist
-            cp ./dist/{macos-release,win-release,linux}/* ./ghr-dist
+            cp --backup=numbered ./dist/{macos-release,win-release,linux}/* ./ghr-dist
       - run:
           name: "Publish Release on GitHub"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,7 +287,7 @@ jobs:
       - run:
           name: "Don't upload if it's not on a tag"
           command: |
-            if [ -z `git tag -l --points-at master` ]; then
+            if [ -z `git name-rev --name-only --tags --no-undefined HEAD 2>/dev/null` ]; then
               circleci-agent step halt
             fi  
       - run:
@@ -324,7 +324,7 @@ jobs:
       - run:
           name: "Don't upload if it's not on a tag"
           command: |
-            if [ -z `git tag -l --points-at master` ]; then
+            if [ -z `git name-rev --name-only --tags --no-undefined HEAD 2>/dev/null` ]; then
               circleci-agent step halt
             fi  
       - run:

--- a/scripts/Makefile.ps1
+++ b/scripts/Makefile.ps1
@@ -533,10 +533,6 @@ function Run-BuildElectron {
     Print-Info "Packaging nodejs/electron for Windows (running npm run package:windows)..."
     npm run package:windows
     #npm run package:windows --prefix="$(Get-RootDir)" "$(Get-RootDir)"
-
-    Print-Info "Cleaning build dir..."
-    Remove-Item "release\win-ia32-unpacked\resources\app.asar.unpacked\" -Force -Recurse
-    Remove-Item "release\win-unpacked\resources\app.asar.unpacked\" -Force -Recurse
 }
 
 function Run-BuildForceSignature {

--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -131,7 +131,7 @@
     </InstallExecuteSequence>
     <CustomAction Id="LaunchApp" FileKey="MattermostDesktopEXE" ExeCommand="" Return="asyncNoWait" />
     <CustomAction Id="KillApp" Directory="INSTALLDIR" Return="ignore" ExeCommand="&quot;[SystemFolder]taskkill.exe&quot; /F /IM &quot;Mattermost.exe&quot;" />
-    <Icon Id="Mattermost.ico" SourceFile="../resources/icon.ico" />
+    <Icon Id="Mattermost.ico" SourceFile="../src/assets/icon.ico" />
     <Property Id="ARPPRODUCTICON">Mattermost.ico</Property>
     <Property Id="ARPCONTACT">https://pre-release.mattermost.com</Property>
     <Property Id="ARPHELPLINK">https://docs.mattermost.com/</Property>


### PR DESCRIPTION
**Summary**

missing change while moving the resources to the assets
also removed an error about not being able to remove a no longer existant files
prevent copy from failing due to having the same name (this is already in 4.7 as it was needed to do the RC1)

**Issue link**

https://github.com/mattermost/desktop/pull/1545

**Test Cases**

msi can be created

**Additional notes**
we'll need to generate a RC2 from this
