### PR TITLE
[MM-44931] Allow zoom in/out when Shift is pressed

### DIFF
--- a/e2e/specs/menu_bar/view_menu.test.js
+++ b/e2e/specs/menu_bar/view_menu.test.js
@@ -122,81 +122,85 @@ describe('menu/view', function desc() {
         zoomLevel.should.be.equal(1);
     });
 
-    it('MM-T818 Zoom in from the menu bar', async () => {
-        const mainWindow = this.app.windows().find((window) => window.url().includes('index'));
-        const browserWindow = await this.app.browserWindow(mainWindow);
-        const loadingScreen = this.app.windows().find((window) => window.url().includes('loadingScreen'));
-        await loadingScreen.waitForSelector('.LoadingScreen', {state: 'hidden'});
-        const firstServer = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].win;
-        const firstServerId = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].webContentsId;
-        await env.loginToMattermost(firstServer);
-        await firstServer.waitForSelector('#searchBox');
+    describe('MM-T818 Zoom in from the menu bar', () => {
+        it('MM-T818 Zoom in when CmdOrCtrl+Plus is pressed', async () => {
+            const mainWindow = this.app.windows().find((window) => window.url().includes('index'));
+            const browserWindow = await this.app.browserWindow(mainWindow);
+            const loadingScreen = this.app.windows().find((window) => window.url().includes('loadingScreen'));
+            await loadingScreen.waitForSelector('.LoadingScreen', {state: 'hidden'});
+            const firstServer = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].win;
+            const firstServerId = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].webContentsId;
+            await env.loginToMattermost(firstServer);
+            await firstServer.waitForSelector('#searchBox');
+    
+            robot.keyTap('=', [env.cmdOrCtrl]);
+            await asyncSleep(1000);
+            const zoomLevel = await browserWindow.evaluate((window, id) => window.getBrowserViews().find((view) => view.webContents.id === id).webContents.getZoomFactor(), firstServerId);
+            zoomLevel.should.be.greaterThan(1);
+        });
 
-        robot.keyTap('=', [env.cmdOrCtrl]);
-        await asyncSleep(1000);
-        const zoomLevel = await browserWindow.evaluate((window, id) => window.getBrowserViews().find((view) => view.webContents.id === id).webContents.getZoomFactor(), firstServerId);
-        zoomLevel.should.be.greaterThan(1);
-    });
+        it('MM-44931 Zoom in when CmdOrCtrl+Shift+Plus is pressed', async () => {
+            const mainWindow = this.app.windows().find((window) => window.url().includes('index'));
+            const browserWindow = await this.app.browserWindow(mainWindow);
+            const loadingScreen = this.app.windows().find((window) => window.url().includes('loadingScreen'));
+            await loadingScreen.waitForSelector('.LoadingScreen', {state: 'hidden'});
+            const firstServer = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].win;
+            const firstServerId = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].webContentsId;
+            await env.loginToMattermost(firstServer);
+            await firstServer.waitForSelector('#searchBox');
 
-    it('MM-44931 Zoom in when CmdOrCtrl+Shift+Plus is pressed', async () => {
-        const mainWindow = this.app.windows().find((window) => window.url().includes('index'));
-        const browserWindow = await this.app.browserWindow(mainWindow);
-        const loadingScreen = this.app.windows().find((window) => window.url().includes('loadingScreen'));
-        await loadingScreen.waitForSelector('.LoadingScreen', {state: 'hidden'});
-        const firstServer = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].win;
-        const firstServerId = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].webContentsId;
-        await env.loginToMattermost(firstServer);
-        await firstServer.waitForSelector('#searchBox');
+            // reset zoom
+            await setZoomFactorOfServer(browserWindow, firstServerId, 1);
+            await asyncSleep(1000);
+            const initialZoom = await getZoomFactorOfServer(browserWindow, firstServerId);
+            initialZoom.should.be.equal(1);
 
-        // reset zoom
-        await setZoomFactorOfServer(browserWindow, firstServerId, 1);
-        await asyncSleep(1000);
-        const initialZoom = await getZoomFactorOfServer(browserWindow, firstServerId);
-        initialZoom.should.be.equal(1);
+            robot.keyTap('=', [env.cmdOrCtrl, 'shift']);
+            await asyncSleep(1000);
+            const zoomLevel = await getZoomFactorOfServer(browserWindow, firstServerId);
+            zoomLevel.should.be.greaterThan(1);
+        });
+    })
 
