### PR TITLE
Change zoom in shortcut to match expected behavior known from other apps

### DIFF
--- a/src/main/menus/app.ts
+++ b/src/main/menus/app.ts
@@ -129,7 +129,7 @@ export function createTemplate(config: Config) {
         accelerator: 'CmdOrCtrl+0',
     }, {
         role: 'zoomIn',
-        accelerator: 'CmdOrCtrl+SHIFT+=',
+        accelerator: 'CmdOrCtrl+=',
     }, {
         role: 'zoomOut',
         accelerator: 'CmdOrCtrl+-',


### PR DESCRIPTION
This PR changes the zoom in shortcut to match the expected behavior known from other apps like Chrome, Firefox, etc.

The 'new' shortcut would be `ctrl/cmd`+`=` instead of `ctrl/cmd`+`shift`+`=`

```release-note
The app now uses 'ctrl+=' or 'cmd+=' to zoom in to match the behavior known from other apps like Chrome or Firefox.
```