### PR TITLE
Fix MAS/TestFlight nightly build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mattermost-desktop",
   "productName": "Mattermost",
-  "version": "5.1.0-develop.1",
+  "version": "5.2.0-develop.1",
   "description": "Mattermost",
   "main": "dist/index.js",
   "author": "Mattermost, Inc. <feedback@mattermost.com>",


### PR DESCRIPTION
#### Summary
Once a version is released, MAS doesn't allow subsequent releases of the same version to be uploaded to TestFlight, so I've updated the version in package.json to v5.2

```release-note
NONE
```
