### PR TITLE
[MM-37797] Re-added the check for flashing the window

### DIFF
--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -227,10 +227,12 @@ export function restoreMain() {
 
 export function flashFrame(flash: boolean) {
     if (process.platform === 'linux' || process.platform === 'win32') {
-        status.mainWindow?.flashFrame(flash);
-        if (status.settingsWindow) {
-            // main might be hidden behind the settings
-            status.settingsWindow.flashFrame(flash);
+        if (status.config?.notifications.flashWindow) {
+            status.mainWindow?.flashFrame(flash);
+            if (status.settingsWindow) {
+                // main might be hidden behind the settings
+                status.settingsWindow.flashFrame(flash);
+            }
         }
     }
     if (process.platform === 'darwin' && status.config?.notifications.bounceIcon) {

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -239,13 +239,13 @@ export default class SettingsPage extends React.PureComponent<Record<string, nev
             key: 'notifications',
             data: {
                 ...this.state.notifications,
-                flashWindow: this.flashWindowRef.current?.checked ? 0 : 2,
+                flashWindow: this.flashWindowRef.current?.checked ? 2 : 0,
             },
         });
         this.setState({
             notifications: {
                 ...this.state.notifications,
-                flashWindow: this.flashWindowRef.current?.checked ? 0 : 2,
+                flashWindow: this.flashWindowRef.current?.checked ? 2 : 0,
             },
         });
     }


### PR DESCRIPTION
#### Summary
The setting determining whether the window should flash or not on Windows/Linux when a new mention arrives was not being checked before flashing the window, so we've re-added the check.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37797

#### Release Note
```release-note
Fixed an issue where the window would flash on Windows/Linux when a new mention arrives regardless of the setting to turn it on/off.
```
