### PR TITLE
[MM-36543] Check for webcontents before trying to load url in case tab was removed

### DIFF
--- a/src/main/views/MattermostView.js
+++ b/src/main/views/MattermostView.js
@@ -110,7 +110,7 @@ export class MattermostView extends EventEmitter {
     retry = (loadURL) => {
         return () => {
             // window was closed while retrying
-            if (!this.view) {
+            if (!this.view || !this.view.webContents) {
                 return;
             }
             const loading = this.view.webContents.loadURL(loadURL, {userAgent: composeUserAgent()});


### PR DESCRIPTION
#### Summary
When removing a tab, we destroy the webcontents object to ensure we don't end up with zombies processes. However, our retry timer still exists and we need to make sure that we don't load anything if the tab has been removed. So we simply check to see if webcontents still exists before trying to load anything into it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36543

#### Release Note
```release-note
NONE
```
