### PR TITLE
Menu > Help > version copied to clipboard on click

### DIFF
--- a/src/main/menus/app.ts
+++ b/src/main/menus/app.ts
@@ -3,7 +3,7 @@
 // See LICENSE.txt for license information.
 'use strict';
 
-import {app, ipcMain, Menu, MenuItemConstructorOptions, MenuItem, session, shell, WebContents, webContents} from 'electron';
+import {app, ipcMain, Menu, MenuItemConstructorOptions, MenuItem, session, shell, WebContents, webContents, clipboard} from 'electron';
 
 import {OPEN_TEAMS_DROPDOWN, SHOW_NEW_SERVER_MODAL} from 'common/communication';
 import {Config} from 'common/config';
@@ -267,12 +267,17 @@ export function createTemplate(config: Config) {
         });
         submenu.push(separatorItem);
     }
+
+    // eslint-disable-next-line no-undef
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const version = `Version ${app.getVersion()}${__HASH_VERSION__ ? ` commit: ${__HASH_VERSION__}` : ''}`;
     submenu.push({
-        // eslint-disable-next-line no-undef
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        label: `Version ${app.getVersion()}${__HASH_VERSION__ ? ` commit: ${__HASH_VERSION__}` : ''}`,
-        enabled: false,
+        label: version,
+        enabled: true,
+        click() {
+            clipboard.writeText(version);
+        },
     });
 
     template.push({label: 'Hel&p', submenu});


### PR DESCRIPTION
#### Summary
Small change to make the `menu > help > version` copy the full version string to the clipboard on click to address the help wanted a ticket. 

This information is also available in `menu > mattermost > about mattermost`, which was not changed in this PR.

#### Ticket Link
  Fixes https://github.com/mattermost/desktop/issues/1868

#### Checklist
- [X] Has UI changes
- [X] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [X] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [X] executed `npm run lint:js` for proper code formatting

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
![Screen Shot 2022-01-07 at 1 34 32 PM](https://user-images.githubusercontent.com/46071821/148590568-31cbfe27-62a1-45ca-bc67-b713648d01c4.png)


#### Release Note

```release-note
Click Menu > Help > Version to copy version string into clipboard.
```
