### PR TITLE
[MM-38275] Use browser history push for deeplinking and other inter-tab navigation when using a v6.0 server

### DIFF
--- a/src/main/views/MattermostView.ts
+++ b/src/main/views/MattermostView.ts
@@ -24,6 +24,7 @@ import {
 
 import {TabView} from 'common/tabs/TabView';
 
+import {ServerInfo} from 'main/server/serverInfo';
 import ContextMenu from '../contextMenu';
 import {getWindowBoundaries, getLocalPreload, composeUserAgent} from '../utils';
 import * as WindowManager from '../windows/windowManager';
@@ -31,7 +32,7 @@ import * as appState from '../appState';
 
 import {removeWebContentsListeners} from './webContentEvents';
 
-enum Status {
+export enum Status {
     LOADING,
     READY,
     WAITING_MM,
@@ -47,6 +48,7 @@ export class MattermostView extends EventEmitter {
     view: BrowserView;
     isVisible: boolean;
     options: BrowserViewConstructorOptions;
+    serverInfo: ServerInfo;
 
     removeLoading?: number;
 
@@ -65,10 +67,11 @@ export class MattermostView extends EventEmitter {
     retryLoad?: NodeJS.Timeout;
     maxRetries: number;
 
-    constructor(tab: TabView, win: BrowserWindow, options: BrowserViewConstructorOptions) {
+    constructor(tab: TabView, serverInfo: ServerInfo, win: BrowserWindow, options: BrowserViewConstructorOptions) {
         super();
         this.tab = tab;
         this.window = win;
+        this.serverInfo = serverInfo;
 
         const preload = getLocalPreload('preload.js');
         this.options = Object.assign({}, options);


### PR DESCRIPTION
#### Summary
Since we now have functionality to have the desktop app update the webapp's current URL without reloading it, we can now leverage that functionality when deep-linking and clicking links in other tabs so that the page doesn't reload.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38275

```release-note
NONE
```
