### PR TITLE
[MM-26016] Hide tray icon theme colour when tray icon not enabled

### DIFF
--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -712,49 +712,51 @@ export default class SettingsPage extends React.PureComponent<Record<string, nev
                 </FormCheck>);
         }
 
-        if (window.process.platform === 'linux' || window.process.platform === 'win32') {
-            options.push(
-                <FormGroup
-                    key='trayIconTheme'
-                    ref={this.trayIconThemeRef}
-                    style={{marginLeft: '20px'}}
-                >
-                    {'Icon theme: '}
-                    {window.process.platform === 'win32' &&
-                        <>
-                            <FormCheck
-                                type='radio'
-                                inline={true}
-                                name='trayIconTheme'
-                                value='use_system'
-                                defaultChecked={this.state.trayIconTheme === 'use_system' || !this.state.trayIconTheme}
-                                onChange={() => this.handleChangeTrayIconTheme('use_system')}
-                                label={'Use system default'}
-                            />
-                            {' '}
-                        </>
-                    }
-                    <FormCheck
-                        type='radio'
-                        inline={true}
-                        name='trayIconTheme'
-                        value='light'
-                        defaultChecked={this.state.trayIconTheme === 'light' || !this.state.trayIconTheme}
-                        onChange={() => this.handleChangeTrayIconTheme('light')}
-                        label={'Light'}
-                    />
-                    {' '}
-                    <FormCheck
-                        type='radio'
-                        inline={true}
-                        name='trayIconTheme'
-                        value='dark'
-                        defaultChecked={this.state.trayIconTheme === 'dark'}
-                        onChange={() => this.handleChangeTrayIconTheme('dark')}
-                        label={'Dark'}
-                    />
-                </FormGroup>,
-            );
+        if (this.state.showTrayIcon) {
+            if (window.process.platform === 'linux' || window.process.platform === 'win32') {
+                options.push(
+                    <FormGroup
+                        key='trayIconTheme'
+                        ref={this.trayIconThemeRef}
+                        style={{marginLeft: '20px'}}
+                    >
+                        {'Icon theme: '}
+                        {window.process.platform === 'win32' &&
+                            <>
+                                <FormCheck
+                                    type='radio'
+                                    inline={true}
+                                    name='trayIconTheme'
+                                    value='use_system'
+                                    defaultChecked={this.state.trayIconTheme === 'use_system' || !this.state.trayIconTheme}
+                                    onChange={() => this.handleChangeTrayIconTheme('use_system')}
+                                    label={'Use system default'}
+                                />
+                                {' '}
+                            </>
+                        }
+                        <FormCheck
+                            type='radio'
+                            inline={true}
+                            name='trayIconTheme'
+                            value='light'
+                            defaultChecked={this.state.trayIconTheme === 'light' || !this.state.trayIconTheme}
+                            onChange={() => this.handleChangeTrayIconTheme('light')}
+                            label={'Light'}
+                        />
+                        {' '}
+                        <FormCheck
+                            type='radio'
+                            inline={true}
+                            name='trayIconTheme'
+                            value='dark'
+                            defaultChecked={this.state.trayIconTheme === 'dark'}
+                            onChange={() => this.handleChangeTrayIconTheme('dark')}
+                            label={'Dark'}
+                        />
+                    </FormGroup>,
+                );
+            }
         }
 
         if (window.process.platform === 'linux' || window.process.platform === 'win32') {


### PR DESCRIPTION
#### Summary
When in the Settings page, the "Tray icon theme" toggle would be visible when the icon itself wasn't enabled on Linux, which could be confusing to some users.

This PR removes that toggle when the icon is disabled.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26016

```release-note
Hid the tray icon theme toggle when the icon itself wasn't enabled
```
