### PR TITLE
[MM-35946] Remove memoization to prevent errors on detecting unread/mention state

### DIFF
--- a/src/main/views/MattermostView.js
+++ b/src/main/views/MattermostView.js
@@ -69,7 +69,6 @@ export class MattermostView extends EventEmitter {
      */
         this.usesAsteriskForUnreads = null;
 
-        this.faviconMemoize = new Map();
         this.currentFavicon = null;
         log.info(`BrowserView created for server ${this.server.name}`);
 
@@ -298,15 +297,10 @@ export class MattermostView extends EventEmitter {
             // if unread state is stored for that favicon, retrieve value.
             // if not, get related info from preload and store it for future changes
             this.currentFavicon = favicons[0];
-            if (this.faviconMemoize.has(favicons[0])) {
-                appState.updateUnreads(this.server.name, this.faviconMemoize.get(favicons[0]));
-            } else {
-                this.findUnreadState(favicons[0]);
-            }
+            this.findUnreadState(favicons[0]);
         }
     }
 
-    // if favicon is null, it will affect appState, but won't be memoized
     findUnreadState = (favicon) => {
         try {
             this.view.webContents.send(IS_UNREAD, favicon, this.server.name);
@@ -320,12 +314,7 @@ export class MattermostView extends EventEmitter {
     // so don't memoize as we don't have the favicons and there is no rush to find out.
     handleFaviconIsUnread = (e, favicon, serverName, result) => {
         if (this.server && serverName === this.server.name) {
-            if (favicon) {
-                this.faviconMemoize.set(favicon, result);
-            }
-            if (favicon === null || favicon === this.currentFavicon) {
-                appState.updateUnreads(serverName, result);
-            }
+            appState.updateUnreads(serverName, result);
         }
     }
 }


### PR DESCRIPTION
#### Summary

Remove memoization as a possible cause for not removing the unread/mention mark

Also this can't be cherry-picked directly, so once we merge this we'll need to do a separate PR to master replicating.

#### Ticket Link

[MM-35946](https://mattermost.atlassian.net/browse/MM-35946)

#### Device Information
This PR was tested on: windows 10, MacOS X

I haven't been able to reproduce with this build, but this doesn't mean it might still happen if there are other causes, so I'd like to have as much feedback as possible on this one.

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

Fix badge not updating properly on some setups

```
