### PR TITLE
MM-41042: Allow trusted plugin routes

### DIFF
--- a/src/common/utils/url.ts
+++ b/src/common/utils/url.ts
@@ -204,6 +204,43 @@ function isCustomLoginURL(url: URL | string, server: ServerFromURL, teams: TeamW
     return false;
 }
 
+function isTrustedPluginRoute(serverUrl: URL | string, inputUrl: URL | string): boolean {
+    if (!serverUrl || !inputUrl) {
+        return false;
+    }
+
+    const parsedURL = parseURL(inputUrl);
+    const server = getServerInfo(serverUrl);
+    if (!parsedURL || !server || (!equalUrlsIgnoringSubpath(server.url, parsedURL))) {
+        return false;
+    }
+
+    const formattedPathName = parsedURL.pathname.toLowerCase();
+
+    if (!formattedPathName.startsWith(`${server.subpath}plugins/`) || !formattedPathName.startsWith('/plugins/')) {
+        return false;
+    }
+
+    // Remove the subpath and plugin/ parts of the pathname,
+    // returning false early if the pathname is not from a plugin
+    let cleanPathname;
+    if (formattedPathName.startsWith(`${server.subpath}plugins/`)) {
+        cleanPathname = formattedPathName.replace(`${server.subpath}plugins/`, '');
+    } else if (formattedPathName.startsWith('/plugins/')) {
+        cleanPathname = formattedPathName.replace('/plugins/', '');
+    } else {
+        return false;
+    }
+
+    // Pathnames at this point are formed as ${pluginID}/${pluginSpecificRoute}
+    switch (cleanPathname) {
+    case 'com.mattermost.plugin-channel-export/api/v1/export':
+        return true;
+    default:
+        return false;
+    }
+}
+
 export default {
     isValidURL,
     isValidURI,
@@ -218,4 +255,5 @@ export default {
     getHost,
     isTrustedURL,
     isCustomLoginURL,
+    isTrustedPluginRoute,
 };

--- a/src/common/utils/url.ts
+++ b/src/common/utils/url.ts
@@ -204,41 +204,8 @@ function isCustomLoginURL(url: URL | string, server: ServerFromURL, teams: TeamW
     return false;
 }
 
-function isTrustedPluginRoute(serverUrl: URL | string, inputUrl: URL | string): boolean {
-    if (!serverUrl || !inputUrl) {
-        return false;
-    }
-
-    const parsedURL = parseURL(inputUrl);
-    const server = getServerInfo(serverUrl);
-    if (!parsedURL || !server || (!equalUrlsIgnoringSubpath(server.url, parsedURL))) {
-        return false;
-    }
-
-    const formattedPathName = parsedURL.pathname.toLowerCase();
-
-    if (!formattedPathName.startsWith(`${server.subpath}plugins/`) || !formattedPathName.startsWith('/plugins/')) {
-        return false;
-    }
-
-    // Remove the subpath and plugin/ parts of the pathname,
-    // returning false early if the pathname is not from a plugin
-    let cleanPathname;
-    if (formattedPathName.startsWith(`${server.subpath}plugins/`)) {
-        cleanPathname = formattedPathName.replace(`${server.subpath}plugins/`, '');
-    } else if (formattedPathName.startsWith('/plugins/')) {
-        cleanPathname = formattedPathName.replace('/plugins/', '');
-    } else {
-        return false;
-    }
-
-    // Pathnames at this point are formed as ${pluginID}/${pluginSpecificRoute}
-    switch (cleanPathname) {
-    case 'com.mattermost.plugin-channel-export/api/v1/export':
-        return true;
-    default:
-        return false;
-    }
+function isChannelExportUrl(serverUrl: URL | string, inputUrl: URL | string): boolean {
+    return isUrlType('plugins/com.mattermost.plugin-channel-export/api/v1/export', serverUrl, inputUrl);
 }
 
 export default {
@@ -255,5 +222,5 @@ export default {
     getHost,
     isTrustedURL,
     isCustomLoginURL,
-    isTrustedPluginRoute,
+    isChannelExportUrl,
 };

--- a/src/main/views/webContentEvents.test.js
+++ b/src/main/views/webContentEvents.test.js
@@ -55,7 +55,7 @@ jest.mock('common/utils/url', () => ({
     isValidURI: jest.fn(),
     isPluginUrl: jest.fn(),
     isManagedResource: jest.fn(),
-    isTrustedPluginRoute: jest.fn(),
+    isChannelExportUrl: jest.fn(),
 }));
 
 jest.mock('../../../electron-builder.json', () => ({
@@ -125,8 +125,8 @@ describe('main/views/webContentsEvents', () => {
             expect(event.preventDefault).not.toBeCalled();
         });
 
-        it('should allow navigation when it isTrustedPluginRoute - Channel Export /api/v1/export', () => {
-            urlUtils.isTrustedPluginRoute.mockImplementation((serverURL, parsedURL) => parsedURL.toString().includes('/plugins/com.mattermost.plugin-channel-export/api/v1/export'));
+        it('should allow navigation when it isChannelExportUrl', () => {
+            urlUtils.isChannelExportUrl.mockImplementation((serverURL, parsedURL) => parsedURL.toString().includes('/plugins/com.mattermost.plugin-channel-export/api/v1/export'));
             willNavigate(event, 'http://server-1.com/plugins/com.mattermost.plugin-channel-export/api/v1/export');
             expect(event.preventDefault).not.toBeCalled();
         });

--- a/src/main/views/webContentEvents.test.js
+++ b/src/main/views/webContentEvents.test.js
@@ -55,6 +55,7 @@ jest.mock('common/utils/url', () => ({
     isValidURI: jest.fn(),
     isPluginUrl: jest.fn(),
     isManagedResource: jest.fn(),
+    isTrustedPluginRoute: jest.fn(),
 }));
 
 jest.mock('../../../electron-builder.json', () => ({
@@ -121,6 +122,12 @@ describe('main/views/webContentsEvents', () => {
         it('should allow navigation when a custom login is in progress', () => {
             webContentsEventManager.customLogins[1] = {inProgress: true};
             willNavigate(event, 'http://anyoldurl.com');
+            expect(event.preventDefault).not.toBeCalled();
+        });
+
+        it('should allow navigation when it isTrustedPluginRoute - Channel Export /api/v1/export', () => {
+            urlUtils.isTrustedPluginRoute.mockImplementation((serverURL, parsedURL) => parsedURL.toString().includes('/plugins/com.mattermost.plugin-channel-export/api/v1/export'));
+            willNavigate(event, 'http://server-1.com/plugins/com.mattermost.plugin-channel-export/api/v1/export');
             expect(event.preventDefault).not.toBeCalled();
         });
 

--- a/src/main/views/webContentEvents.ts
+++ b/src/main/views/webContentEvents.ts
@@ -56,6 +56,10 @@ export class WebContentsEventManager {
                 return;
             }
 
+            if (server && urlUtils.isTrustedPluginRoute(server.url, parsedURL)) {
+                return;
+            }
+
             if (server && urlUtils.isCustomLoginURL(parsedURL, server, configServers)) {
                 return;
             }

--- a/src/main/views/webContentEvents.ts
+++ b/src/main/views/webContentEvents.ts
@@ -56,7 +56,7 @@ export class WebContentsEventManager {
                 return;
             }
 
-            if (server && urlUtils.isTrustedPluginRoute(server.url, parsedURL)) {
+            if (server && urlUtils.isChannelExportUrl(server.url, parsedURL)) {
                 return;
             }
 


### PR DESCRIPTION
#### Summary
This PR adds a function to allow trusted plugin routes. This is designed to be easily expanded in the future for other routes but, for now, it only allows the `/api/v1/export` endpoint from the channel export plugin.

By allowing that specific endpoint here, we fix [the bug](https://mattermost.atlassian.net/browse/MM-41042) that prevented the channel log from being downloaded.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41042

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [X] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [X] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [X] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [X] executed `npm run lint:js` for proper code formatting

#### Device Information
This PR was tested on: laptop, Linux

#### Screenshots
https://user-images.githubusercontent.com/3924815/150202926-519882d9-fb34-42f9-a0c1-013e39e733bc.mp4

#### Release Note
```release-note
Fixed a bug that prevented the channel log from being downloaded from Playbooks.
```
