### PR TITLE
[MM-32371] Communicate history information to webapp for disable/enabling Back/Forward buttons

### DIFF
--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -89,6 +89,7 @@ export const REQUEST_TEAMS_DROPDOWN_INFO = 'request-teams-dropdown-info';
 export const RECEIVE_DROPDOWN_MENU_SIZE = 'receive-dropdown-menu-size';
 export const SEND_DROPDOWN_MENU_SIZE = 'send-dropdown-menu-size';
 
+export const BROWSER_HISTORY_BUTTON = 'browser-history-button';
 export const BROWSER_HISTORY_PUSH = 'browser-history-push';
 export const APP_LOGGED_IN = 'app-logged-in';
 export const APP_LOGGED_OUT = 'app-logged-out';

--- a/src/main/menus/app.ts
+++ b/src/main/menus/app.ts
@@ -3,7 +3,7 @@
 // See LICENSE.txt for license information.
 'use strict';
 
-import {app, ipcMain, Menu, MenuItemConstructorOptions, MenuItem, session, shell, WebContents, webContents, clipboard} from 'electron';
+import {app, ipcMain, Menu, MenuItemConstructorOptions, MenuItem, session, shell, WebContents, clipboard} from 'electron';
 
 import {BROWSER_HISTORY_BUTTON, OPEN_TEAMS_DROPDOWN, SHOW_NEW_SERVER_MODAL} from 'common/communication';
 import {Config} from 'common/config';

--- a/src/main/menus/app.ts
+++ b/src/main/menus/app.ts
@@ -3,9 +3,9 @@
 // See LICENSE.txt for license information.
 'use strict';
 
-import {app, ipcMain, Menu, MenuItemConstructorOptions, MenuItem, session, shell, WebContents, webContents} from 'electron';
+import {app, ipcMain, Menu, MenuItemConstructorOptions, MenuItem, session, shell, WebContents} from 'electron';
 
-import {SHOW_NEW_SERVER_MODAL} from 'common/communication';
+import {BROWSER_HISTORY_BUTTON, SHOW_NEW_SERVER_MODAL} from 'common/communication';
 import {Config} from 'common/config';
 import {TabType, getTabDisplayName} from 'common/tabs/TabView';
 
