### PR TITLE
[MM-34884] Only call `show()` on an existing mainWindow if the window is actually closed or hidden (#1552) - cherry-pick

### DIFF
--- a/src/main/windows/windowManager.js
+++ b/src/main/windows/windowManager.js
@@ -59,7 +59,11 @@ export function showSettingsWindow() {
 
 export function showMainWindow(deeplinkingURL) {
     if (status.mainWindow) {
-        status.mainWindow.show();
+        if (status.mainWindow.isVisible()) {
+            status.mainWindow.focus();
+        } else {
+            status.mainWindow.show();
+        }
     } else {
         status.mainWindow = createMainWindow(status.config, {
             linuxAppIcon: path.join(assetsDir, 'linux', 'app_icon.png'),


### PR DESCRIPTION
Cherry-pick of #1552 to `release-4.7`
