### PR TITLE
[MM-38642] Set a max-width for the dropdown button and menu

### DIFF
--- a/src/renderer/css/components/TeamDropdownButton.scss
+++ b/src/renderer/css/components/TeamDropdownButton.scss
@@ -8,6 +8,7 @@
     font-family: Open Sans;
     overflow: hidden;
     -webkit-font-smoothing: auto;
+    max-width: 400px;
 
     &.disabled {
         opacity: 0.5;

--- a/src/renderer/css/dropdown.scss
+++ b/src/renderer/css/dropdown.scss
@@ -10,6 +10,7 @@ body {
 #app {
     padding: 24px;
     display: inline-block;
+    max-width: 600px;
 }
 
 .TeamDropdown {


### PR DESCRIPTION
#### Summary
Set a max-width of 400px on the dropdown button and 600px on the menu to avoid it being ridiculously long with really long server names.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38642

#### Release Note
```release-note
NONE
```