### PR TITLE
Fix mac installer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,6 +217,9 @@ jobs:
       - attach_workspace:
           at: ./dist
       - run:
+          name: Update node to v16
+          command: brew upgrade node
+      - run:
           name: Installing npm dependencies
           command: npm ci
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,7 @@ jobs:
           at: ./dist
       - run:
           name: Update node to v16
-          command: brew upgrade node
+          command: brew upgrade node || true
       - run:
           name: Installing npm dependencies
           command: npm ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -449,7 +449,7 @@ workflows:
             branches:
               only:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
-                - pull/1651
+                - pull/1681
 
       - store_artifacts:
           # for master/PR builds


### PR DESCRIPTION
#### Summary
We upgraded `electron-builder` to v22.11.x, which should be using Node v14+. Unfortunately, the `mac_installer` uses Node 12 by default, so we have to upgrade it on build.

```release-note
NONE
```