### PR TITLE
add rpm build option to electron builder

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -47,7 +47,8 @@
     "target": [
       "deb",
       "tar.gz",
-      "appimage"
+      "appimage",
+      "rpm"
     ],
     "extraFiles": [
       {


### PR DESCRIPTION
adds an option to also build rpm packages for deployment in RPM based distros like Fedora and RHEL

we should probably mark this as unoffical or something like that for now.


But tested and working on Fedora 34 with latest master.