### PR TITLE
[MM-36753] Revert to Electron v12.0.1 (#1665) - cherrypick

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "mattermost-desktop",
-      "version": "4.8.0-develop",
+      "version": "4.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hapi/joi": "^16.1.8",
@@ -52,7 +52,7 @@
         "cross-env": "^5.2.0",
         "css-loader": "^1.0.1",
         "devtron": "^1.4.0",
-        "electron": "^12.0.10",
+        "electron": "12.0.1",
         "electron-builder": "^22.10.5",
         "electron-connect": "^0.6.3",
         "electron-mocha": "^10.0.0",
@@ -9298,9 +9298,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-12.0.10.tgz",
-      "integrity": "sha512-qaNvFG4AgeuT3PkSljQ9MlY7hz87wIwJ5cmSZ1453IVsUd0BV7pcaLViSpR1bRSqxetDDWxCLtCp0N9RXeDZww==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-12.0.1.tgz",
+      "integrity": "sha512-4bTfLSTmuFkMxq3RMyjd8DxuzbxI1Bde879XDrBA4kFWbKhZ3hfXqHXQz3129eCmcLre5odcNsWq7/xzyJilMA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -32373,9 +32373,9 @@
       "dev": true
     },
     "electron": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-12.0.10.tgz",
-      "integrity": "sha512-qaNvFG4AgeuT3PkSljQ9MlY7hz87wIwJ5cmSZ1453IVsUd0BV7pcaLViSpR1bRSqxetDDWxCLtCp0N9RXeDZww==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-12.0.1.tgz",
+      "integrity": "sha512-4bTfLSTmuFkMxq3RMyjd8DxuzbxI1Bde879XDrBA4kFWbKhZ3hfXqHXQz3129eCmcLre5odcNsWq7/xzyJilMA==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/mattermost/desktop.git"
   },
   "config": {
-    "target": "12.0.10",
+    "target": "12.0.1",
     "arch": "x64",
     "target_arch": "x64",
     "disturl": "https://electronjs.org/headers",
@@ -73,7 +73,7 @@
     "cross-env": "^5.2.0",
     "css-loader": "^1.0.1",
     "devtron": "^1.4.0",
-    "electron": "^12.0.10",
+    "electron": "12.0.1",
     "electron-builder": "^22.10.5",
     "electron-connect": "^0.6.3",
     "electron-mocha": "^10.0.0",


### PR DESCRIPTION
#### Summary
Cherrypick of #1665 to `release-4.7`
