### PR TITLE
[MM-36938] Disable gpu before reading the registry

### DIFF
--- a/src/common/config/index.js
+++ b/src/common/config/index.js
@@ -25,7 +25,7 @@ export default class Config extends EventEmitter {
     constructor(configFilePath) {
         super();
         this.configFilePath = configFilePath;
-        this.registryConfigData = new Object();
+        this.registryConfigData = {};
     }
 
     // separating constructor from init so main can setup event listeners

--- a/src/common/config/index.js
+++ b/src/common/config/index.js
@@ -25,10 +25,12 @@ export default class Config extends EventEmitter {
     constructor(configFilePath) {
         super();
         this.configFilePath = configFilePath;
+        this.registryConfigData = new Object();
     }
 
     // separating constructor from init so main can setup event listeners
     init = () => {
+        this.reload();
         this.registryConfig = new RegistryConfig();
         this.registryConfig.once(REGISTRY_READ_EVENT, this.loadRegistry);
         this.registryConfig.init();
@@ -65,7 +67,6 @@ export default class Config extends EventEmitter {
         this.localConfigData = this.loadLocalConfigFile();
         this.localConfigData = this.checkForConfigUpdates(this.localConfigData);
         this.regenerateCombinedConfigData();
-
         this.emit('update', this.combinedData);
         this.emit('synchronize');
     }

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -142,11 +142,18 @@ function initializeArgs() {
 async function initializeConfig() {
     const loadConfig = new Promise((resolve) => {
         config = new Config(app.getPath('userData') + '/config.json');
+
         config.once('update', (configData) => {
             config.on('update', handleConfigUpdate);
             config.on('synchronize', handleConfigSynchronize);
             config.on('darkModeChange', handleDarkModeChange);
             handleConfigUpdate(configData);
+
+            // can only call this before the app is ready
+            if (config.enableHardwareAcceleration === false) {
+                app.disableHardwareAcceleration();
+            }
+
             resolve();
         });
         config.init();
@@ -178,11 +185,6 @@ function initializeBeforeAppReady() {
     if (process.cwd() !== expectedPath && !isDev) {
         log.warn(`Current working directory is ${process.cwd()}, changing into ${expectedPath}`);
         process.chdir(expectedPath);
-    }
-
-    // can only call this before the app is ready
-    if (config.enableHardwareAcceleration === false) {
-        app.disableHardwareAcceleration();
     }
 
     refreshTrayImages(config.trayIconTheme);


### PR DESCRIPTION
#### Summary

Disabling the gpu once the app is ready had some unexpected results (see #1645 ) this will trigger reading the config file and applying the change before the app is ready and before it finishes reading the registry (which is really slow in windows)

After merging this, we'll need to reimplement it in master as TS, so don't cherry pick.

#### Ticket Link

Fixes #1645 
Jira: [MM-36938](https://mattermost.atlassian.net/browse/MM-36938)

#### Device Information
This PR was tested on: windows 10 with and without GPO policies

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Fixed GUI missbehaviour by disabling GPU after app initialization.
```
