### PR TITLE
Automated cherry pick of #1818

### DIFF
--- a/src/main/notifications/Mention.ts
+++ b/src/main/notifications/Mention.ts
@@ -20,22 +20,22 @@ const defaultOptions = {
 export const DEFAULT_WIN7 = 'Ding';
 
 export class Mention extends Notification {
-    customSound: boolean;
+    customSound: string;
     channel: {id: string}; // TODO: Channel from mattermost-redux
     teamId: string;
 
     constructor(customOptions: MentionOptions, channel: {id: string}, teamId: string) {
-        super({...defaultOptions, ...customOptions});
         const options = {...defaultOptions, ...customOptions};
         if (process.platform === 'darwin') {
             // Notification Center shows app's icon, so there were two icons on the notification.
             Reflect.deleteProperty(options, 'icon');
         }
         const isWin7 = (process.platform === 'win32' && osVersion.isLowerThanOrEqualWindows8_1() && DEFAULT_WIN7);
-        const customSound = Boolean(!options.silent && ((options.data && options.data.soundName !== 'None' && options.data.soundName) || isWin7));
+        const customSound = String(!options.silent && ((options.data && options.data.soundName !== 'None' && options.data.soundName) || isWin7));
         if (customSound) {
             options.silent = true;
         }
+        super(options);
 
         this.customSound = customSound;
         this.channel = channel;


### PR DESCRIPTION
Cherry pick of #1818 on release-5.0.

/cc  @devinbinnie

```release-note
NONE
```