### PR TITLE
[MM-40573] Stop asterisk detection on versions newer than 5.28, force space for the others

### DIFF
--- a/src/main/views/MattermostView.test.js
+++ b/src/main/views/MattermostView.test.js
@@ -310,7 +310,7 @@ describe('main/views/MattermostView', () => {
     });
 
     describe('updateMentionsFromTitle', () => {
-        const mattermostView = new MattermostView(tabView, {}, {}, {});
+        const mattermostView = new MattermostView(tabView, {remoteInfo: {serverVersion: '5.28.0'}}, {}, {});
 
         it('should parse mentions from title', () => {
             mattermostView.updateMentionsFromTitle('(7) Mattermost');
@@ -320,6 +320,11 @@ describe('main/views/MattermostView', () => {
         it('should parse unreads from title', () => {
             mattermostView.updateMentionsFromTitle('* Mattermost');
             expect(appState.updateMentions).toHaveBeenCalledWith(mattermostView.tab.name, 0, true);
+        });
+
+        it('should not parse unreads when title is on a channel with an asterisk before it', () => {
+            mattermostView.updateMentionsFromTitle('*testChannel - Mattermost');
+            expect(appState.updateMentions).toHaveBeenCalledWith(mattermostView.tab.name, 0, false);
         });
     });
 });

--- a/src/main/views/MattermostView.ts
+++ b/src/main/views/MattermostView.ts
@@ -316,13 +316,17 @@ export class MattermostView extends EventEmitter {
         }
     }
 
-    titleParser = /(\((\d+)\) )?(\*)?/g
+    titleParser = /(\((\d+)\) )?(\*\s)?/g
 
     handleTitleUpdate = (e: Event, title: string) => {
         this.updateMentionsFromTitle(title);
     }
 
     updateMentionsFromTitle = (title: string) => {
+        if (this.serverInfo.remoteInfo.serverVersion && Util.isVersionGreaterThanOrEqualTo(this.serverInfo.remoteInfo.serverVersion, '5.29.0')) {
+            return;
+        }
+
         //const title = this.view.webContents.getTitle();
         const resultsIterator = title.matchAll(this.titleParser);
         const results = resultsIterator.next(); // we are only interested in the first set

--- a/src/main/views/MattermostView.ts
+++ b/src/main/views/MattermostView.ts
@@ -316,7 +316,7 @@ export class MattermostView extends EventEmitter {
         }
     }
 
-    titleParser = /(\((\d+)\) )?(\*\s)?/g
+    titleParser = /(\((\d+)\) )?(\* )?/g
 
     handleTitleUpdate = (e: Event, title: string) => {
         this.updateMentionsFromTitle(title);


### PR DESCRIPTION
#### Summary
If you are on a channel that begins with an asterisk, even if the server had no unreads it would show unreads.

This was caused by the regex we used to parse out the title for unreads/mentions. 

This PR stops that process from being used by versions newer than 5.28, and at least ensures you must have a space when searching for the asterisk on older versions.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40573
Closes https://github.com/mattermost/desktop/issues/1690

```release-note
Fixed an issue where being on a channel with an asterisk at the front would cause unreads to return a false positive.
```
