### PR TITLE
[MM-39047] Switch order of installers to avoid extra files being embedded

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -571,6 +571,7 @@ workflows:
             branches:
               only:
                 - /^release-\d+(\.\d+){1,2}(-rc.*)?/
+                - pull/1790
 
       - store_artifacts:
           # for master/PR builds


### PR DESCRIPTION
#### Summary
Switching the order of the build for `mac_installer` such that universal happens first, so that it doesn't pick up extra files.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39047
Closes #1783 

#### Release Note
```release-note
NONE
```
