### PR TITLE
[MM-38679] Fix download notification title on Windows

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -759,7 +759,7 @@ function initializeAfterAppReady() {
 
         item.on('done', (doneEvent, state) => {
             if (state === 'completed') {
-                displayDownloadCompleted(filename, item.savePath, urlUtils.getView(webContents.getURL(), config.teams)!);
+                displayDownloadCompleted(filename, item.savePath, WindowManager.getServerNameByWebContentsId(webContents.id) || '');
             }
         });
     });

--- a/src/main/notifications/Download.ts
+++ b/src/main/notifications/Download.ts
@@ -3,7 +3,6 @@
 
 import path from 'path';
 import {app, Notification} from 'electron';
-import {ServerFromURL} from 'types/utils';
 
 const assetsDir = path.resolve(app.getAppPath(), 'assets');
 const appIconURL = path.resolve(assetsDir, 'appicon_48.png');
@@ -17,7 +16,7 @@ const defaultOptions = {
 };
 
 export class DownloadNotification extends Notification {
-    constructor(fileName: string, serverInfo: ServerFromURL) {
+    constructor(fileName: string, serverName: string) {
         const options = {...defaultOptions};
         if (process.platform === 'win32') {
             options.icon = appIconURL;
@@ -26,7 +25,7 @@ export class DownloadNotification extends Notification {
             Reflect.deleteProperty(options, 'icon');
         }
 
-        options.title = process.platform === 'win32' ? serverInfo.name : 'Download Complete';
+        options.title = process.platform === 'win32' ? serverName : 'Download Complete';
         options.body = process.platform === 'win32' ? `Download Complete \n ${fileName}` : fileName;
 
         super(options);

--- a/src/main/notifications/index.ts
+++ b/src/main/notifications/index.ts
@@ -60,12 +60,12 @@ export function displayMention(title: string, body: string, channel: {id: string
     mention.show();
 }
 
-export function displayDownloadCompleted(fileName: string, path: string, serverInfo: ServerFromURL) {
+export function displayDownloadCompleted(fileName: string, path: string, serverName: string) {
     if (!Notification.isSupported()) {
         log.error('notification not supported');
         return;
     }
-    const download = new DownloadNotification(fileName, serverInfo);
+    const download = new DownloadNotification(fileName, serverName);
 
     download.on('show', () => {
         windowManager.flashFrame(true);

--- a/src/main/notifications/index.ts
+++ b/src/main/notifications/index.ts
@@ -5,7 +5,6 @@ import {shell, Notification} from 'electron';
 import log from 'electron-log';
 
 import {MentionData} from 'types/notification';
-import {ServerFromURL} from 'types/utils';
 
 import {PLAY_SOUND} from 'common/communication';
 import {TAB_MESSAGING} from 'common/tabs/TabView';


### PR DESCRIPTION
#### Summary
The download notification title was using the raw view name instead of just the server name for the download notification title on Windows 10. Now it will use just the server name, like before.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38679

#### Release Note
```release-note
NONE
```
