### PR TITLE
[MM-36309] Completely remove menu bar from Linux/Windows

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -845,6 +845,7 @@ function handleCloseAppMenu() {
 function handleUpdateMenuEvent(event: IpcMainEvent, menuConfig: Config) {
     const aMenu = appMenu.createMenu(menuConfig);
     Menu.setApplicationMenu(aMenu);
+    WindowManager.removeWindowMenu();
     aMenu.addListener('menu-will-close', handleCloseAppMenu);
 
     // set up context menu for tray icon

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -547,3 +547,7 @@ function handleBrowserHistoryPush(e: IpcMainEvent, viewName: string, pathName: s
 export function getCurrentTeamName() {
     return status.currentServerName;
 }
+
+export function removeWindowMenu() {
+    status.mainWindow?.removeMenu();
+}


### PR DESCRIPTION
#### Summary
The menubar isn't needed on Linux/Windows since we define our own dropdown menu, so I've completely removed it for both.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36309

#### Release Note
```release-note
Fixed an issue where pressing `Alt+<somekey>` could cause the menubar to disable and overlap the top bar on Linux.
```
