### PR TITLE
[MM-38535] Overlay drag region with clickable area when menu is open

### DIFF
--- a/src/renderer/components/MainPage.tsx
+++ b/src/renderer/components/MainPage.tsx
@@ -330,6 +330,7 @@ export default class MainPage extends React.PureComponent<Props, State> {
                 onCloseTab={this.handleCloseTab}
                 onDrop={this.handleDragAndDrop}
                 tabsDisabled={this.state.modalOpen}
+                isMenuOpen={this.state.isMenuOpen}
             />
         );
 

--- a/src/renderer/components/TabBar.tsx
+++ b/src/renderer/components/TabBar.tsx
@@ -24,6 +24,7 @@ type Props = {
     mentionCounts: Record<string, number>;
     onDrop: (result: DropResult) => void;
     tabsDisabled?: boolean;
+    isMenuOpen?: boolean;
 };
 
 function getStyle(style?: DraggingStyle | NotDraggingStyle) {
@@ -151,12 +152,15 @@ export default class TabBar extends React.PureComponent<Props> {
                     {(provided) => (
                         <Nav
                             ref={provided.innerRef}
-                            className={`TabBar${this.props.isDarkMode ? ' darkMode' : ''}`}
+                            className={classNames('TabBar', {
+                                darkMode: this.props.isDarkMode,
+                            })}
                             id={this.props.id}
                             variant='tabs'
                             {...provided.droppableProps}
                         >
                             {tabs}
+                            {this.props.isMenuOpen ? <span className='TabBar-nonDrag'/> : null}
                             {provided.placeholder}
                         </Nav>
                     )}

--- a/src/renderer/css/components/TabBar.css
+++ b/src/renderer/css/components/TabBar.css
@@ -9,6 +9,11 @@
   padding: 6px 8px;
 }
 
+.TabBar-nonDrag {
+  flex-grow: 1;
+  -webkit-app-region: no-drag;
+}
+
 .TabBar .teamTabItem span {
   flex: 0 1 auto;
   overflow: hidden;


### PR DESCRIPTION
#### Summary
When the menu is open, the drag region was eating all click events include the event that is supposed to close the menu. This PR add an overlay `span` over top of the drag region when the menu is open so that when you click on the top bar, the menu should close like normal.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38535

#### Release Note
```release-note
NONE
```
