### PR TITLE
Make daily links in s3 look always the same to help with rainforest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,9 +307,19 @@ jobs:
       - attach_workspace:
           at: ./dist
       - run:
+          name: "install renaming utility"
+          command: |
+            apt-get install rename
+      - run:
           name: "Normalize folder names"
           command: |
             mv ./dist/macos-release ./dist/macos
+      - run:
+          name: "Rename to daily for consistency"
+          command: |
+            rename 's/\d+\.\d+\.\d+/daily/' macos/*
+            rename 's/\d+\.\d+\.\d+/daily/' linux/*
+            rename 's/\d+\.\d+\.\d+/daily/' win/*
       - aws-s3/copy:
           from: ./dist/
           to: s3://mattermost-desktop-daily-builds/


### PR DESCRIPTION
#### Summary

In order to help rainforest testing, we need to provide the same link for every daily build, so we rename the files removing its version and adding daily so they can be easily recognized

#### Release Note
```release-note
NONE
```
