### PR TITLE
[MM-35010] Fix m1 release pipeline (cherry-pick v4.7)

### DIFF
--- a/scripts/cp_artifacts.sh
+++ b/scripts/cp_artifacts.sh
@@ -28,7 +28,7 @@ if [[ ${MM_WIN_INSTALLERS-0} -eq 1 && -f "${SRC}/mattermost-desktop-setup-${VERS
 fi
 if [[ -f "${SRC}/mattermost-desktop-${VERSION}-mac.zip" ]]; then
     echo -e "Copying mac\n"
-    cp "${SRC}"/mattermost-desktop-*-mac.* "${DEST}/"
+    cp "${SRC}"/mattermost-desktop-*-mac*.* "${DEST}/"
     if [[ -f "${SRC}"/mattermost-desktop-${VERSION}-mac.dmg ]]; then
         cp "${SRC}"/*.blockmap "${DEST}/"
     fi


### PR DESCRIPTION
#### Summary

see original https://github.com/mattermost/desktop/pull/1559

#### Release Note
```release-note
NONE
```
