### PR TITLE
[MM-38649] Put top bar in a BrowserView

### DIFF
--- a/src/main/menus/app.ts
+++ b/src/main/menus/app.ts
@@ -142,14 +142,7 @@ function createTemplate(config: Config) {
             return 'Ctrl+Shift+I';
         })(),
         click(item: Electron.MenuItem, focusedWindow?: WebContents) {
-            if (focusedWindow) {
-                // toggledevtools opens it in the last known position, so sometimes it goes below the browserview
-                if (focusedWindow.isDevToolsOpened()) {
-                    focusedWindow.closeDevTools();
-                } else {
-                    focusedWindow.openDevTools({mode: 'detach'});
-                }
-            }
+            WindowManager.openAppWrapperDevTools(focusedWindow);
         },
     }, {
         label: 'Developer Tools for Current Tab',

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -22,12 +22,12 @@ export function shouldBeHiddenOnStartup(parsedArgv: Args) {
     return false;
 }
 
-export function getTabViewBounds(windowWidth: number) {
+export function getMainViewBounds(windowWidth: number, windowHeight: number) {
     return {
         x: 0,
         y: 0,
         width: windowWidth,
-        height: TAB_BAR_HEIGHT,
+        height: windowHeight,
     };
 }
 

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -22,6 +22,15 @@ export function shouldBeHiddenOnStartup(parsedArgv: Args) {
     return false;
 }
 
+export function getTabViewBounds(windowWidth: number) {
+    return {
+        x: 0,
+        y: 0,
+        width: windowWidth,
+        height: TAB_BAR_HEIGHT,
+    };
+}
+
 export function getWindowBoundaries(win: BrowserWindow, hasBackBar = false) {
     const {width, height} = win.getContentBounds();
     return getAdjustedWindowBoundaries(width, height, hasBackBar);

--- a/src/main/views/teamDropdownView.ts
+++ b/src/main/views/teamDropdownView.ts
@@ -128,8 +128,12 @@ export default class TeamDropdownView {
     }
 
     getBounds = (width: number, height: number) => {
+        let threeDotMenuWidth = THREE_DOT_MENU_WIDTH;
+        if (process.platform === 'darwin') {
+            threeDotMenuWidth = this.window.isFullScreen() ? 6 : THREE_DOT_MENU_WIDTH_MAC;
+        }
         return {
-            x: (process.platform === 'darwin' ? THREE_DOT_MENU_WIDTH_MAC : THREE_DOT_MENU_WIDTH) - MENU_SHADOW_WIDTH,
+            x: threeDotMenuWidth - MENU_SHADOW_WIDTH,
             y: TAB_BAR_HEIGHT - MENU_SHADOW_WIDTH,
             width,
             height,

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -184,9 +184,11 @@ export class ViewManager {
             if (newView.isReady()) {
                 // if view is not ready, the renderer will have something to display instead.
                 newView.show();
+
                 // Need to call this function so that macOS has a draggable top bar
                 // https://github.com/electron/electron/issues/31068
                 this.mainView.setBounds(this.mainView.getBounds());
+
                 ipcMain.emit(UPDATE_LAST_ACTIVE, true, newView.tab.server.name, newView.tab.type);
                 if (newView.needsLoadingScreen()) {
                     this.showLoadingScreen();

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -45,14 +45,16 @@ export class ViewManager {
     urlView?: BrowserView;
     urlViewCancel?: () => void;
     mainWindow: BrowserWindow;
+    mainView: BrowserView;
     loadingScreen?: BrowserView;
 
-    constructor(config: CombinedConfig, mainWindow: BrowserWindow) {
+    constructor(config: CombinedConfig, mainWindow: BrowserWindow, mainView: BrowserView) {
         this.configServers = config.teams;
         this.lastActiveServer = config.lastActiveTeam;
         this.viewOptions = {webPreferences: {spellcheck: config.useSpellChecker}};
         this.views = new Map(); // keep in mind that this doesn't need to hold server order, only tabs on the renderer need that.
         this.mainWindow = mainWindow;
+        this.mainView = mainView;
         this.closedViews = new Map();
     }
 
@@ -130,7 +132,7 @@ export class ViewManager {
                 delete this.currentView;
                 this.showInitial();
             } else {
-                this.mainWindow.webContents.send(SET_ACTIVE_VIEW);
+                this.mainView.webContents.send(SET_ACTIVE_VIEW);
             }
         }
         oldviews.forEach((unused) => {
@@ -177,7 +179,7 @@ export class ViewManager {
             if (newView.needsLoadingScreen()) {
                 this.showLoadingScreen();
             }
-            newView.window.webContents.send(SET_ACTIVE_VIEW, newView.tab.server.name, newView.tab.type);
+            this.mainView.webContents.send(SET_ACTIVE_VIEW, newView.tab.server.name, newView.tab.type);
             ipcMain.emit(SET_ACTIVE_VIEW, true, newView.tab.server.name, newView.tab.type);
             if (newView.isReady()) {
                 // if view is not ready, the renderer will have something to display instead.

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -184,6 +184,9 @@ export class ViewManager {
             if (newView.isReady()) {
                 // if view is not ready, the renderer will have something to display instead.
                 newView.show();
+                // Need to call this function so that macOS has a draggable top bar
+                // https://github.com/electron/electron/issues/31068
+                this.mainView.setBounds(this.mainView.getBounds());
                 ipcMain.emit(UPDATE_LAST_ACTIVE, true, newView.tab.server.name, newView.tab.type);
                 if (newView.needsLoadingScreen()) {
                     this.showLoadingScreen();

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -6,7 +6,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 
-import {app, BrowserWindow, BrowserWindowConstructorOptions, ipcMain} from 'electron';
+import {app,  BrowserWindow, BrowserWindowConstructorOptions, ipcMain} from 'electron';
 import log from 'electron-log';
 
 import {CombinedConfig} from 'types/config';
@@ -17,7 +17,6 @@ import {DEFAULT_WINDOW_HEIGHT, DEFAULT_WINDOW_WIDTH, MINIMUM_WINDOW_HEIGHT, MINI
 
 import * as Validator from '../Validator';
 import ContextMenu from '../contextMenu';
-import {getLocalPreload, getLocalURLString} from '../utils';
 
 function saveWindowState(file: string, window: BrowserWindow) {
     const windowState: SavedWindowState = {
@@ -39,7 +38,6 @@ function isFramelessWindow() {
 
 function createMainWindow(config: CombinedConfig, options: {linuxAppIcon: string}) {
     // Create the browser window.
-    const preload = getLocalPreload('mainWindow.js');
     const boundsInfoPath = path.join(app.getPath('userData'), 'bounds-info.json');
     let savedWindowState;
     try {
@@ -54,8 +52,6 @@ function createMainWindow(config: CombinedConfig, options: {linuxAppIcon: string
     }
 
     const {maximized: windowIsMaximized} = savedWindowState;
-
-    const spellcheck = (typeof config.useSpellChecker === 'undefined' ? true : config.useSpellChecker);
 
     const windowOptions: BrowserWindowConstructorOptions = Object.assign({}, savedWindowState, {
         title: app.name,
@@ -74,8 +70,6 @@ function createMainWindow(config: CombinedConfig, options: {linuxAppIcon: string
             nodeIntegration: process.env.NODE_ENV === 'test',
             contextIsolation: process.env.NODE_ENV !== 'test',
             disableBlinkFeatures: 'Auxclick',
-            preload,
-            spellcheck,
         },
     });
 
@@ -92,22 +86,11 @@ function createMainWindow(config: CombinedConfig, options: {linuxAppIcon: string
         log.error('Tried to register second handler, skipping');
     }
 
-    const localURL = getLocalURLString('index.html');
-    mainWindow.loadURL(localURL).catch(
-        (reason) => {
-            log.error(`Main window failed to load: ${reason}`);
-        });
-    mainWindow.once('ready-to-show', () => {
-        mainWindow.webContents.zoomLevel = 0;
-
+    mainWindow.once('show', () => {
         mainWindow.show();
         if (windowIsMaximized) {
             mainWindow.maximize();
         }
-    });
-
-    mainWindow.once('show', () => {
-        mainWindow.show();
     });
 
     mainWindow.once('restore', () => {

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -6,7 +6,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 
-import {app,  BrowserWindow, BrowserWindowConstructorOptions, ipcMain} from 'electron';
+import {app, BrowserWindow, BrowserWindowConstructorOptions, ipcMain} from 'electron';
 import log from 'electron-log';
 
 import {CombinedConfig} from 'types/config';

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -203,6 +203,9 @@ function handleResizeMainWindow() {
         if (currentView) {
             currentView.setBounds(getAdjustedWindowBoundaries(bounds.width!, bounds.height!, !(urlUtils.isTeamUrl(currentView.tab.url, currentView.view.webContents.getURL()) || urlUtils.isAdminUrl(currentView.tab.url, currentView.view.webContents.getURL()))));
         }
+        status.mainView?.setBounds(getTabViewBounds(bounds.width!));
+        status.viewManager?.setLoadingScreenBounds();
+        status.teamDropdown?.updateWindowBounds();
     };
 
     // Another workaround since the window doesn't update properly under Linux for some reason
@@ -212,9 +215,6 @@ function handleResizeMainWindow() {
     } else {
         setBoundsFunction();
     }
-    status.mainView?.setBounds(getTabViewBounds(bounds.width!));
-    status.viewManager.setLoadingScreenBounds();
-    status.teamDropdown?.updateWindowBounds();
 }
 
 export function sendToRenderer(channel: string, ...args: any[]) {

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -23,7 +23,7 @@ import urlUtils from 'common/utils/url';
 
 import {getTabViewName} from 'common/tabs/TabView';
 
-import {getAdjustedWindowBoundaries, getLocalPreload, getLocalURLString, getTabViewBounds} from '../utils';
+import {getAdjustedWindowBoundaries, getLocalPreload, getLocalURLString, getMainViewBounds} from '../utils';
 
 import {ViewManager} from '../views/viewManager';
 import CriticalErrorHandler from '../CriticalErrorHandler';
@@ -122,7 +122,8 @@ export function showMainWindow(deeplinkingURL?: string | URL) {
                 log.error(`Main view failed to load: ${reason}`);
             });
         status.mainWindow.addBrowserView(status.mainView);
-        status.mainView.setBounds(getTabViewBounds(status.mainWindow.getContentBounds().width));
+        const windowBounds = status.mainWindow.getContentBounds();
+        status.mainView.setBounds(getMainViewBounds(windowBounds.width, windowBounds.height));
 
         status.mainView.webContents.once('did-finish-load', () => {
             if (status.mainView) {
@@ -203,7 +204,7 @@ function handleResizeMainWindow() {
         if (currentView) {
             currentView.setBounds(getAdjustedWindowBoundaries(bounds.width!, bounds.height!, !(urlUtils.isTeamUrl(currentView.tab.url, currentView.view.webContents.getURL()) || urlUtils.isAdminUrl(currentView.tab.url, currentView.view.webContents.getURL()))));
         }
-        status.mainView?.setBounds(getTabViewBounds(bounds.width!));
+        status.mainView?.setBounds(getMainViewBounds(bounds.width!, bounds.height!));
         status.viewManager?.setLoadingScreenBounds();
         status.teamDropdown?.updateWindowBounds();
     };

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import path from 'path';
-import {app, BrowserWindow, nativeImage, systemPreferences, ipcMain, IpcMainEvent, BrowserView} from 'electron';
+import {app, BrowserWindow, nativeImage, systemPreferences, ipcMain, IpcMainEvent, BrowserView, WebContents} from 'electron';
 import log from 'electron-log';
 
 import {CombinedConfig} from 'types/config';
@@ -603,4 +603,17 @@ export function getCurrentTeamName() {
 
 function handleAppLoggedIn(event: IpcMainEvent, viewName: string) {
     status.viewManager?.reloadViewIfNeeded(viewName);
+}
+
+export function openAppWrapperDevTools(focusedWindow?: WebContents) {
+    if (focusedWindow) {
+        // toggledevtools opens it in the last known position, so sometimes it goes below the browserview
+        if (focusedWindow.isDevToolsOpened()) {
+            focusedWindow.closeDevTools();
+        } else if (focusedWindow.id === status.mainWindow?.webContents.id) {
+            status.mainView?.webContents.openDevTools({mode: 'detach'});
+        } else {
+            focusedWindow.openDevTools({mode: 'detach'});
+        }
+    }
 }


### PR DESCRIPTION
#### Summary
There's a very annoying Electron bug causing issues on macOS in which the top 40px of our app isn't as interactable, as the framework is popping a draggable area there. Bug report here: https://github.com/electron/electron/issues/31052

As a workaround, I've put the entire top bar in a BrowserView in order to circumvent this issue. In the past there was problems with doing this, but I think the changes in infrastructure has made this easier to do.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38649

#### Release Note
```release-note
Fixed the top bar dragging issue on macOS by placing the top bar in its own BrowserView
```
