### PR TITLE
Fix issue where opening a new view causes the original view still to push

### DIFF
--- a/src/main/windows/windowManager.test.js
+++ b/src/main/windows/windowManager.test.js
@@ -788,7 +788,6 @@ describe('main/windows/windowManager', () => {
 
             windowManager.handleBrowserHistoryPush(null, 'server-1_tab-messaging', '/other_type_2/subpath');
             expect(windowManager.viewManager.openClosedTab).toBeCalledWith('server-1_other_type_2', 'http://server-1.com/other_type_2/subpath');
-            expect(windowManager.viewManager.showByName).toBeCalledWith('server-1_other_type_2');
         });
 
         it('should open redirect view if different from current view', () => {

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -596,7 +596,9 @@ export class WindowManager {
         const cleanedPathName = currentView?.tab.server.url.pathname === '/' ? pathName : pathName.replace(currentView?.tab.server.url.pathname || '', '');
         const redirectedViewName = urlUtils.getView(`${currentView?.tab.server.url}${cleanedPathName}`, Config.teams)?.name || viewName;
         if (this.viewManager?.closedViews.has(redirectedViewName)) {
+            // If it's a closed view, just open it and stop
             this.viewManager.openClosedTab(redirectedViewName, `${currentView?.tab.server.url}${cleanedPathName}`);
+            return;
         }
         let redirectedView = this.viewManager?.views.get(redirectedViewName) || currentView;
         if (redirectedView !== currentView && redirectedView?.tab.server.name === this.currentServerName && redirectedView?.isLoggedIn) {


### PR DESCRIPTION
#### Summary
When using the Global Header (or some other non `target=_blank` link) to open a new tab, the original tab would also navigate to the new location. This was due to the check for `isLoggedIn` on the new view, which of course won't be set until the view has finished loading.

This PR stops the rest of the `handleBrowserHistoryPush` flow from happening after the tab is opened, as when we open a tab we always go directly to where the push link told us to go.

```release-note
Fixed an issue where opening a new view causes the original view to go to the requested link as well
```
