### PR TITLE
Fixed serverAPI throwing error on proxy server challenge, improved modals

### DIFF
--- a/src/main/authManager.ts
+++ b/src/main/authManager.ts
@@ -62,7 +62,7 @@ export class AuthManager {
         if (!mainWindow) {
             return;
         }
-        const modalPromise = addModal<LoginModalData, LoginModalResult>(`login-${request.url}`, loginModalHtml, modalPreload, {request, authInfo}, mainWindow);
+        const modalPromise = addModal<LoginModalData, LoginModalResult>(authInfo.isProxy ? `proxy-${authInfo.host}` : `login-${request.url}`, loginModalHtml, modalPreload, {request, authInfo}, mainWindow);
         if (modalPromise) {
             modalPromise.then((data) => {
                 const {username, password} = data;

--- a/src/main/server/serverAPI.ts
+++ b/src/main/server/serverAPI.ts
@@ -49,6 +49,7 @@ export async function getServerAPI<T>(url: URL, isAuthenticated: boolean, onSucc
             } else {
                 onError?.(new Error(`Bad status code requesting from ${url.toString()}`));
             }
+            response.on('error', onError || (() => {}));
         });
     }
     if (onAbort) {


### PR DESCRIPTION
#### Summary
When trying to use the Desktop App with a proxy server, the app would crash. This is due to a bug in the request logic here: https://github.com/electron/electron/issues/24948

I've implemented a workaround that catches the error. Also did some improvements on how the modals are handled for proxy servers, so now you should only get 1 modal instead of n where n is the number of views.

#### Ticket Link
Closes https://github.com/mattermost/desktop/issues/1814

#### Release Note
```release-note
Fixed an issue where using a proxy server with the Desktop app causes the app to crash.
```
