### PR TITLE
[MM-41891] Improve error and reload states

### DIFF
--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -118,3 +118,5 @@ export const UPDATE_URL_VIEW_WIDTH = 'update-url-view-width';
 export const DISPATCH_GET_DESKTOP_SOURCES = 'dispatch-get-desktop-sources';
 export const DESKTOP_SOURCES_RESULT = 'desktop-sources-result';
 
+export const RELOAD_CURRENT_VIEW = 'reload-current-view';
+

--- a/src/main/preload/mattermost.js
+++ b/src/main/preload/mattermost.js
@@ -6,7 +6,7 @@
 
 /* eslint-disable no-magic-numbers */
 
-import {contextBridge, ipcRenderer, webFrame, desktopCapturer} from 'electron';
+import {contextBridge, ipcRenderer, webFrame} from 'electron';
 
 // I've filed an issue in electron-log https://github.com/megahertz/electron-log/issues/267
 // we'll be able to use it again if there is a workaround for the 'os' import

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -98,7 +98,7 @@ export class ViewManager {
         view.load(url);
         view.on(UPDATE_TARGET_URL, this.showURLView);
         view.on(LOADSCREEN_END, this.finishLoading);
-        view.once(LOAD_FAILED, this.failLoading);
+        view.on(LOAD_FAILED, this.failLoading);
     }
 
     reloadViewIfNeeded = (viewName: string) => {

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -24,6 +24,7 @@ import {
     BROWSER_HISTORY_BUTTON,
     DISPATCH_GET_DESKTOP_SOURCES,
     DESKTOP_SOURCES_RESULT,
+    RELOAD_CURRENT_VIEW,
 } from 'common/communication';
 import urlUtils from 'common/utils/url';
 import {SECOND} from 'common/utils/constants';
@@ -68,6 +69,7 @@ export class WindowManager {
         ipcMain.handle(GET_VIEW_NAME, this.handleGetViewName);
         ipcMain.handle(GET_VIEW_WEBCONTENTS_ID, this.handleGetWebContentsId);
         ipcMain.on(DISPATCH_GET_DESKTOP_SOURCES, this.handleGetDesktopSources);
+        ipcMain.on(RELOAD_CURRENT_VIEW, this.handleReloadCurrentView);
     }
 
     handleUpdateConfig = () => {
@@ -649,6 +651,15 @@ export class WindowManager {
                 };
             }));
         });
+    }
+
+    handleReloadCurrentView = () => {
+        const view = this.viewManager?.getCurrentView();
+        if (!view) {
+            return;
+        }
+        view?.reload();
+        this.viewManager?.showByName(view?.name);
     }
 }
 

--- a/src/renderer/components/ErrorView.tsx
+++ b/src/renderer/components/ErrorView.tsx
@@ -13,6 +13,7 @@ type Props = {
     id?: string;
     active?: boolean;
     appName?: string;
+    handleLink: () => void;
 };
 
 export default function ErrorView(props: Props) {
@@ -42,27 +43,26 @@ export default function ErrorView(props: Props) {
                         >
                             <h2>{`Cannot connect to ${props.appName}`}</h2>
                             <hr/>
-                            <p>{`We're having trouble connecting to ${props.appName}. If refreshing this page (Ctrl+R or Command+R) does not work please verify that:`}</p>
-                            <br/>
+                            <p>
+                                {`We're having trouble connecting to ${props.appName}. We'll continue to try and establish a connection.`}
+                                <br/>
+                                {'If refreshing this page (Ctrl+R or Command+R) does not work please verify that:'}
+                            </p>
                             <ul className='ErrorView-bullets' >
                                 <li>{'Your computer is connected to the internet.'}</li>
                                 <li>{`The ${props.appName} URL `}
                                     <a
 
-                                        //onClick={handleClick}
-                                        href={props.url}
-                                        target='_blank'
-                                        rel='noreferrer'
+                                        onClick={props.handleLink}
+                                        href='#'
                                     >
                                         {props.url}
                                     </a>{' is correct.'}</li>
                                 <li>{'You can reach '}
                                     <a
 
-                                        // onClick={handleClick}
-                                        href={props.url}
-                                        target='_blank'
-                                        rel='noreferrer'
+                                        onClick={props.handleLink}
+                                        href='#'
                                     >
                                         {props.url}
                                     </a>{' from a browser window.'}</li>

--- a/src/renderer/components/MainPage.tsx
+++ b/src/renderer/components/MainPage.tsx
@@ -44,6 +44,7 @@ import {
     START_UPGRADE,
     START_DOWNLOAD,
     CLOSE_TAB,
+    RELOAD_CURRENT_VIEW,
 } from 'common/communication';
 
 import restoreButton from '../../assets/titlebar/chrome-restore.svg';
@@ -358,6 +359,10 @@ export default class MainPage extends React.PureComponent<Props, State> {
         this.handleCloseTeamsDropdown();
     }
 
+    reloadCurrentView = () => {
+        window.ipcRenderer.send(RELOAD_CURRENT_VIEW);
+    }
+
     render() {
         const currentTabs = this.props.teams.find((team) => team.name === this.state.activeServerName)?.tabs || [];
 
@@ -528,16 +533,6 @@ export default class MainPage extends React.PureComponent<Props, State> {
                 return null;
             }
             switch (tabStatus.status) {
-            case Status.NOSERVERS: // TODO: substitute with https://mattermost.atlassian.net/browse/MM-25003
-                component = (
-                    <ErrorView
-                        id={'NoServers'}
-                        errorInfo={'No Servers configured'}
-                        url={tabStatus.extra ? tabStatus.extra.url : ''}
-                        active={true}
-                        appName={this.props.appName}
-                    />);
-                break;
             case Status.FAILED:
                 component = (
                     <ErrorView
@@ -546,6 +541,7 @@ export default class MainPage extends React.PureComponent<Props, State> {
                         url={tabStatus.extra ? tabStatus.extra.url : ''}
                         active={true}
                         appName={this.props.appName}
+                        handleLink={this.reloadCurrentView}
                     />);
                 break;
             case Status.LOADING:


### PR DESCRIPTION
#### Summary
This PR extends the retry logic for tabs that are unable to load (likely due to network conditions) to retry indefinitely.
Now, the app will still show an error screen after a small amount of retries (prompting users to double check the URL) but will continue to retry in the background at the same interval in case network conditions change and the URL is now accessible as a result. This should improve the reliability a bit such that users that need to login to a VPN, or connect to a different WiFi network will have their tabs automatically loaded for them once the network conditions change.

Also a couple small fixes were made to improve the error screen behaviour.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41891
Closes #2002

```release-note
Support retrying to load tabs indefinitely instead of stopping after a few tries.
```