### PR TITLE
[MM-39194] Removing call to focus() causing crash on macOS

### DIFF
--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -79,7 +79,6 @@ export function showSettingsWindow() {
         status.settingsWindow = createSettingsWindow(status.mainWindow!, status.config, withDevTools);
         status.settingsWindow.on('closed', () => {
             delete status.settingsWindow;
-            focusBrowserView();
         });
     }
 }


### PR DESCRIPTION
#### Summary
The call to `focus()` on the most recent active MattermostView is causing the Electron runtime to crash for some unknown reason. So I've removed the call since it doesn't seem to be necessary

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39194

#### Release Note
```release-note
NONE
```
