### PR TITLE
[MM-45740] Allow users to authenticate using a server that isn't their current server

### DIFF
--- a/src/main/authManager.ts
+++ b/src/main/authManager.ts
@@ -14,6 +14,7 @@ import modalManager from 'main/views/modalManager';
 import TrustedOriginsStore from 'main/trustedOrigins';
 import {getLocalURLString, getLocalPreload} from 'main/utils';
 import WindowManager from 'main/windows/windowManager';
+import WebContentsEventManager from 'main/views/webContentEvents';
 
 const modalPreload = getLocalPreload('modalPreload.js');
 const loginModalHtml = getLocalURLString('loginModal.html');
@@ -40,12 +41,12 @@ export class AuthManager {
             return;
         }
         const server = urlUtils.getView(parsedURL, Config.teams);
-        if (!server) {
+        if (!server && !WebContentsEventManager.isInCustomLogin(webContents.id)) {
             return;
         }
 
         this.loginCallbackMap.set(request.url, callback); // if callback is undefined set it to null instead so we know we have set it up with no value
-        if (urlUtils.isTrustedURL(request.url, Config.teams) || urlUtils.isCustomLoginURL(parsedURL, server, Config.teams) || TrustedOriginsStore.checkPermission(request.url, BASIC_AUTH_PERMISSION)) {
+        if (urlUtils.isTrustedURL(request.url, Config.teams) || (server && urlUtils.isCustomLoginURL(parsedURL, server, Config.teams)) || TrustedOriginsStore.checkPermission(request.url, BASIC_AUTH_PERMISSION)) {
             this.popLoginModal(request, authInfo);
         } else {
             this.popPermissionModal(request, authInfo, BASIC_AUTH_PERMISSION);

--- a/src/main/views/webContentEvents.ts
+++ b/src/main/views/webContentEvents.ts
@@ -35,6 +35,10 @@ export class WebContentsEventManager {
         this.listeners = {};
     }
 
+    isInCustomLogin = (contentID: number) => {
+        return Boolean(this.customLogins[contentID]);
+    }
+
     isTrustedPopupWindow = (webContents: WebContents) => {
         if (!webContents) {
             return false;
@@ -93,8 +97,10 @@ export class WebContentsEventManager {
             const serverURL = urlUtils.parseURL(server?.url || '');
 
             if (server && urlUtils.isCustomLoginURL(parsedURL, server, serverList)) {
+                log.debug('start custom login for', serverURL);
                 this.customLogins[contentID].inProgress = true;
             } else if (server && this.customLogins[contentID].inProgress && urlUtils.isInternalURL(serverURL || new URL(''), parsedURL)) {
+                log.debug('stop custom login for', serverURL);
                 this.customLogins[contentID].inProgress = false;
             }
         };


### PR DESCRIPTION
#### Summary
NOTE: Depends on this first: https://github.com/mattermost/desktop/pull/2209

When a user tries to use basic authentication where the login request hits a different server (ie. same as custom login flow), it will be rejected since the server URLs don't match.

This PR fixes the auth manager so that it will first check if the server has entered a custom login flow and will allow the user to confirm the login via a permission modal that will show the login URL.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45740

```release-note
Fixed an issue where users using basic authentication against a different URL than their server URL would be silently rejected.
```
