### PR TITLE
[MM-41559] Dynamically size URL view to avoid overlapping bottom links

### DIFF
--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -104,3 +104,5 @@ export const GET_MODAL_UNCLOSEABLE = 'get-modal-uncloseable';
 export const MODAL_UNCLOSEABLE = 'modal-uncloseable';
 
 export const UPDATE_PATHS = 'update-paths';
+
+export const UPDATE_URL_VIEW_WIDTH = 'update-url-view-width';

--- a/src/main/preload/urlView.js
+++ b/src/main/preload/urlView.js
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+// Copyright (c) 2015-2016 Yuya Ochiai
+
+'use strict';
+
+import {ipcRenderer} from 'electron';
+
+import {UPDATE_URL_VIEW_WIDTH} from 'common/communication';
+
+console.log('preloaded for the url view');
+
+window.addEventListener('message', async (event) => {
+    switch (event.data.type) {
+    case UPDATE_URL_VIEW_WIDTH:
+        ipcRenderer.send(UPDATE_URL_VIEW_WIDTH, event.data.data);
+        break;
+    default:
+        console.log(`got a message: ${event}`);
+        console.log(event);
+    }
+});

--- a/src/renderer/components/urlDescription.tsx
+++ b/src/renderer/components/urlDescription.tsx
@@ -1,12 +1,23 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {useEffect} from 'react';
+
+import {UPDATE_URL_VIEW_WIDTH} from 'common/communication';
 
 export default function UrlDescription(props: {url: string}) {
+    const urlRef = React.createRef<HTMLDivElement>();
+
+    useEffect(() => {
+        window.postMessage({type: UPDATE_URL_VIEW_WIDTH, data: urlRef.current?.scrollWidth}, window.location.href);
+    }, []);
+
     if (props.url) {
         return (
-            <div className='HoveringURL HoveringURL-left'>
+            <div
+                ref={urlRef}
+                className='HoveringURL HoveringURL-left'
+            >
                 <p>{props.url}</p>
             </div>
         );

--- a/webpack.config.main.js
+++ b/webpack.config.main.js
@@ -22,6 +22,7 @@ module.exports = merge(base, {
         preload: './src/main/preload/mattermost.js',
         modalPreload: './src/main/preload/modalPreload.js',
         loadingScreenPreload: './src/main/preload/loadingScreenPreload.js',
+        urlView: './src/main/preload/urlView.js',
     },
     output: {
         path: path.join(__dirname, 'dist/'),


### PR DESCRIPTION
#### Summary
When you hover over a URL near the bottom of the page (eg. OneLogin links) they will be covered by the URL view browser view. This PR adds dynamic sizing to the URL view that will stop this from happening.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41559

#### Release Note
```release-note
Fixed an issue where external links at the bottom of the page were not clickable.
```
