### PR TITLE
[MM-38570] Fixed the keyboard shortcuts for switching tabs when some tabs are closed

### DIFF
--- a/src/main/menus/app.ts
+++ b/src/main/menus/app.ts
@@ -220,7 +220,7 @@ function createTemplate(config: Config) {
                 },
             });
             if (WindowManager.getCurrentTeamName() === team.name) {
-                team.tabs.slice(0, 9).sort((teamA, teamB) => teamA.order - teamB.order).forEach((tab, i) => {
+                team.tabs.filter((tab) => tab.isOpen).slice(0, 9).sort((teamA, teamB) => teamA.order - teamB.order).forEach((tab, i) => {
                     items.push({
                         label: `    ${getTabDisplayName(tab.name as TabType)}`,
                         accelerator: `CmdOrCtrl+${i + 1}`,

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -353,7 +353,7 @@ function initializeViewManager() {
         status.viewManager = new ViewManager(status.config, status.mainWindow);
         status.viewManager.load();
         status.viewManager.showInitial();
-        status.currentServerName = status.config.teams.find((team) => team.order === 0)?.name;
+        status.currentServerName = (status.config.teams.find((team) => team.order === status.config?.lastActiveTeam) || status.config.teams.find((team) => team.order === 0))?.name;
     }
 }
 


### PR DESCRIPTION
#### Summary
When some of the tabs for a server were closed, the keyboard shortcuts and menu items did not reflect the ordering and visibility of the tabs. This PR fixes that by only showing the tabs that are visible in the menu.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38570

#### Release Note
```release-note
NONE
```
