### PR TITLE
Upgrade to Electron v18.0.3 to fix MAS rejection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "copy-webpack-plugin": "10.2.4",
         "cross-env": "7.0.3",
         "css-loader": "6.7.1",
-        "electron": "18.0.1",
+        "electron": "18.0.3",
         "electron-builder": "23.0.3",
         "electron-connect": "0.6.3",
         "electron-mocha": "11.0.2",
@@ -15010,9 +15010,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-18.0.1.tgz",
-      "integrity": "sha512-8y3nxmK+v/tiuaR8yd4K83ApHxgomMIPAEl3J+2Jfv/D5G6M3KnvxNlNiNoTXI8uOegfmoqiDm5/2xlWFLzfLQ==",
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-18.0.3.tgz",
+      "integrity": "sha512-QRUZkGL8O/8CyDmTLSjBeRsZmGTPlPVeWnnpkdNqgHYYaOc/A881FKMiNzvQ9Cj0a+rUavDdwBUfUL82U3Ay7w==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -42977,9 +42977,9 @@
       }
     },
     "electron": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-18.0.1.tgz",
-      "integrity": "sha512-8y3nxmK+v/tiuaR8yd4K83ApHxgomMIPAEl3J+2Jfv/D5G6M3KnvxNlNiNoTXI8uOegfmoqiDm5/2xlWFLzfLQ==",
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-18.0.3.tgz",
+      "integrity": "sha512-QRUZkGL8O/8CyDmTLSjBeRsZmGTPlPVeWnnpkdNqgHYYaOc/A881FKMiNzvQ9Cj0a+rUavDdwBUfUL82U3Ay7w==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.13.0",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "copy-webpack-plugin": "10.2.4",
     "cross-env": "7.0.3",
     "css-loader": "6.7.1",
-    "electron": "18.0.1",
+    "electron": "18.0.3",
     "electron-builder": "23.0.3",
     "electron-connect": "0.6.3",
     "electron-mocha": "11.0.2",


### PR DESCRIPTION
#### Summary
An issue with Electron v18.0.1 was including a deprecated Chromium API. Our app was rejected from MAS because of this.
This PR upgrades to Electron v18.0.3 which has this API removed.

```release-note
NONE
```
