### PR TITLE
Fix GitHub release markdown for mac universal change

### DIFF
--- a/scripts/generate_release_markdown.sh
+++ b/scripts/generate_release_markdown.sh
@@ -33,7 +33,7 @@ $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win-ia32.zip")
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win-x64.zip")
 
 #### Mac
-$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-mac-universal.dmg")
+$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-mac-universal.dmg") (beta)
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-mac-x64.dmg")
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-mac-m1.dmg") (beta)
 

--- a/scripts/generate_release_markdown.sh
+++ b/scripts/generate_release_markdown.sh
@@ -33,7 +33,8 @@ $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win-ia32.zip")
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win-x64.zip")
 
 #### Mac
-$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-mac.dmg")
+$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-mac-universal.dmg")
+$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-mac-x64.dmg")
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-mac-m1.dmg") (beta)
 
 #### Linux


### PR DESCRIPTION
#### Summary
Adding the Mac universal binary changed the way we write the release description. This PR fixes that.

```release-note
NONE
```
