### PR TITLE
[GH-1635] don't validate custom protocol URLs

### DIFF
--- a/src/main/views/webContentEvents.test.js
+++ b/src/main/views/webContentEvents.test.js
@@ -185,12 +185,17 @@ describe('main/views/webContentsEvents', () => {
 
         it('should deny invalid URI', () => {
             urlUtils.isValidURI.mockReturnValue(false);
-            expect(newWindow({url: 'baduri::'})).toStrictEqual({action: 'deny'});
+            expect(newWindow({url: 'http::'})).toStrictEqual({action: 'deny'});
         });
 
         it('should divert to allowProtocolDialog for custom protocols that are not mattermost or http', () => {
             expect(newWindow({url: 'spotify:album:2OZbaW9tgO62ndm375lFZr'})).toStrictEqual({action: 'deny'});
             expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith('spotify:', 'spotify:album:2OZbaW9tgO62ndm375lFZr');
+        });
+
+        it('should divert to allowProtocolDialog for invalid URIs with custom protocols', () => {
+            expect(newWindow({url: 'customproto:test\\data'})).toStrictEqual({action: 'deny'});
+            expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith('customproto:', 'customproto:test\\data');
         });
 
         it('should open in the browser when there is no server matching', () => {

--- a/src/main/views/webContentEvents.ts
+++ b/src/main/views/webContentEvents.ts
@@ -112,14 +112,14 @@ export class WebContentsEventManager {
                 return {action: 'allow'};
             }
 
-            // Check for valid URL
-            if (!urlUtils.isValidURI(details.url)) {
-                return {action: 'deny'};
-            }
-
             // Check for custom protocol
             if (parsedURL.protocol !== 'http:' && parsedURL.protocol !== 'https:' && parsedURL.protocol !== `${scheme}:`) {
                 allowProtocolDialog.handleDialogEvent(parsedURL.protocol, details.url);
+                return {action: 'deny'};
+            }
+
+            // Check for valid URL
+            if (!urlUtils.isValidURI(details.url)) {
                 return {action: 'deny'};
             }
 


### PR DESCRIPTION
#### Summary
With this change, URLs with custom protocols won't be validated any longer. This allows usage of technically invalid URLs for custom protocols 
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.



Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/desktop/issues/1635

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [x] executed `npm run lint:js` for proper code formatting

#### Device Information
This PR was tested on: Windows 10


#### Release Note

```release-note
NONE
```
