### PR TITLE
Add `skip_waiting_for_build_processing` to CI build

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,6 +30,7 @@ lane :publish_test do |options|
     end
     pilot(
       pkg: options[:path],
+      skip_waiting_for_build_processing: ENV['CI'] === 'true',
       api_key: api_key
     )
 end


### PR DESCRIPTION
#### Summary
Turn on the `skip_waiting_for_build_processing` option for MAS so that the build finishes before the cutoff time.

```release-note
NONE
```
