### PR TITLE
allow webpack to resolve .json

### DIFF
--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -36,7 +36,7 @@ module.exports = {
             common: path.resolve(__dirname, './src/common'),
             static: path.resolve(__dirname, './src/assets'),
         },
-        extensions: ['.ts', '.tsx', '.js', '.jsx'],
+        extensions: ['.ts', '.tsx', '.js', '.jsx', '.json'],
     },
 };
 


### PR DESCRIPTION
#### Summary

I was having trouble building from master, and seems we [couldn't resolve .json files](https://github.com/MarshallOfSound/electron-devtools-installer/pull/60#issuecomment-320229210). this should fix it.



#### Device Information
This PR was tested on: compiles on macOS big sur

#### Release Note

```release-note
NONE
```
