### PR TITLE
[MM-39737] E2E test checking for focused input in Add Server Modal

### DIFF
--- a/test/specs/browser/modal_test.js
+++ b/test/specs/browser/modal_test.js
@@ -161,6 +161,11 @@ describe('modals', function desc() {
             existing.should.be.true;
         });
 
+        it('should focus the first text input', async () => {
+            const isFocused = await newServerView.$eval('#teamNameInput', (el) => el === document.activeElement);
+            isFocused.should.be.true;
+        });
+
         it('should close the window after clicking cancel', async () => {
             await newServerView.click('#cancelNewServerModal');
             await asyncSleep(1000);


### PR DESCRIPTION
#### Summary
E2E test checking to make sure the first input is focused in the Add Server modal

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39737

```release-note
NONE
```
