### PR TITLE
[MM-44339] Remove unnecessary calls to show the main window

### DIFF
--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -124,10 +124,6 @@ function createMainWindow(options: {linuxAppIcon: string; fullscreen?: boolean})
         }
     });
 
-    mainWindow.once('show', () => {
-        mainWindow.show();
-    });
-
     mainWindow.once('restore', () => {
         mainWindow.restore();
     });

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -213,7 +213,6 @@ export class WindowManager {
     // max retries allows the message to get to the renderer even if it is sent while the app is starting up.
     sendToRendererWithRetry = (maxRetries: number, channel: string, ...args: any[]) => {
         if (!this.mainWindow || !this.mainWindowReady) {
-            this.showMainWindow();
             if (maxRetries > 0) {
                 log.info(`Can't send ${channel}, will retry`);
                 setTimeout(() => {


### PR DESCRIPTION
#### Summary
When the app starts, we had a few extra calls made to show the main window. These weren't being caught by the `hideOnStart` setting meaning that it wasn't working, so I've removed those extra calls.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44339
Closes https://github.com/mattermost/desktop/issues/2109

```release-note
Fixed an issue where the `hideOnStart` setting wasn't working
```
