### PR TITLE
Fixed issue with GPO navigation between tabs

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -318,6 +318,8 @@ function handleConfigSynchronize() {
 
     if (process.platform === 'win32' && !didCheckForAddServerModal && typeof config.registryConfigData !== 'undefined') {
         didCheckForAddServerModal = true;
+        updateServerInfos(config.teams);
+        WindowManager.initializeCurrentServerName();
         if (config.teams.length === 0) {
             handleNewServerModal();
         }

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -352,6 +352,12 @@ function initializeViewManager() {
         status.viewManager = new ViewManager(status.config, status.mainWindow);
         status.viewManager.load();
         status.viewManager.showInitial();
+        initializeCurrentServerName();
+    }
+}
+
+export function initializeCurrentServerName() {
+    if (status.config && !status.currentServerName) {
         status.currentServerName = (status.config.teams.find((team) => team.order === status.config?.lastActiveTeam) || status.config.teams.find((team) => team.order === 0))?.name;
     }
 }


### PR DESCRIPTION
#### Summary
Users with predefined servers (ie. GPO or built-in servers) were not able to open the Boards/Playbooks tabs correctly. This PR adds ephemeral config (that lasts as long as the app is open) for predefined teams so that the tabs can be opened, closed and moved around as normal, the config will just not persist after the app is closed. 

#### Ticket Link
Reported here: https://community-daily.mattermost.com/core/pl/hytbycmj5prfframjpzq1e9ste

#### Release Note
```release-note
Fixed an issue with GPO and built-in servers not working correctly with Boards/Playbooks tabs
```
