### PR TITLE
[MM-45980] Add entitlements for read/write to a few key user directories

### DIFF
--- a/entitlements.mas.plist
+++ b/entitlements.mas.plist
@@ -18,9 +18,15 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
-	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.files.downloads.read-write</key>
+	<true/>
+	<key>com.apple.security.assets.pictures.read-write</key>
+	<true/>
+	<key>com.apple.security.assets.music.read-write</key>
+	<true/>
+	<key>com.apple.security.assets.movies.read-write</key>
 	<true/>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>


### PR DESCRIPTION
#### Summary
There's an issue with Electron currently blocking users from replacing files if there are using the MAS build. This PR mitigates the issue by explicitly adding the entitlements for available folders (Downloads, Pictures, Movies, Music) that will allow file replacement.

#### Ticket Link
Partial resolution:
https://mattermost.atlassian.net/browse/MM-45980
https://github.com/mattermost/desktop/issues/2199

```release-note
Fixed an issue where the user could not replace files in the Downloads folder
```
