### PR TITLE
[MM-30147] [MM-30146] fix loading path for cert modal

### DIFF
--- a/src/main/certificateManager.js
+++ b/src/main/certificateManager.js
@@ -1,6 +1,5 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import path from 'path';
 import log from 'electron-log';
 
 import * as WindowManager from './windows/windowManager';

--- a/src/main/certificateManager.js
+++ b/src/main/certificateManager.js
@@ -6,9 +6,9 @@ import log from 'electron-log';
 import * as WindowManager from './windows/windowManager';
 
 import {addModal} from './views/modalManager';
-import {getLocalURLString} from './utils';
+import {getLocalURLString, getLocalPreload} from './utils';
 
-const modalPreload = path.resolve(__dirname, '../../dist/modalPreload.js');
+const modalPreload = getLocalPreload('modalPreload.js');
 const html = getLocalURLString('certificateModal.html');
 
 export class CertificateManager {


### PR DESCRIPTION
#### Summary

When there is more than one client certificates that fits to authenticate, we show a modal for choosing the right one. currently this was failing as it was using an old method for detecting were to get the preload info, updating to the new one seems to fix the issue.

#### Ticket Link
[MM-30147](https://mattermost.atlassian.net/browse/MM-30147)
[MM-30146](https://mattermost.atlassian.net/browse/MM-30146)

#### Release Note
```release-note
NONE
```
