### PR TITLE
[MM-42010] Remove CircleCI check for E2E tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,8 +149,6 @@ jobs:
       - run: cp test-results.xml /tmp/test-results/
       - store_test_results:
           path: /tmp/test-results
-      - store_test_results:
-          path: ./reports/jest
       - save_cache:
           key: lint-{{ arch }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ executors:
       - image: electronuserland/builder:wine-chrome
         environment:
           TAR_OPTIONS: --no-same-owner
-      - image: mattermost/mattermost-preview
   wine-chrome:
     working_directory: ~/mattermost-desktop
     docker:
@@ -139,7 +138,6 @@ jobs:
       - checkout
       - update_image:
           apt_opts: "--no-install-recommends"
-      - run: wget https://github.com/mattermost/mmctl/releases/download/v6.0.0/linux_amd64.tar && tar -xvf linux_amd64.tar
       - run: npm run check-types
       - run:
           name: Setup MM Docker Image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
           command: npm run test:docker
           environment:
             MMCTL_PATH: ./mmctl
-      - run: ELECTRON_DISABLE_SANDBOX=1 xvfb-run npm run test
+      - run: ELECTRON_DISABLE_SANDBOX=1 xvfb-run npm run test:unit
       - run: mkdir -p /tmp/test-results
       - run: cp test-results.xml /tmp/test-results/
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,11 +139,6 @@ jobs:
       - update_image:
           apt_opts: "--no-install-recommends"
       - run: npm run check-types
-      - run:
-          name: Setup MM Docker Image
-          command: npm run test:docker
-          environment:
-            MMCTL_PATH: ./mmctl
       - run: ELECTRON_DISABLE_SANDBOX=1 npm run test:unit-ci
       - run: mkdir -p /tmp/test-results
       - run: cp test-results.xml /tmp/test-results/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,10 @@ jobs:
           environment:
             MMCTL_PATH: ./mmctl
       - run: ELECTRON_DISABLE_SANDBOX=1 npm run test:unit-ci
+      - run: mkdir -p /tmp/test-results
+      - run: cp test-results.xml /tmp/test-results/
+      - store_test_results:
+          path: /tmp/test-results
       - store_test_results:
           path: ./reports/jest
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,11 +146,9 @@ jobs:
           command: npm run test:docker
           environment:
             MMCTL_PATH: ./mmctl
-      - run: ELECTRON_DISABLE_SANDBOX=1 xvfb-run npm run test:unit
-      - run: mkdir -p /tmp/test-results
-      - run: cp test-results.xml /tmp/test-results/
+      - run: ELECTRON_DISABLE_SANDBOX=1 npm run test:unit-ci
       - store_test_results:
-          path: /tmp/test-results
+          path: ./reports/jest
       - save_cache:
           key: lint-{{ arch }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,5 @@ test-results.xml
 test_config.json
 .idea
 testUserData
-reports/
 
 .gitattributes

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ test-results.xml
 test_config.json
 .idea
 testUserData
+reports/
 
 .gitattributes

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
         "file-loader": "^2.0.0",
         "image-webpack-loader": "5.0.0",
         "jest": "^27.3.1",
+        "jest-junit": "^13.0.0",
         "mdi-react": "^6.2.0",
         "mini-css-extract-plugin": "1.6.0",
         "mocha": "^5.2.0",
@@ -20325,6 +20326,54 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jest-junit": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-13.0.0.tgz",
+      "integrity": "sha512-JSHR+Dhb32FGJaiKkqsB7AR3OqWKtldLd6ZH2+FJ8D4tsweb8Id8zEVReU4+OlrRO1ZluqJLQEETm+Q6/KilBg==",
+      "dev": true,
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^8.3.2",
+        "xml": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/jest-junit/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-junit/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-junit/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/jest-leak-detector": {
@@ -47898,6 +47947,41 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        }
+      }
+    },
+    "jest-junit": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-13.0.0.tgz",
+      "integrity": "sha512-JSHR+Dhb32FGJaiKkqsB7AR3OqWKtldLd6ZH2+FJ8D4tsweb8Id8zEVReU4+OlrRO1ZluqJLQEETm+Q6/KilBg==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^8.3.2",
+        "xml": "^1.0.1"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -92,8 +92,7 @@
         "jest-junit",
         {
           "suiteName": "unit tests",
-          "outputDirectory": "reports/jest",
-          "outputName": "js-test-results.xml",
+          "outputName": "test-results.xml",
           "classNameTemplate": "{classname}-{title}",
           "titleTemplate": "{classname}-{title}",
           "ancestorSeparator": "> "

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test:e2e:build": "webpack-cli --bail --config webpack.config.test.js",
     "test:e2e:run": "electron-mocha -r @babel/register --reporter mocha-circleci-reporter dist/tests/e2e_bundle.js",
     "test:unit": "jest",
+    "test:unit-ci": "jest --runInBand",
     "test:coverage": "jest --coverage",
     "package:all": "cross-env NODE_ENV=production npm-run-all check-build-config package:windows package:mac package:mac-universal package:linux",
     "package:windows": "cross-env NODE_ENV=production npm-run-all check-build-config build && electron-builder --win --x64 --ia32 --publish=never",
@@ -84,6 +85,20 @@
     },
     "setupFiles": [
       "./src/jestSetup.js"
+    ],
+    "reporters": [
+      "default",
+      [
+        "jest-junit",
+        {
+          "suiteName": "unit tests",
+          "outputDirectory": "reports/jest",
+          "outputName": "js-test-results.xml",
+          "classNameTemplate": "{classname}-{title}",
+          "titleTemplate": "{classname}-{title}",
+          "ancestorSeparator": "> "
+        }
+      ]
     ]
   },
   "devDependencies": {
@@ -137,6 +152,7 @@
     "file-loader": "^2.0.0",
     "image-webpack-loader": "5.0.0",
     "jest": "^27.3.1",
+    "jest-junit": "^13.0.0",
     "mdi-react": "^6.2.0",
     "mini-css-extract-plugin": "1.6.0",
     "mocha": "^5.2.0",


### PR DESCRIPTION
#### Summary
Since the E2E tests are kind of flaky, we're electing to turn off the CircleCI check to ensure that the tests pass.
We will run them manually from now on.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42010

```release-note
NONE
```
