### PR TITLE
[MM-41392] Ensure pathname starts with `/`

### DIFF
--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -542,7 +542,7 @@ export class WindowManager {
 
     handleBrowserHistoryPush = (e: IpcMainEvent, viewName: string, pathName: string) => {
         const currentView = this.viewManager?.views.get(viewName);
-        const cleanedPathName = pathName.replace(currentView?.tab.server.url.pathname || '', '');
+        const cleanedPathName = currentView?.tab.server.url.pathname === '/' ? pathName : pathName.replace(currentView?.tab.server.url.pathname || '', '');
         const redirectedViewName = urlUtils.getView(`${currentView?.tab.server.url}${cleanedPathName}`, Config.teams)?.name || viewName;
         if (this.viewManager?.closedViews.has(redirectedViewName)) {
             this.viewManager.openClosedTab(redirectedViewName, `${currentView?.tab.server.url}${cleanedPathName}`);


### PR DESCRIPTION
#### Summary
An issue was caused by the changes made for subpath navigation, in which servers without a subpath did not receive the correct path names on returns.

#### Ticket Link
Closes https://github.com/mattermost/focalboard/issues/2270

#### Release Note
```release-note
NONE
```
