### PR TITLE
[MM-37743] Fix URL validation when editing/adding a server

### DIFF
--- a/src/common/utils/url.ts
+++ b/src/common/utils/url.ts
@@ -30,7 +30,7 @@ function getDomain(inputURL: URL | string) {
 }
 
 function isValidURL(testURL: string) {
-    return Boolean(isHttpUri(testURL) || isHttpsUri(testURL)) && parseURL(testURL) !== null;
+    return Boolean(isHttpUri(testURL) || isHttpsUri(testURL)) && Boolean(parseURL(testURL));
 }
 
 function isValidURI(testURL: string) {


### PR DESCRIPTION
#### Summary
We were explicitly checking for `null` when calling `isValidURL`, when it now returns `undefined`. So the check has been fixed to check for falsy instead.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37743

#### Release Note
```release-note
NONE
```
