### PR TITLE
[MM-39310] Add setTimeout to new server modal pop to make sure it renders correctly.

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -718,13 +718,6 @@ function initializeAfterAppReady() {
 
     WindowManager.showMainWindow(deeplinkingURL);
 
-    // only check for non-Windows, as with Windows we have to wait for GPO teams
-    if (process.platform !== 'win32' || typeof config.registryConfigData !== 'undefined') {
-        if (config.teams.length === 0) {
-            handleNewServerModal();
-        }
-    }
-
     criticalErrorHandler.setMainWindow(WindowManager.getMainWindow()!);
 
     // listen for status updates and pass on to renderer
@@ -797,6 +790,15 @@ function initializeAfterAppReady() {
         // is the requesting url trusted?
         callback(urlUtils.isTrustedURL(requestingURL, config.teams));
     });
+
+    // only check for non-Windows, as with Windows we have to wait for GPO teams
+    if (process.platform !== 'win32' || typeof config.registryConfigData !== 'undefined') {
+        if (config.teams.length === 0) {
+            setTimeout(() => {
+                handleNewServerModal();
+            }, 200);
+        }
+    }
 }
 
 //


### PR DESCRIPTION
#### Summary
On Linux, the new server modal wasn't popping correctly due to some timing issue with when the BrowserView was added, and the user was not able to manually pop it. This PR fixes the issue by adding a `setTimeout` so that the modal pops slightly later.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39310
Fixes #1808

#### Release Note
```release-note
Fixed the new server modal not be accessible on Linux when no other servers exist.
```
