### PR TITLE
Fixed an issue with a permission modal translation

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -228,7 +228,7 @@
   "renderer.modals.login.loginModal.title": "Authentication Required",
   "renderer.modals.login.loginModal.username": "User Name",
   "renderer.modals.permission.permissionModal.body": "A site that's not included in your Mattermost server configuration requires access for {permission}.",
-  "renderer.modals.permission.permissionModal.requestOriginatedFrom": "This request originated from ",
+  "renderer.modals.permission.permissionModal.requestOriginatedFromOrigin": "This request originated from <link>{origin}</link>",
   "renderer.modals.permission.permissionModal.title": "{permission} Required",
   "renderer.modals.permission.permissionModal.unknownOrigin": "unknown origin"
 }

--- a/src/renderer/modals/permission/permissionModal.tsx
+++ b/src/renderer/modals/permission/permissionModal.tsx
@@ -91,10 +91,21 @@ class PermissionModal extends React.PureComponent<Props, State> {
                 </p>
                 <p>
                     <FormattedMessage
-                        id='renderer.modals.permission.permissionModal.requestOriginatedFrom'
-                        defaultMessage='This request originated from '
+                        id='renderer.modals.permission.permissionModal.requestOriginatedFromOrigin'
+                        defaultMessage='This request originated from <link>{origin}</link>'
+                        values={{
+                            origin: originDisplay,
+                            link: (msg: React.ReactNode) => (
+                                <a
+
+                                    onClick={click}
+                                    href='#'
+                                >
+                                    {msg}
+                                </a>
+                            ),
+                        }}
                     />
-                    <a onClick={click}>{originDisplay}</a>
                 </p>
             </div>
         );


### PR DESCRIPTION
#### Summary
One of the `permissionModal` translations had a concatenation issue making translating it difficult. I've resolved it by using the same rich text pattern I used for the other ones.

```release-note
NONE
```
