### PR TITLE
[MM-44022] Switch to using current BrowserView for determining window bounds for URL view

### DIFF
--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -6,7 +6,7 @@ import {BrowserViewConstructorOptions} from 'electron/main';
 
 import {Tab, TeamWithTabs} from 'types/config';
 
-import {SECOND} from 'common/utils/constants';
+import {SECOND, TAB_BAR_HEIGHT} from 'common/utils/constants';
 import {
     UPDATE_TARGET_URL,
     LOAD_SUCCESS,
@@ -322,7 +322,7 @@ export class ViewManager {
             const localURL = getLocalURLString('urlView.html', query);
             urlView.webContents.loadURL(localURL);
             this.mainWindow.addBrowserView(urlView);
-            const boundaries = this.mainWindow.getBounds();
+            const boundaries = this.views.get(this.currentView || '')?.view.getBounds() ?? this.mainWindow.getBounds();
 
             const hideView = () => {
                 delete this.urlViewCancel;
@@ -338,12 +338,15 @@ export class ViewManager {
             const adjustWidth = (event: IpcMainEvent, width: number) => {
                 log.silly('showURLView.adjustWidth', width);
 
-                urlView.setBounds({
+                const bounds = {
                     x: 0,
-                    y: boundaries.height - URL_VIEW_HEIGHT,
+                    y: (boundaries.height + TAB_BAR_HEIGHT) - URL_VIEW_HEIGHT,
                     width: width + 5, // add some padding to ensure that we don't cut off the border
                     height: URL_VIEW_HEIGHT,
-                });
+                };
+
+                log.silly('showURLView setBounds', boundaries, bounds);
+                urlView.setBounds(bounds);
             };
 
             ipcMain.on(UPDATE_URL_VIEW_WIDTH, adjustWidth);


### PR DESCRIPTION
#### Summary
When the Mattermost window is maximized on Windows 10/11, the URL hover view was not showing correctly. This was due to window bounds being incorrect for the entire window when maximized.

This PR changes to use the current Mattermost view for bounds since those report correctly even when maximized.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44022
Closes #2086

#### Release Note
```release-note
NONE
```
