### PR TITLE
[MM-37480]Fix no handler

### DIFF
--- a/src/common/config/index.js
+++ b/src/common/config/index.js
@@ -37,6 +37,13 @@ export default class Config extends EventEmitter {
     // separating constructor from init so main can setup event listeners
     init = () => {
         this.reload();
+        ipcMain.handle(GET_CONFIGURATION, this.handleGetConfiguration);
+        ipcMain.handle(GET_LOCAL_CONFIGURATION, this.handleGetLocalConfiguration);
+        ipcMain.handle(UPDATE_TEAMS, this.handleUpdateTeams);
+        ipcMain.on(UPDATE_CONFIGURATION, this.setMultiple);
+        if (process.platform === 'darwin' || process.platform === 'win32') {
+            nativeTheme.on('updated', this.handleUpdateTheme);
+        }
         this.registryConfig = new RegistryConfig();
         this.registryConfig.once(REGISTRY_READ_EVENT, this.loadRegistry);
         this.registryConfig.init();
@@ -51,13 +58,6 @@ export default class Config extends EventEmitter {
     loadRegistry = (registryData) => {
         this.registryConfigData = registryData;
         this.reload();
-        ipcMain.handle(GET_CONFIGURATION, this.handleGetConfiguration);
-        ipcMain.handle(GET_LOCAL_CONFIGURATION, this.handleGetLocalConfiguration);
-        ipcMain.handle(UPDATE_TEAMS, this.handleUpdateTeams);
-        ipcMain.on(UPDATE_CONFIGURATION, this.setMultiple);
-        if (process.platform === 'darwin' || process.platform === 'win32') {
-            nativeTheme.on('updated', this.handleUpdateTheme);
-        }
     }
 
     /**


### PR DESCRIPTION
#### Summary

make handlers available before finishing reading the registry

#### Ticket Link
[MM-37480](https://mattermost.atlassian.net/browse/MM-37480)

#### Checklist

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
fixed crash on windows due to configuration handlers not being ready
```
