### PR TITLE
[MM-43185] Fix size of BrowserView for URLView

### DIFF
--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -35,7 +35,7 @@ import modalManager from './modalManager';
 import WebContentsEventManager from './webContentEvents';
 
 const URL_VIEW_DURATION = 10 * SECOND;
-const URL_VIEW_HEIGHT = 36;
+const URL_VIEW_HEIGHT = 20;
 
 enum LoadingScreenState {
     VISIBLE = 1,

--- a/src/renderer/css/components/HoveringURL.css
+++ b/src/renderer/css/components/HoveringURL.css
@@ -1,3 +1,7 @@
+body {
+  margin: 0;
+}
+
 .HoveringURL {
   position: fixed;
   bottom: 0;


### PR DESCRIPTION
#### Summary
When trying to click a button directly above the URL View component, the button would be blocked by the BrowserView containing the URL View. This is due to the fact that URL View was too tall.

This PR corrects the height to 20px, the same height of the URL View.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43185

```release-note
Fixed an issue where the URL View stopped users from clicking a button directly above it
```
