### PR TITLE
fix crash on invalid download paths

### DIFF
--- a/src/common/config/defaultPreferences.ts
+++ b/src/common/config/defaultPreferences.ts
@@ -2,6 +2,9 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import path from 'path';
+import os from 'os';
+
 /**
  * Default user preferences. End-users can change these parameters by editing config.json
  * @param {number} version - Scheme version. (Not application version)
@@ -9,15 +12,8 @@
 
 import {ConfigV2} from 'types/config';
 
-export const getDefaultDownloadLocation = () => {
-    switch (process.platform) {
-    case 'darwin':
-        return `/Users/${process.env.USER || process.env.USERNAME}/Downloads`;
-    case 'win32':
-        return `C:\\Users\\${process.env.USER || process.env.USERNAME}\\Downloads`;
-    default:
-        return `/home/${process.env.USER || process.env.USERNAME}/Downloads`;
-    }
+export const getDefaultDownloadLocation = (): string => {
+    return path.join(os.homedir(), 'Downloads');
 };
 
 const defaultPreferences: ConfigV2 = {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -282,7 +282,11 @@ function handleConfigSynchronize() {
     WindowManager.setConfig(config.data);
     setUnreadBadgeSetting(config.data.showUnreadBadge);
     if (config.data.downloadLocation) {
-        app.setPath('downloads', config.data.downloadLocation);
+        try {
+            app.setPath('downloads', config.data.downloadLocation);
+        } catch (e) {
+            log.error(`There was a problem trying to set the default download path: ${e}`);
+        }
     }
     if (app.isReady()) {
         WindowManager.sendToRenderer(RELOAD_CONFIGURATION);


### PR DESCRIPTION
#### Summary
 
Cherry pick from #1659 

#### Ticket Link

[MM-37117](https://mattermost.atlassian.net/browse/MM-37117)

#### Release Note

```release-note
Prevented crash on malformed default download location.
```
