### PR TITLE
Remove old `src/node_modules` on `clean` if it exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "start": "electron dist/ --disable-dev-mode",
     "restart": "npm run build && npm run start",
     "storybook": "start-storybook -p 9001 -c src/.storybook",
-    "clean": "rm -rf release/ node_modules/ dist/ && find src -name '*_bundle.js' | xargs rm",
+    "clean": "rm -rf release/ node_modules/ src/node_modules/ dist/ && find src -name '*_bundle.js' | xargs rm",
     "clean-install": "npm run clean && npm install",
     "clean-dist": "rm -rf dist/",
     "watch": "run-p watch:*",


### PR DESCRIPTION
#### Summary
In some cases, the old `src/node_modules` folder that existed in v4.6 and earlier causes problems when running webpack. More recently it was compiling an older version of `react-bootstrap` which causes the app not to function correctly.

Now we will make sure to blow it away on `npm run clean` so that if its there causing issues again it will get deleted and fix that issue.

```release-note
NONE
```
