### PR TITLE
[MM-34836] Cleanse URLs of extra slashes on parsing, and add the image proxy case

### DIFF
--- a/src/common/utils/url.js
+++ b/src/common/utils/url.js
@@ -40,7 +40,7 @@ function parseURL(inputURL) {
         return inputURL;
     }
     try {
-        return new URL(inputURL);
+        return new URL(inputURL.replace(/([^:]\/)\/+/g, '$1'));
     } catch (e) {
         return null;
     }

--- a/src/main/views/webContentEvents.js
+++ b/src/main/views/webContentEvents.js
@@ -136,6 +136,12 @@ const generateNewWindowListener = (getServersFunction, spellcheck) => {
             return;
         }
 
+        // Image proxy case
+        if (parsedURL.pathname.match(/^\/api\/v[3-4]\/image/)) {
+            shell.openExternal(url);
+            return;
+        }
+
         if (parsedURL.pathname.match(/^\/help\//)) {
             // Help links case
             // continue to open special case internal urls in default browser

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -2,3 +2,4 @@
 // See LICENSE.txt for license information.
 
 import './trusted_origins_test';
+import './url_test';

--- a/test/unit/url_test.js
+++ b/test/unit/url_test.js
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+'use strict';
+
+import assert from 'assert';
+
+import urlUtils from 'common/utils/url';
+
+describe('URL', () => {
+    describe('parseURL', () => {
+        it('should remove duplicate slashes in a URL when parsing', () => {
+            const urlWithExtraSlashes = 'https://mattermost.com//sub//path//example';
+            const parsedURL = urlUtils.parseURL(urlWithExtraSlashes);
+
+            assert.strictEqual(parsedURL.toString(), 'https://mattermost.com/sub/path/example');
+        });
+    });
+});


### PR DESCRIPTION
#### Summary
When working with URLs that have multiple slashes in the pathname, if we tried to match them using one of our `is___URL` functions they wouldn't match due to the extra slashes.

This PR adds some code to cleanse the extra slashes out of URLs (since apparently the URL library doesn't do that on parsing), and explicitly defines the image proxy case such that those links will open in a browser.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34836

```release-note
NONE
```
