### PR TITLE
[MM-36747] Allow users to specify spellchecker url for downloading dictionaries

### DIFF
--- a/src/common/config/index.js
+++ b/src/common/config/index.js
@@ -200,6 +200,11 @@ export default class Config extends EventEmitter {
     get useSpellChecker() {
         return this.combinedData.useSpellChecker;
     }
+
+    get spellCheckerURL() {
+        return this.combinedData.spellCheckerURL;
+    }
+
     get spellCheckerLocale() {
         return this.combinedData.spellCheckerLocale;
     }

--- a/src/main/Validator.js
+++ b/src/main/Validator.js
@@ -78,7 +78,7 @@ const configDataSchemaV2 = Joi.object({
     }),
     showUnreadBadge: Joi.boolean().default(true),
     useSpellChecker: Joi.boolean().default(true),
-    spellCheckerURL: Joi.string(),
+    spellCheckerURL: Joi.string().allow(null),
     enableHardwareAcceleration: Joi.boolean().default(true),
     autostart: Joi.boolean().default(true),
     spellCheckerLocale: Joi.string().regex(/^[a-z]{2}-[A-Z]{2}$/).default('en-US'),

--- a/src/main/Validator.js
+++ b/src/main/Validator.js
@@ -78,6 +78,7 @@ const configDataSchemaV2 = Joi.object({
     }),
     showUnreadBadge: Joi.boolean().default(true),
     useSpellChecker: Joi.boolean().default(true),
+    spellCheckerURL: Joi.string(),
     enableHardwareAcceleration: Joi.boolean().default(true),
     autostart: Joi.boolean().default(true),
     spellCheckerLocale: Joi.string().regex(/^[a-z]{2}-[A-Z]{2}$/).default('en-US'),
@@ -164,6 +165,10 @@ export function validateV2ConfigData(data) {
 
         // replace original teams
         data.teams = teams;
+    }
+    if (data.spellCheckerURL && !urlUtils.isValidURL(data.spellCheckerURL)) {
+        log.error('Invalid download location for spellchecker dictionary, removing from config');
+        delete data.spellCheckerURL;
     }
     return validateAgainstSchema(data, configDataSchemaV2);
 }

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -463,7 +463,7 @@ function initializeAfterAppReady() {
 
     defaultSession.on('spellcheck-dictionary-download-failure', (event, lang) => {
         if (config.spellCheckerURL) {
-            log.error(`There was an error while trying to load the dictionary definitions dor ${lang} fromfully the specified url. Please review you have access to the needed files. Url used was ${config.spellCheckerURL}`);
+            log.error(`There was an error while trying to load the dictionary definitions for ${lang} fromfully the specified url. Please review you have access to the needed files. Url used was ${config.spellCheckerURL}`);
         } else {
             log.warn(`There was an error while trying to download the dictionary definitions for ${lang}, spellchecking might not work properly.`);
         }

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -461,33 +461,21 @@ function initializeAfterAppReady() {
     app.setAppUserModelId('Mattermost.Desktop'); // Use explicit AppUserModelID
     const defaultSession = session.defaultSession;
 
-    defaultSession.on('spellcheck-dictionary-initialized', (e, lang) => {
-        log.info(`spellchecker initialized: ${lang}`);
+    defaultSession.on('spellcheck-dictionary-download-failure', (event, lang) => {
+        if (config.spellCheckerURL) {
+            log.error(`There was an error while trying to load the dictionary definitions dor ${lang} fromfully the specified url. Please review you have access to the needed files. Url used was ${config.spellCheckerURL}`);
+        } else {
+            log.warn(`There was an error while trying to download the dictionary definitions for ${lang}, spellchecking might not work properly.`);
+        }
     });
 
-    log.info(`spellcheckerURL: ${config.spellCheckerURL}`);
     if (process.platform !== 'darwin' && config.spellCheckerURL) {
         const spellCheckerURL = config.spellCheckerURL.endsWith('/') ? config.spellCheckerURL : `${config.spellCheckerURL}/`;
         log.info(`Configuring spellchecker using download URL: ${spellCheckerURL}`);
         defaultSession.setSpellCheckerDictionaryDownloadURL(spellCheckerURL);
-        defaultSession.on('spellcheck-dictionary-download-begin', (event, lang) => {
-            log.info(`### Downloading dictionary for ${lang}`);
-        });
-
-        defaultSession.on('spellcheck-dictionary-download-begin', (event, lang) => {
-            log.info(`### starting dictionary download ${lang}`);
-        });
 
         defaultSession.on('spellcheck-dictionary-download-success', (event, lang) => {
-            log.info(`### Download success for ${lang}`);
-        });
-
-        defaultSession.on('spellcheck-dictionary-download-failure', (event, lang) => {
-            if (config.spellCheckerURL) {
-                log.error(`There was an error while trying to load the dictionary definitions for ${lang} from the specified url. Please review you have access to the needed files. Url used was ${config.spellCheckerURL}`);
-            } else {
-                log.warn(`There was an error while trying to download the dictionary definitions for ${lang}, spellchecking might not work properly.`);
-            }
+            log.info(`Dictionary definitions downloaded successfully for ${lang}`);
         });
     }
 

--- a/src/main/views/MattermostView.js
+++ b/src/main/views/MattermostView.js
@@ -136,6 +136,10 @@ export class MattermostView extends EventEmitter {
     loadSuccess = (loadURL) => {
         return () => {
             log.info(`[${Util.shorten(this.server.name)}] finished loading ${loadURL}`);
+            this.view.webContents.session.on('spellcheck-dictionary-initialized', (e, lang) => {
+                log.info(`spellchecker initialized: ${lang}`);
+                log.info(e);
+            });
             WindowManager.sendToRenderer(LOAD_SUCCESS, this.server.name);
             this.maxRetries = MAX_SERVER_RETRIES;
             if (this.status === LOADING) {

--- a/src/renderer/components/SettingsPage.jsx
+++ b/src/renderer/components/SettingsPage.jsx
@@ -289,35 +289,29 @@ export default class SettingsPage extends React.PureComponent {
         this.setState({userOpenedDownloadDialog: false});
     }
 
-    saveSpellCheckerURL = (dictionaryURL) => {
-        this.setState({SpellCheckerURL: dictionaryURL});
-        window.timers.setImmediate(this.saveSetting, CONFIG_TYPE_APP_OPTIONS, {key: 'spellCheckerURL', data: dictionaryURL});
+    saveSpellCheckerURL = () => {
+        window.timers.setImmediate(this.saveSetting, CONFIG_TYPE_APP_OPTIONS, {key: 'spellCheckerURL', data: this.state.spellCheckerURL});
+    }
+
+    resetSpellCheckerURL = () => {
+        this.setState({spellCheckerURL: null, allowSaveSpellCheckerURL: false});
+        window.timers.setImmediate(this.saveSetting, CONFIG_TYPE_APP_OPTIONS, {key: 'spellCheckerURL', data: null});
     }
 
     handleChangeSpellCheckerURL= (e) => {
         const dictionaryURL = e.target.value;
         let allowSaveSpellCheckerURL;
-        if (dictionaryURL) {
-            try {
-                // eslint-disable-next-line no-new
-                new URL(dictionaryURL);
-                allowSaveSpellCheckerURL = true;
-            } catch {
-                allowSaveSpellCheckerURL = false;
-            }
-
-            this.setState({
-                SpellCheckerURL: dictionaryURL,
-                allowSaveSpellCheckerURL,
-            });
-        } else {
-            // use default
+        try {
+            // eslint-disable-next-line no-new
+            new URL(dictionaryURL);
             allowSaveSpellCheckerURL = true;
-            this.setState({
-                SpellCheckerURL: null,
-                allowSaveSpellCheckerURL,
-            });
+        } catch {
+            allowSaveSpellCheckerURL = false;
         }
+        this.setState({
+            spellCheckerURL: dictionaryURL,
+            allowSaveSpellCheckerURL,
+        });
     }
 
     updateTeam = (index, newData) => {
@@ -499,32 +493,52 @@ export default class SettingsPage extends React.PureComponent {
                 </HelpBlock>
             </Checkbox>);
 
-        // if ( process.platform !== 'darwin') {
-            options.push(
-                <div style={settingsPage.container}>
-                    <div>{'Use alternate url for dictionary downloads'}</div>
-                    <input
-                        disabled={!this.state.useSpellChecker}
-                        style={settingsPage.downloadLocationInput}
-                        key='inputSpellCheckerURL'
-                        id='inputSpellCheckerURL'
-                        ref={this.spellCheckerURLRef}
-                        onChange={this.handleChangeSpellCheckerURL}
-                        value={this.state.spellCheckerURL}
-                    />
+        if (process.platform !== 'darwin') {
+            if (this.state.spellCheckerURL === null || typeof this.state.spellCheckerURL === 'undefined') {
+                options.push(
                     <Button
-                        disabled={!this.state.useSpellChecker && !this.state.allowSaveSpellCheckerURL}
-                        style={settingsPage.downloadLocationButton}
-                        id='saveSpellCheckerURL'
-                        onClick={this.saveSpellCheckerURL}
+                        id='editSpellcheckerURL'
+                        key='editSpellcheckerURL'
+                        onClick={() => this.setState({spellCheckerURL: '', allowSaveSpellCheckerURL: false})}
+                        bsStyle='link'
+                    >{'Use alternate dictionary URL'}</Button>,
+                );
+            } else {
+                options.push(
+                    <div
+                        style={settingsPage.container}
+                        key='containerInputSpellchekerURL'
                     >
-                        <span>{'Save'}</span>
-                    </Button>
-                    <HelpBlock>
-                        {'Specify the url where dictionary definitions can be retrieved, leave blank for default'}
-                    </HelpBlock>
-                </div>);
-        // }
+                        <input
+                            disabled={!this.state.useSpellChecker}
+                            style={settingsPage.downloadLocationInput}
+                            key='inputSpellCheckerURL'
+                            id='inputSpellCheckerURL'
+                            ref={this.spellCheckerURLRef}
+                            onChange={this.handleChangeSpellCheckerURL}
+                            value={this.state.spellCheckerURL}
+                        />
+                        <Button
+                            disabled={!this.state.allowSaveSpellCheckerURL}
+                            key='saveSpellCheckerURL'
+                            style={settingsPage.downloadLocationButton}
+                            id='saveSpellCheckerURL'
+                            onClick={this.saveSpellCheckerURL}
+                        >
+                            <span>{'Save'}</span>
+                        </Button>
+                        <HelpBlock>
+                            {'Specify the url where dictionary definitions can be retrieved'}
+                        </HelpBlock>
+                        <Button
+                            id='revertSpellcheckerURL'
+                            key='revertSpellcheckerURL'
+                            onClick={this.resetSpellCheckerURL}
+                            bsStyle='link'
+                        >{'Revert to default'}</Button>
+                    </div>);
+            }
+        }
 
         if (window.process.platform === 'darwin' || window.process.platform === 'win32') {
             const TASKBAR = window.process.platform === 'win32' ? 'taskbar' : 'Dock';

--- a/src/renderer/components/SettingsPage.jsx
+++ b/src/renderer/components/SettingsPage.jsx
@@ -501,7 +501,7 @@ export default class SettingsPage extends React.PureComponent {
                         key='editSpellcheckerURL'
                         onClick={() => this.setState({spellCheckerURL: '', allowSaveSpellCheckerURL: false})}
                         bsStyle='link'
-                    >{'Use alternate dictionary URL'}</Button>,
+                    >{'Use an alternative dictionary URL'}</Button>,
                 );
             } else {
                 options.push(


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

This PR allows people who would prefer not to download dictionary definitions from chromium's CDN to use an alternate url.

This requires a separate PR for documenting the process.
This requires a separate PR for cherry-picking into master as we moved towards TS

Testing this is complicated, I've detailed the steps in the jira ticket, but feel free to DM me if you need any help

#### Ticket Link

Fixes #1642 
[MM-36747](https://mattermost.atlassian.net/browse/MM-36747)

#### Device Information
This PR was tested on: windows and linux

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Allow users to specify a different download location for hunspell dictionaries
```