-        robot.keyTap('=', [env.cmdOrCtrl, 'shift']);
-        await asyncSleep(1000);
-        const zoomLevel = await getZoomFactorOfServer(browserWindow, firstServerId);
-        zoomLevel.should.be.greaterThan(1);
-    });
+    describe('MM-T818 Zoom out from the menu bar', () => {
+        it('MM-T819 Zoom out when CmdOrCtrl+Minus is pressed', async () => {
+            const mainWindow = this.app.windows().find((window) => window.url().includes('index'));
+            const browserWindow = await this.app.browserWindow(mainWindow);
+            const loadingScreen = this.app.windows().find((window) => window.url().includes('loadingScreen'));
+            await loadingScreen.waitForSelector('.LoadingScreen', {state: 'hidden'});
+            const firstServer = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].win;
+            const firstServerId = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].webContentsId;
+            await env.loginToMattermost(firstServer);
+            await firstServer.waitForSelector('#searchBox');
 
-    it('MM-T819 Zoom out from the menu bar', async () => {
-        const mainWindow = this.app.windows().find((window) => window.url().includes('index'));
-        const browserWindow = await this.app.browserWindow(mainWindow);
-        const loadingScreen = this.app.windows().find((window) => window.url().includes('loadingScreen'));
-        await loadingScreen.waitForSelector('.LoadingScreen', {state: 'hidden'});
-        const firstServer = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].win;
-        const firstServerId = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].webContentsId;
-        await env.loginToMattermost(firstServer);
-        await firstServer.waitForSelector('#searchBox');
+            robot.keyTap('-', [env.cmdOrCtrl]);
+            await asyncSleep(1000);
+            const zoomLevel = await browserWindow.evaluate((window, id) => window.getBrowserViews().find((view) => view.webContents.id === id).webContents.getZoomFactor(), firstServerId);
+            zoomLevel.should.be.lessThan(1);
+        });
 
-        robot.keyTap('-', [env.cmdOrCtrl]);
-        await asyncSleep(1000);
-        const zoomLevel = await browserWindow.evaluate((window, id) => window.getBrowserViews().find((view) => view.webContents.id === id).webContents.getZoomFactor(), firstServerId);
-        zoomLevel.should.be.lessThan(1);
-    });
+        it('MM-44931 Zoom out when CmdOrCtrl+Shift+Minus is pressed', async () => {
+            const mainWindow = this.app.windows().find((window) => window.url().includes('index'));
+            const browserWindow = await this.app.browserWindow(mainWindow);
+            const loadingScreen = this.app.windows().find((window) => window.url().includes('loadingScreen'));
+            await loadingScreen.waitForSelector('.LoadingScreen', {state: 'hidden'});
+            const firstServer = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].win;
+            const firstServerId = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].webContentsId;
+            await env.loginToMattermost(firstServer);
+            await firstServer.waitForSelector('#searchBox');
 
-    it('MM-44931 Zoom out when CmdOrCtrl+Shift+Minus is pressed', async () => {
-        const mainWindow = this.app.windows().find((window) => window.url().includes('index'));
-        const browserWindow = await this.app.browserWindow(mainWindow);
-        const loadingScreen = this.app.windows().find((window) => window.url().includes('loadingScreen'));
-        await loadingScreen.waitForSelector('.LoadingScreen', {state: 'hidden'});
-        const firstServer = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].win;
-        const firstServerId = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].webContentsId;
-        await env.loginToMattermost(firstServer);
-        await firstServer.waitForSelector('#searchBox');
+            // reset zoom
+            await setZoomFactorOfServer(browserWindow, firstServerId, 1.0);
+            await asyncSleep(1000);
+            const initialZoom = await getZoomFactorOfServer(browserWindow, firstServerId);
+            initialZoom.should.be.equal(1);
 
