### PR TITLE
change "tab" to "server" in developer tools menu

### DIFF
--- a/src/main/menus/app.ts
+++ b/src/main/menus/app.ts
@@ -152,7 +152,7 @@ export function createTemplate(config: Config) {
             }
         },
     }, {
-        label: 'Developer Tools for Current Tab',
+        label: 'Developer Tools for Current Server',
         click() {
             WindowManager.openBrowserViewDevTools();
         },


### PR DESCRIPTION
Since we recently changed the layout of the desktop app and moved the server tabs into a drop down I think it makes more sense to change the wording for this to refer to the "Server" instead of "Tab". Another one I considered was "View" instead of "Tab". I'd be good with either one.

The changes refer to this menu: 
![image](https://user-images.githubusercontent.com/7526550/149041954-928cb9e2-6b64-40cd-b268-454f2d9517d1.png)


```release-note
Changed wording in "File -> View" Menu from "Tab" to "Server" to reflect recent changes in UI.
```