### PR TITLE
[MM-44344] Restore zip build for Windows and remove auto-updater from it

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -38,6 +38,7 @@
   ],
   "afterPack": "scripts/afterpack.js",
   "afterSign": "scripts/notarize.js",
+  "afterAllArtifactBuild": "scripts/afterbuild.js",
   "deb": {
     "artifactName": "${version}/${name}_${version}-1_${arch}.${ext}",
     "synopsis": "Mattermost Desktop App",

--- a/scripts/afterbuild.js
+++ b/scripts/afterbuild.js
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+const {spawnSync} = require('child_process');
+
+const {path7za} = require('7zip-bin');
+
+const windowsZipRegex = /win-[A-Za-z0-9]+\.zip$/g;
+
+async function removeAppUpdate(path) {
+    const result = await spawnSync(path7za, ['d', path, 'resources/app-update.yml', '-r']);
+    if (result.error) {
+        throw new Error(
+            `Failed to remove files from ${path}: ${result.error} ${result.stderr} ${result.stdout}`,
+        );
+    }
+}
+
+exports.default = async function afterAllArtifactBuild(context) {
+    await context.artifactPaths.forEach(async (path) => {
+        if (path.match(windowsZipRegex)) {
+            await removeAppUpdate(path);
+        }
+    });
+};

--- a/scripts/generate_release_markdown.sh
+++ b/scripts/generate_release_markdown.sh
@@ -28,6 +28,10 @@ $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-x86.msi")
 #### Windows - setup exe files
 $(print_link "${BASE_URL}/mattermost-desktop-setup-${VERSION}-win.exe")
 
+#### Windows - zip files
+$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win32.zip")
+$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win64.zip")
+
 #### Mac
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-mac-universal.dmg")
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-mac-x64.dmg")

--- a/src/common/config/index.ts
+++ b/src/common/config/index.ts
@@ -41,6 +41,12 @@ function checkWriteableApp() {
     if (process.platform === 'win32') {
         try {
             fs.accessSync(path.join(path.dirname(app.getAppPath()), '../../'), fs.constants.W_OK);
+
+            // check to make sure that app-update.yml exists
+            if (!fs.existsSync(path.join(process.resourcesPath, 'app-update.yml'))) {
+                log.warn('app-update.yml does not exist, disabling auto-updates');
+                return false;
+            }
         } catch (error) {
             log.info(`${app.getAppPath()}: ${error}`);
             log.warn('autoupgrade disabled');


### PR DESCRIPTION
#### Summary
We chose to remove the ZIP build for Windows since we did not believe it was relevant, and the auto-updater caused some odd issues with it. We have decided after a few people have mentioned it to restore it with the auto-updater removed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44344
Closes https://github.com/mattermost/desktop/issues/2112

#### Release Note
```release-note
Restore Windows ZIP build
```
