### PR TITLE
[MM-36577] Fix electron-builder path for linux files

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -58,7 +58,7 @@
         ]
       },
       {
-        "from": "resources/linux",
+        "from": "src/assets",
         "filter": [
           "create_desktop_file.sh",
           "app_icon.png",


### PR DESCRIPTION
#### Summary
`electron-builder.json` had the wrong path for some of the linux assets, this PR fixes that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36577

#### Release Note
```release-note
NONE
```
