### PR TITLE
[MM-38991] Remove mentions and unreads when unloading a view

### DIFF
--- a/src/main/views/MattermostView.ts
+++ b/src/main/views/MattermostView.ts
@@ -217,6 +217,7 @@ export class MattermostView extends EventEmitter {
 
     destroy = () => {
         removeWebContentsListeners(this.view.webContents.id);
+        appState.updateMentions(this.tab.name, 0, false);
         if (this.window) {
             this.window.removeBrowserView(this.view);
         }


### PR DESCRIPTION
#### Summary
When removing a server, mentions and unreads that were on that server would remain visible in the global count and wouldn't go away until restart. This PR removes those when the view is destroyed so that they don't persist when the view doesn't exist.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38991

#### Release Note
```release-note
NONE
```
