### PR TITLE
[MM-35666] Re-ordered the priority of badge sources to leave session expired to last

### DIFF
--- a/src/main/app/initialize.test.js
+++ b/src/main/app/initialize.test.js
@@ -202,11 +202,13 @@ describe('main/app/initialize', () => {
     });
 
     describe('initializeAfterAppReady', () => {
-        it('should set spell checker URL if applicable', async () => {
-            Config.spellCheckerURL = 'http://server-1.com';
-            await initialize();
-            expect(session.defaultSession.setSpellCheckerDictionaryDownloadURL).toHaveBeenCalledWith('http://server-1.com/');
-        });
+        if (process.platform !== 'darwin') {
+            it('should set spell checker URL if applicable', async () => {
+                Config.spellCheckerURL = 'http://server-1.com';
+                await initialize();
+                expect(session.defaultSession.setSpellCheckerDictionaryDownloadURL).toHaveBeenCalledWith('http://server-1.com/');
+            });
+        }
 
         it('should clear app cache if last version opened was older', async () => {
             wasUpdated.mockReturnValue(true);

--- a/src/main/badge.ts
+++ b/src/main/badge.ts
@@ -16,26 +16,26 @@ let showUnreadBadgeSetting: boolean;
 export function showBadgeWindows(sessionExpired: boolean, mentionCount: number, showUnreadBadge: boolean) {
     let description = 'You have no unread messages';
     let text;
-    if (sessionExpired) {
-        text = '•';
-        description = 'Session Expired: Please sign in to continue receiving notifications.';
-    } else if (mentionCount > 0) {
+    if (mentionCount > 0) {
         text = (mentionCount > MAX_WIN_COUNT) ? `${MAX_WIN_COUNT}+` : mentionCount.toString();
         description = `You have unread mentions (${mentionCount})`;
     } else if (showUnreadBadge && showUnreadBadgeSetting) {
         text = '•';
         description = 'You have unread channels';
+    } else if (sessionExpired) {
+        text = '•';
+        description = 'Session Expired: Please sign in to continue receiving notifications.';
     }
     WindowManager.setOverlayIcon(text, description, mentionCount > 99);
 }
 
 export function showBadgeOSX(sessionExpired: boolean, mentionCount: number, showUnreadBadge: boolean) {
     let badge = '';
-    if (sessionExpired) {
-        badge = '•';
-    } else if (mentionCount > 0) {
+    if (mentionCount > 0) {
         badge = mentionCount.toString();
     } else if (showUnreadBadge && showUnreadBadgeSetting) {
+        badge = '•';
+    } else if (sessionExpired) {
         badge = '•';
     }
     app.dock.setBadge(badge);

--- a/src/main/preload/mattermost.js
+++ b/src/main/preload/mattermost.js
@@ -149,13 +149,6 @@ window.addEventListener('message', ({origin, data = {}} = {}) => {
         ipcRenderer.send(BROWSER_HISTORY_BUTTON, viewName);
         break;
     }
-    default:
-        if (typeof type === 'undefined') {
-            console.log('ignoring message of undefined type:');
-            console.log(data);
-        } else {
-            console.log(`ignored message of type: ${type}`);
-        }
     }
 });
 

--- a/src/main/tray/tray.ts
+++ b/src/main/tray/tray.ts
@@ -93,12 +93,12 @@ export function setupTray(icontheme: string) {
     });
 
     AppState.on(UPDATE_TRAY, (anyExpired, anyMentions, anyUnreads) => {
-        if (anyExpired) {
-            setTray('mention', 'Session Expired: Please sign in to continue receiving notifications.');
-        } else if (anyMentions) {
+        if (anyMentions) {
             setTray('mention', 'You have been mentioned');
         } else if (anyUnreads) {
             setTray('unread', 'You have unread channels');
+        } else if (anyExpired) {
+            setTray('mention', 'Session Expired: Please sign in to continue receiving notifications.');
         } else {
             setTray('normal', app.name);
         }

--- a/src/main/views/MattermostView.test.js
+++ b/src/main/views/MattermostView.test.js
@@ -310,7 +310,7 @@ describe('main/views/MattermostView', () => {
     });
 
     describe('updateMentionsFromTitle', () => {
-        const mattermostView = new MattermostView(tabView, {remoteInfo: {serverVersion: '5.28.0'}}, {}, {});
+        const mattermostView = new MattermostView(tabView, {}, {}, {});
 
         it('should parse mentions from title', () => {
             mattermostView.updateMentionsFromTitle('(7) Mattermost');

--- a/src/main/views/MattermostView.ts
+++ b/src/main/views/MattermostView.ts
@@ -335,10 +335,6 @@ export class MattermostView extends EventEmitter {
     }
 
     updateMentionsFromTitle = (title: string) => {
-        if (this.serverInfo.remoteInfo.serverVersion && Util.isVersionGreaterThanOrEqualTo(this.serverInfo.remoteInfo.serverVersion, '5.29.0')) {
-            return;
-        }
-
         //const title = this.view.webContents.getTitle();
         const resultsIterator = title.matchAll(this.titleParser);
         const results = resultsIterator.next(); // we are only interested in the first set


### PR DESCRIPTION
#### Summary
When the user has more than 1 server configured, where at least 1 server has mentions and another has a session expired, both the tray and the badge display the session expired message/badge before mentions. This PR flips that, such that session expired is shown last after mentions and unreads. You can still view session expired from the server menu.

Also I fixed some stuff that I broke. Oops.
And removed some logging that bothered me :P

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35666

```release-note
Mentions/unreads will now take precedence when setting the badge/tray icon over session expired
```