@@ -178,18 +178,20 @@ export function createTemplate(config: Config) {
             label: 'Back',
             accelerator: process.platform === 'darwin' ? 'Cmd+[' : 'Alt+Left',
             click: () => {
-                const focused = webContents.getFocusedWebContents();
-                if (focused.canGoBack()) {
-                    focused.goBack();
+                const view = WindowManager.viewManager?.getCurrentView();
+                if (view && view.view.webContents.canGoBack() && !view.isAtRoot) {
+                    view.view.webContents.goBack();
+                    ipcMain.emit(BROWSER_HISTORY_BUTTON, null, view.name);
                 }
             },
         }, {
             label: 'Forward',
             accelerator: process.platform === 'darwin' ? 'Cmd+]' : 'Alt+Right',
             click: () => {
-                const focused = webContents.getFocusedWebContents();
-                if (focused.canGoForward()) {
-                    focused.goForward();
+                const view = WindowManager.viewManager?.getCurrentView();
+                if (view && view.view.webContents.canGoForward()) {
+                    view.view.webContents.goForward();
+                    ipcMain.emit(BROWSER_HISTORY_BUTTON, null, view.name);
                 }
             },
         }],

--- a/src/main/preload/mattermost.js
+++ b/src/main/preload/mattermost.js
@@ -21,6 +21,7 @@ import {
     REACT_APP_INITIALIZED,
     USER_ACTIVITY_UPDATE,
     CLOSE_TEAMS_DROPDOWN,
+    BROWSER_HISTORY_BUTTON,
     BROWSER_HISTORY_PUSH,
     APP_LOGGED_IN,
     APP_LOGGED_OUT,
@@ -82,6 +83,7 @@ window.addEventListener('load', () => {
     }
     watchReactAppUntilInitialized(() => {
         ipcRenderer.send(REACT_APP_INITIALIZED, viewName);
+        ipcRenderer.send(BROWSER_HISTORY_BUTTON, viewName);
     });
 });
 
@@ -141,6 +143,10 @@ window.addEventListener('message', ({origin, data = {}} = {}) => {
     case 'browser-history-push': {
         const {path} = message;
         ipcRenderer.send(BROWSER_HISTORY_PUSH, viewName, path);
+        break;
+    }
+    case 'history-button': {
+        ipcRenderer.send(BROWSER_HISTORY_BUTTON, viewName);
         break;
     }
     default:
@@ -247,6 +253,19 @@ ipcRenderer.on(BROWSER_HISTORY_PUSH, (event, pathName) => {
             type: 'browser-history-push-return',
             message: {
                 pathName,
+            },
+        },
+        window.location.origin,
+    );
+});
+
+ipcRenderer.on(BROWSER_HISTORY_BUTTON, (event, enableBack, enableForward) => {
+    window.postMessage(
+        {
+            type: 'history-button-return',
+            message: {
+                enableBack,
+                enableForward,
             },
         },
         window.location.origin,

--- a/src/main/views/MattermostView.ts
+++ b/src/main/views/MattermostView.ts
@@ -48,6 +48,7 @@ export class MattermostView extends EventEmitter {
     view: BrowserView;
     isVisible: boolean;
     isLoggedIn: boolean;
+    isAtRoot: boolean;
     options: BrowserViewConstructorOptions;
     serverInfo: ServerInfo;
 
@@ -88,6 +89,7 @@ export class MattermostView extends EventEmitter {
         };
         this.isVisible = false;
         this.isLoggedIn = false;
+        this.isAtRoot = true;
         this.view = new BrowserView(this.options);
         this.resetLoadingStatus();
 

--- a/src/main/windows/windowManager.test.js
+++ b/src/main/windows/windowManager.test.js
@@ -759,6 +759,7 @@ describe('main/windows/windowManager', () => {
             openClosedTab: jest.fn(),
             showByName: jest.fn(),
         };
+        windowManager.handleBrowserHistoryButton = jest.fn();
 
         beforeEach(() => {
             Config.teams = [
@@ -815,6 +816,67 @@ describe('main/windows/windowManager', () => {
             urlUtils.getView.mockReturnValue({name: 'server-1_tab-messaging'});
             windowManager.handleBrowserHistoryPush(null, 'server-1_other_type_1', '/');
             expect(view1.view.webContents.send).not.toBeCalled();
+        });
+    });
+
+    describe('handleBrowserHistoryButton', () => {
+        const windowManager = new WindowManager();
+        const view1 = {
+            name: 'server-1_tab-messaging',
+            isLoggedIn: true,
+            isAtRoot: true,
+            tab: {
+                type: TAB_MESSAGING,
+                server: {
+                    url: 'http://server-1.com',
+                },
+                url: new URL('http://server-1.com'),
+            },
+            view: {
+                webContents: {
+                    canGoBack: jest.fn(),
+                    canGoForward: jest.fn(),
+                    clearHistory: jest.fn(),
+                    send: jest.fn(),
+                    getURL: jest.fn(),
+                },
+            },
+        };
+        windowManager.viewManager = {
+            views: new Map([
+                ['server-1_tab-messaging', view1],
+            ]),
+        };
+
+        beforeEach(() => {
+            Config.teams = [
+                {
+                    name: 'server-1',
+                    url: 'http://server-1.com',
+                    order: 0,
+                    tabs: [
+                        {
+                            name: 'tab-messaging',
+                            order: 0,
+                            isOpen: true,
+                        },
+                    ],
+                },
+            ];
+        });
+
+        afterEach(() => {
+            jest.resetAllMocks();
+            Config.teams = [];
+            view1.isAtRoot = true;
+        });
+
+        it('should erase history and set isAtRoot when navigating to root URL', () => {
+            view1.isAtRoot = false;
+            view1.view.webContents.getURL.mockReturnValue(view1.tab.url.toString());
+            windowManager.handleBrowserHistoryButton(null, 'server-1_tab-messaging');
+            expect(view1.view.webContents.clearHistory).toHaveBeenCalled();
+            expect(view1.isAtRoot).toBe(true);
         });
     });
 });

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -21,6 +21,7 @@ import {
     GET_VIEW_WEBCONTENTS_ID,
     RESIZE_MODAL,
     APP_LOGGED_OUT,
+    BROWSER_HISTORY_BUTTON,
 } from 'common/communication';
 import urlUtils from 'common/utils/url';
 import Config from 'common/config';
@@ -56,6 +57,7 @@ export class WindowManager {
         ipcMain.on(REACT_APP_INITIALIZED, this.handleReactAppInitialized);
         ipcMain.on(LOADING_SCREEN_ANIMATION_FINISHED, this.handleLoadingScreenAnimationFinished);
         ipcMain.on(BROWSER_HISTORY_PUSH, this.handleBrowserHistoryPush);
+        ipcMain.on(BROWSER_HISTORY_BUTTON, this.handleBrowserHistoryButton);
         ipcMain.on(APP_LOGGED_IN, this.handleAppLoggedIn);
         ipcMain.on(APP_LOGGED_OUT, this.handleAppLoggedOut);
         ipcMain.handle(GET_VIEW_NAME, this.handleGetViewName);
@@ -558,6 +560,22 @@ export class WindowManager {
         // Special case check for Channels to not force a redirect to "/", causing a refresh
         if (!(redirectedView !== currentView && redirectedView?.tab.type === TAB_MESSAGING && pathName === '/')) {
             redirectedView?.view.webContents.send(BROWSER_HISTORY_PUSH, pathName);
+            if (redirectedView) {
+                this.handleBrowserHistoryButton(e, redirectedView.name);
+            }
+        }
+    }
+
+    handleBrowserHistoryButton = (e: IpcMainEvent, viewName: string) => {
+        const currentView = this.viewManager?.views.get(viewName);
+        if (currentView) {
+            if (currentView.view.webContents.getURL() === currentView.tab.url.toString()) {
+                currentView.view.webContents.clearHistory();
+                currentView.isAtRoot = true;
+            } else {
+                currentView.isAtRoot = false;
+            }
+            currentView?.view.webContents.send(BROWSER_HISTORY_BUTTON, currentView.view.webContents.canGoBack(), currentView.view.webContents.canGoForward());
         }
     }
 


### PR DESCRIPTION
#### Summary
This PR adds some communication logic to facilitate message passing for history information, so that the webapp is aware when the page can actually go back or forward.

Related Webapp PR: https://github.com/mattermost/mattermost-webapp/pull/9614

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32371

```release-note
NONE
```
