### PR TITLE
[MM-35454] Fix default downloads path for Windows and Linux, only set for the app if the path is not blank

### DIFF
--- a/src/common/config/defaultPreferences.js
+++ b/src/common/config/defaultPreferences.js
@@ -13,11 +13,9 @@ const getDefaultDownloadLocation = () => {
         return `/Users/${process.env.USER || process.env.USERNAME}/Downloads`;
     case 'win32':
         return `C:\\Users\\${process.env.USER || process.env.USERNAME}\\Downloads`;
-    case 'linux':
-        return `/home/${process.env.USER || process.env.USERNAME}/Downloads`;
     default:
-        return '';
-    };
+        return `/home/${process.env.USER || process.env.USERNAME}/Downloads`;
+    }
 };
 
 const defaultPreferences = {

--- a/src/common/config/defaultPreferences.js
+++ b/src/common/config/defaultPreferences.js
@@ -6,6 +6,20 @@
  * Default user preferences. End-users can change these parameters by editing config.json
  * @param {number} version - Scheme version. (Not application version)
  */
+
+const getDefaultDownloadLocation = () => {
+    switch (process.platform) {
+    case 'darwin':
+        return `/Users/${process.env.USER || process.env.USERNAME}/Downloads`;
+    case 'win32':
+        return `C:\\Users\\${process.env.USER || process.env.USERNAME}\\Downloads`;
+    case 'linux':
+        return `/home/${process.env.USER || process.env.USERNAME}/Downloads`;
+    default:
+        return '';
+    };
+};
+
 const defaultPreferences = {
     version: 2,
     teams: [],
@@ -23,7 +37,7 @@ const defaultPreferences = {
     autostart: true,
     spellCheckerLocale: 'en-US',
     darkMode: false,
-    downloadLocation: `/Users/${process.env.USER || process.env.USERNAME}/Downloads`,
+    downloadLocation: getDefaultDownloadLocation(),
 };
 
 export default defaultPreferences;

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -257,7 +257,9 @@ function handleConfigSynchronize() {
     // TODO: send this to server manager
     WindowManager.setConfig(config.data);
     setUnreadBadgeSetting(config.data.showUnreadBadge);
-    app.setPath('downloads', config.data.downloadLocation);
+    if (config.data.downloadLocation) {
+        app.setPath('downloads', config.data.downloadLocation);
+    }
     if (app.isReady()) {
         WindowManager.sendToRenderer(RELOAD_CONFIGURATION);
     }


### PR DESCRIPTION
#### Summary
When I had forced the entire app to use the downloads path we use in our config, it revealed that we were defaulting to a path used only by Mac. So now we support Windows and Linux (and don't set a default for other OSes) and will only set the path if it exists at all.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35454

#### Release Note
```release-note
NONE
```
