### PR TITLE
[MM-45031] Don't use infinite background retry logic when the certificate is invalid

### DIFF
--- a/src/main/app/app.test.js
+++ b/src/main/app/app.test.js
@@ -36,6 +36,10 @@ jest.mock('main/certificateStore', () => ({
 jest.mock('main/tray/tray', () => ({}));
 jest.mock('main/windows/windowManager', () => ({
     getMainWindow: jest.fn(),
+    getViewNameByWebContentsId: jest.fn(),
+    viewManager: {
+        views: new Map(),
+    },
 }));
 
 describe('main/app/app', () => {
@@ -53,6 +57,7 @@ describe('main/app/app', () => {
         });
 
         afterEach(() => {
+            WindowManager.viewManager.views.clear();
             jest.resetAllMocks();
         });
 
@@ -137,6 +142,16 @@ describe('main/app/app', () => {
             expect(certificateErrorCallbacks.has('http://server-1.com:error-1')).toBe(false);
             expect(CertificateStore.add).toHaveBeenCalledWith('http://server-1.com', certificate);
             expect(CertificateStore.save).toHaveBeenCalled();
+        });
+
+        it('should load URL using MattermostView when trusting certificate', async () => {
+            dialog.showMessageBox.mockResolvedValue({response: 0});
+            const load = jest.fn();
+            WindowManager.viewManager.views.set('view-name', {load});
+            WindowManager.getViewNameByWebContentsId.mockReturnValue('view-name');
+            await handleAppCertificateError(event, webContents, testURL, 'error-1', certificate, callback);
+            expect(callback).toHaveBeenCalledWith(true);
+            expect(load).toHaveBeenCalledWith(testURL);
         });
 
         it('should explicitly untrust if user selects More Details and then cancel with the checkbox checked', async () => {

--- a/src/main/app/app.ts
+++ b/src/main/app/app.ts
@@ -136,7 +136,14 @@ export async function handleAppCertificateError(event: Event, webContents: WebCo
                 CertificateStore.add(origin, certificate);
                 CertificateStore.save();
                 certificateErrorCallbacks.get(errorID)(true);
-                webContents.loadURL(url);
+
+                const viewName = WindowManager.getViewNameByWebContentsId(webContents.id);
+                if (viewName) {
+                    const view = WindowManager.viewManager?.views.get(viewName);
+                    view?.load(url);
+                } else {
+                    webContents.loadURL(url);
+                }
             } else {
                 if (result.checkboxChecked) {
                     CertificateStore.add(origin, certificate, true);

--- a/src/main/views/MattermostView.test.js
+++ b/src/main/views/MattermostView.test.js
@@ -97,6 +97,17 @@ describe('main/views/MattermostView', () => {
             expect(mattermostView.view.webContents.loadURL).toBeCalledWith('http://server-1.com/', expect.any(Object));
             expect(mattermostView.loadRetry).toBeCalledWith('http://server-1.com/', error);
         });
+
+        it('should not retry when failing to load due to cert error', async () => {
+            const error = new Error('test');
+            error.code = 'ERR_CERT_ERROR';
+            const promise = Promise.reject(error);
+            mattermostView.view.webContents.loadURL.mockImplementation(() => promise);
+            mattermostView.load('a-bad<url');
+            await expect(promise).rejects.toThrow(error);
+            expect(mattermostView.view.webContents.loadURL).toBeCalledWith('http://server-1.com/', expect.any(Object));
+            expect(mattermostView.loadRetry).not.toBeCalled();
+        });
     });
 
     describe('retry', () => {

--- a/src/main/views/MattermostView.ts
+++ b/src/main/views/MattermostView.ts
@@ -174,6 +174,13 @@ export class MattermostView extends EventEmitter {
         log.info(`[${Util.shorten(this.tab.name)}] Loading ${loadURL}`);
         const loading = this.view.webContents.loadURL(loadURL, {userAgent: composeUserAgent()});
         loading.then(this.loadSuccess(loadURL)).catch((err) => {
+            if (err.code && err.code.startsWith('ERR_CERT')) {
+                WindowManager.sendToRenderer(LOAD_FAILED, this.tab.name, err.toString(), loadURL.toString());
+                this.emit(LOAD_FAILED, this.tab.name, err.toString(), loadURL.toString());
+                log.info(`[${Util.shorten(this.tab.name)}] Invalid certificate, stop retrying until the user decides what to do: ${err}.`);
+                this.status = Status.ERROR;
+                return;
+            }
             this.loadRetry(loadURL, err);
         });
     }


### PR DESCRIPTION
#### Summary
If a user tries to connect to a server with an invalid certificate, then attempts to cancel the connection and fix the URL, the dialog prompt to reconnect will happen infinitely as the app retries to connect to the server after failing. This is a very annoying UX.

This PR stops the retry logic from happening if the error emitted from `loadURL` is a certificate error and instead will just show the error page and will not reload until the user explicitly changes something.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45031
Closes https://github.com/mattermost/desktop/issues/2142

```release-note
Fixed an issue where the certificate error dialog box would respawn infinitely
```
