### PR TITLE
Turn off updates for non-AppImage Linux targets

### DIFF
--- a/src/common/config/index.ts
+++ b/src/common/config/index.ts
@@ -315,7 +315,7 @@ export class Config extends EventEmitter {
     }
 
     get canUpgrade() {
-        return this.canUpgradeValue && this.buildConfigData?.enableAutoUpdater && !(process.platform === 'win32' && this.registryConfigData?.enableAutoUpdater === false);
+        return this.canUpgradeValue && this.buildConfigData?.enableAutoUpdater && !(process.platform === 'linux' && !process.env.APPIMAGE) && !(process.platform === 'win32' && this.registryConfigData?.enableAutoUpdater === false);
     }
 
     get autoCheckForUpdates() {


### PR DESCRIPTION
#### Summary
The "Check for Updates" menu item and setting were still visible on all Linux distributions, so I've made sure that we only enable it for AppImage.

```release-note
NONE
```
