### PR TITLE
[MM-40603] Add timeout for alt press to make sure it doesn't interfere with OS shortcuts

### DIFF
--- a/src/main/views/MattermostView.ts
+++ b/src/main/views/MattermostView.ts
@@ -61,6 +61,7 @@ export class MattermostView extends EventEmitter {
 
     currentFavicon?: string;
     hasBeenShown: boolean;
+    altTimeout?: number;
     altLastPressed?: boolean;
     contextMenu: ContextMenu;
 
@@ -285,6 +286,7 @@ export class MattermostView extends EventEmitter {
         // Handler for pressing the Alt key to focus the 3-dot menu
         if (input.key === 'Alt' && input.type === 'keyUp' && this.altLastPressed) {
             this.altLastPressed = false;
+            clearTimeout(this.altTimeout);
             WindowManager.focusThreeDotMenu();
             return;
         }
@@ -292,8 +294,12 @@ export class MattermostView extends EventEmitter {
         // Hack to detect keyPress so that alt+<key> combinations don't default back to the 3-dot menu
         if (input.key === 'Alt' && input.type === 'keyDown') {
             this.altLastPressed = true;
+            this.altTimeout = setTimeout(() => {
+                this.altLastPressed = false;
+            }, 500) as unknown as number;
         } else {
             this.altLastPressed = false;
+            clearTimeout(this.altTimeout);
         }
     }
 


### PR DESCRIPTION
#### Summary
Sometimes when using an Alt shortcut on your OS while the MM Desktop App was focused, the app would not register any future key presses until the app was refocused. This would happen when switching workspaces using the Alt key for example.

This PR adds a timeout to clear the `altLastPressed` value so that it only will trigger the 3-dot focus if the key was lifted within 500ms of being held.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40603
Closes https://github.com/mattermost/desktop/issues/1297

```release-note
Fixed an issue where OS-level shortcuts could cause unexpected focus behaviour in the app.
```
