### PR TITLE
[MM-38301] Check for admin URL when adding space for back bar

### DIFF
--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -172,7 +172,7 @@ function handleResizeMainWindow() {
 
     const setBoundsFunction = () => {
         if (currentView) {
-            currentView.setBounds(getAdjustedWindowBoundaries(bounds.width!, bounds.height!, !urlUtils.isTeamUrl(currentView.tab.url, currentView.view.webContents.getURL())));
+            currentView.setBounds(getAdjustedWindowBoundaries(bounds.width!, bounds.height!, !(urlUtils.isTeamUrl(currentView.tab.url, currentView.view.webContents.getURL()) || urlUtils.isAdminUrl(currentView.tab.url, currentView.view.webContents.getURL()))));
         }
     };
 


### PR DESCRIPTION
#### Summary
When resizing, we weren't checking if the URL could have been an admin link, so now we are so that the space for the back bar doesn't show up when it doesn't need to.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38301

#### Release Note
```release-note
Fixed an issue where resizing the app while in the System Console causes a white bar to appear at the top.
```
