### PR TITLE
[MM-35581] Rename arm64 to m1 (Cherry-pic #1620)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,15 @@ jobs:
           os: mac
           path: ./dist/macos-release
           subpath: ./macos-release/
+      - run:
+          name: Get rename without brew as it might fail
+          command: curl -L https://github.com/ap/rename/archive/v1.601.tar.gz --output rename.tgz
+      - run:
+          name: extract rename
+          command: tar -xzf rename.tgz
+      - run:
+          name: rename arm64 to m1
+          command: ./rename-1.601/rename 's/arm64/m1/' release/*
 
   store_artifacts:
     executor: wine-chrome


### PR DESCRIPTION
#### Summary

Rename arm64 builds to m1 so people can find them. See #1620 

#### Release Note
```release-note
arm64 mac builds are now named m1 so people can easily spot them
```
