### PR TITLE
[MM-39428] Check for EBUSY, add retry logic and logging for writing to config

### DIFF
--- a/src/common/config/index.ts
+++ b/src/common/config/index.ts
@@ -179,7 +179,11 @@ export default class Config extends EventEmitter {
         try {
             this.writeFile(this.configFilePath, this.localConfigData, (error: NodeJS.ErrnoException | null) => {
                 if (error) {
-                    throw new Error(error.message);
+                    if (error.code === 'EBUSY') {
+                        this.saveLocalConfigData();
+                    } else {
+                        this.emit('error', error);
+                    }
                 }
                 this.emit('update', this.combinedData);
                 this.emit('synchronize');

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -166,6 +166,9 @@ async function initializeConfig() {
             config.on('update', handleConfigUpdate);
             config.on('synchronize', handleConfigSynchronize);
             config.on('darkModeChange', handleDarkModeChange);
+            config.on('error', (error) => {
+                log.error(error);
+            });
             handleConfigUpdate(configData);
 
             // can only call this before the app is ready


### PR DESCRIPTION
#### Summary
Some situations can cause the config file to be locked while trying to write to it. This PR adds retry logic to avoid this issue, and also adds logging if any other file related issues happen.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39428
Closes https://github.com/mattermost/desktop/issues/1840
Closes https://github.com/mattermost/desktop/issues/1825

#### Release Note
```release-note
Fixed an issue where the app would crash trying to write to the config
```
