### PR TITLE
[MM-34884] Only call `show()` on an existing mainWindow if the window is actually closed or hidden

### DIFF
--- a/src/main/windows/windowManager.js
+++ b/src/main/windows/windowManager.js
@@ -59,7 +59,11 @@ export function showSettingsWindow() {
 
 export function showMainWindow(deeplinkingURL) {
     if (status.mainWindow) {
-        status.mainWindow.show();
+        if (status.mainWindow.isVisible()) {
+            status.mainWindow.focus();
+        } else {
+            status.mainWindow.show();
+        }
     } else {
         status.mainWindow = createMainWindow(status.config, {
             linuxAppIcon: path.join(assetsDir, 'linux', 'app_icon.png'),


### PR DESCRIPTION
**Summary**
When calling `show()` on a BrowserWindow, the app, if tiled, would revert to an untiled state. This PR only calls `focus()` if the BrowserWindow is already visible and only calls `show()` if the window is not visible to the user.

**Issue link**
https://mattermost.atlassian.net/browse/MM-34884
