### PR TITLE
 [MM-35278] Remove dependency libappindicator1 (cherry-pick v4.7)

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -37,7 +37,10 @@
   "afterPack": "scripts/afterpack.js",
   "afterSign": "scripts/notarize.js",
   "deb": {
-    "synopsis": "Mattermost Desktop App"
+    "synopsis": "Mattermost Desktop App",
+    "depends": ["gconf2", "gconf-service", "libnotify4", "libxtst6", "libnss3"],
+    "category": "contrib/net",
+    "priority": "optional"
   },
   "linux": {
     "category": "Network;InstantMessaging",


### PR DESCRIPTION
#### Summary

Cherry-pick of #1572 

#### Release Note

```release-note
Removed libappnotify1 as a dependency requirement in deb installers as it is no longer shipped in Debian's Bullseye. It is still recommeded to install where available.
```
