### PR TITLE
fix version flags displaying bad version on linux (#1422)

### DIFF
--- a/src/main/ParseArgs.test.js
+++ b/src/main/ParseArgs.test.js
@@ -1,12 +1,28 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+const dummyVersion = '1.2.3-test';
+
+jest.mock('electron', () => ({
+    app: {
+        getVersion: () => dummyVersion,
+    },
+}));
+
 import parse from 'main/ParseArgs';
 
 describe('main/ParseArgs', () => {
     it('should remove arguments following a deeplink', () => {
-        const args = parse(['mattermost', '--disableDevMode', 'mattermost://server-1.com', '--version']);
+        const args = parse(['mattermost', '--disableDevMode', 'mattermost://server-1.com']);
         expect(args.disableDevMode).toBe(true);
-        expect(args.version).toBeUndefined();
+    });
+
+    it('should show version and exit when specified', async () => {
+        jest.spyOn(process.stdout, 'write').mockImplementation(() => {});
+        const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
+        const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+        parse(['mattermost', '--version', 'mattermost://server-1.com']);
+        expect(exitSpy).toHaveBeenCalledWith(0);
+        expect(logSpy).toHaveBeenCalledWith(dummyVersion);
     });
 });

--- a/src/main/ParseArgs.ts
+++ b/src/main/ParseArgs.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {app} from 'electron';
 import {Args} from 'types/args';
 import yargs from 'yargs';
 
@@ -24,12 +25,32 @@ function triageArgs(args: string[]) {
     return args;
 }
 
+// Note that yargs is able to exit the node process when handling
+// certain flags, like version or help.
+// https://github.com/yargs/yargs/blob/main/docs/api.md#exitprocessenable
 function parseArgs(args: string[]) {
     return yargs.
-        alias('dataDir', 'd').string('dataDir').describe('dataDir', 'Set the path to where user data is stored.').
-        alias('disableDevMode', 'p').boolean('disableDevMode').describe('disableDevMode', 'Disable development mode. Allows for testing as if it was Production.').
-        alias('version', 'v').boolean('version').describe('version', 'Prints the application version.').
-        alias('fullscreen', 'f').boolean('fullscreen').describe('fullscreen', 'Opens the application in fullscreen mode.').
+        alias('dataDir', 'd').
+        string('dataDir').
+        describe('dataDir', 'Set the path to where user data is stored.').
+
+        alias('disableDevMode', 'p').
+        boolean('disableDevMode').
+        describe('disableDevMode', 'Disable development mode. Allows for testing as if it was Production.').
+
+        alias('version', 'v').
+        boolean('version').
+        describe('version', 'Prints the application version.').
+
+        alias('fullscreen', 'f').
+        boolean('fullscreen').
+        describe('fullscreen', 'Opens the application in fullscreen mode.').
+
+        // Typically, yargs is capable of acquiring the app's version
+        // through package.json.  However, for us this is
+        // unsuccessful, perhaps due to a complication during the
+        // build.  As such, we provide the version manually.
+        version(app.getVersion()).
         help('help').
         parse(args);
 }

--- a/src/main/app/initialize.test.js
+++ b/src/main/app/initialize.test.js
@@ -170,16 +170,6 @@ describe('main/app/initialize', () => {
             await initialize();
             expect(app.setPath).toHaveBeenCalledWith('userData', '/basedir/some/dir');
         });
-
-        it('should show version and exit when specified', async () => {
-            jest.spyOn(process.stdout, 'write').mockImplementation(() => {});
-            const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
-            parseArgs.mockReturnValue({
-                version: true,
-            });
-            await initialize();
-            expect(exitSpy).toHaveBeenCalledWith(0);
-        });
     });
 
     describe('initializeConfig', () => {

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -138,12 +138,6 @@ export async function initialize() {
 function initializeArgs() {
     global.args = parseArgs(process.argv.slice(1));
 
-    // output the application version via cli when requested (-v or --version)
-    if (global.args.version) {
-        process.stdout.write(`v.${app.getVersion()}\n`);
-        process.exit(0); // eslint-disable-line no-process-exit
-    }
-
     global.isDev = isDev && !global.args.disableDevMode; // this doesn't seem to be right and isn't used as the single source of truth
 
     if (global.args.dataDir) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

yargs, the command line parsing library, was unable to read the app's version automatically from `package.json`.

Fix by passing the app's version as electron sees it.

<!--
A brief description of what this pull request does.
-->

#### Notes

I was able to identify yargs was behaving improperly by polyfilling `console.log` and `process.exit` and making them throw on call, then cross-checking with yargs' source code.

It is also possible to disable yargs exiting. I opted for allowing yargs to handle it. It is possibly unwanted for an external process to call `process.exit` for us as it results in truly mysterious behaviour in edge cases such as this. This is exacerbated by yargs being overengineered for its relatively trivial task.

#### Ticket Link

Fixes https://github.com/mattermost/desktop/issues/1422

<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.



Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [x] executed `npm run lint:js` for proper code formatting

#### Device Information

This PR was tested on: Debian sid, 5.17.3-1.

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Fixed improper reporting of app version when the --version or -v command-line flags were passed.
```