### PR TITLE
remove electron-log from preload

### DIFF
--- a/src/main/preload/mattermost.js
+++ b/src/main/preload/mattermost.js
@@ -7,21 +7,22 @@
 /* eslint-disable no-magic-numbers */
 
 import {ipcRenderer, webFrame} from 'electron';
-import log from 'electron-log';
+
+// I've filed an issue in electron-log https://github.com/megahertz/electron-log/issues/267
+// we'll be able to use it again if there is a workaround for the 'os' import
+//import log from 'electron-log';
 
 import {NOTIFY_MENTION, IS_UNREAD, UNREAD_RESULT, SESSION_EXPIRED, SET_VIEW_NAME, REACT_APP_INITIALIZED, USER_ACTIVITY_UPDATE, CLOSE_TEAMS_DROPDOWN} from 'common/communication';
 
 const UNREAD_COUNT_INTERVAL = 1000;
 const CLEAR_CACHE_INTERVAL = 6 * 60 * 60 * 1000; // 6 hours
 
-Reflect.deleteProperty(global.Buffer); // http://electron.atom.io/docs/tutorial/security/#buffer-global
-
 let appVersion;
 let appName;
 let sessionExpired;
 let viewName;
 
-log.info('Initializing preload');
+console.log('Preload initialized');
 
 ipcRenderer.invoke('get-app-version').then(({name, version}) => {
     appVersion = version;


### PR DESCRIPTION
#### Summary

Seems electron-log requires os when compiled for the preload script (probably due to it being compiled for the main process instead of the renderer one). I've [filed an issue for it](https://github.com/megahertz/electron-log/issues/267), so if it gets resolved we can go back to use electron-log.

this might need to be manually cherry-picked to 4.7 before rc, I'll check the branch and do the PR there if needed.

#### Device Information
This PR was tested on: MacOs BigSur

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
