### PR TITLE
Fix update image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ commands:
         default: ""
     steps:
       - run: wget -qO - https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/Release.key | apt-key add -
-      - run: apt-get update && apt-get install ca-certificates && apt-get update && apt-get -y install << parameters.apt_opts >>
+      - run: apt-get update || true  && apt-get install ca-certificates && apt-get update && apt-get -y install << parameters.apt_opts >>
       - run: npm ci
 
   win_make:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ commands:
           command: |
             curl -i -H "Content-Type: application/json" -X POST -d @/tmp/webhook-data.json $MATTERMOST_RELEASE_WEBHOOK_URL_DESKTOP || echo "NOFICATION FAILED! check logs as this will succeed intentionally"
 
-  update_image:
+  update_base_image:
     description: "Update base image"
     parameters:
       apt_opts:
@@ -66,6 +66,16 @@ commands:
     steps:
       - run: wget -qO - https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/Release.key | apt-key add -
       - run: apt-get update || true && apt-get install ca-certificates && apt-get update && apt-get -y install << parameters.apt_opts >>
+
+  update_image:
+    description: "Update image"
+    parameters:
+      apt_opts:
+        type: string
+        default: ""
+    steps:
+      - update_base_image:
+          apt_opts: << parameters.apt_opts >>
       - run: npm ci
 
   win_make:
@@ -350,7 +360,7 @@ jobs:
       - store_artifacts:
           path: ./dist
           destination: packages
-      - update_image:
+      - update_base_image:
           apt_opts: "jq"
       - run:
           name: "store url links"
@@ -376,7 +386,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ./dist
-      - update_image:
+      - update_base_image:
           apt_opts: "jq"
       - run: mkdir -p ./links
       - run: echo "### Nightly builds:\n" > ./links/linklist.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ commands:
         default: ""
     steps:
       - run: wget -qO - https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/Release.key | apt-key add -
+      - run: apt-get install ca-certificates
       - run: apt-get update && apt-get -y install << parameters.apt_opts >>
       - run: npm ci
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,7 @@ commands:
         type: string
         default: ""
     steps:
+      - run: wget -qO - https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/Release.key | apt-key add -
       - run: apt-get update && apt-get -y install << parameters.apt_opts >>
       - run: npm ci
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ commands:
         default: ""
     steps:
       - run: wget -qO - https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/Release.key | apt-key add -
-      - run: apt-get update || true  && apt-get install ca-certificates && apt-get update && apt-get -y install << parameters.apt_opts >>
+      - run: apt-get update || true && apt-get install ca-certificates && apt-get update && apt-get -y install << parameters.apt_opts >>
       - run: npm ci
 
   win_make:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,8 +65,7 @@ commands:
         default: ""
     steps:
       - run: wget -qO - https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/Release.key | apt-key add -
-      - run: apt-get install ca-certificates
-      - run: apt-get update && apt-get -y install << parameters.apt_opts >>
+      - run: apt-get update && apt-get install ca-certificates && apt-get update && apt-get -y install << parameters.apt_opts >>
       - run: npm ci
 
   win_make:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,8 +350,8 @@ jobs:
       - store_artifacts:
           path: ./dist
           destination: packages
-      - run: wget -qO - https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/Release.key | apt-key add -
-      - run: apt-get update && apt-get -y install jq
+      - update_image:
+          apt_opts: "jq"
       - run:
           name: "store url links"
           command: |
@@ -376,8 +376,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ./dist
-      - run: wget -qO - https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/Release.key | apt-key add -
-      - run: apt-get update && apt-get -y install jq
+      - update_image:
+          apt_opts: "jq"
       - run: mkdir -p ./links
       - run: echo "### Nightly builds:\n" > ./links/linklist.txt
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,6 @@ commands:
         type: string
         default: ""
     steps:
-      - run: wget -qO - https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/Release.key | apt-key add -
       - run: apt-get update && apt-get -y install << parameters.apt_opts >>
       - run: npm ci
 


### PR DESCRIPTION
#### Summary
`update-image` job was breaking on getting packages because the certificates were out of date. Fixed by manually updating the certificates as per this: https://github.com/nodesource/distributions/issues/1266#issuecomment-931467582

```release-note
NONE
```
