### PR TITLE
[MM-19510][MM-19511] Remove ToastActivatorCLSID from Start Menu shortcut on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,7 +423,7 @@ workflows:
                 # release-XX.YY.ZZ
                 # release-XX.YY.ZZ-rc-something
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
-                - MM-19510_MM-19511
+                - devinbinnie:MM-19510_MM-19511
 
       - mac_installer:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,6 +423,7 @@ workflows:
                 # release-XX.YY.ZZ
                 # release-XX.YY.ZZ-rc-something
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
+                - MM-19510_MM-19511
 
       - mac_installer:
           requires:

--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -72,7 +72,6 @@
               <RegistryValue Id="RegShortcutStartMenu" Root="HKCU" Key="SOFTWARE\Mattermost\Desktop\settings" Name="MattermostDesktopShortcutStartMenu" Value="1" Type="integer" KeyPath="yes" />
               <Shortcut Id="MattermostDesktopShortcutStartMenu" Directory="ProgramMenuDir" Name="Mattermost" WorkingDirectory="INSTALLDIR" Icon="Mattermost.ico" IconIndex="0" Advertise="no" Target="[INSTALLDIR]Mattermost.exe">
                 <ShortcutProperty Key="System.AppUserModel.ID" Value="Mattermost.Desktop" />
-                <ShortcutProperty Key="System.AppUserModel.ToastActivatorCLSID" Value="{082F98DC-8BD8-4771-9D01-3A75930884D1}"></ShortcutProperty>
               </Shortcut>
             </Component>
             <Directory Id="GPOFiles" Name="gpo">


### PR DESCRIPTION
#### Summary
The shortcut produced by the MSI installer was malformed and was causing an issue when clicking on a notification that wouldn't open the application. I've removed the offending line that doesn't need to be there.

Thanks a bunch to @zpersichetti for finding this for us! :)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19510
https://mattermost.atlassian.net/browse/MM-19511
https://github.com/mattermost/desktop/issues/1523

#### Release Note
```release-note
NONE
```
