### PR TITLE
[MM-44071] Fixed an issue where the first client certificate could not be selected

### DIFF
--- a/src/renderer/modals/certificate/certificateModal.tsx
+++ b/src/renderer/modals/certificate/certificateModal.tsx
@@ -95,7 +95,7 @@ export default class SelectCertificateModal extends React.PureComponent<Props, S
     }
 
     getSelectedCert = () => {
-        if (this.state.list && this.state.selectedIndex) {
+        if (this.state.list && this.state.selectedIndex !== undefined) {
             return this.state.list[this.state.selectedIndex];
         }
         return undefined;


### PR DESCRIPTION
#### Summary
Due to an issue caused during the TS migration, the first certificate in the client certificate list was unable to be selected.

This PR fixes that issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44071

```release-note
Fixed an issue where the first client certificate could not be selected
```
