### PR TITLE
[MM-35278] Remove dependency libappindicator1

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -40,7 +40,7 @@
     "synopsis": "Mattermost Desktop App",
     "depends": ["gconf2", "gconf-service", "libnotify4", "libxtst6", "libnss3"],
     "category": "contrib/net",
-    "prioity": "optional"
+    "priority": "optional"
   },
   "linux": {
     "category": "Network;InstantMessaging",

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -46,6 +46,11 @@
       "tar.gz",
       "appimage"
     ],
+    "deb": {
+      "depends": ["gconf2", "gconf-service", "libnotify4", "libxtst6", "libnss3"],
+      "category": "contrib/net",
+      "prioity": "optional"
+    },
     "extraFiles": [
       {
         "filter": [

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -37,7 +37,10 @@
   "afterPack": "scripts/afterpack.js",
   "afterSign": "scripts/notarize.js",
   "deb": {
-    "synopsis": "Mattermost Desktop App"
+    "synopsis": "Mattermost Desktop App",
+    "depends": ["gconf2", "gconf-service", "libnotify4", "libxtst6", "libnss3"],
+    "category": "contrib/net",
+    "prioity": "optional"
   },
   "linux": {
     "category": "Network;InstantMessaging",
@@ -46,11 +49,6 @@
       "tar.gz",
       "appimage"
     ],
-    "deb": {
-      "depends": ["gconf2", "gconf-service", "libnotify4", "libxtst6", "libnss3"],
-      "category": "contrib/net",
-      "prioity": "optional"
-    },
     "extraFiles": [
       {
         "filter": [


### PR DESCRIPTION
#### Summary

remove libappnotify1 as a dependency as it is being deprecated in newer debian  versions.

#### Ticket Link

fixes #1570 

[MM-35278](https://mattermost.atlassian.net/browse/MM-35278)

#### Release Note
```release-note
Removed libappnotify1 as a dependency requirement in deb installers as it is no longer shipped in Debian's Bullseye. It is still recommeded to install where available.
```
