### PR TITLE
[MM-35131] Set default app downloads path to specified path in config

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -257,6 +257,7 @@ function handleConfigSynchronize() {
     // TODO: send this to server manager
     WindowManager.setConfig(config.data);
     setUnreadBadgeSetting(config.data.showUnreadBadge);
+    app.setPath('downloads', config.data.downloadLocation);
     if (app.isReady()) {
         WindowManager.sendToRenderer(RELOAD_CONFIGURATION);
     }


### PR DESCRIPTION
#### Summary
`electron-context-menu` uses the default downloads path provided by the app when saving stuff. Turns out that we can actually override that, so I've done that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35131

#### Release Note
```release-note
NONE
```
