### PR TITLE
[MM-35588] Ensure that the window exists before calling minimize/maximize/restore

### DIFF
--- a/src/main/windows/windowManager.js
+++ b/src/main/windows/windowManager.js
@@ -287,6 +287,9 @@ export function handleDoubleClick(e, windowType) {
         action = systemPreferences.getUserDefault('AppleActionOnDoubleClick', 'string');
     }
     const win = (windowType === 'settings') ? status.settingsWindow : status.mainWindow;
+    if (!win) {
+        return;
+    }
     switch (action) {
     case 'Minimize':
         if (win.isMinimized()) {
@@ -382,15 +385,21 @@ export function close() {
 }
 export function maximize() {
     const focused = BrowserWindow.getFocusedWindow();
-    focused.maximize();
+    if (focused) {
+        focused.maximize();
+    }
 }
 export function minimize() {
     const focused = BrowserWindow.getFocusedWindow();
-    focused.minimize();
+    if (focused) {
+        focused.minimize();
+    }
 }
 export function restore() {
     const focused = BrowserWindow.getFocusedWindow();
-    focused.restore();
+    if (focused) {
+        focused.restore();
+    }
 }
 
 export function reload() {


### PR DESCRIPTION
#### Summary
We had a crash reported when minimize was called. It's not reproducible easily, but to make sure it doesn't happen again, I'm making sure we check if the window exists before calling maximize/minimize/restore.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35588

#### Release Note
```release-note
NONE
```
