### PR TITLE
[MM-40192] Don't send message until server is finished reloading

### DIFF
--- a/src/main/views/MattermostView.ts
+++ b/src/main/views/MattermostView.ts
@@ -100,7 +100,9 @@ export class MattermostView extends EventEmitter {
         }
 
         this.view.webContents.on('did-finish-load', () => {
-            this.view.webContents.send(SET_VIEW_OPTIONS, this.tab.name, this.tab.shouldNotify);
+            if (!this.view.webContents.isLoading()) {
+                this.view.webContents.send(SET_VIEW_OPTIONS, this.tab.name, this.tab.shouldNotify);
+            }
         });
 
         this.contextMenu = new ContextMenu({}, this.view);

--- a/src/main/views/MattermostView.ts
+++ b/src/main/views/MattermostView.ts
@@ -101,7 +101,11 @@ export class MattermostView extends EventEmitter {
 
         this.view.webContents.on('did-finish-load', () => {
             if (!this.view.webContents.isLoading()) {
-                this.view.webContents.send(SET_VIEW_OPTIONS, this.tab.name, this.tab.shouldNotify);
+                try {
+                    this.view.webContents.send(SET_VIEW_OPTIONS, this.tab.name, this.tab.shouldNotify);
+                } catch (e) {
+                    log.error('failed to send view options to view', this.tab.name);
+                }
             }
         });
 


### PR DESCRIPTION
#### Summary
Sometimes, if you press Ctrl/Cmd+R while the app is still loading, the `did-finish-load` event will fire for the first load while the page is reloading. Since we can't send messages down to a page that isn't loaded, the app will crash.

This PR checks to make sure the page isn't loading when sending the message down, and will avoid a crash if the send fails.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40192
Closes #1888

```release-note
Fixed an issue where the app could crash while trying to reload a page that is currently loading.
```
