### PR TITLE
Fixed multiple reloads happening on launch

### DIFF
--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -91,8 +91,8 @@ export class ViewManager {
 
     reloadViewIfNeeded = (viewName: string) => {
         const view = this.views.get(viewName);
-        if (!view?.getWebContents()?.getURL().startsWith(view.tab.url.toString())) {
-            view?.load(view.tab.url);
+        if (view && !view.view.webContents.getURL().startsWith(view.tab.url.toString())) {
+            view.load(view.tab.url);
         }
     }
 
@@ -430,6 +430,7 @@ export class ViewManager {
                     } else {
                         // attempting to change parsedURL protocol results in it not being modified.
                         view.resetLoadingStatus();
+                        log.info('viewManager.handleDeepLink', urlWithSchema);
                         view.load(urlWithSchema);
                         view.once(LOAD_SUCCESS, this.deeplinkSuccess);
                         view.once(LOAD_FAILED, this.deeplinkFailed);

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -430,7 +430,6 @@ export class ViewManager {
                     } else {
                         // attempting to change parsedURL protocol results in it not being modified.
                         view.resetLoadingStatus();
-                        log.info('viewManager.handleDeepLink', urlWithSchema);
                         view.load(urlWithSchema);
                         view.once(LOAD_SUCCESS, this.deeplinkSuccess);
                         view.once(LOAD_FAILED, this.deeplinkFailed);


### PR DESCRIPTION
#### Summary
In some cases, on initial load of the app, the first server/view opened would refresh multiple times unnecessarily.
This was caused by extra calls to `reloadViewIfNecessary` when the view wasn't completely ready. This PR makes sure we're always working with the webContents for the view, other than the window.

```release-note
NONE
```
