### PR TITLE
[MM-44117] Fix stack overflow where window resize would constantly emit the restore event

### DIFF
--- a/src/main/app/utils.ts
+++ b/src/main/app/utils.ts
@@ -168,11 +168,7 @@ export function resizeScreen(browserWindow: BrowserWindow) {
         }
     }
 
-    const handler = () => {
-        browserWindow.off('restore', handler);
-        handle();
-    };
-    browserWindow.on('restore', handler);
+    browserWindow.once('restore', handle);
     handle();
 }
 

--- a/src/main/app/utils.ts
+++ b/src/main/app/utils.ts
@@ -168,7 +168,11 @@ export function resizeScreen(browserWindow: BrowserWindow) {
         }
     }
 
-    browserWindow.on('restore', handle);
+    const handler = () => {
+        browserWindow.off('restore', handler);
+        handle();
+    };
+    browserWindow.on('restore', handler);
     handle();
 }
 


### PR DESCRIPTION
#### Summary
There seems to be a case on some Linux installs where the `restore` event will be emitted every time the window is resized. In the `resizeScreen` function, this was causing a stack overflow. This PR stops the handler from being called more than once unless explicitly needed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44117
Fixes #2098 

```release-note
NONE
```
