### PR TITLE
test:MM-T1308 Check that external links dont open in the app

### DIFF
--- a/e2e/specs/relative_url/relative_url.test.js
+++ b/e2e/specs/relative_url/relative_url.test.js
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+'use strict';
+
+const fs = require('fs');
+
+const {expect} = require('chai');
+
+const env = require('../../modules/environment');
+const {asyncSleep} = require('../../modules/utils');
+
+describe('copylink', function desc() {
+    this.timeout(30000);
+
+    const config = env.demoMattermostConfig;
+
+    beforeEach(async () => {
+        env.cleanDataDir();
+        env.createTestUserDataDir();
+        env.cleanTestConfig();
+        fs.writeFileSync(env.configFilePath, JSON.stringify(config));
+        await asyncSleep(1000);
+        this.app = await env.getApp();
+        this.serverMap = await env.getServerMap(this.app);
+    });
+
+    afterEach(async () => {
+        if (this.app) {
+            await this.app.close();
+        }
+    });
+
+    it('MM-T1308 Check that external links dont open in the app', async () => {
+        const loadingScreen = this.app.windows().find((window) => window.url().includes('loadingScreen'));
+        await loadingScreen.waitForSelector('.LoadingScreen', {state: 'hidden'});
+        const firstServer = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].win;
+        await env.loginToMattermost(firstServer);
+        await firstServer.waitForSelector('#sidebarItem_suscipit-4');
+        await firstServer.click('#sidebarItem_suscipit-4');
+        await firstServer.click('#post_textbox');
+        await firstServer.fill('#post_textbox', 'https://electronjs.org/apps/mattermost');
+        await firstServer.press('#post_textbox', 'Enter');
+        const newPageWindow = this.app.windows().find((window) => window.url().includes('apps/mattermost'));
+        expect(newPageWindow === undefined);
+    });
+});


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

test:MM-T1308 Check that external links dont open in the app
#### Summary
<!--
A brief description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.


Otherwise, link the JIRA ticket.
-->

  Fixes https://github.com/mattermost/desktop/issues/1906

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](http://www.mattermost.org/mattermost-contributor-agreement/)
- [x] executed `npm run lint:js` for proper code formatting

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
