### PR TITLE
[MM-37117] Prevent crashing if the download path is not set correctly

### DIFF
--- a/src/common/config/defaultPreferences.js
+++ b/src/common/config/defaultPreferences.js
@@ -2,20 +2,16 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import path from 'path';
+import os from 'os';
+
 /**
  * Default user preferences. End-users can change these parameters by editing config.json
  * @param {number} version - Scheme version. (Not application version)
  */
 
 const getDefaultDownloadLocation = () => {
-    switch (process.platform) {
-    case 'darwin':
-        return `/Users/${process.env.USER || process.env.USERNAME}/Downloads`;
-    case 'win32':
-        return `C:\\Users\\${process.env.USER || process.env.USERNAME}\\Downloads`;
-    default:
-        return `/home/${process.env.USER || process.env.USERNAME}/Downloads`;
-    }
+    return path.join(os.homedir(), 'Downloads');
 };
 
 const defaultPreferences = {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -260,7 +260,11 @@ function handleConfigSynchronize() {
     WindowManager.setConfig(config.data);
     setUnreadBadgeSetting(config.data.showUnreadBadge);
     if (config.data.downloadLocation) {
-        app.setPath('downloads', config.data.downloadLocation);
+        try {
+            app.setPath('downloads', config.data.downloadLocation);
+        } catch (e) {
+            log.error(`There was a problem trying to set the default download path: ${e}`);
+        }
     }
     if (app.isReady()) {
         WindowManager.sendToRenderer(RELOAD_CONFIGURATION);


### PR DESCRIPTION
#### Summary

If the path is not absolute, the app crashes. Also removed custom function that was assuming user's home dir was in `C:/` drive by a node api call.

Once merged, we'll need to recreate this in master.

#### Ticket Link

[MM-37117](https://mattermost.atlassian.net/browse/MM-37117)

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots

```release-note
Prevented crash on malformed default download location.
```
