### PR TITLE
Fix GitHub release asset upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,7 +494,7 @@ jobs:
           name: "Setup files for ghr"
           command: |
             mkdir -p ./ghr-dist
-            cp -r --backup=numbered ./build/{macos-release,win-release,linux}/* ./ghr-dist
+            find ./build/{macos-release,win-release,linux} -type f -exec cp --backup=numbered -t ./ghr-dist {} +
       - run:
           name: "Publish Release on GitHub"
           command: |


### PR DESCRIPTION
`ghr` only looks at immediate descendents of the path it is provided, so we need to ensure that `ghr-dist/` is flattened.

Fixes: #2113

```release-note
NONE
```