### PR TITLE
Automated cherry pick of #2074

### DIFF
--- a/src/main/views/MattermostView.test.js
+++ b/src/main/views/MattermostView.test.js
@@ -315,7 +315,13 @@ describe('main/views/MattermostView', () => {
 
         it('should not emit tooltip URL if internal', () => {
             mattermostView.handleUpdateTarget(null, 'http://server-1.com/path/to/channels');
-            expect(mattermostView.emit).not.toHaveBeenCalled();
+            expect(mattermostView.emit).toHaveBeenCalled();
+            expect(mattermostView.emit).not.toHaveBeenCalledWith(UPDATE_TARGET_URL, 'http://server-1.com/path/to/channels');
+        });
+
+        it('should still emit even if URL is blank', () => {
+            mattermostView.handleUpdateTarget(null, '');
+            expect(mattermostView.emit).toHaveBeenCalled();
         });
     });
 

--- a/src/main/views/MattermostView.ts
+++ b/src/main/views/MattermostView.ts
@@ -360,6 +360,8 @@ export class MattermostView extends EventEmitter {
         log.silly('MattermostView.handleUpdateTarget', {tabName: this.tab.name, url});
         if (url && !urlUtils.isInternalURL(urlUtils.parseURL(url), this.tab.server.url)) {
             this.emit(UPDATE_TARGET_URL, url);
+        } else {
+            this.emit(UPDATE_TARGET_URL);
         }
     }
 


### PR DESCRIPTION
Cherry pick of #2074 on release-5.1.

/cc  @devinbinnie

```release-note
NONE
```