### PR TITLE
Fix release markdown

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,11 +290,7 @@ jobs:
           command: tar -xzf rename.tgz
       - run:
           name: rename arm64 to m1
-          command: ./rename-1.601/rename 's/arm64/m1/' ./build/macos-release/$(jq -r .version package.json)/*
-      - persist_to_workspace:
-          root: ./build
-          paths:
-            - "./macos-release/"
+          command: ./rename-1.601/rename 's/arm64/m1/' ./release/$(jq -r .version package.json)/*
       - save:
           filename: "$(jq -r .version package.json)/*.dmg"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ jobs:
           command: tar -xzf rename.tgz
       - run:
           name: rename arm64 to m1
-          command: ./rename-1.601/rename 's/arm64/m1/' ./build/macos-release/*
+          command: ./rename-1.601/rename 's/arm64/m1/' ./build/macos-release/$(jq -r .version package.json)*
       - persist_to_workspace:
           root: ./build
           paths:
@@ -346,7 +346,7 @@ jobs:
           command: tar -xzf rename.tgz
       - run:
           name: rename arm64 to m1
-          command: ./rename-1.601/rename 's/arm64/m1/' ./build/macos-release/*
+          command: ./rename-1.601/rename 's/arm64/m1/' ./build/macos-release/$(jq -r .version package.json)*
       - persist_to_workspace:
           root: ./build
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ jobs:
           command: tar -xzf rename.tgz
       - run:
           name: rename arm64 to m1
-          command: ./rename-1.601/rename 's/arm64/m1/' ./build/macos-release/$(jq -r .version package.json)*
+          command: ./rename-1.601/rename 's/arm64/m1/' ./build/macos-release/$(jq -r .version package.json)/*
       - persist_to_workspace:
           root: ./build
           paths:
@@ -346,7 +346,7 @@ jobs:
           command: tar -xzf rename.tgz
       - run:
           name: rename arm64 to m1
-          command: ./rename-1.601/rename 's/arm64/m1/' ./build/macos-release/$(jq -r .version package.json)*
+          command: ./rename-1.601/rename 's/arm64/m1/' ./build/macos-release/$(jq -r .version package.json)/*
       - persist_to_workspace:
           root: ./build
           paths:

--- a/scripts/generate_release_markdown.sh
+++ b/scripts/generate_release_markdown.sh
@@ -28,10 +28,6 @@ $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-x86.msi")
 #### Windows - setup exe files
 $(print_link "${BASE_URL}/mattermost-desktop-setup-${VERSION}-win.exe")
 
-#### Windows - zip files
-$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win-ia32.zip")
-$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win-x64.zip")
-
 #### Mac
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-mac-universal.dmg")
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-mac-x64.dmg")
@@ -46,7 +42,7 @@ $(print_link "${BASE_URL}/mattermost-desktop_${VERSION}-1_i386.deb")
 $(print_link "${BASE_URL}/mattermost-desktop_${VERSION}-1_amd64.deb")
 
 #### Linux (Unofficial) - rpm files (beta)
-$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-linux-i386.rpm")
+$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-linux-i686.rpm")
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-linux-x86_64.rpm")
 
 #### Linux (Unofficial) - AppImage files


### PR DESCRIPTION
#### Summary
@JulienTant pointed out a couple issues with the release markdown, so I've made the changes here
- Fix the renaming of `arm64` to `m1` for macOS builds
- Removed Windows ZIP files from release (since we don't build them anymore)
- Renamed RPM build for `i386` to `i686` (those poor 486 users :P)

```release-note
NONE
```
