### PR TITLE
[MM-35007] don't try to use pressed images with templates

### DIFF
--- a/src/main/tray/tray.js
+++ b/src/main/tray/tray.js
@@ -72,7 +72,6 @@ export function setupTray(icontheme) {
     refreshTrayImages(icontheme);
     trayIcon = new Tray(trayImages.normal);
     if (process.platform === 'darwin') {
-        trayIcon.setPressedImage(trayImages.clicked.normal);
         systemPreferences.subscribeNotification('AppleInterfaceThemeChangedNotification', () => {
             trayIcon.setImage(trayImages.normal);
         });
@@ -107,9 +106,6 @@ function setTray(status, message) {
     lastStatus = status;
     lastMessage = message;
     trayIcon.setImage(trayImages[status]);
-    if (process.platform === 'darwin') {
-        trayIcon.setPressedImage(trayImages.clicked[status]);
-    }
     trayIcon.setToolTip(message);
 }
 


### PR DESCRIPTION
**Summary**
Since we are now using templates on macOS, we dont need to set pressed images

**Issue link**

[MM-35007](https://mattermost.atlassian.net/browse/MM-35007)

