### PR TITLE
Fix URL view cutoff for long URLs

### DIFF
--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -304,7 +304,7 @@ export class ViewManager {
             urlView.setBounds({
                 x: 0,
                 y: boundaries.height - URL_VIEW_HEIGHT,
-                width: Math.floor(boundaries.width / 3),
+                width: boundaries.width,
                 height: URL_VIEW_HEIGHT,
             });
 


### PR DESCRIPTION
#### Summary
The URL View visible at the bottom cuts off some URLs, so I've extended the BrowserView its contained within to the full width of the window. Since it's transparent it won't show overtop of anything that it's not supposed to.

#### Release Note
```release-note
NONE
```
