### PR TITLE
[MM-19510][MM-19511] Remove ToastActivatorCLSID from Start Menu shortcut on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,7 +423,7 @@ workflows:
                 # release-XX.YY.ZZ
                 # release-XX.YY.ZZ-rc-something
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
-                - MM-19510_MM-19511
+                - devinbinnie:MM-19510_MM-19511
 
       - mac_installer:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,7 +423,7 @@ workflows:
                 # release-XX.YY.ZZ
                 # release-XX.YY.ZZ-rc-something
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
-                - devinbinnie:MM-19510_MM-19511
+                - MM-19510_MM-19511
 
       - mac_installer:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,6 +423,7 @@ workflows:
                 # release-XX.YY.ZZ
                 # release-XX.YY.ZZ-rc-something
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
+                - MM-19510_MM-19511
 
       - mac_installer:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,6 +403,8 @@ workflows:
             branches:
               ignore:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
+                - MM-19510_MM-19511
+
 
       - build-mac-no-dmg:
           requires:
@@ -438,7 +440,7 @@ workflows:
           # for master/PR builds
           requires:
             - build-linux
-            - build-win-no-installer
+            - msi_installer
             - build-mac-no-dmg
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,7 +404,6 @@ workflows:
               ignore:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
 
-
       - build-mac-no-dmg:
           requires:
             - check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,7 +403,6 @@ workflows:
             branches:
               ignore:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
-                - MM-19510_MM-19511
 
 
       - build-mac-no-dmg:
@@ -425,7 +424,6 @@ workflows:
                 # release-XX.YY.ZZ
                 # release-XX.YY.ZZ-rc-something
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
-                - MM-19510_MM-19511
 
       - mac_installer:
           requires:
@@ -440,7 +438,7 @@ workflows:
           # for master/PR builds
           requires:
             - build-linux
-            - msi_installer
+            - build-win-no-installer
             - build-mac-no-dmg
           filters:
             branches:

--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -72,7 +72,6 @@
               <RegistryValue Id="RegShortcutStartMenu" Root="HKCU" Key="SOFTWARE\Mattermost\Desktop\settings" Name="MattermostDesktopShortcutStartMenu" Value="1" Type="integer" KeyPath="yes" />
               <Shortcut Id="MattermostDesktopShortcutStartMenu" Directory="ProgramMenuDir" Name="Mattermost" WorkingDirectory="INSTALLDIR" Icon="Mattermost.ico" IconIndex="0" Advertise="no" Target="[INSTALLDIR]Mattermost.exe">
                 <ShortcutProperty Key="System.AppUserModel.ID" Value="Mattermost.Desktop" />
-                <ShortcutProperty Key="System.AppUserModel.ToastActivatorCLSID" Value="{082F98DC-8BD8-4771-9D01-3A75930884D1}"></ShortcutProperty>
               </Shortcut>
             </Component>
             <Directory Id="GPOFiles" Name="gpo">

--- a/scripts/msi_installer.wxs
+++ b/scripts/msi_installer.wxs
@@ -72,6 +72,7 @@
               <RegistryValue Id="RegShortcutStartMenu" Root="HKCU" Key="SOFTWARE\Mattermost\Desktop\settings" Name="MattermostDesktopShortcutStartMenu" Value="1" Type="integer" KeyPath="yes" />
               <Shortcut Id="MattermostDesktopShortcutStartMenu" Directory="ProgramMenuDir" Name="Mattermost" WorkingDirectory="INSTALLDIR" Icon="Mattermost.ico" IconIndex="0" Advertise="no" Target="[INSTALLDIR]Mattermost.exe">
                 <ShortcutProperty Key="System.AppUserModel.ID" Value="Mattermost.Desktop" />
+                <ShortcutProperty Key="System.AppUserModel.ToastActivatorCLSID" Value="{082F98DC-8BD8-4771-9D01-3A75930884D1}"></ShortcutProperty>
               </Shortcut>
             </Component>
             <Directory Id="GPOFiles" Name="gpo">


### PR DESCRIPTION
#### Summary
The shortcut produced by the MSI installer was malformed and was causing an issue when clicking on a notification that wouldn't open the application. I've removed the offending line that doesn't need to be there.

Thanks a bunch to @zpersichetti for finding this for us! :)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19510
https://mattermost.atlassian.net/browse/MM-19511
https://github.com/mattermost/desktop/issues/1523

#### Release Note
```release-note
Fixed an issue with the MSI build that caused notifications when clicked, to not open the application and navigate to the correct channel.
```
