### PR TITLE
[MM-35781] Another workaround for Linux resizing

### DIFF
--- a/src/main/windows/windowManager.js
+++ b/src/main/windows/windowManager.js
@@ -144,8 +144,18 @@ function handleResizeMainWindow() {
         bounds = status.mainWindow.getContentBounds();
     }
 
-    if (currentView) {
-        currentView.setBounds(getAdjustedWindowBoundaries(bounds.width, bounds.height, !urlUtils.isTeamUrl(currentView.server.url, currentView.view.webContents.getURL())));
+    const setBoundsFunction = () => {
+        if (currentView) {
+            currentView.setBounds(getAdjustedWindowBoundaries(bounds.width, bounds.height, !urlUtils.isTeamUrl(currentView.server.url, currentView.view.webContents.getURL())));
+        }
+    };
+
+    // Another workaround since the window doesn't update properly under Linux for some reason
+    // See above comment
+    if (process.platform === 'linux') {
+        setTimeout(setBoundsFunction, 10);
+    } else {
+        setBoundsFunction();
     }
     status.viewManager.setLoadingScreenBounds();
 }


### PR DESCRIPTION
#### Summary
Apparently the fix I added for Linux resizing wasn't enough, as the outer window doesn't seem to resize properly. So we have to add a `setTimeout` as a workaround. See comments for the bugs that are affecting this.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35781

#### Release Note
```release-note
NONE
```
