### PR TITLE
Make the Window menu on macOS more standard

### DIFF
--- a/src/main/menus/app.ts
+++ b/src/main/menus/app.ts
@@ -198,12 +198,16 @@ function createTemplate(config: Config) {
     const teams = config.data?.teams || [];
     const windowMenu = {
         label: '&Window',
+        role: isMac ? 'windowMenu' : null,
         submenu: [{
             role: 'minimize',
 
             // empty string removes shortcut on Windows; null will default by OS
             accelerator: process.platform === 'win32' ? '' : null,
-        }, {
+        }, ...(isMac ? [{
+            role: 'zoom',
+        }, separatorItem,
+        ] : []), {
             role: 'close',
             accelerator: 'CmdOrCtrl+W',
         }, separatorItem, ...teams.slice(0, 9).sort((teamA, teamB) => teamA.order - teamB.order).map((team, i) => {
@@ -241,7 +245,10 @@ function createTemplate(config: Config) {
                 WindowManager.selectPreviousTab();
             },
             enabled: (teams.length > 1),
-        }],
+        }, ...(isMac ? [separatorItem, {
+            role: 'front',
+        }] : []),
+        ],
     };
     template.push(windowMenu);
     const submenu = [];


### PR DESCRIPTION
#### Summary

The Mattermost desktop app's Window menu on macOS is highly non-standard.

A typical macOS app's Window menu contains, in order:

- Minimize
- Zoom
- Tile Window (or Move Window, depending on window type) to Left of Screen
- Tile Window (or Move Window, depending on window type) to Right of Screen
- Separator
- Move to [name of next display] (when multiple displays are connected)
- Separator
- [Other app-specific window options]
- Separator
- Bring All to Front
- Separator
- [List of current windows for the app]


Example, for the Finder app:

<img width="286" alt="finder-example-window-menu" src="https://user-images.githubusercontent.com/487498/132421250-cad7e8db-b0db-421c-b269-6dbb7e470f8c.png">


Mattermost is missing most of these items. In fact, the only standard item it has is Minimize. (Close Window is normally in the File menu, not the Window menu.)

Here's a current screenshot from master:

<img width="220" alt="mattermost-current-window-menu" src="https://user-images.githubusercontent.com/487498/132421303-9a68b27c-4d20-47dc-a5b4-621470684e14.png">

However, most of the missing items can been added for free by adding the suitable `role` to the menu and some items within it.

Specifically, this PR adds (conditionally for macOS only):

- The 'windowMenu' role to the window menu, which automatically adds the "tile window..." items, the "move to [next display]" item, and the list of current windows
- The Zoom item after the Minimize item (using the predefined electron role)
- The Bring All to Front item (using the predefined electron role)
- Some separators as needed

with the resulting menu looking like:

<img width="291" alt="mattermost-after-change" src="https://user-images.githubusercontent.com/487498/132421331-24a74b7d-933b-4dd0-91a3-760bc3010e64.png">


#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Has UI changes
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [x] executed `npm run lint:js` for proper code formatting

#### Device Information
This PR was tested on:

- macOS 11.5.2
- Mattermost Server 5.37.0

#### Release Note

```release-note
Made the Window menu on macOS more consistent with system standards
```
