### PR TITLE
[MM-44607] Only cleanse subpath if it occurs at the beginning

### DIFF
--- a/src/common/utils/url.test.js
+++ b/src/common/utils/url.test.js
@@ -303,6 +303,20 @@ describe('common/utils/url', () => {
         });
     });
 
+    describe('cleanPathName', () => {
+        it('should not clean path name if it occurs other than the beginning', () => {
+            expect(urlUtils.cleanPathName('/mattermost', '/home/channels/mattermost/test')).toBe('/home/channels/mattermost/test');
+        });
+
+        it('should clean path name if it occurs at the beginning', () => {
+            expect(urlUtils.cleanPathName('/mattermost', '/mattermost/channels/home/test')).toBe('/channels/home/test');
+        });
+
+        it('should do nothing if it doesnt occur', () => {
+            expect(urlUtils.cleanPathName('/mattermost', '/channels/home/test')).toBe('/channels/home/test');
+        });
+    });
+
     describe('isCustomLoginURL', () => {
         it('should match correct URL', () => {
             expect(urlUtils.isCustomLoginURL(

--- a/src/common/utils/url.ts
+++ b/src/common/utils/url.ts
@@ -208,6 +208,18 @@ function isChannelExportUrl(serverUrl: URL | string, inputUrl: URL | string): bo
     return isUrlType('plugins/com.mattermost.plugin-channel-export/api/v1/export', serverUrl, inputUrl);
 }
 
+function cleanPathName(basePathName: string, pathName: string) {
+    if (basePathName === '/') {
+        return pathName;
+    }
+
+    if (pathName.startsWith(basePathName)) {
+        return pathName.replace(basePathName, '');
+    }
+
+    return pathName;
+}
+
 export default {
     isValidURL,
     isValidURI,
@@ -224,4 +236,5 @@ export default {
     isCustomLoginURL,
     isChannelExportUrl,
     isUrlType,
+    cleanPathName,
 };

--- a/src/main/windows/windowManager.test.js
+++ b/src/main/windows/windowManager.test.js
@@ -46,6 +46,7 @@ jest.mock('common/utils/url', () => ({
     isTeamUrl: jest.fn(),
     isAdminUrl: jest.fn(),
     getView: jest.fn(),
+    cleanPathName: jest.fn(),
 }));
 jest.mock('common/tabs/TabView', () => ({
     getTabViewName: jest.fn(),
@@ -770,6 +771,7 @@ describe('main/windows/windowManager', () => {
                     ],
                 },
             ];
+            urlUtils.cleanPathName.mockImplementation((base, path) => path);
         });
 
         afterEach(() => {

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -589,7 +589,7 @@ export class WindowManager {
         log.debug('WwindowManager.handleBrowserHistoryPush', {viewName, pathName});
 
         const currentView = this.viewManager?.views.get(viewName);
-        const cleanedPathName = currentView?.tab.server.url.pathname === '/' ? pathName : pathName.replace(currentView?.tab.server.url.pathname || '', '');
+        const cleanedPathName = urlUtils.cleanPathName(currentView?.tab.server.url.pathname || '', pathName);
         const redirectedViewName = urlUtils.getView(`${currentView?.tab.server.url}${cleanedPathName}`, Config.teams)?.name || viewName;
         if (this.viewManager?.closedViews.has(redirectedViewName)) {
             // If it's a closed view, just open it and stop


### PR DESCRIPTION
#### Summary
When switching to a channel that matches (or starts with) the name of the server subpath (eg. server url `http://server.com/mattermost` and channel name `mattermosty`), navigation would not happen. This was caused by an issue with the replacement function that removes the subpath when switching tabs.

This PR fixes the function to only remove the subpath if its at the beginning of the path that's being cleansed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44607
Closes https://github.com/mattermost/desktop/issues/2125

```release-note
Fixed an issue where a channel name matching the server subpath would not be navigable
```
