### PR TITLE
[MM-35581] Rename arm64 to m1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,15 @@ jobs:
           os: mac
           path: ./dist/macos-release
           subpath: ./macos-release/
+      - run:
+          name: Get rename without brew as it might fail
+          command: curl -L https://github.com/ap/rename/archive/v1.601.tar.gz --output rename.tgz
+      - run:
+          name: extract rename
+          command: tar -xzf rename.tgz
+      - run:
+          name: rename arm64 to m1
+          command: ./rename-1.601/rename 's/arm64/m1/' release/*
 
   store_artifacts:
     executor: wine-chrome
@@ -432,6 +441,7 @@ workflows:
             branches:
               only:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
+                - rename_m1
 
       - store_artifacts:
           # for master/PR builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,12 +434,13 @@ workflows:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
 
       - mac_installer:
+          requires:
+            - check
           context: codesign-certificates
           filters:
             branches:
               only:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
-                - rename_m1
 
       - store_artifacts:
           # for master/PR builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,8 +434,6 @@ workflows:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
 
       - mac_installer:
-          requires:
-            - check
           context: codesign-certificates
           filters:
             branches:


### PR DESCRIPTION
#### Summary
Renames distributable Mac files from arm64 to m1

It downloads rename directly instead of using brew as CircleCI is [having some trouble with brew](https://discuss.circleci.com/t/macos-image-users-homebrew-brownout-2021-04-26/39872) at the moment.

#### Ticket Link
[MM-35581](https://mattermost.atlassian.net/browse/MM-35581)

#### Release Note

```release-note
rename package from arm64 to m1 on CI
```
