### PR TITLE
[MM-35245] Null check to prevent console error in preload script on unloaded server

### DIFF
--- a/src/main/preload/mattermost.js
+++ b/src/main/preload/mattermost.js
@@ -63,7 +63,7 @@ window.addEventListener('load', () => {
 });
 
 const parentTag = (target) => {
-    if (target.parentNode) {
+    if (target.parentNode && target.parentNode.tagName) {
         return target.parentNode.tagName.toUpperCase();
     }
     return null;


### PR DESCRIPTION
#### Summary
When a Mattermost server wasn't loaded, the preload script can sometimes generate an `undefined` error. So we now check that the object exists before running `toUpperCase`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35245

#### Release Note
```release-note
NONE
```
