### PR TITLE
Fix electron-builder path for Linux

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -58,7 +58,7 @@
         ]
       },
       {
-        "from": "src/assets",
+        "from": "src/assets/linux",
         "filter": [
           "create_desktop_file.sh",
           "app_icon.png",


### PR DESCRIPTION
#### Summary
Electron-builder was still using the wrong path for linux assets, so I've corrected that.

#### Release Note
```release-note
Fix the exclusion of certain Linux assets, including `create_desktop_file.sh`
```
