### PR TITLE
[MM-44023] Remove Settings window flash, change wording on Settings page

### DIFF
--- a/src/main/windows/windowManager.test.js
+++ b/src/main/windows/windowManager.test.js
@@ -348,7 +348,6 @@ describe('main/windows/windowManager', () => {
                 value: originalPlatform,
             });
             expect(windowManager.mainWindow.flashFrame).toBeCalledWith(true);
-            expect(windowManager.settingsWindow.flashFrame).toBeCalledWith(true);
         });
 
         it('mac - should not bounce icon when config item is not set', () => {

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -280,10 +280,6 @@ export class WindowManager {
         if (process.platform === 'linux' || process.platform === 'win32') {
             if (Config.notifications.flashWindow) {
                 this.mainWindow?.flashFrame(flash);
-                if (this.settingsWindow) {
-                    // main might be hidden behind the settings
-                    this.settingsWindow.flashFrame(flash);
-                }
             }
         }
         if (process.platform === 'darwin' && Config.notifications.bounceIcon) {

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -629,9 +629,9 @@ export default class SettingsPage extends React.PureComponent<Record<string, nev
                         checked={!this.state.notifications || this.state.notifications.flashWindow === 2}
                         onChange={this.handleFlashWindow}
                     />
-                    {'Flash app window and taskbar icon when a new message is received'}
+                    {'Flash taskbar icon when a new message is received'}
                     <FormText>
-                        {'If enabled, app window and taskbar icon flash for a few seconds when a new message is received.'}
+                        {'If enabled, the taskbar icon will flash for a few seconds when a new message is received.'}
                         {window.process.platform === 'linux' && (
                             <>
                                 <br/>


### PR DESCRIPTION
#### Summary
Flashing the main window no longer works without a valid window frame on Windows 10, so we've removed reference to that functionality. It will still work on Linux (with the right window manager) since the app still has a frame there.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44023

#### Release Note
```release-note
Removed reference to the flashing window to avoid confusion when the window doesn't flash.
```
