### PR TITLE
[MM-44066] Truncate server names in the system tray to 50 characters

### DIFF
--- a/src/main/menus/tray.ts
+++ b/src/main/menus/tray.ts
@@ -13,7 +13,7 @@ export function createTemplate(config: CombinedConfig) {
     const template = [
         ...teams.sort((teamA, teamB) => teamA.order - teamB.order).slice(0, 9).map((team) => {
             return {
-                label: team.name,
+                label: team.name.length > 50 ? `${team.name.slice(0, 50)}...` : team.name,
                 click: () => {
                     WindowManager.switchServer(team.name);
                 },


### PR DESCRIPTION
#### Summary
The server name was overflowing on the tray menu, causing bad UX (specifically on Ubuntu). This PR truncates the server name to 50 characters so that it doesn't cause any issues.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44066

```release-note
Fixed bad UX for the system tray menu with long server names
```
