### PR TITLE
[MM-42024] Enable React Developer Tools for nightly builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     ],
     "globals": {
       "__HASH_VERSION__": "5.0.0",
-      "__CAN_UPGRADE__": false
+      "__CAN_UPGRADE__": false,
+      "__IS_NIGHTLY_BUILD__": false
     },
     "setupFiles": [
       "./src/jestSetup.js"

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -302,7 +302,10 @@ function initializeAfterAppReady() {
         AutoLauncher.upgradeAutoLaunch();
     }
 
-    if (global.isDev) {
+    // eslint-disable-next-line no-undef
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    if (global.isDev || __IS_NIGHTLY_BUILD__) {
         installExtension(REACT_DEVELOPER_TOOLS).
             then((name) => log.info(`Added Extension:  ${name}`)).
             catch((err) => log.error('An error occurred: ', err));

--- a/src/main/preload/mattermost.js
+++ b/src/main/preload/mattermost.js
@@ -6,7 +6,7 @@
 
 /* eslint-disable no-magic-numbers */
 
-import {contextBridge, ipcRenderer, webFrame, desktopCapturer} from 'electron';
+import {contextBridge, ipcRenderer, webFrame} from 'electron';
 
 // I've filed an issue in electron-log https://github.com/megahertz/electron-log/issues/267
 // we'll be able to use it again if there is a workaround for the 'os' import

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -19,6 +19,7 @@ const isRelease = process.env.CIRCLE_BRANCH && process.env.CIRCLE_BRANCH.startsW
 const codeDefinitions = {
     __HASH_VERSION__: !isRelease && JSON.stringify(VERSION),
     __CAN_UPGRADE__: JSON.stringify(true), // we should set this to false when working on a store version. Hardcoding for now.
+    __IS_NIGHTLY_BUILD__: JSON.stringify(process.env.CIRCLE_BRANCH === 'nightly'),
 };
 codeDefinitions['process.env.NODE_ENV'] = JSON.stringify(process.env.NODE_ENV);
 


### PR DESCRIPTION
#### Summary
For the `nightly` branch we will turn on React Developer Tools so that people on an 'unstable' branch can debug various React issues if necessary.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42024

```release-note
NONE
```
