### PR TITLE
[MM-42098] Remove icon from Windows 10/11 notification

### DIFF
--- a/src/main/notifications/Download.ts
+++ b/src/main/notifications/Download.ts
@@ -1,8 +1,11 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import os from 'os';
 import path from 'path';
 import {app, Notification} from 'electron';
+
+import Utils from 'common/utils/util';
 
 const assetsDir = path.resolve(app.getAppPath(), 'assets');
 const appIconURL = path.resolve(assetsDir, 'appicon_48.png');
@@ -18,9 +21,7 @@ const defaultOptions = {
 export class DownloadNotification extends Notification {
     constructor(fileName: string, serverName: string) {
         const options = {...defaultOptions};
-        if (process.platform === 'win32') {
-            options.icon = appIconURL;
-        } else if (process.platform === 'darwin') {
+        if (process.platform === 'darwin' || (process.platform === 'win32' && Utils.isVersionGreaterThanOrEqualTo(os.release(), '10.0'))) {
             // Notification Center shows app's icon, so there were two icons on the notification.
             Reflect.deleteProperty(options, 'icon');
         }

--- a/src/main/notifications/Mention.ts
+++ b/src/main/notifications/Mention.ts
@@ -28,11 +28,11 @@ export class Mention extends Notification {
 
     constructor(customOptions: MentionOptions, channel: {id: string}, teamId: string) {
         const options = {...defaultOptions, ...customOptions};
-        if (process.platform === 'darwin') {
+        if (process.platform === 'darwin' || (process.platform === 'win32' && Utils.isVersionGreaterThanOrEqualTo(os.release(), '10.0'))) {
             // Notification Center shows app's icon, so there were two icons on the notification.
             Reflect.deleteProperty(options, 'icon');
         }
-        const isWin7 = (process.platform === 'win32' && !Utils.isVersionGreaterThanOrEqualTo(os.version(), '6.3') && DEFAULT_WIN7);
+        const isWin7 = (process.platform === 'win32' && !Utils.isVersionGreaterThanOrEqualTo(os.release(), '6.3') && DEFAULT_WIN7);
         const customSound = String(!options.silent && ((options.data && options.data.soundName !== 'None' && options.data.soundName) || isWin7));
         if (customSound) {
             options.silent = true;

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -71,7 +71,6 @@ export default class SettingsPage extends React.PureComponent<Record<string, nev
     startInFullscreenRef: React.RefObject<HTMLInputElement>;
     autoCheckForUpdatesRef: React.RefObject<HTMLInputElement>;
 
-
     saveQueue: SaveQueueItem[];
 
     selectedSpellCheckerLocales: Array<{label: string; value: string}>;


### PR DESCRIPTION
#### Summary
When receiving a notification on a Windows 10/11 machine, you will see 2 icons on the notification. This PR removes the extra icon so that there's only 1.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42098

#### Release Note
```release-note
Removed redundant icon from Windows 10+ notifications
```
