### PR TITLE
[MM-35454] Fix default downloads path for Windows and Linux, only set for the app if the path is not blank (#1583) - cherry-pick

### DIFF
--- a/src/common/config/defaultPreferences.js
+++ b/src/common/config/defaultPreferences.js
@@ -6,6 +6,18 @@
  * Default user preferences. End-users can change these parameters by editing config.json
  * @param {number} version - Scheme version. (Not application version)
  */
+
+const getDefaultDownloadLocation = () => {
+    switch (process.platform) {
+    case 'darwin':
+        return `/Users/${process.env.USER || process.env.USERNAME}/Downloads`;
+    case 'win32':
+        return `C:\\Users\\${process.env.USER || process.env.USERNAME}\\Downloads`;
+    default:
+        return `/home/${process.env.USER || process.env.USERNAME}/Downloads`;
+    }
+};
+
 const defaultPreferences = {
     version: 2,
     teams: [],
@@ -23,7 +35,7 @@ const defaultPreferences = {
     autostart: true,
     spellCheckerLocale: 'en-US',
     darkMode: false,
-    downloadLocation: `/Users/${process.env.USER || process.env.USERNAME}/Downloads`,
+    downloadLocation: getDefaultDownloadLocation(),
 };
 
 export default defaultPreferences;

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -257,7 +257,9 @@ function handleConfigSynchronize() {
     // TODO: send this to server manager
     WindowManager.setConfig(config.data);
     setUnreadBadgeSetting(config.data.showUnreadBadge);
-    app.setPath('downloads', config.data.downloadLocation);
+    if (config.data.downloadLocation) {
+        app.setPath('downloads', config.data.downloadLocation);
+    }
     if (app.isReady()) {
         WindowManager.sendToRenderer(RELOAD_CONFIGURATION);
     }


### PR DESCRIPTION
#### Summary
Cherry-pick of #1583 to `release-4.7`
