### PR TITLE
[MM-38857] Fix spellcheck locales regex

### DIFF
--- a/src/main/Validator.ts
+++ b/src/main/Validator.ts
@@ -119,7 +119,7 @@ const configDataSchemaV3 = Joi.object<ConfigV3>({
     useSpellChecker: Joi.boolean().default(true),
     enableHardwareAcceleration: Joi.boolean().default(true),
     autostart: Joi.boolean().default(true),
-    spellCheckerLocales: Joi.array().items(Joi.string().regex(/^[a-z]{2}-[A-Z]{2}$/)).default([]),
+    spellCheckerLocales: Joi.array().items(Joi.string().regex(/^[A-Za-z-]+$/)).default([]),
     spellCheckerURL: Joi.string().allow(null),
     darkMode: Joi.boolean().default(false),
     downloadLocation: Joi.string(),

--- a/src/main/Validator.ts
+++ b/src/main/Validator.ts
@@ -119,7 +119,7 @@ const configDataSchemaV3 = Joi.object<ConfigV3>({
     useSpellChecker: Joi.boolean().default(true),
     enableHardwareAcceleration: Joi.boolean().default(true),
     autostart: Joi.boolean().default(true),
-    spellCheckerLocales: Joi.array().items(Joi.string().regex(/^[A-Za-z-]+$/)).default([]),
+    spellCheckerLocales: Joi.array().items(Joi.string()).default([]),
     spellCheckerURL: Joi.string().allow(null),
     darkMode: Joi.boolean().default(false),
     downloadLocation: Joi.string(),


### PR DESCRIPTION
#### Summary
This PR fixes the regex used for validating spell checker locales. It was previously expecting locales with a dash, which not all of them have.

#### Ticket Link
Closes #1754.
https://mattermost.atlassian.net/browse/MM-38857

```release-note
NONE
```
