### PR TITLE
[MM-40025] Stop app from redirecting to tabs when not logged in

### DIFF
--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -98,6 +98,7 @@ export const SEND_DROPDOWN_MENU_SIZE = 'send-dropdown-menu-size';
 
 export const BROWSER_HISTORY_PUSH = 'browser-history-push';
 export const APP_LOGGED_IN = 'app-logged-in';
+export const APP_LOGGED_OUT = 'app-logged-out';
 
 export const GET_AVAILABLE_SPELL_CHECKER_LANGUAGES = 'get-available-spell-checker-languages';
 

--- a/src/main/preload/mattermost.js
+++ b/src/main/preload/mattermost.js
@@ -23,6 +23,7 @@ import {
     CLOSE_TEAMS_DROPDOWN,
     BROWSER_HISTORY_PUSH,
     APP_LOGGED_IN,
+    APP_LOGGED_OUT,
     GET_VIEW_NAME,
     GET_VIEW_WEBCONTENTS_ID,
 } from 'common/communication';
@@ -255,6 +256,9 @@ ipcRenderer.on(BROWSER_HISTORY_PUSH, (event, pathName) => {
 window.addEventListener('storage', (e) => {
     if (e.key === '__login__' && e.storageArea === localStorage && e.newValue) {
         ipcRenderer.send(APP_LOGGED_IN, viewName);
+    }
+    if (e.key === '__logout__' && e.storageArea === localStorage && e.newValue) {
+        ipcRenderer.send(APP_LOGGED_OUT, viewName);
     }
 });
 

--- a/src/main/views/MattermostView.ts
+++ b/src/main/views/MattermostView.ts
@@ -47,6 +47,7 @@ export class MattermostView extends EventEmitter {
     window: BrowserWindow;
     view: BrowserView;
     isVisible: boolean;
+    isLoggedIn: boolean;
     options: BrowserViewConstructorOptions;
     serverInfo: ServerInfo;
 
@@ -85,6 +86,7 @@ export class MattermostView extends EventEmitter {
             ...options.webPreferences,
         };
         this.isVisible = false;
+        this.isLoggedIn = false;
         this.view = new BrowserView(this.options);
         this.resetLoadingStatus();
 

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -20,6 +20,7 @@ import {
     APP_LOGGED_IN,
     GET_VIEW_NAME,
     GET_VIEW_WEBCONTENTS_ID,
+    APP_LOGGED_OUT,
 } from 'common/communication';
 import urlUtils from 'common/utils/url';
 
@@ -56,6 +57,7 @@ ipcMain.on(REACT_APP_INITIALIZED, handleReactAppInitialized);
 ipcMain.on(LOADING_SCREEN_ANIMATION_FINISHED, handleLoadingScreenAnimationFinished);
 ipcMain.on(BROWSER_HISTORY_PUSH, handleBrowserHistoryPush);
 ipcMain.on(APP_LOGGED_IN, handleAppLoggedIn);
+ipcMain.on(APP_LOGGED_OUT, handleAppLoggedOut);
 ipcMain.handle(GET_VIEW_NAME, handleGetViewName);
 ipcMain.handle(GET_VIEW_WEBCONTENTS_ID, handleGetWebContentsId);
 
@@ -570,10 +572,12 @@ function handleBrowserHistoryPush(e: IpcMainEvent, viewName: string, pathName: s
     if (status.viewManager?.closedViews.has(redirectedViewName)) {
         status.viewManager.openClosedTab(redirectedViewName, `${currentView?.tab.server.url}${pathName}`);
     }
-    const redirectedView = status.viewManager?.views.get(redirectedViewName) || currentView;
-    if (redirectedView !== currentView && redirectedView?.tab.server.name === status.currentServerName) {
+    let redirectedView = status.viewManager?.views.get(redirectedViewName) || currentView;
+    if (redirectedView !== currentView && redirectedView?.tab.server.name === status.currentServerName && redirectedView?.isLoggedIn) {
         log.info('redirecting to a new view', redirectedView?.name || viewName);
         status.viewManager?.showByName(redirectedView?.name || viewName);
+    } else {
+        redirectedView = currentView;
     }
 
     // Special case check for Channels to not force a redirect to "/", causing a refresh
@@ -587,7 +591,18 @@ export function getCurrentTeamName() {
 }
 
 function handleAppLoggedIn(event: IpcMainEvent, viewName: string) {
-    status.viewManager?.reloadViewIfNeeded(viewName);
+    const view = status.viewManager?.views.get(viewName);
+    if (view) {
+        view.isLoggedIn = true;
+        status.viewManager?.reloadViewIfNeeded(viewName);
+    }
+}
+
+function handleAppLoggedOut(event: IpcMainEvent, viewName: string) {
+    const view = status.viewManager?.views.get(viewName);
+    if (view) {
+        view.isLoggedIn = false;
+    }
 }
 
 function handleGetViewName(event: IpcMainInvokeEvent) {


### PR DESCRIPTION
#### Summary
In some cases due to the redirect logic, the app think it needs to redirect to another tab immediately after signin. When this happens, the app tries to call a logged-in route and our webapp emits a logged out event when this happens. This creates a race condition potentially logging out the user simply when they try to log in.

This PR stops any redirection to a tab that is not currently logged in, stopping the weird login issues.

#### Ticket Link
Closes https://github.com/mattermost/desktop/issues/1861
https://mattermost.atlassian.net/browse/MM-40025

#### Release Note
```release-note
Fixed an issue where a user might an erroneous "Your session has expired" error and be unable to login.
```
