### PR TITLE
[MM-40822] Remove app.dock.show from restoreMain

### DIFF
--- a/src/main/windows/windowManager.test.js
+++ b/src/main/windows/windowManager.test.js
@@ -304,19 +304,6 @@ describe('main/windows/windowManager', () => {
             expect(windowManager.settingsWindow.focus).toHaveBeenCalled();
             windowManager.settingsWindow.focus.mockClear();
         });
-
-        it('should call macOS show on macOS', () => {
-            windowManager.mainWindow.isVisible.mockReturnValue(false);
-            const originalPlatform = process.platform;
-            Object.defineProperty(process, 'platform', {
-                value: 'darwin',
-            });
-            windowManager.restoreMain();
-            Object.defineProperty(process, 'platform', {
-                value: originalPlatform,
-            });
-            expect(app.dock.show).toHaveBeenCalled();
-        });
     });
 
     describe('flashFrame', () => {

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -228,9 +228,6 @@ export class WindowManager {
             } else {
                 this.mainWindow!.focus();
             }
-            if (process.platform === 'darwin') {
-                app.dock.show();
-            }
         } else if (this.settingsWindow) {
             this.settingsWindow.focus();
         } else {


### PR DESCRIPTION
#### Summary
When opening the app from the tray icon, for some reason we were showing the dock as well on macOS. This was odd behaviour as if the dock was auto-hidden, it would remain stuck open afterwards.

This PR removes that call.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40822
Closes #1938 

```release-note
Fixed an issue where the macOS dock would stay open after clicking the tray icon
```
