### PR TITLE
[MM-20677] Quarantine files downloaded from electron

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -84,7 +84,8 @@
     "entitlementsInherit": "./build/entitlements.mac.plist",
     "extendInfo": {
       "NSMicrophoneUsageDescription": "Microphone access may be used by Mattermost plugins, such as Jitsi video conferencing.",
-      "NSCameraUsageDescription": "Camera access may be used by Mattermost plugins, such as Jitsi video conferencing."
+      "NSCameraUsageDescription": "Camera access may be used by Mattermost plugins, such as Jitsi video conferencing.",
+      "LSFileQuarantineEnabled": true
   }
   },
   "dmg": {


### PR DESCRIPTION
**Summary**
added quarantine to files downloaded from mattermost
this is added as part of the info.plist so the OS is responsible to enforce it

**Issue link**

[MM-20677](https://mattermost.atlassian.net/browse/MM-20677)

**Test Cases**

Download a .terminal file created from the terminal app (menu->

**Screenshot**
<img width="262" alt="Screen Shot 2021-04-20 at 16 18 36" src="https://user-images.githubusercontent.com/1515906/115412322-7d3a5880-a1f4-11eb-87f4-9e8bcff97da8.png">