### PR TITLE
[MM-39139] Workaround for transparency issue for BrowserViews on Electron v14.1.0+

### DIFF
--- a/src/main/views/modalView.ts
+++ b/src/main/views/modalView.ts
@@ -35,6 +35,11 @@ export class ModalView<T, T2> {
             contextIsolation: process.env.NODE_ENV !== 'test',
             preload,
             nodeIntegration: process.env.NODE_ENV === 'test',
+
+            // Workaround for this issue: https://github.com/electron/electron/issues/30993
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            transparent: true,
         }});
         this.onReject = onReject;
         this.onResolve = onResolve;

--- a/src/main/views/teamDropdownView.ts
+++ b/src/main/views/teamDropdownView.ts
@@ -49,6 +49,11 @@ export default class TeamDropdownView {
             contextIsolation: process.env.NODE_ENV !== 'test',
             preload,
             nodeIntegration: process.env.NODE_ENV === 'test',
+
+            // Workaround for this issue: https://github.com/electron/electron/issues/30993
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            transparent: true,
         }});
 
         this.view.webContents.loadURL(getLocalURLString('dropdown.html'));

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -295,6 +295,11 @@ export class ViewManager {
                     nativeWindowOpen: true,
                     contextIsolation: process.env.NODE_ENV !== 'test',
                     nodeIntegration: process.env.NODE_ENV === 'test',
+
+                    // Workaround for this issue: https://github.com/electron/electron/issues/30993
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-ignore
+                    transparent: true,
                 }});
             const query = new Map([['url', urlString]]);
             const localURL = getLocalURLString('urlView.html', query);


### PR DESCRIPTION
#### Summary
Found a workaround for forcing `BrowserViews` to be transparent anyways. It's not supported by Electron, so a fix is still likely to be needed, but this will work for the time being.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39139

#### Release Note
```release-note
NONE
```
