### PR TITLE
MM-36234: CRT, handle click on notification

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -747,8 +747,8 @@ function initializeAfterAppReady() {
 // ipc communication event handlers
 //
 
-function handleMentionNotification(event: IpcMainEvent, title: string, body: string, channel: {id: string}, teamId: string, silent: boolean, data: MentionData) {
-    displayMention(title, body, channel, teamId, silent, event.sender, data);
+function handleMentionNotification(event: IpcMainEvent, title: string, body: string, channel: {id: string}, teamId: string, url: string, silent: boolean, data: MentionData) {
+    displayMention(title, body, channel, teamId, url, silent, event.sender, data);
 }
 
 function handleOpenAppMenu() {

--- a/src/main/notifications/index.ts
+++ b/src/main/notifications/index.ts
@@ -16,7 +16,7 @@ import {DownloadNotification} from './Download';
 
 const currentNotifications = new Map();
 
-export function displayMention(title: string, body: string, channel: {id: string}, teamId: string, silent: boolean, webcontents: Electron.WebContents, data: MentionData) {
+export function displayMention(title: string, body: string, channel: {id: string}, teamId: string, url: string, silent: boolean, webcontents: Electron.WebContents, data: MentionData) {
     if (!Notification.isSupported()) {
         log.error('notification not supported');
         return;
@@ -53,7 +53,7 @@ export function displayMention(title: string, body: string, channel: {id: string
     mention.on('click', () => {
         if (serverName) {
             windowManager.switchServer(serverName);
-            webcontents.send('notification-clicked', {channel, teamId});
+            webcontents.send('notification-clicked', {channel, teamId, url});
         }
     });
     mention.show();

--- a/src/main/preload/mattermost.js
+++ b/src/main/preload/mattermost.js
@@ -110,8 +110,8 @@ window.addEventListener('message', ({origin, data = {}} = {}) => {
     // it will be captured by itself too
         break;
     case 'dispatch-notification': {
-        const {title, body, channel, teamId, silent, data: messageData} = message;
-        ipcRenderer.send(NOTIFY_MENTION, title, body, channel, teamId, silent, messageData);
+        const {title, body, channel, teamId, url, silent, data: messageData} = message;
+        ipcRenderer.send(NOTIFY_MENTION, title, body, channel, teamId, url, silent, messageData);
         break;
     }
     default:
@@ -124,13 +124,14 @@ window.addEventListener('message', ({origin, data = {}} = {}) => {
     }
 });
 
-const handleNotificationClick = ({channel, teamId}) => {
+const handleNotificationClick = ({channel, teamId, url}) => {
     window.postMessage(
         {
             type: 'notification-clicked',
             message: {
                 channel,
                 teamId,
+                url,
             },
         },
         window.location.origin,


### PR DESCRIPTION
#### Summary

Clicking on a notification that regards a reply to a thread,
and when the user has CRT set to ON, should open the corresponding thread.

This is done by passing the URL to push to the browser along side the
notification.

Webapp: If a `url` is passed it will be used, otherwise the URL pushed to
history would be the corresponding channel (as is right now).

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-36234

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [x] executed `npm run lint:js` for proper code formatting

#### Device Information

This PR was tested on: MacBook Pro, Version 11.2.3

#### Release Note

```release-note
NONE
```
