### PR TITLE
[MM-44161] Show both validation messages when adding new server if both fields are invalid

### DIFF
--- a/src/renderer/components/NewTeamModal.tsx
+++ b/src/renderer/components/NewTeamModal.tsx
@@ -125,7 +125,13 @@ export default class NewTeamModal extends React.PureComponent<Props, State> {
         const urlError = this.getTeamUrlValidationError();
 
         if (nameError && urlError) {
-            return 'Name and URL are required.';
+            return (
+                <>
+                    {nameError}
+                    <br/>
+                    {urlError}
+                </>
+            );
         } else if (nameError) {
             return nameError;
         } else if (urlError) {


### PR DESCRIPTION
#### Summary
When adding a new server, if both the Name and URL fields are invalid, the user will see a message that says 'Name and URL are required'. This can be misleading if they've entered something for both, and doesn't give them a good indication as to what is wrong with their entry.

This PR changes the modal to show both messages so that the user understands better what is wrong.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44161

```release-note
NONE
```
