### PR TITLE
[MM-36309] Restore window menu, override shortcuts for window menu so they don't interfere

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -781,6 +781,12 @@ function initializeAfterAppReady() {
     globalShortcut.register(`${process.platform === 'darwin' ? 'Cmd+Ctrl' : 'Ctrl+Shift'}+S`, () => {
         ipcMain.emit(OPEN_TEAMS_DROPDOWN);
     });
+
+    if (process.platform === 'linux') {
+        globalShortcut.registerAll(['Alt+F', 'Alt+E', 'Alt+V', 'Alt+H', 'Alt+W', 'Alt+P'], () => {
+            // do nothing because we want to supress the menu popping up
+        });
+    }
 }
 
 //
@@ -846,7 +852,6 @@ function handleCloseAppMenu() {
 function handleUpdateMenuEvent(event: IpcMainEvent, menuConfig: Config) {
     const aMenu = appMenu.createMenu(menuConfig);
     Menu.setApplicationMenu(aMenu);
-    WindowManager.removeWindowMenu();
     aMenu.addListener('menu-will-close', handleCloseAppMenu);
 
     // set up context menu for tray icon

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -554,7 +554,3 @@ function handleBrowserHistoryPush(e: IpcMainEvent, viewName: string, pathName: s
 export function getCurrentTeamName() {
     return status.currentServerName;
 }
-
-export function removeWindowMenu() {
-    status.mainWindow?.removeMenu();
-}


### PR DESCRIPTION
#### Summary
My original method of removing the menu from the window caused all the keyboard shortcuts to stop working. So now instead, on Linux, I will simply suppress the shortcuts that cause the issue to happen in the first place.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36309

#### Release Note
```release-note
NONE
```
