### PR TITLE
Make WEBSERVER_PORT configurable with env variable

### DIFF
--- a/webpack.config.renderer.js
+++ b/webpack.config.renderer.js
@@ -13,7 +13,7 @@ const merge = require('webpack-merge');
 
 const base = require('./webpack.config.base');
 
-const WEBSERVER_PORT = 9001;
+const WEBSERVER_PORT = process.env.WEBSERVER_PORT ?? 9001;
 
 module.exports = merge(base, {
     entry: {

--- a/webpack.config.test.js
+++ b/webpack.config.test.js
@@ -12,7 +12,7 @@ const merge = require('webpack-merge');
 
 const base = require('./webpack.config.base');
 
-const WEBSERVER_PORT = 9001;
+const WEBSERVER_PORT = process.env.WEBSERVER_PORT ?? 9001;
 
 module.exports = merge(base, {
     entry: {


### PR DESCRIPTION
#### Summary
The PR https://github.com/mattermost/desktop/pull/1437 changed the default port from 9000 to 9001 to solve an issue with minio port on https://github.com/mattermost/mattermost-server. The port 9001 is now used by the container "inbucket" since the PR https://github.com/mattermost/mattermost-server/pull/18145. So if you have an instance of mattermost-server running, you cannot start the desktop project.

This PR introduces an environment variable `WEBSERVER_PORT` to change the port on-demand:

```shell
$ WEBSERVER_PORT=9005 npm run watch

# ...
ℹ ｢wds｣: Project is running at http://localhost:9005/
# ...
``` 

This PR **does NOT** change the default port, so it does not have any impact for somebody who changed their ports elsewhere. If you guys want me to change the default port, I'm happy to add a new commit to do so.

#### Ticket Link
N/A

#### Checklist
~- [ ] Added or updated unit tests (required for all new features)~
~- [ ] Has UI changes~
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [x] executed `npm run lint:js` for proper code formatting

#### Device Information
This PR was tested on: Arch Linux (wm xmonad)

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```