### PR TITLE
[MM-35984] Make sure Select Downloads Folder dialog always uses the default location if none is selected (#1613) - cherrypick

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -621,7 +621,7 @@ function handleUpdateMenuEvent(event, menuConfig) {
 
 async function handleSelectDownload(event, startFrom) {
     const message = 'Specify the folder where files will download';
-    const result = await dialog.showOpenDialog({defaultPath: startFrom,
+    const result = await dialog.showOpenDialog({defaultPath: startFrom || config.data.downloadLocation,
         message,
         properties:
      ['openDirectory', 'createDirectory', 'dontAddToRecent', 'promptToCreate']});

--- a/src/renderer/components/SettingsPage.jsx
+++ b/src/renderer/components/SettingsPage.jsx
@@ -279,7 +279,7 @@ export default class SettingsPage extends React.PureComponent {
 
     selectDownloadLocation = () => {
         if (!this.state.userOpenedDownloadDialog) {
-            window.ipcRenderer.invoke(GET_DOWNLOAD_LOCATION, `/Users/${window.process.env.USER || window.process.env.USERNAME}/Downloads`).then((result) => this.saveDownloadLocation(result));
+            window.ipcRenderer.invoke(GET_DOWNLOAD_LOCATION, this.state.downloadLocation).then((result) => this.saveDownloadLocation(result));
             this.setState({userOpenedDownloadDialog: true});
         }
         this.setState({userOpenedDownloadDialog: false});


### PR DESCRIPTION
#### Summary
Cherrypick of #1613 to `release-4.7`