### PR TITLE
[MM-36032] Add electron-context-menu to popup windows

### DIFF
--- a/src/main/views/webContentEvents.ts
+++ b/src/main/views/webContentEvents.ts
@@ -8,6 +8,8 @@ import {TeamWithTabs} from 'types/config';
 
 import urlUtils from 'common/utils/url';
 
+import ContextMenu from 'main/contextMenu';
+
 import * as WindowManager from '../windows/windowManager';
 
 import {protocols} from '../../../electron-builder.json';
@@ -190,6 +192,9 @@ const generateNewWindowListener = (getServersFunction: () => TeamWithTabs[], spe
                     userAgent: composeUserAgent(),
                 });
             }
+
+            const contextMenu = new ContextMenu({}, popupWindow);
+            contextMenu.reload();
         }
 
         return {action: 'deny'};


### PR DESCRIPTION
#### Summary
`electron-context-menu` was missing from popup windows. This PR adds it in.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36032

#### Release Note
```release-note
Fixed the missing context menu for popup windows
```
