### PR TITLE
test:Preferences in the Menu Bar opens the Settings page

### DIFF
--- a/e2e/specs/menu_bar/file_menu.test.js
+++ b/e2e/specs/menu_bar/file_menu.test.js
@@ -39,4 +39,28 @@ describe('file_menu/dropdown', function desc() {
             settingsWindow.should.not.be.null;
         }
     });
+
+    it('MM-T804 Preferences in Menu Bar open the Settings page', async () => {
+        if (process.platform !== 'darwin') {
+            const mainWindow = this.app.windows().find((window) => window.url().includes('index'));
+            mainWindow.should.not.be.null;
+            robot.keyTap(',', ['control']);
+            const settingsWindow = await this.app.waitForEvent('window', {
+                predicate: (window) => window.url().includes('settings'),
+            });
+            settingsWindow.should.not.be.null;
+            robot.keyTap('w', ['control']);
+
+            //Opening the menu bar
+            robot.keyTap('alt');
+            robot.keyTap('enter');
+            robot.keyTap('f');
+            robot.keyTap('s');
+            robot.keyTap('enter');
+            const settingsWindowFromMenu = await this.app.waitForEvent('window', {
+                predicate: (window) => window.url().includes('settings'),
+            });
+            settingsWindowFromMenu.should.not.be.null;
+        }
+    });
 });


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

e2e test:Preferences in the Menu Bar opens the Settings page

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/desktop/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

  Fixes https://github.com/mattermost/desktop/issues/1893

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [ ] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [ ] executed `npm run lint:js` for proper code formatting

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note

```
-->

```release-note
NONE
```
