### PR TITLE
[MM-39799] E2E Test: MM-T4050 Long server name

### DIFF
--- a/e2e/specs/server_management/long_server_name.test.js
+++ b/e2e/specs/server_management/long_server_name.test.js
@@ -8,7 +8,7 @@ const fs = require('fs');
 const env = require('../../modules/environment');
 const {asyncSleep} = require('../../modules/utils');
 
-describe.only('LongServerName', function desc() {
+describe('LongServerName', function desc() {
     this.timeout(30000);
     const config = env.demoConfig;
     const longServerName = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus quis malesuada dolor, vel scelerisque sem';
@@ -79,7 +79,7 @@ describe.only('LongServerName', function desc() {
             isTruncated.should.be.true;
         });
 
-        it('MM-T4050_3 should display server tab with max width of 224px', async () => {
+        it('MM-T4050_3 should display server tab with max width of 400px', async () => {
             await asyncSleep(1000);
             const existing = Boolean(await this.app.windows().find((window) => window.url().includes('newServer')));
             existing.should.be.false;
@@ -90,7 +90,7 @@ describe.only('LongServerName', function desc() {
             const isWithinMaxWidth = await serverNameLocator.evaluate((element) => {
                 const width = parseFloat(window.getComputedStyle(element).getPropertyValue('width'));
 
-                return width <= 224;
+                return width <= 400;
             });
 
             isWithinMaxWidth.should.be.true;

--- a/e2e/specs/server_management/long_server_name.test.js
+++ b/e2e/specs/server_management/long_server_name.test.js
@@ -8,7 +8,7 @@ const fs = require('fs');
 const env = require('../../modules/environment');
 const {asyncSleep} = require('../../modules/utils');
 
-describe('LongServerName', function desc() {
+describe.only('LongServerName', function desc() {
     this.timeout(30000);
     const config = env.demoConfig;
     const longServerName = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus quis malesuada dolor, vel scelerisque sem';
@@ -90,7 +90,7 @@ describe('LongServerName', function desc() {
             const isWithinMaxWidth = await serverNameLocator.evaluate((element) => {
                 const width = parseFloat(window.getComputedStyle(element).getPropertyValue('width'));
 
-                return width < 224;
+                return width <= 224;
             });
 
             isWithinMaxWidth.should.be.true;

--- a/e2e/specs/server_management/long_server_name.test.js
+++ b/e2e/specs/server_management/long_server_name.test.js
@@ -1,0 +1,99 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+'use strict';
+
+const fs = require('fs');
+
+const env = require('../../modules/environment');
+const {asyncSleep} = require('../../modules/utils');
+
+describe('LongServerName', function desc() {
+    this.timeout(30000);
+    const config = env.demoConfig;
+    const longServerName = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus quis malesuada dolor, vel scelerisque sem';
+    const longServerUrl = 'https://example.org';
+
+    beforeEach(async () => {
+        env.createTestUserDataDir();
+        env.cleanTestConfig();
+        fs.writeFileSync(env.configFilePath, JSON.stringify(config));
+        await asyncSleep(1000);
+        this.app = await env.getApp();
+
+        const mainView = this.app.windows().find((window) => window.url().includes('index'));
+        const dropdownView = this.app.windows().find((window) => window.url().includes('dropdown'));
+
+        await mainView.click('.TeamDropdownButton');
+        await dropdownView.click('.TeamDropdown .TeamDropdown__button.addServer');
+        newServerView = await this.app.waitForEvent('window', {
+            predicate: (window) => window.url().includes('newServer'),
+        });
+
+        // wait for autofocus to finish
+        await asyncSleep(500);
+    });
+
+    afterEach(async () => {
+        if (this.app) {
+            await this.app.close();
+        }
+    });
+
+    let newServerView;
+
+    describe('MM-T4050 Long server name', () => {
+        beforeEach(async () => {
+            await newServerView.type('#teamNameInput', longServerName);
+            await newServerView.type('#teamUrlInput', longServerUrl);
+            await newServerView.click('#saveNewServerModal');
+        });
+
+        it('MM-T4050_1 should add new server tab', async () => {
+            await asyncSleep(1000);
+            const existing = Boolean(await this.app.windows().find((window) => window.url().includes('newServer')));
+            existing.should.be.false;
+
+            const mainView = this.app.windows().find((window) => window.url().includes('index'));
+            const dropdownView = this.app.windows().find((window) => window.url().includes('dropdown'));
+
+            const isServerTabExists = Boolean(await mainView.locator(`text=${longServerName}`));
+            const isServerAddedDropdown = Boolean(await dropdownView.locator(`text=${longServerName}`));
+
+            isServerTabExists.should.be.true;
+            isServerAddedDropdown.should.be.true;
+        });
+
+        it('MM-T4050_2 should truncate server name', async () => {
+            await asyncSleep(1000);
+            const existing = Boolean(await this.app.windows().find((window) => window.url().includes('newServer')));
+            existing.should.be.false;
+
+            const mainView = this.app.windows().find((window) => window.url().includes('index'));
+            const serverNameLocator = await mainView.locator(`text=${longServerName}`);
+
+            const isTruncated = await serverNameLocator.evaluate((element) => {
+                return element.offsetWidth < element.scrollWidth;
+            });
+
+            isTruncated.should.be.true;
+        });
+
+        it('MM-T4050_3 should display server tab with max width of 224px', async () => {
+            await asyncSleep(1000);
+            const existing = Boolean(await this.app.windows().find((window) => window.url().includes('newServer')));
+            existing.should.be.false;
+
+            const mainView = this.app.windows().find((window) => window.url().includes('index'));
+            const serverNameLocator = await mainView.locator('.TeamDropdownButton');
+
+            const isWithinMaxWidth = await serverNameLocator.evaluate((element) => {
+                const width = parseFloat(window.getComputedStyle(element).getPropertyValue('width'));
+
+                return width < 224;
+            });
+
+            isWithinMaxWidth.should.be.true;
+        });
+    });
+});

--- a/src/renderer/css/components/TeamDropdownButton.scss
+++ b/src/renderer/css/components/TeamDropdownButton.scss
@@ -8,7 +8,7 @@
     font-family: Open Sans;
     overflow: hidden;
     -webkit-font-smoothing: auto;
-    max-width: 400px;
+    max-width: 224px;
 
     &.disabled {
         opacity: 0.5;

--- a/src/renderer/css/components/TeamDropdownButton.scss
+++ b/src/renderer/css/components/TeamDropdownButton.scss
@@ -8,7 +8,7 @@
     font-family: Open Sans;
     overflow: hidden;
     -webkit-font-smoothing: auto;
-    max-width: 224px;
+    max-width: 400px;
 
     &.disabled {
         opacity: 0.5;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

Adds e2e tests for long server names.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/desktop/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes https://mattermost.atlassian.net/browse/MM-39799

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [x] executed `npm run lint:js` for proper code formatting

#### Device Information
This PR was tested on:  MacBook Pro, MacOS 12.1

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
