### PR TITLE
add a reminder on how to proceed with releases

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -112,6 +112,11 @@ case "${1}" in
             tag "${new_pkg_version}" "Released on $(date -u)"
             print_info "Locally created an final version. In order to build you'll have to:"
             print_info "$ git push --follow-tags ${git_origin} ${branch_name}:${branch_name}"
+            print_info "--------\n"
+            print_info "  == AFTER RELEASE FINISHES == "
+            print_info "once the release is created you'll need to go to latest/.gitlab-ci.yml"
+            print_info "and update the latest version variables for the desktop,"
+            print_info "run the the pipeline and from the list of jobs run the desktop one"
         else
             print_error "Can't release on a non release-X.Y branch"
             exit 2


### PR DESCRIPTION
#### Summary

Whenever we do a release we need to update the links that point to the latests mattermost release

this should live in a release playbook, but since we don't have one yet, this would serve as a reminder of the process.

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
