### PR TITLE
[MM-42587] Fix typo in unread checking code

### DIFF
--- a/src/main/preload/mattermost.js
+++ b/src/main/preload/mattermost.js
@@ -177,7 +177,7 @@ ipcRenderer.on('notification-clicked', (event, data) => {
 });
 
 const findUnread = (favicon) => {
-    const classes = ['team-container unreads', 'SidebarChannel unread', 'sidebar-item unread-title'];
+    const classes = ['team-container unread', 'SidebarChannel unread', 'sidebar-item unread-title'];
     const isUnread = classes.some((classPair) => {
         const result = document.getElementsByClassName(classPair);
         return result && result.length > 0;


### PR DESCRIPTION
#### Summary
There was a typo in the preload code that checked for unreads in the team sidebar when you were on a different team, this PR fixes that typo so that the unreads should work correctly now.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42587

```release-note
Fixed an issue where unreads on a different team wouldn't trigger an unread badge in the Desktop App.
```
