### PR TITLE
Automated cherry pick of #1932

### DIFF
--- a/src/main/views/MattermostView.ts
+++ b/src/main/views/MattermostView.ts
@@ -61,6 +61,7 @@ export class MattermostView extends EventEmitter {
 
     currentFavicon?: string;
     hasBeenShown: boolean;
+    altTimeout?: number;
     altLastPressed?: boolean;
     contextMenu: ContextMenu;
 
@@ -293,6 +294,7 @@ export class MattermostView extends EventEmitter {
         // Handler for pressing the Alt key to focus the 3-dot menu
         if (input.key === 'Alt' && input.type === 'keyUp' && this.altLastPressed) {
             this.altLastPressed = false;
+            clearTimeout(this.altTimeout);
             WindowManager.focusThreeDotMenu();
             return;
         }
@@ -300,8 +302,12 @@ export class MattermostView extends EventEmitter {
         // Hack to detect keyPress so that alt+<key> combinations don't default back to the 3-dot menu
         if (input.key === 'Alt' && input.type === 'keyDown') {
             this.altLastPressed = true;
+            this.altTimeout = setTimeout(() => {
+                this.altLastPressed = false;
+            }, 500) as unknown as number;
         } else {
             this.altLastPressed = false;
+            clearTimeout(this.altTimeout);
         }
     }
 


### PR DESCRIPTION
Cherry pick of #1932 on release-5.0.

/cc  @devinbinnie

```release-note
NONE
```