### PR TITLE
add no_output_timeout to 30m (default 10m)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,10 @@ commands:
         type: string
         default: "./linux/"
     steps:
-      - run: npm run package:<< parameters.os >>
+      - run: 
+          name: npn run
+          command: npm run package:<< parameters.os >>
+          no_output_timeout: 30m
       - run: mkdir -p << parameters.path >>
       - run: bash -x ./scripts/cp_artifacts.sh release << parameters.path >>
       - persist_to_workspace:


### PR DESCRIPTION
#### Summary
we saw some time out while building the MAC app https://app.circleci.com/pipelines/github/mattermost/desktop/2783/workflows/1553e084-09d6-4de4-a705-4fe562113240/jobs/12710

increasing to 30m without no output, but might be an issue in the apple signing service as well



#### Ticket Link
n/a

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [ ] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [ ] executed `npm run lint:js` for proper code formatting

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->

```release-note
NONE
```
