### PR TITLE
[MM-38577] Allow exit of full screen mode using the restore button on Windows

### DIFF
--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -466,6 +466,9 @@ export function restore() {
     if (focused) {
         focused.restore();
     }
+    if (focused?.isFullScreen()) {
+        focused.setFullScreen(false);
+    }
 }
 
 export function reload() {

--- a/src/renderer/components/MainPage.tsx
+++ b/src/renderer/components/MainPage.tsx
@@ -346,7 +346,7 @@ export default class MainPage extends React.PureComponent<Props, State> {
         }
 
         let maxButton;
-        if (this.state.maximized) {
+        if (this.state.maximized || this.state.fullScreen) {
             maxButton = (
                 <div
                     className='button restore-button'


### PR DESCRIPTION
#### Summary
When pressing F11 on Windows, the app would enter full screen mode and there would be no clear indication to the user how to get out. This PR adds the full screen toggle functionality to the restore button such that the same action as unmaximizing will get the app out of fullscreen mode.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38577

#### Release Note
```release-note
Fixed an issue where the app could get stuck in full screen mode without the users knowledge.
```
