### PR TITLE
[MM-41392] Clean path name on browser pushes for subpaths

### DIFF
--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -542,9 +542,10 @@ export class WindowManager {
 
     handleBrowserHistoryPush = (e: IpcMainEvent, viewName: string, pathName: string) => {
         const currentView = this.viewManager?.views.get(viewName);
-        const redirectedViewName = urlUtils.getView(`${currentView?.tab.server.url}${pathName}`, Config.teams)?.name || viewName;
+        const cleanedPathName = pathName.replace(currentView?.tab.server.url.pathname || '', '');
+        const redirectedViewName = urlUtils.getView(`${currentView?.tab.server.url}${cleanedPathName}`, Config.teams)?.name || viewName;
         if (this.viewManager?.closedViews.has(redirectedViewName)) {
-            this.viewManager.openClosedTab(redirectedViewName, `${currentView?.tab.server.url}${pathName}`);
+            this.viewManager.openClosedTab(redirectedViewName, `${currentView?.tab.server.url}${cleanedPathName}`);
         }
         let redirectedView = this.viewManager?.views.get(redirectedViewName) || currentView;
         if (redirectedView !== currentView && redirectedView?.tab.server.name === this.currentServerName && redirectedView?.isLoggedIn) {
@@ -555,8 +556,8 @@ export class WindowManager {
         }
 
         // Special case check for Channels to not force a redirect to "/", causing a refresh
-        if (!(redirectedView !== currentView && redirectedView?.tab.type === TAB_MESSAGING && pathName === '/')) {
-            redirectedView?.view.webContents.send(BROWSER_HISTORY_PUSH, pathName);
+        if (!(redirectedView !== currentView && redirectedView?.tab.type === TAB_MESSAGING && cleanedPathName === '/')) {
+            redirectedView?.view.webContents.send(BROWSER_HISTORY_PUSH, cleanedPathName);
             if (redirectedView) {
                 this.handleBrowserHistoryButton(e, redirectedView.name);
             }


### PR DESCRIPTION
#### Summary
When navigating on a server with a subpath, the path name of the server URL would be included when sending URLs back and would be append to the pathname (eg. for a server with site URL: `http://myserver.com/subpath`, urls would end up being `http://myserver.com/subpath/subpath/<rest of url>`)

This PR cleanses out the subpath from the pushed URL and pushes back the pathname without the server URL subpath.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41392

```release-note
NONE
```

