### PR TITLE
[MM-30713] Stop Linux and Windows app from minimizing/hiding without user warning

### DIFF
--- a/src/common/config/defaultPreferences.ts
+++ b/src/common/config/defaultPreferences.ts
@@ -21,7 +21,7 @@ const defaultPreferences: ConfigV3 = {
     teams: [],
     showTrayIcon: true,
     trayIconTheme: 'use_system',
-    minimizeToTray: true,
+    minimizeToTray: process.platform !== 'linux',
     notifications: {
         flashWindow: 2,
         bounceIcon: true,

--- a/src/common/config/index.ts
+++ b/src/common/config/index.ts
@@ -275,6 +275,12 @@ export class Config extends EventEmitter {
     get lastActiveTeam() {
         return this.combinedData?.lastActiveTeam;
     }
+    get alwaysClose() {
+        return this.combinedData?.alwaysClose;
+    }
+    get alwaysMinimize() {
+        return this.combinedData?.alwaysMinimize;
+    }
 
     // initialization/processing methods
 

--- a/src/main/Validator.ts
+++ b/src/main/Validator.ts
@@ -125,6 +125,8 @@ const configDataSchemaV3 = Joi.object<ConfigV3>({
     darkMode: Joi.boolean().default(false),
     downloadLocation: Joi.string(),
     lastActiveTeam: Joi.number().integer().min(0).default(0),
+    alwaysMinimize: Joi.boolean(),
+    alwaysClose: Joi.boolean(),
 });
 
 // eg. data['community.mattermost.com'] = { data: 'certificate data', issuerName: 'COMODO RSA Domain Validation Secure Server CA'};

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -150,7 +150,7 @@ function createMainWindow(options: {linuxAppIcon: string}) {
                     } else {
                         dialog.showMessageBox(mainWindow, {
                             title: 'Minimize to Tray',
-                            message: 'Upon closing the Mattermost window, it will continue to run in the system tray. This can be disabled in the Settings.',
+                            message: 'Mattermost will continue to run in the system tray. This can be disabled in Settings.',
                             type: 'info',
                             checkboxChecked: true,
                             checkboxLabel: 'Don\'t show again',
@@ -164,8 +164,8 @@ function createMainWindow(options: {linuxAppIcon: string}) {
                 } else {
                     dialog.showMessageBox(mainWindow, {
                         title: 'Close Application',
-                        message: 'Are you sure you would like to close Mattermost?',
-                        detail: 'You will no longer receive notifications for messages. If you wish to minimize to the system tray instead, you can enable this in the Settings.',
+                        message: 'Are you sure you want to quit?',
+                        detail: 'You will no longer receive notifications for messages. If you want to leave Mattermost running in the system tray, you can enable this in Settings.',
                         type: 'question',
                         buttons: ['Yes', 'No'],
                         checkboxChecked: true,

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -143,8 +143,6 @@ function createMainWindow(options: {linuxAppIcon: string}) {
             }
             switch (process.platform) {
             case 'win32':
-                hideWindow(mainWindow);
-                break;
             case 'linux':
                 if (Config.minimizeToTray) {
                     if (Config.alwaysMinimize) {

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -150,7 +150,7 @@ function createMainWindow(options: {linuxAppIcon: string}) {
                     } else {
                         dialog.showMessageBox(mainWindow, {
                             title: 'Minimize to Tray',
-                            message: 'Upon closing the Mattermost window, the application will continue to run in the system tray. You can disable this behaviour in the Settings window.',
+                            message: 'Upon closing the Mattermost window, it will continue to run in the system tray. This can be disabled in the Settings.',
                             type: 'info',
                             checkboxChecked: true,
                             checkboxLabel: 'Don\'t show again',
@@ -164,8 +164,8 @@ function createMainWindow(options: {linuxAppIcon: string}) {
                 } else {
                     dialog.showMessageBox(mainWindow, {
                         title: 'Close Application',
-                        message: 'Upon closing the Mattermost window, the application will close and you will no longer receive notifications for messages. If you wish to minimize to the system tray, you can enable the behaviour in the Settings window.',
-                        detail: 'Are you sure you would like to close Mattermost?',
+                        message: 'Are you sure you would like to close Mattermost?',
+                        detail: 'You will no longer receive notifications for messages. If you wish to minimize to the system tray instead, you can enable this in the Settings.',
                         type: 'question',
                         buttons: ['Yes', 'No'],
                         checkboxChecked: true,

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -214,7 +214,7 @@ export default class SettingsPage extends React.PureComponent<Record<string, nev
     }
 
     handleChangeMinimizeToTray = () => {
-        const shouldMinimizeToTray = this.state.showTrayIcon && this.minimizeToTrayRef.current?.checked;
+        const shouldMinimizeToTray = (process.platform === 'win32' || this.state.showTrayIcon) && this.minimizeToTrayRef.current?.checked;
 
         window.timers.setImmediate(this.saveSetting, CONFIG_TYPE_APP_OPTIONS, {key: 'minimizeToTray', data: shouldMinimizeToTray});
         this.setState({
@@ -691,7 +691,7 @@ export default class SettingsPage extends React.PureComponent<Record<string, nev
                         type='checkbox'
                         id='inputMinimizeToTray'
                         ref={this.minimizeToTrayRef}
-                        disabled={!this.state.showTrayIcon}
+                        disabled={process.platform !== 'win32' && !this.state.showTrayIcon}
                         checked={this.state.minimizeToTray}
                         onChange={this.handleChangeMinimizeToTray}
                     />

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -40,6 +40,8 @@ export type ConfigV3 = {
     downloadLocation: string;
     spellCheckerURL?: string;
     lastActiveTeam?: number;
+    alwaysMinimize?: boolean;
+    alwaysClose?: boolean;
 }
 
 export type ConfigV2 = {


### PR DESCRIPTION
#### Summary
Many Linux users have reported that the app doesn't obey closing rules as they would normally expect, so we've refined the way the app closes on Linux and added some dialog boxes to inform the user of what happens when they close the main window:

- Upon pressing X, if the 'Leave app running in notification area when application window is closed' is checked, a dialog box will pop up telling the user that the app will still be running even if the window is closed. If 'Don't show again' is checked (it is by default) then the user will not see that message again.
![image](https://user-images.githubusercontent.com/52460000/152236824-9c3629d8-37d4-43bc-8670-5129fdc972c4.png)

- If the above setting is NOT checked, the user will see a dialog box asking them whether they really want to close the app permanently. If they reply 'Yes', the app is quit. If they reply 'No', nothing happens. If the 'Don't ask again' box is check and the user replies yes, they will not see the dialog again.
![image](https://user-images.githubusercontent.com/52460000/152236954-508c5a39-a639-4e83-ba75-b09e150bfc4a.png)

Additionally, the 'Leave app running in notification area when application window is closed' checkbox is now false by default on Linux, so it will need to be enabled before minimizing to tray will work correctly.

I've also mimicked the same behavior on Windows to give users the option to turn that on.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30713

#### Release Note
```release-note
Updated Linux closing behaviour to allow the app to close complely when pressing X.
Changed the default setting for 'Leave app running in notification area when application window is closed' on Linux to 'false'
```
