### PR TITLE
[MM-39843] Show main window on second instance

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -355,9 +355,7 @@ function handleAppSecondInstance(event: Event, argv: string[]) {
     // Protocol handler for win32
     // argv: An array of the second instance’s (command line / deep linked) arguments
     const deeplinkingUrl = getDeeplinkingURL(argv);
-    if (deeplinkingUrl) {
-        openDeepLink(deeplinkingUrl);
-    }
+    WindowManager.showMainWindow(deeplinkingUrl);
 }
 
 function handleAppWindowAllClosed() {


### PR DESCRIPTION
#### Summary
When opening a second instance, we aren't showing the main window if it was hidden, this PR fixes that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39843
Closes https://github.com/mattermost/desktop/issues/1833

#### Release Note
```release-note
Fixed an issue where opening the app again doesn't show the main window if the app is already running.
```
