### PR TITLE
[MM-38532] Use currentView to check for most recently used view

### DIFF
--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -114,7 +114,7 @@ export class ViewManager {
             server.tabs.forEach((tab) => {
                 const tabView = getServerView(srv, tab);
                 const recycle = oldviews.get(tabView.name);
-                if (recycle && recycle.isVisible) {
+                if (recycle && recycle.name === this.currentView) {
                     setFocus = recycle.name;
                 }
                 if (!tab.isOpen) {


### PR DESCRIPTION
#### Summary
When reloading the configuration, we were checking for the most recently visible view instead of the next view we plan to load if it exists. This PR makes sure we're checking for the next view that needs to be loaded, which will solve the issue when creating a new server.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38532

#### Release Note
```release-note
NONE
```
