### PR TITLE
[MM-35662] Added media-src tag to CSP to allow data blobs to play for notification sounds

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; media-src data:">
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body>


### PR DESCRIPTION
#### Summary
When trying to play notification sounds from the desktop app, the CSP in our app wrapper was stopping the sounds from playing. This PR allows those `data:` URIs to play correctly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35662

#### Release Note
```release-note
NONE
```
