### PR TITLE
[MM-43632] Ensure handleURLView is called when removing the target URL

### DIFF
--- a/src/main/views/MattermostView.test.js
+++ b/src/main/views/MattermostView.test.js
@@ -315,7 +315,13 @@ describe('main/views/MattermostView', () => {
 
         it('should not emit tooltip URL if internal', () => {
             mattermostView.handleUpdateTarget(null, 'http://server-1.com/path/to/channels');
-            expect(mattermostView.emit).not.toHaveBeenCalled();
+            expect(mattermostView.emit).toHaveBeenCalled();
+            expect(mattermostView.emit).not.toHaveBeenCalledWith(UPDATE_TARGET_URL, 'http://server-1.com/path/to/channels');
+        });
+
+        it('should still emit even if URL is blank', () => {
+            mattermostView.handleUpdateTarget(null, '');
+            expect(mattermostView.emit).toHaveBeenCalled();
         });
     });
 

--- a/src/main/views/MattermostView.ts
+++ b/src/main/views/MattermostView.ts
@@ -360,6 +360,8 @@ export class MattermostView extends EventEmitter {
         log.silly('MattermostView.handleUpdateTarget', {tabName: this.tab.name, url});
         if (url && !urlUtils.isInternalURL(urlUtils.parseURL(url), this.tab.server.url)) {
             this.emit(UPDATE_TARGET_URL, url);
+        } else {
+            this.emit(UPDATE_TARGET_URL);
         }
     }
 


### PR DESCRIPTION
#### Summary
When the user hovers over an external URL, we show a URL preview display at the bottom. When the user moves their mouse away, the app was supposed to remove the view, but it wasn't doing that, since we were checking that the URL exists on removing hover (which it wouldn't). So I've updated the login to make sure we're sending the event even when the URL is blank.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43632

#### Release Note
```release-note
Fixed an issue where the URL view would persist once the user had moved their moved off of an external URL
```
