### PR TITLE
[MM-35249] Set window bounds on initial load success

### DIFF
--- a/src/main/views/MattermostView.js
+++ b/src/main/views/MattermostView.js
@@ -147,6 +147,7 @@ export class MattermostView extends EventEmitter {
             this.removeLoading = setTimeout(this.setInitialized, MAX_LOADING_SCREEN_SECONDS, true);
             this.emit(LOAD_SUCCESS, this.server.name, loadURL.toString());
             this.view.webContents.send(SET_SERVER_NAME, this.server.name);
+            this.setBounds(getWindowBoundaries(this.window, !(urlUtils.isTeamUrl(this.server.url, this.view.webContents.getURL()) || urlUtils.isAdminUrl(this.server.url, this.view.webContents.getURL()))));
         };
     }
 


### PR DESCRIPTION
#### Summary
The value of `window.innerWidth` was being calculated as 0 when the Mattermost app was first loaded inside of BrowserView. This is because we didn't set the bounds of the view until much later, so we now set the bounds on successful loading of the URL.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35249

#### Release Note
```release-note
NONE
```
