### PR TITLE
[MM-44644] Update configured server URL from SiteURL if available

### DIFF
--- a/src/main/app/intercom.ts
+++ b/src/main/app/intercom.ts
@@ -161,6 +161,7 @@ export function handleEditServerModal(e: IpcMainEvent, name: string) {
             teams[serverIndex].name = data.name;
             teams[serverIndex].url = data.url;
             Config.set('teams', teams);
+            updateServerInfos([teams[serverIndex]]);
         }).catch((e) => {
             // e is undefined for user cancellation
             if (e) {

--- a/src/main/app/utils.test.js
+++ b/src/main/app/utils.test.js
@@ -102,6 +102,7 @@ describe('main/app/utils', () => {
         it('should open all tabs', async () => {
             ServerInfo.mockReturnValue({promise: {
                 name: 'server-1',
+                siteURL: 'http://server-1.com',
                 serverVersion: '6.0.0',
                 hasPlaybooks: true,
                 hasFocalboard: true,
@@ -117,6 +118,7 @@ describe('main/app/utils', () => {
         it('should open only playbooks', async () => {
             ServerInfo.mockReturnValue({promise: {
                 name: 'server-1',
+                siteURL: 'http://server-1.com',
                 serverVersion: '6.0.0',
                 hasPlaybooks: true,
                 hasFocalboard: false,
@@ -132,6 +134,7 @@ describe('main/app/utils', () => {
         it('should open none when server version is too old', async () => {
             ServerInfo.mockReturnValue({promise: {
                 name: 'server-1',
+                siteURL: 'http://server-1.com',
                 serverVersion: '5.0.0',
                 hasPlaybooks: true,
                 hasFocalboard: true,
@@ -142,6 +145,21 @@ describe('main/app/utils', () => {
 
             expect(Config.teams.find((team) => team.name === 'server-1').tabs.find((tab) => tab.name === TAB_PLAYBOOKS).isOpen).toBeUndefined();
             expect(Config.teams.find((team) => team.name === 'server-1').tabs.find((tab) => tab.name === TAB_FOCALBOARD).isOpen).toBeUndefined();
+        });
+
+        it('should update server URL using site URL', async () => {
+            ServerInfo.mockReturnValue({promise: {
+                name: 'server-1',
+                siteURL: 'http://server-2.com',
+                serverVersion: '6.0.0',
+                hasPlaybooks: true,
+                hasFocalboard: true,
+            }});
+
+            updateServerInfos(Config.teams);
+            await new Promise(setImmediate); // workaround since Promise.all seems to not let me wait here
+
+            expect(Config.teams.find((team) => team.name === 'server-1').url).toBe('http://server-2.com');
         });
     });
 

--- a/src/main/app/utils.ts
+++ b/src/main/app/utils.ts
@@ -55,11 +55,21 @@ export function updateServerInfos(teams: TeamWithTabs[]) {
     });
     Promise.all(serverInfos).then((data: Array<RemoteInfo | string | undefined>) => {
         const teams = Config.teams;
-        teams.forEach((team) => openExtraTabs(data, team));
+        teams.forEach((team) => {
+            updateServerURL(data, team);
+            openExtraTabs(data, team);
+        });
         Config.set('teams', teams);
     }).catch((reason: any) => {
         log.error('Error getting server infos', reason);
     });
+}
+
+function updateServerURL(data: Array<RemoteInfo | string | undefined>, team: TeamWithTabs) {
+    const remoteInfo = data.find((info) => info && typeof info !== 'string' && info.name === team.name) as RemoteInfo;
+    if (remoteInfo && remoteInfo.siteURL) {
+        team.url = remoteInfo.siteURL;
+    }
 }
 
 function openExtraTabs(data: Array<RemoteInfo | string | undefined>, team: TeamWithTabs) {

--- a/src/main/server/serverInfo.ts
+++ b/src/main/server/serverInfo.ts
@@ -3,7 +3,7 @@
 
 import log from 'electron-log';
 
-import {RemoteInfo} from 'types/server';
+import {ClientConfig, RemoteInfo} from 'types/server';
 
 import {MattermostServer} from 'common/servers/MattermostServer';
 
@@ -26,7 +26,7 @@ export class ServerInfo {
     }
 
     getRemoteInfo = () => {
-        getServerAPI<{Version: string}>(
+        getServerAPI<ClientConfig>(
             new URL(`${this.server.url.toString()}/api/v4/config/client?format=old`),
             false,
             this.onGetConfig,
@@ -41,8 +41,9 @@ export class ServerInfo {
             this.onRetrievedRemoteInfo);
     }
 
-    onGetConfig = (data: {Version: string}) => {
+    onGetConfig = (data: ClientConfig) => {
         this.remoteInfo.serverVersion = data.Version;
+        this.remoteInfo.siteURL = data.SiteURL;
 
         this.trySendRemoteInfo();
     }

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -4,6 +4,12 @@
 export type RemoteInfo = {
     name: string;
     serverVersion?: string;
+    siteURL?: string;
     hasFocalboard?: boolean;
     hasPlaybooks?: boolean;
 };
+
+export type ClientConfig = {
+    Version: string;
+    SiteURL: string;
+}


### PR DESCRIPTION
#### Summary
Whenever the server is configured not using the `SiteURL` that is configured on the server, a lot of unexpected issues can occur. This most recently manifested itself when we started redirecting `community-daily` to `community`. 

This PR uses the same API the app uses to check for installed plugins and server version to grab the SiteURL and update the configured server URL with it.

This does appear to work with GPO configurations as well!

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44644

```release-note
Force servers to update their configuration using the configured SiteURL if available
```
