### PR TITLE
[MM-36923] Wait to return to the application before turning off the custom login setting

### DIFF
--- a/src/main/views/webContentEvents.ts
+++ b/src/main/views/webContentEvents.ts
@@ -76,7 +76,7 @@ const generateDidStartNavigation = (getServersFunction: () => TeamWithTabs[]) =>
 
         if (server && urlUtils.isCustomLoginURL(parsedURL, server, serverList)) {
             customLogins[contentID].inProgress = true;
-        } else if (customLogins[contentID].inProgress) {
+        } else if (server && customLogins[contentID].inProgress && urlUtils.isInternalURL(server.url, parsedURL)) {
             customLogins[contentID].inProgress = false;
         }
     };


### PR DESCRIPTION
#### Summary
Some login providers like GitLab require a CloudFlare check before hitting the login page, which will trigger a redirect. This PR allows us to stay in 'custom login' mode until we return back to the application.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36923

#### Release Note
```release-note
NONE
```
