### PR TITLE
Fix typo in mattermost.adml

### DIFF
--- a/resources/windows/gpo/en-US/mattermost.adml
+++ b/resources/windows/gpo/en-US/mattermost.adml
@@ -8,7 +8,7 @@
 			<string id="mattermost">Mattermost</string>
 			<!--
       <string id="EnableAutoUpdater">EnableAutoUpdater</string>
-			<string id="EnableAutoUpdaterDescription">If this policy is enabled, users will receive notifications when new versions of the desktop app are available. System Administrator privilages on the computer are required to install the update.</string>
+			<string id="EnableAutoUpdaterDescription">If this policy is enabled, users will receive notifications when new versions of the desktop app are available. System Administrator privileges on the computer are required to install the update.</string>
       -->
 			<string id="EnableServerManagement">EnableServerManagement</string>
 			<string id="EnableServerManagementDescription">If this policy is enabled, users can add or remove servers in their app settings, even if default servers are configured in DefaultServerList.


### PR DESCRIPTION
Fix typo in mattermost.adml as discovered [here](https://community-daily.mattermost.com/core/pl/6zsmpbtzqpnbzktn4b3bqbamwo) by @mark.piermarini

```release-note
NONE
```