### PR TITLE
fix wrong folder name for s3_daily

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,9 +317,9 @@ jobs:
       - run:
           name: "Rename to daily for consistency"
           command: |
-            rename 's/\d+\.\d+\.\d+/daily/' macos/*
-            rename 's/\d+\.\d+\.\d+/daily/' linux/*
-            rename 's/\d+\.\d+\.\d+/daily/' win/*
+            rename 's/\d+\.\d+\.\d+/daily/' ./dist/macos/*
+            rename 's/\d+\.\d+\.\d+/daily/' ./dist/linux/*
+            rename 's/\d+\.\d+\.\d+/daily/' ./dist/win/*
       - aws-s3/copy:
           from: ./dist/
           to: s3://mattermost-desktop-daily-builds/


### PR DESCRIPTION
#### Summary

fix path names for renaming to daily builds so rainforest doesn't need to figure it out.

#### Ticket Link

follow up to https://github.com/mattermost/desktop/pull/1568

#### Release Note
```release-note
NONE
```
