### PR TITLE
[MM-38524] Rework the closing and opening tab logic, fixed login issue

### DIFF
--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -97,3 +97,4 @@ export const RECEIVE_DROPDOWN_MENU_SIZE = 'receive-dropdown-menu-size';
 export const SEND_DROPDOWN_MENU_SIZE = 'send-dropdown-menu-size';
 
 export const BROWSER_HISTORY_PUSH = 'browser-history-push';
+export const APP_LOGGED_IN = 'app-logged-in';

--- a/src/common/tabs/TabView.ts
+++ b/src/common/tabs/TabView.ts
@@ -30,17 +30,15 @@ export function getDefaultTeamWithTabsFromTeam(team: Team) {
             {
                 name: TAB_MESSAGING,
                 order: 0,
-                isClosed: false,
+                isOpen: true,
             },
             {
                 name: TAB_FOCALBOARD,
                 order: 1,
-                isClosed: false,
             },
             {
                 name: TAB_PLAYBOOKS,
                 order: 2,
-                isClosed: false,
             },
         ],
     };

--- a/src/common/utils/util.ts
+++ b/src/common/utils/util.ts
@@ -37,7 +37,17 @@ function shorten(string: string, max?: number) {
     return string;
 }
 
-export function isServerVersionGreaterThanOrEqualTo(currentVersion: string, compareVersion: string): boolean {
+// eslint-disable-next-line @typescript-eslint/ban-types
+function debounce<T extends Function>(cb: T, wait: number) {
+    let h: NodeJS.Timeout;
+    const callable = (...args: any) => {
+        clearTimeout(h);
+        h = setTimeout(() => cb(...args), wait);
+    };
+    return callable;
+}
+
+function isServerVersionGreaterThanOrEqualTo(currentVersion: string, compareVersion: string): boolean {
     if (currentVersion === compareVersion) {
         return true;
     }
@@ -63,6 +73,7 @@ export function isServerVersionGreaterThanOrEqualTo(currentVersion: string, comp
 }
 
 export default {
+    debounce,
     getDisplayBoundaries,
     runMode,
     shorten,

--- a/src/common/utils/util.ts
+++ b/src/common/utils/util.ts
@@ -37,16 +37,6 @@ function shorten(string: string, max?: number) {
     return string;
 }
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-function debounce<T extends Function>(cb: T, wait: number) {
-    let h: NodeJS.Timeout;
-    const callable = (...args: any) => {
-        clearTimeout(h);
-        h = setTimeout(() => cb(...args), wait);
-    };
-    return callable;
-}
-
 function isServerVersionGreaterThanOrEqualTo(currentVersion: string, compareVersion: string): boolean {
     if (currentVersion === compareVersion) {
         return true;
@@ -73,7 +63,6 @@ function isServerVersionGreaterThanOrEqualTo(currentVersion: string, compareVers
 }
 
 export default {
-    debounce,
     getDisplayBoundaries,
     runMode,
     shorten,

--- a/src/main/Validator.ts
+++ b/src/main/Validator.ts
@@ -11,8 +11,8 @@ import {AppState} from 'types/appState';
 import {ComparableCertificate} from 'types/certificate';
 import {PermissionType, TrustedOrigin} from 'types/trustedOrigin';
 
+import {TAB_MESSAGING} from 'common/tabs/TabView';
 import urlUtils from 'common/utils/url';
-import { TAB_MESSAGING } from 'common/tabs/TabView';
 
 const defaultOptions = {
     stripUnknown: true,
@@ -227,6 +227,7 @@ export function validateV3ConfigData(data: ConfigV3) {
             return {
                 ...team,
                 url: cleanURL(team.url),
+
                 // Force messaging to stay open regardless of user config
                 tabs: team.tabs.map((tab) => {
                     return {

--- a/src/main/Validator.ts
+++ b/src/main/Validator.ts
@@ -103,7 +103,7 @@ const configDataSchemaV3 = Joi.object<ConfigV3>({
         tabs: Joi.array().items(Joi.object({
             name: Joi.string().required(),
             order: Joi.number().integer().min(0),
-            isClosed: Joi.boolean().default(false),
+            isOpen: Joi.boolean(),
         })).default([]),
     })).default([]),
     showTrayIcon: Joi.boolean().default(false),

--- a/src/main/Validator.ts
+++ b/src/main/Validator.ts
@@ -12,6 +12,7 @@ import {ComparableCertificate} from 'types/certificate';
 import {PermissionType, TrustedOrigin} from 'types/trustedOrigin';
 
 import urlUtils from 'common/utils/url';
+import { TAB_MESSAGING } from 'common/tabs/TabView';
 
 const defaultOptions = {
     stripUnknown: true,
@@ -226,6 +227,13 @@ export function validateV3ConfigData(data: ConfigV3) {
             return {
                 ...team,
                 url: cleanURL(team.url),
+                // Force messaging to stay open regardless of user config
+                tabs: team.tabs.map((tab) => {
+                    return {
+                        ...tab,
+                        isOpen: tab.name === TAB_MESSAGING ? true : tab.isOpen,
+                    };
+                }),
             };
         });
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -47,7 +47,7 @@ import {
 import Config from 'common/config';
 import {MattermostServer} from 'common/servers/MattermostServer';
 import {getDefaultTeamWithTabsFromTeam, TAB_FOCALBOARD, TAB_MESSAGING, TAB_PLAYBOOKS} from 'common/tabs/TabView';
-import Utils, {isServerVersionGreaterThanOrEqualTo} from 'common/utils/util';
+import Utils from 'common/utils/util';
 
 import urlUtils from 'common/utils/url';
 
@@ -826,7 +826,7 @@ function openExtraTabs(data: Array<RemoteInfo | string | undefined>, team: TeamW
     const remoteInfo = data.find((info) => info && typeof info !== 'string' && info.name === team.name) as RemoteInfo;
     if (remoteInfo) {
         team.tabs.forEach((tab) => {
-            if (tab.name !== TAB_MESSAGING && remoteInfo.serverVersion && isServerVersionGreaterThanOrEqualTo(remoteInfo.serverVersion, '6.0.0')) {
+            if (tab.name !== TAB_MESSAGING && remoteInfo.serverVersion && Utils.isServerVersionGreaterThanOrEqualTo(remoteInfo.serverVersion, '6.0.0')) {
                 if (tab.name === TAB_PLAYBOOKS && remoteInfo.hasPlaybooks && tab.isOpen !== false) {
                     log.info(`opening ${team.name}___${tab.name} on hasPlaybooks`);
                     tab.isOpen = true;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -505,12 +505,12 @@ function handleCloseTab(event: IpcMainEvent, serverName: string, tabName: string
         if (team.name === serverName) {
             team.tabs.forEach((tab) => {
                 if (tab.name === tabName) {
-                    tab.isClosed = true;
+                    tab.isOpen = false;
                 }
             });
         }
     });
-    const nextTab = teams.find((team) => team.name === serverName)!.tabs.filter((tab) => !tab.isClosed)[0].name;
+    const nextTab = teams.find((team) => team.name === serverName)!.tabs.filter((tab) => tab.isOpen)[0].name;
     WindowManager.switchTab(serverName, nextTab);
     config.set('teams', teams);
 }
@@ -521,7 +521,7 @@ function handleOpenTab(event: IpcMainEvent, serverName: string, tabName: string)
         if (team.name === serverName) {
             team.tabs.forEach((tab) => {
                 if (tab.name === tabName) {
-                    tab.isClosed = false;
+                    tab.isOpen = true;
                 }
             });
         }
@@ -799,28 +799,26 @@ function updateServerInfos(teams: TeamWithTabs[]) {
     });
     Promise.all(serverInfos).then((data: Array<RemoteInfo | string | undefined>) => {
         const teams = config.teams;
-        teams.forEach((team) => closeUnneededTabs(data, team));
+        teams.forEach((team) => openExtraTabs(data, team));
         config.set('teams', teams);
     }).catch((reason: any) => {
         log.error('Error getting server infos', reason);
     });
 }
 
-function closeUnneededTabs(data: Array<RemoteInfo | string | undefined>, team: TeamWithTabs) {
+function openExtraTabs(data: Array<RemoteInfo | string | undefined>, team: TeamWithTabs) {
     const remoteInfo = data.find((info) => info && typeof info !== 'string' && info.name === team.name) as RemoteInfo;
     if (remoteInfo) {
         team.tabs.forEach((tab) => {
-            if (tab.name === TAB_PLAYBOOKS && !remoteInfo.hasPlaybooks) {
-                log.info(`closing ${team.name}___${tab.name} on !hasPlaybooks`);
-                tab.isClosed = true;
-            }
-            if (tab.name === TAB_FOCALBOARD && !remoteInfo.hasFocalboard) {
-                log.info(`closing ${team.name}___${tab.name} on !hasFocalboard`);
-                tab.isClosed = true;
-            }
-            if (tab.name !== TAB_MESSAGING && remoteInfo.serverVersion && !isServerVersionGreaterThanOrEqualTo(remoteInfo.serverVersion, '6.0.0')) {
-                log.info(`closing ${team.name}___${tab.name} on !serverVersion`);
-                tab.isClosed = true;
+            if (tab.name !== TAB_MESSAGING && remoteInfo.serverVersion && isServerVersionGreaterThanOrEqualTo(remoteInfo.serverVersion, '6.0.0')) {
+                if (tab.name === TAB_PLAYBOOKS && remoteInfo.hasPlaybooks && tab.isOpen !== false) {
+                    log.info(`opening ${team.name}___${tab.name} on hasPlaybooks`);
+                    tab.isOpen = true;
+                }
+                if (tab.name === TAB_FOCALBOARD && remoteInfo.hasFocalboard && tab.isOpen !== false) {
+                    log.info(`opening ${team.name}___${tab.name} on hasFocalboard`);
+                    tab.isOpen = true;
+                }
             }
         });
     }

--- a/src/main/preload/mattermost.js
+++ b/src/main/preload/mattermost.js
@@ -22,6 +22,7 @@ import {
     USER_ACTIVITY_UPDATE,
     CLOSE_TEAMS_DROPDOWN,
     BROWSER_HISTORY_PUSH,
+    APP_LOGGED_IN,
 } from 'common/communication';
 
 const UNREAD_COUNT_INTERVAL = 1000;
@@ -240,6 +241,12 @@ ipcRenderer.on(BROWSER_HISTORY_PUSH, (event, pathName) => {
         },
         window.location.origin,
     );
+});
+
+window.addEventListener('storage', (e) => {
+    if (e.key === '__login__' && e.storageArea === localStorage && e.newValue) {
+        ipcRenderer.send(APP_LOGGED_IN, viewName);
+    }
 });
 
 /* eslint-enable no-magic-numbers */

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -20,7 +20,7 @@ import {
     UPDATE_LAST_ACTIVE,
 } from 'common/communication';
 import urlUtils from 'common/utils/url';
-import {isServerVersionGreaterThanOrEqualTo} from 'common/utils/util';
+import Utils from 'common/utils/util';
 
 import {getServerView, getTabViewName} from 'common/tabs/TabView';
 
@@ -87,6 +87,13 @@ export class ViewManager {
         view.on(UPDATE_TARGET_URL, this.showURLView);
         view.on(LOADSCREEN_END, this.finishLoading);
         view.once(LOAD_FAILED, this.failLoading);
+    }
+
+    reloadViewIfNeeded = (viewName: string) => {
+        const view = this.views.get(viewName);
+        if (!view?.getWebContents()?.getURL().startsWith(view.tab.url.toString())) {
+            view?.load(view.tab.url);
+        }
     }
 
     load = () => {
@@ -416,7 +423,7 @@ export class ViewManager {
                         return;
                     }
 
-                    if (view.status === Status.READY && view.serverInfo.remoteInfo.serverVersion && isServerVersionGreaterThanOrEqualTo(view.serverInfo.remoteInfo.serverVersion, '6.0.0')) {
+                    if (view.status === Status.READY && view.serverInfo.remoteInfo.serverVersion && Utils.isServerVersionGreaterThanOrEqualTo(view.serverInfo.remoteInfo.serverVersion, '6.0.0')) {
                         const pathName = `/${urlWithSchema.replace(view.tab.server.url.toString(), '')}`;
                         view.view.webContents.send(BROWSER_HISTORY_PUSH, pathName);
                         this.deeplinkSuccess(view.name);

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -120,6 +120,7 @@ export class ViewManager {
         });
         if (this.currentView && (oldviews.has(this.currentView) || this.closedViews.has(this.currentView))) {
             if (configServers.length) {
+                delete this.currentView;
                 this.showInitial();
             } else {
                 this.mainWindow.webContents.send(SET_ACTIVE_VIEW);

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -363,7 +363,7 @@ export function switchServer(serverName: string) {
         return;
     }
     status.currentServerName = serverName;
-    const lastActiveTab = server.tabs.find((tab) => !tab.isClosed && tab.order === (server.lastActiveTab || 0)) || server.tabs[0];
+    const lastActiveTab = server.tabs.find((tab) => tab.isOpen && tab.order === (server.lastActiveTab || 0)) || server.tabs[0];
     const tabViewName = getTabViewName(serverName, lastActiveTab.name);
     status.viewManager?.showByName(tabViewName);
     ipcMain.emit(UPDATE_SHORTCUT_MENU);
@@ -489,7 +489,7 @@ export function selectNextTab() {
     }
 
     const currentTeamTabs = status.config?.teams.find((team) => team.name === currentView.tab.server.name)?.tabs;
-    const filteredTabs = currentTeamTabs?.filter((tab) => !tab.isClosed);
+    const filteredTabs = currentTeamTabs?.filter((tab) => tab.isOpen);
     const currentTab = currentTeamTabs?.find((tab) => tab.name === currentView.tab.type);
     if (!currentTeamTabs || !currentTab || !filteredTabs) {
         return;
@@ -514,7 +514,7 @@ export function selectPreviousTab() {
     }
 
     const currentTeamTabs = status.config?.teams.find((team) => team.name === currentView.tab.server.name)?.tabs;
-    const filteredTabs = currentTeamTabs?.filter((tab) => !tab.isClosed);
+    const filteredTabs = currentTeamTabs?.filter((tab) => tab.isOpen);
     const currentTab = currentTeamTabs?.find((tab) => tab.name === currentView.tab.type);
     if (!currentTeamTabs || !currentTab || !filteredTabs) {
         return;

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -17,8 +17,10 @@ import {
     GET_DARK_MODE,
     UPDATE_SHORTCUT_MENU,
     BROWSER_HISTORY_PUSH,
+    APP_LOGGED_IN,
 } from 'common/communication';
 import urlUtils from 'common/utils/url';
+import Utils from 'common/utils/util';
 
 import {getTabViewName} from 'common/tabs/TabView';
 
@@ -52,6 +54,7 @@ ipcMain.handle(GET_DARK_MODE, handleGetDarkMode);
 ipcMain.on(REACT_APP_INITIALIZED, handleReactAppInitialized);
 ipcMain.on(LOADING_SCREEN_ANIMATION_FINISHED, handleLoadingScreenAnimationFinished);
 ipcMain.on(BROWSER_HISTORY_PUSH, handleBrowserHistoryPush);
+ipcMain.on(APP_LOGGED_IN, handleAppLoggedIn);
 
 export function setConfig(data: CombinedConfig) {
     if (data) {
@@ -557,4 +560,8 @@ function handleBrowserHistoryPush(e: IpcMainEvent, viewName: string, pathName: s
 
 export function getCurrentTeamName() {
     return status.currentServerName;
+}
+
+function handleAppLoggedIn(event: IpcMainEvent, viewName: string) {
+    status.viewManager?.reloadViewIfNeeded(viewName);
 }

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -363,8 +363,12 @@ export function switchServer(serverName: string) {
         return;
     }
     status.currentServerName = serverName;
-    const lastActiveTab = server.tabs.find((tab) => tab.isOpen && tab.order === (server.lastActiveTab || 0)) || server.tabs[0];
-    const tabViewName = getTabViewName(serverName, lastActiveTab.name);
+    let nextTab = server.tabs.find((tab) => tab.isOpen && tab.order === (server.lastActiveTab || 0));
+    if (!nextTab) {
+        const openTabs = server.tabs.filter((tab) => tab.isOpen);
+        nextTab = openTabs.find((e) => e.order === 0) || openTabs[0];
+    }
+    const tabViewName = getTabViewName(serverName, nextTab.name);
     status.viewManager?.showByName(tabViewName);
     ipcMain.emit(UPDATE_SHORTCUT_MENU);
 }

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -20,7 +20,6 @@ import {
     APP_LOGGED_IN,
 } from 'common/communication';
 import urlUtils from 'common/utils/url';
-import Utils from 'common/utils/util';
 
 import {getTabViewName} from 'common/tabs/TabView';
 

--- a/src/renderer/components/MainPage.tsx
+++ b/src/renderer/components/MainPage.tsx
@@ -104,8 +104,8 @@ export default class MainPage extends React.PureComponent<Props, State> {
 
         const firstServer = this.props.teams.find((team) => team.order === this.props.lastActiveTeam || 0);
         let firstTab = firstServer?.tabs.find((tab) => tab.order === firstServer.lastActiveTab || 0);
-        if (firstTab?.isClosed) {
-            const openTabs = firstServer?.tabs.filter((tab) => !tab.isClosed) || [];
+        if (!firstTab?.isOpen) {
+            const openTabs = firstServer?.tabs.filter((tab) => tab.isOpen) || [];
             firstTab = openTabs?.find((e) => e.order === 0) || openTabs[0];
         }
 

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -15,7 +15,6 @@ import {CombinedConfig, LocalConfiguration, Team} from 'types/config';
 import {DeepPartial} from 'types/utils';
 
 import {GET_LOCAL_CONFIGURATION, UPDATE_CONFIGURATION, DOUBLE_CLICK_ON_WINDOW, GET_DOWNLOAD_LOCATION, ADD_SERVER, RELOAD_CONFIGURATION} from 'common/communication';
-import {getDefaultTeamWithTabsFromTeam} from 'common/tabs/TabView';
 
 import AutoSaveIndicator, {SavingState} from './AutoSaveIndicator';
 
@@ -347,23 +346,6 @@ export default class SettingsPage extends React.PureComponent<Record<string, nev
         this.setState({
             spellCheckerURL: dictionaryURL,
             allowSaveSpellCheckerURL,
-        });
-    }
-    updateTeam = (index: number, newData: Team) => {
-        const teams = this.state.teams || [];
-        teams[index] = newData;
-        window.timers.setImmediate(this.saveSetting, CONFIG_TYPE_SERVERS, {key: 'teams', data: teams});
-        this.setState({
-            teams,
-        });
-    }
-
-    addServer = (team: Team) => {
-        const teams = this.state.teams || [];
-        teams.push(getDefaultTeamWithTabsFromTeam(team));
-        window.timers.setImmediate(this.saveSetting, CONFIG_TYPE_SERVERS, {key: 'teams', data: teams});
-        this.setState({
-            teams,
         });
     }
 

--- a/src/renderer/components/TabBar.tsx
+++ b/src/renderer/components/TabBar.tsx
@@ -85,7 +85,7 @@ export default class TabBar extends React.PureComponent<Props> {
                     index={orderedIndex}
                 >
                     {(provided, snapshot) => {
-                        if (tab.isClosed) {
+                        if (!tab.isOpen) {
                             return (
                                 <div
                                     ref={provided.innerRef}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -4,7 +4,7 @@
 export type Tab = {
     name: string;
     order: number;
-    isClosed?: boolean;
+    isOpen?: boolean;
 }
 
 export type Team = {


### PR DESCRIPTION
#### Summary
I've changed around some of the closed tab logic to allow us to be explicit if the tab should be open or closed, and if there's no value we can open it. We will also open the Boards and Playbooks tabs for servers that support them instead of have them open by default and close them if not needed.

This should solve a couple issues with creating servers in which you would not see the loading screen for the new tab, and with removing servers in which you wouldn't be redirected to an active tab.

I've also added a tap into the logic functionality so that the desktop tabs will reload correctly when logging in on one of them.

```release-note
NONE
```
