### PR TITLE
[MM-35581] fix m1 rename not being persisted, add rpm to release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -405,7 +405,9 @@ workflows:
                 # release-XX.YY.ZZ
                 # release-XX.YY.ZZ-rc-something
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
-      - build-linux
+      - build-linux:
+          requires:
+            - check
 
       - build-win-no-installer:
           requires:
@@ -436,18 +438,20 @@ workflows:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
 
       - mac_installer:
+          requires:
+            - check
           context: codesign-certificates
           filters:
             branches:
               only:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
-                - fixPipeline
 
       - store_artifacts:
           # for master/PR builds
           requires:
             - build-linux
-            - mac_installer
+            - build-win-no-installer
+            - build-mac-no-dmg
           filters:
             branches:
               ignore:
@@ -456,7 +460,9 @@ workflows:
       - upload_to_s3:
           # for release builds
           requires:
+            - msi_installer
             - mac_installer
+            - build-linux
           context: mattermost-release-s3
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -405,9 +405,7 @@ workflows:
                 # release-XX.YY.ZZ
                 # release-XX.YY.ZZ-rc-something
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
-      - build-linux:
-          requires:
-            - check
+      - build-linux
 
       - build-win-no-installer:
           requires:
@@ -438,20 +436,18 @@ workflows:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
 
       - mac_installer:
-          requires:
-            - check
           context: codesign-certificates
           filters:
             branches:
               only:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
+                - fixPipeline
 
       - store_artifacts:
           # for master/PR builds
           requires:
             - build-linux
-            - build-win-no-installer
-            - build-mac-no-dmg
+            - mac_installer
           filters:
             branches:
               ignore:
@@ -460,9 +456,7 @@ workflows:
       - upload_to_s3:
           # for release builds
           requires:
-            - msi_installer
             - mac_installer
-            - build-linux
           context: mattermost-release-s3
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,7 +230,11 @@ jobs:
           command: tar -xzf rename.tgz
       - run:
           name: rename arm64 to m1
-          command: ./rename-1.601/rename 's/arm64/m1/' release/*
+          command: ./rename-1.601/rename 's/arm64/m1/' ./dist/macos-release/*
+      - persist_to_workspace:
+          root: ./dist
+          paths:
+            - "./macos-release/"
 
   store_artifacts:
     executor: wine-chrome

--- a/scripts/generate_release_markdown.sh
+++ b/scripts/generate_release_markdown.sh
@@ -34,7 +34,7 @@ $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win-x64.zip")
 
 #### Mac
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-mac.dmg")
-$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-mac-arm64.dmg") (beta)
+$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-mac-m1.dmg") (beta)
 
 #### Linux
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-linux-ia32.tar.gz")
@@ -43,6 +43,10 @@ $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-linux-x64.tar.gz")
 #### Linux (Unofficial) - deb files
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-linux-i386.deb")
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-linux-amd64.deb")
+
+#### Linux (Unofficial) - rpm files (beta)
+$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-linux-i386.rpm")
+$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-linux-x86_64.rpm")
 
 #### Linux (Unofficial) - AppImage files
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-linux-i386.AppImage")


### PR DESCRIPTION
#### Summary

Rename was occurring after persisting the workspace, so changes were lost when circle job ended
Also, add rpm to the list of files in the release.

#### Ticket Link

Follow up to #1620 and #1611 
#### Release Note

```release-note
NONE
```
