### PR TITLE
[MM-36030] Allow for duplicate servers with different names to behave normally

### DIFF
--- a/src/common/config/index.js
+++ b/src/common/config/index.js
@@ -336,7 +336,7 @@ export default class Config extends EventEmitter {
         let newTeams = teams;
         const uniqueURLs = new Set();
         newTeams = newTeams.filter((team) => {
-            return uniqueURLs.has(team.url) ? false : uniqueURLs.add(team.url);
+            return uniqueURLs.has(`${team.name}:${team.url}`) ? false : uniqueURLs.add(`${team.name}:${team.url}`);
         });
         return newTeams;
     }

--- a/src/main/views/viewManager.js
+++ b/src/main/views/viewManager.js
@@ -72,7 +72,7 @@ export class ViewManager {
             if (recycle && recycle.isVisible) {
                 setFocus = recycle.name;
             }
-            if (recycle && recycle.server.url.toString() === urlUtils.parseURL(server.url).toString()) {
+            if (recycle && recycle.server.name === server.name && recycle.server.url.toString() === urlUtils.parseURL(server.url).toString()) {
                 oldviews.delete(recycle.name);
                 this.views.set(recycle.name, recycle);
             } else {


### PR DESCRIPTION
#### Summary
When adding a server with a different name but the same URL, the app would crash due to differences between what the config was reporting as the server list, and what views actually exists. Now the config will filter on both the server name and URL, effectively allowing users to access the same server with multiple different names,

NOTE: You can still add the same server (ie. same name and URL) twice, it just won't cause a crash. We should be adding some validation on server creation to remedy this in a future ticket.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36030

#### Release Note
```release-note
NONE
```
