### PR TITLE
[MM-35131] Don't set the download location in config if we hit Cancel

### DIFF
--- a/src/renderer/components/SettingsPage.jsx
+++ b/src/renderer/components/SettingsPage.jsx
@@ -264,6 +264,9 @@ export default class SettingsPage extends React.PureComponent {
     }
 
     saveDownloadLocation = (location) => {
+        if (!location) {
+            return;
+        }
         this.setState({
             downloadLocation: location,
         });


### PR DESCRIPTION
#### Summary
When pressing Cancel on the download location dialog, it would set the download location in the config to undefined. This was because we weren't checking for an undefined response from the dialog, so now we do.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35131

#### Release Note
```release-note
NONE
```
