### PR TITLE
[MM-44666] Set default window size to 1280x800

### DIFF
--- a/src/common/utils/constants.ts
+++ b/src/common/utils/constants.ts
@@ -18,8 +18,8 @@ export const THREE_DOT_MENU_WIDTH = 40;
 export const THREE_DOT_MENU_WIDTH_MAC = 80;
 export const MENU_SHADOW_WIDTH = 24;
 
-export const DEFAULT_WINDOW_WIDTH = 1000;
-export const DEFAULT_WINDOW_HEIGHT = 700;
+export const DEFAULT_WINDOW_WIDTH = 1280;
+export const DEFAULT_WINDOW_HEIGHT = 800;
 export const MINIMUM_WINDOW_WIDTH = 700;
 export const MINIMUM_WINDOW_HEIGHT = 240;
 


### PR DESCRIPTION
#### Summary
To better fit the new login screen, I've updated the default Desktop App window size to 1280x800, so that you can see other login options as well on first load.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44666

```release-note
Updated default window size to 1280x800
```