-        // reset zoom
-        await setZoomFactorOfServer(browserWindow, firstServerId, 1.0);
-        await asyncSleep(1000);
-        const initialZoom = await getZoomFactorOfServer(browserWindow, firstServerId);
-        initialZoom.should.be.equal(1);
-
-        robot.keyTap('-', [env.cmdOrCtrl, 'shift']);
-        await asyncSleep(1000);
-        const zoomLevel = await getZoomFactorOfServer(browserWindow, firstServerId);
-        zoomLevel.should.be.lessThan(1);
-    });
+            robot.keyTap('-', [env.cmdOrCtrl, 'shift']);
+            await asyncSleep(1000);
+            const zoomLevel = await getZoomFactorOfServer(browserWindow, firstServerId);
+            zoomLevel.should.be.lessThan(1);
+        });
+    })
 
     describe('Reload', () => {
         let browserWindow;

--- a/e2e/specs/menu_bar/view_menu.test.js
+++ b/e2e/specs/menu_bar/view_menu.test.js
@@ -132,7 +132,7 @@ describe('menu/view', function desc() {
             const firstServerId = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].webContentsId;
             await env.loginToMattermost(firstServer);
             await firstServer.waitForSelector('#searchBox');
-    
+
             robot.keyTap('=', [env.cmdOrCtrl]);
             await asyncSleep(1000);
             const zoomLevel = await browserWindow.evaluate((window, id) => window.getBrowserViews().find((view) => view.webContents.id === id).webContents.getZoomFactor(), firstServerId);
@@ -160,7 +160,7 @@ describe('menu/view', function desc() {
             const zoomLevel = await getZoomFactorOfServer(browserWindow, firstServerId);
             zoomLevel.should.be.greaterThan(1);
         });
-    })
+    });
 
     describe('MM-T818 Zoom out from the menu bar', () => {
         it('MM-T819 Zoom out when CmdOrCtrl+Minus is pressed', async () => {
@@ -200,7 +200,7 @@ describe('menu/view', function desc() {
             const zoomLevel = await getZoomFactorOfServer(browserWindow, firstServerId);
             zoomLevel.should.be.lessThan(1);
         });
-    })
+    });
 
     describe('Reload', () => {
         let browserWindow;

--- a/e2e/specs/menu_bar/view_menu.test.js
+++ b/e2e/specs/menu_bar/view_menu.test.js
@@ -139,7 +139,7 @@ describe('menu/view', function desc() {
             zoomLevel.should.be.greaterThan(1);
         });
 
-        it('MM-44931 Zoom in when CmdOrCtrl+Shift+Plus is pressed', async () => {
+        it('MM-T818_1 Zoom in when CmdOrCtrl+Shift+Plus is pressed', async () => {
             const mainWindow = this.app.windows().find((window) => window.url().includes('index'));
             const browserWindow = await this.app.browserWindow(mainWindow);
             const loadingScreen = this.app.windows().find((window) => window.url().includes('loadingScreen'));

--- a/e2e/specs/menu_bar/view_menu.test.js
+++ b/e2e/specs/menu_bar/view_menu.test.js
@@ -28,8 +28,8 @@ function getZoomFactorOfServer(browserWindow, serverId) {
 }
 function setZoomFactorOfServer(browserWindow, serverId, zoomFactor) {
     return browserWindow.evaluate(
-        (window, {serverId, zoomFactor}) => window.getBrowserViews().find((view) => view.webContents.id === serverId).webContents.setZoomFactor(zoomFactor),
-        {serverId, zoomFactor},
+        (window, {id, zoom}) => window.getBrowserViews().find((view) => view.webContents.id === id).webContents.setZoomFactor(zoom),
+        {id: serverId, zoom: zoomFactor},
     );
 }
 
@@ -189,12 +189,12 @@ describe('menu/view', function desc() {
         // reset zoom
         await setZoomFactorOfServer(browserWindow, firstServerId, 1.0);
         await asyncSleep(1000);
-        const initialZoom = await getZoomFactorOfServer(browserWindow, firstServerId)
+        const initialZoom = await getZoomFactorOfServer(browserWindow, firstServerId);
         initialZoom.should.be.equal(1);
 
         robot.keyTap('-', [env.cmdOrCtrl, 'shift']);
         await asyncSleep(1000);
-        const zoomLevel = await getZoomFactorOfServer(browserWindow, firstServerId)
+        const zoomLevel = await getZoomFactorOfServer(browserWindow, firstServerId);
         zoomLevel.should.be.lessThan(1);
     });
 

--- a/e2e/specs/menu_bar/view_menu.test.js
+++ b/e2e/specs/menu_bar/view_menu.test.js
@@ -156,7 +156,7 @@ describe('menu/view', function desc() {
 
         robot.keyTap('=', [env.cmdOrCtrl, 'shift']);
         await asyncSleep(1000);
-        const zoomLevel = getZoomFactorOfServer(browserWindow, firstServerId);
+        const zoomLevel = await getZoomFactorOfServer(browserWindow, firstServerId);
         zoomLevel.should.be.greaterThan(1);
     });
 

--- a/e2e/specs/menu_bar/view_menu.test.js
+++ b/e2e/specs/menu_bar/view_menu.test.js
@@ -179,7 +179,7 @@ describe('menu/view', function desc() {
             zoomLevel.should.be.lessThan(1);
         });
 
-        it('MM-44931 Zoom out when CmdOrCtrl+Shift+Minus is pressed', async () => {
+        it('MM-T819_1 Zoom out when CmdOrCtrl+Shift+Minus is pressed', async () => {
             const mainWindow = this.app.windows().find((window) => window.url().includes('index'));
             const browserWindow = await this.app.browserWindow(mainWindow);
             const loadingScreen = this.app.windows().find((window) => window.url().includes('loadingScreen'));

--- a/e2e/specs/menu_bar/view_menu.test.js
+++ b/e2e/specs/menu_bar/view_menu.test.js
@@ -20,6 +20,13 @@ async function setupPromise(window, id) {
     return true;
 }
 
+function getZoomFactorOfServer(browserWindow, serverId) {
+    return browserWindow.evaluate((window, id) => window.getBrowserViews().find((view) => view.webContents.id === id).webContents.getZoomFactor(), serverId);
+}
+function setZoomFactorOfServer(browserWindow, serverId, zoomFactor) {
+    return browserWindow.evaluate((window, id) => window.getBrowserViews().find((view) => view.webContents.id === id).webContents.setZoomFactor(zoomFactor), serverId);
+}
+
 describe('menu/view', function desc() {
     this.timeout(30000);
 
@@ -126,6 +133,27 @@ describe('menu/view', function desc() {
         zoomLevel.should.be.greaterThan(1);
     });
 
+    it('MM-44931 Zoom in when CmdOrCtrl+Shift+Plus is pressed', async () => {
+        const mainWindow = this.app.windows().find((window) => window.url().includes('index'));
+        const browserWindow = await this.app.browserWindow(mainWindow);
+        const loadingScreen = this.app.windows().find((window) => window.url().includes('loadingScreen'));
+        await loadingScreen.waitForSelector('.LoadingScreen', {state: 'hidden'});
+        const firstServer = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].win;
+        const firstServerId = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].webContentsId;
+        await env.loginToMattermost(firstServer);
+        await firstServer.waitForSelector('#searchBox');
+
+        // reset zoom
+        await setZoomFactorOfServer(browserWindow, firstServerId, 1);
+        await asyncSleep(1000);
+        zoomLevel.should.be.equal(1);
+
+        robot.keyTap('=', [env.cmdOrCtrl, 'shift']);
+        await asyncSleep(1000);
+        const zoomLevel = getZoomFactorOfServer(browserWindow, firstServerId);
+        zoomLevel.should.be.greaterThan(1);
+    });
+
     it('MM-T819 Zoom out from the menu bar', async () => {
         const mainWindow = this.app.windows().find((window) => window.url().includes('index'));
         const browserWindow = await this.app.browserWindow(mainWindow);
@@ -139,6 +167,27 @@ describe('menu/view', function desc() {
         robot.keyTap('-', [env.cmdOrCtrl]);
         await asyncSleep(1000);
         const zoomLevel = await browserWindow.evaluate((window, id) => window.getBrowserViews().find((view) => view.webContents.id === id).webContents.getZoomFactor(), firstServerId);
+        zoomLevel.should.be.lessThan(1);
+    });
+
+    it('MM-T819 Zoom out from the menu bar', async () => {
+        const mainWindow = this.app.windows().find((window) => window.url().includes('index'));
+        const browserWindow = await this.app.browserWindow(mainWindow);
+        const loadingScreen = this.app.windows().find((window) => window.url().includes('loadingScreen'));
+        await loadingScreen.waitForSelector('.LoadingScreen', {state: 'hidden'});
+        const firstServer = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].win;
+        const firstServerId = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].webContentsId;
+        await env.loginToMattermost(firstServer);
+        await firstServer.waitForSelector('#searchBox');
+
+        // reset zoom
+        await setZoomFactorOfServer(browserWindow, firstServerId, 1.0);
+        await asyncSleep(1000);
+        zoomLevel.should.be.equal(1);
+
+        robot.keyTap('-', [env.cmdOrCtrl, 'shift']);
+        await asyncSleep(1000);
+        const zoomLevel = await getZoomFactorOfServer(browserWindow, firstServerId)
         zoomLevel.should.be.lessThan(1);
     });
 

--- a/src/main/menus/app.ts
+++ b/src/main/menus/app.ts
@@ -132,8 +132,16 @@ export function createTemplate(config: Config, updateManager: UpdateManager) {
         role: 'zoomIn',
         accelerator: 'CmdOrCtrl+=',
     }, {
+        role: 'zoomIn',
+        visible: false,
+        accelerator: 'CmdOrCtrl+Shift+=',
+    }, {
         role: 'zoomOut',
         accelerator: 'CmdOrCtrl+-',
+    }, {
+        role: 'zoomOut',
+        visible: false,
+        accelerator: 'CmdOrCtrl+Shift+-',
     }, separatorItem, {
         label: 'Developer Tools for Application Wrapper',
         accelerator: (() => {


### PR DESCRIPTION
#### Summary
Add hidden MenuItems that add keyboard shortcuts for Zoom In/Out when Shift is pressed.
I tried using the default role for `zoomIn` and `zoomOut` that electron provides, but it didn't work on Windows, so I followed this approach.

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-44931

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated e2e tests
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [x] executed `npm run lint:js` for proper code formatting

#### Device Information
This PR was tested on:
- macbook pro, Macos Monterey 12.4 
- pc, Windows 11
- pc, Ubuntu 22

#### Release Note
```release-note
Fix zoom in/out not working when Shift is pressed.
```
