### PR TITLE
[MM-45646] Change download notification text to display saved filename instead of original

### DIFF
--- a/src/main/app/initialize.test.js
+++ b/src/main/app/initialize.test.js
@@ -8,6 +8,7 @@ import {app, session} from 'electron';
 import Config from 'common/config';
 import urlUtils from 'common/utils/url';
 
+import {displayDownloadCompleted} from 'main/notifications';
 import parseArgs from 'main/ParseArgs';
 import WindowManager from 'main/windows/windowManager';
 
@@ -142,6 +143,7 @@ jest.mock('main/windows/windowManager', () => ({
     getMainWindow: jest.fn(),
     showMainWindow: jest.fn(),
     sendToMattermostViews: jest.fn(),
+    getServerNameByWebContentsId: jest.fn(),
 }));
 
 describe('main/app/initialize', () => {
@@ -245,6 +247,31 @@ describe('main/app/initialize', () => {
                 title: 'filename.txt',
                 defaultPath: '/some/dir/filename.txt',
             }));
+        });
+
+        it('should use name of saved file instead of original file name', async () => {
+            const item = {
+                getFilename: () => 'filename.txt',
+                on: jest.fn(),
+                setSaveDialogOptions: jest.fn(),
+                savePath: '/some/dir/new_filename.txt',
+            };
+            Config.downloadLocation = '/some/dir';
+            path.resolve.mockImplementation((base, p) => `${base}/${p}`);
+            session.defaultSession.on.mockImplementation((event, cb) => {
+                if (event === 'will-download') {
+                    cb(null, item, {id: 0, getURL: jest.fn()});
+                }
+            });
+
+            item.on.mockImplementation((event, cb) => {
+                if (event === 'done') {
+                    cb(null, 'completed');
+                }
+            });
+
+            await initialize();
+            expect(displayDownloadCompleted).toHaveBeenCalledWith('new_filename.txt', '/some/dir/new_filename.txt', expect.anything());
         });
 
         it('should allow permission requests for supported types from trusted URLs', async () => {

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -372,7 +372,7 @@ function initializeAfterAppReady() {
 
         item.on('done', (doneEvent, state) => {
             if (state === 'completed') {
-                displayDownloadCompleted(filename, item.savePath, WindowManager.getServerNameByWebContentsId(webContents.id) || '');
+                displayDownloadCompleted(path.basename(item.savePath), item.savePath, WindowManager.getServerNameByWebContentsId(webContents.id) || '');
             }
         });
     });


### PR DESCRIPTION
#### Summary
When downloading a file, the user is allowed to save the file as any name they want. However, when the notification displays that the file is done, it would always show the original name, which can be confusing.

This PR makes a change to always show the saved file name instead.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45646

```release-note
Fixed an issue where the download notification would show the wrong file name
```
