### PR TITLE
Changed version checking code for native window and correctly support frameless on Windows 8

### DIFF
--- a/src/common/config/index.ts
+++ b/src/common/config/index.ts
@@ -24,6 +24,7 @@ import {UPDATE_TEAMS, GET_CONFIGURATION, UPDATE_CONFIGURATION, GET_LOCAL_CONFIGU
 
 import * as Validator from 'main/Validator';
 import {getDefaultTeamWithTabsFromTeam} from 'common/tabs/TabView';
+import Utils from 'common/utils/util';
 
 import defaultPreferences, {getDefaultDownloadLocation} from './defaultPreferences';
 import upgradeConfigData from './upgradePreferences';
@@ -57,7 +58,7 @@ export default class Config extends EventEmitter {
             this.predefinedTeams.push(...buildConfig.defaultTeams.map((team) => getDefaultTeamWithTabsFromTeam(team)));
         }
         try {
-            this.useNativeWindow = os.platform() === 'win32' && (parseInt(os.release().split('.')[0], 10) < 10);
+            this.useNativeWindow = os.platform() === 'win32' && !Utils.isVersionGreaterThanOrEqualTo(os.release(), '6.2');
         } catch {
             this.useNativeWindow = false;
         }

--- a/src/common/utils/util.ts
+++ b/src/common/utils/util.ts
@@ -37,7 +37,7 @@ function shorten(string: string, max?: number) {
     return string;
 }
 
-function isServerVersionGreaterThanOrEqualTo(currentVersion: string, compareVersion: string): boolean {
+function isVersionGreaterThanOrEqualTo(currentVersion: string, compareVersion: string): boolean {
     if (currentVersion === compareVersion) {
         return true;
     }
@@ -66,5 +66,5 @@ export default {
     getDisplayBoundaries,
     runMode,
     shorten,
-    isServerVersionGreaterThanOrEqualTo,
+    isVersionGreaterThanOrEqualTo,
 };

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -830,7 +830,7 @@ function openExtraTabs(data: Array<RemoteInfo | string | undefined>, team: TeamW
     const remoteInfo = data.find((info) => info && typeof info !== 'string' && info.name === team.name) as RemoteInfo;
     if (remoteInfo) {
         team.tabs.forEach((tab) => {
-            if (tab.name !== TAB_MESSAGING && remoteInfo.serverVersion && Utils.isServerVersionGreaterThanOrEqualTo(remoteInfo.serverVersion, '6.0.0')) {
+            if (tab.name !== TAB_MESSAGING && remoteInfo.serverVersion && Utils.isVersionGreaterThanOrEqualTo(remoteInfo.serverVersion, '6.0.0')) {
                 if (tab.name === TAB_PLAYBOOKS && remoteInfo.hasPlaybooks && tab.isOpen !== false) {
                     log.info(`opening ${team.name}___${tab.name} on hasPlaybooks`);
                     tab.isOpen = true;

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -430,7 +430,7 @@ export class ViewManager {
                         return;
                     }
 
-                    if (view.status === Status.READY && view.serverInfo.remoteInfo.serverVersion && Utils.isServerVersionGreaterThanOrEqualTo(view.serverInfo.remoteInfo.serverVersion, '6.0.0')) {
+                    if (view.status === Status.READY && view.serverInfo.remoteInfo.serverVersion && Utils.isVersionGreaterThanOrEqualTo(view.serverInfo.remoteInfo.serverVersion, '6.0.0')) {
                         const pathName = `/${urlWithSchema.replace(view.tab.server.url.toString(), '')}`;
                         view.view.webContents.send(BROWSER_HISTORY_PUSH, pathName);
                         this.deeplinkSuccess(view.name);

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -14,6 +14,7 @@ import {SavedWindowState} from 'types/mainWindow';
 
 import {SELECT_NEXT_TAB, SELECT_PREVIOUS_TAB, GET_FULL_SCREEN_STATUS, OPEN_TEAMS_DROPDOWN} from 'common/communication';
 import {DEFAULT_WINDOW_HEIGHT, DEFAULT_WINDOW_WIDTH, MINIMUM_WINDOW_HEIGHT, MINIMUM_WINDOW_WIDTH} from 'common/utils/constants';
+import Utils from 'common/utils/util';
 
 import * as Validator from '../Validator';
 import ContextMenu from '../contextMenu';
@@ -38,7 +39,7 @@ function isInsideRectangle(container: Electron.Rectangle, rect: Electron.Rectang
 }
 
 function isFramelessWindow() {
-    return os.platform() === 'darwin' || (os.platform() === 'win32' && os.release().startsWith('10'));
+    return os.platform() === 'darwin' || (os.platform() === 'win32' && Utils.isVersionGreaterThanOrEqualTo(os.release(), '6.2'));
 }
 
 function createMainWindow(config: CombinedConfig, options: {linuxAppIcon: string}) {


### PR DESCRIPTION
#### Summary
On Windows 8, the top bar buttons disappeared. This was caused by a change in how we detected the version. Normally Windows 8 should be using the native frame, but that doesn't seem to be working, so I've turned it on frameless for Windows 8 as well.

#### Ticket Link
Closes https://github.com/mattermost/desktop/issues/1826

#### Release Note
```release-note
Fixed an issue where the top bar buttons on Windows 8 were missing.
```
