### PR TITLE
[MM-36308] New way to get signature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ commands:
         type: string
         default: ""
     steps:
-      - run: wget -qO - https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/Release.key | apt-key add -
+      - run: curl -fsSL https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/wine.gpg > /dev/null
       - run: apt-get update && apt-get -y install << parameters.apt_opts >>
       - run: npm ci
 


### PR DESCRIPTION
#### Summary

Seems opensuse.org changed the signature two days ago and it wasn't working for us. changing how we acquire that signature seems to work.

This is already working on 4.7 as I needed to cut the RC

#### Ticket Link

[MM-36308](https://mattermost.atlassian.net/browse/MM-36308)

```release-note
NONE
```