### PR TITLE
Expose native API call to get desktop screen sources

### DIFF
--- a/src/main/preload/mattermost.js
+++ b/src/main/preload/mattermost.js
@@ -6,7 +6,7 @@
 
 /* eslint-disable no-magic-numbers */
 
-import {contextBridge, ipcRenderer, webFrame} from 'electron';
+import {contextBridge, ipcRenderer, webFrame, desktopCapturer} from 'electron';
 
 // I've filed an issue in electron-log https://github.com/megahertz/electron-log/issues/267
 // we'll be able to use it again if there is a workaround for the 'os' import
@@ -263,3 +263,17 @@ window.addEventListener('storage', (e) => {
 });
 
 /* eslint-enable no-magic-numbers */
+
+contextBridge.exposeInMainWorld('desktopCapturer', {
+    getSources: async (options) => {
+        const sources = await desktopCapturer.getSources(options);
+        return sources.map((source) => {
+            return {
+                id: source.id,
+                name: source.name,
+                thumbnailURL: source.thumbnail.toDataURL(),
+            };
+        });
+    },
+});
+

--- a/src/main/preload/mattermost.js
+++ b/src/main/preload/mattermost.js
@@ -262,8 +262,6 @@ window.addEventListener('storage', (e) => {
     }
 });
 
-/* eslint-enable no-magic-numbers */
-
 contextBridge.exposeInMainWorld('desktopCapturer', {
     getSources: async (options) => {
         const sources = await desktopCapturer.getSources(options);
@@ -276,4 +274,6 @@ contextBridge.exposeInMainWorld('desktopCapturer', {
         });
     },
 });
+
+/* eslint-enable no-magic-numbers */
 


### PR DESCRIPTION
#### Summary

Calls plugin makes use of the [Screen Capture API](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Capture_API/Using_Screen_Capture) to allow users to share their screen. However, while the browser implements [`getDisplayMedia()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia), Electron only provides [`getUserMedia()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia). This has worked so far but the limitation is that only the main screen source (full desktop) can be shared. This has also led to some weird issues with multiple monitor setups. 

To improve on this I did some quick research and figured out we may need some help from the Electron side itself through the use of [`desktopCapturer`](https://www.electronjs.org/docs/latest/api/desktop-capturer). PR exposes a very small (1 method) API to the web context to retrieve the available screen sources.

This is how the code would look like on the webapp (plugin) side:

```js
if (window.desktopCapturer) {
    // electron
    const sources = await window.desktopCapturer.getSources({
        types: ['window', 'screen'],
        thumbnailSize: {
            width: 400,
            height: 400,
        },
    });
    screenStream = await navigator.mediaDevices.getUserMedia({
        video: {
            mandatory: {
                chromeMediaSource: 'desktop',
                chromeMediaSourceId: sources[1].id,
            },
        },
        audio: false,
    });
} else {
    // browser
    screenStream = await navigator.mediaDevices.getDisplayMedia({
        video: {
            frameRate: maxFrameRate,
            width: captureWidth,
        },
        audio: false,
    });
}
```

I've purposely tried to apply the minimum set of changes that could get me what I needed on the other side, namely the list of screen sources. Please let me know if you see a better approach as I am happy to rework this if necessary.