### PR TITLE
Create configuration folder for notice.txt generation

### DIFF
--- a/.config/notice-file/Readme.md
+++ b/.config/notice-file/Readme.md
@@ -1,0 +1,34 @@
+# Notice.txt File Configuration
+
+We are automatically generating Notice.txt by using first-level dependencies of the project. The related pipeline uses `config.yaml` stored in this folder.
+
+
+## Configuration
+
+Sample:
+
+```
+title: "Mattermost Desktop"
+copyright: "© 2016-2017 Mattermost, Inc.  All Rights Reserved.  See LICENSE.txt for license information."
+description: "This document includes a list of open source components used in Mattermost Desktop, including those that have been modified."
+reviewers: 
+  - mattermost/release-managers
+  - mattermost/team-desktop
+search:
+  - "package.json"
+dependencies:
+  - "wix"
+devDependencies: 
+  - "webpack"
+```
+
+| Field | Type   | Purpose |
+| :--   | :--    | :--     |
+| title | string | Field content will be used as a title of the application. See first line of `NOTICE.txt` file. |
+| copyright | string | Field content will be used as a copyright message. See second line of `NOTICE.txt` file. |
+| description | string | Field content will be used as notice file description. See third line of `NOTICE.txt` file. |
+| reviewers | array of GitHub user/teams | Those will be automatically assigned to the PRs as reviewers. |
+| dependencies | array | If any dependency name mentioned, it will be automatically added even if it is not a first-level dependency. |
+| devDependencies | array | If any dependency name mentioned, it will be added when it is referenced in devDependency section. |
+| search | array | Pipeline will search for package.json files mentioned here. Globstar format is supported ie. `packages/**/package.json`. |
+

--- a/.config/notice-file/config.yaml
+++ b/.config/notice-file/config.yaml
@@ -1,0 +1,15 @@
+---
+
+title: "Mattermost Desktop"
+copyright: "© 2016-2017 Mattermost, Inc.  All Rights Reserved.  See LICENSE.txt for license information."
+description: "This document includes a list of open source components used in Mattermost Desktop, including those that have been modified."
+reviewers: 
+  - mattermost/release-managers
+  - mattermost/team-desktop
+search:
+  - "package.json"
+dependencies:
+  - "wix"
+devDependencies: []
+
+...


### PR DESCRIPTION
#### Summary
We are working to automate Notice.txt file generation and some of the properties need to be managed by developers.

To support that feature, we created a configuration file in the repo under build folder. 

#### Ticket Link
https://mattermost.atlassian.net/browse/DOPS-448

#### Release Note
```release-note
NONE
```
