### PR TITLE
[MM-46101] Move allowed protocols to build config

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -28,12 +28,7 @@
     {
       "name": "Mattermost",
       "schemes": [
-        "mattermost",
-        "http",
-        "https",
-        "ftp",
-        "mailto",
-        "tel"
+        "mattermost"
       ]
     }
   ],

--- a/src/common/config/buildConfig.ts
+++ b/src/common/config/buildConfig.ts
@@ -18,6 +18,7 @@ import {BuildConfig} from 'types/config';
  *                                          Specify at least one server for "defaultTeams"
  *                                          when "enableServerManagement is set to false
  * @prop {[]} managedResources - Defines which paths are managed
+ * @prop {[]} allowedProtocols - Defines which protocols should be automatically allowed
  */
 const buildConfig: BuildConfig = {
     defaultTeams: [/*
@@ -30,6 +31,12 @@ const buildConfig: BuildConfig = {
     enableServerManagement: true,
     enableAutoUpdater: true,
     managedResources: ['trusted'],
+    allowedProtocols: [
+        'mattermost',
+        'ftp',
+        'mailto',
+        'tel',
+    ],
 };
 
 export default buildConfig;

--- a/src/main/allowProtocolDialog.test.js
+++ b/src/main/allowProtocolDialog.test.js
@@ -31,14 +31,11 @@ jest.mock('electron', () => ({
     },
 }));
 
-jest.mock('../../electron-builder.json', () => ({
-    protocols: [{
-        name: 'Mattermost',
-        schemes: [
-            'pone',
-            'ptwo',
-        ],
-    }],
+jest.mock('common/config/buildConfig', () => ({
+    allowedProtocols: [
+        'pone',
+        'ptwo',
+    ],
 }));
 
 jest.mock('./Validator', () => ({

--- a/src/main/allowProtocolDialog.ts
+++ b/src/main/allowProtocolDialog.ts
@@ -10,7 +10,7 @@ import log from 'electron-log';
 
 import {localizeMessage} from 'main/i18nManager';
 
-import {protocols} from '../../electron-builder.json';
+import buildConfig from 'common/config/buildConfig';
 
 import * as Validator from './Validator';
 import WindowManager from './windows/windowManager';
@@ -31,11 +31,7 @@ export class AllowProtocolDialog {
             }
             this.addScheme('http');
             this.addScheme('https');
-            protocols.forEach((protocol) => {
-                if (protocol.schemes && protocol.schemes.length > 0) {
-                    protocol.schemes.forEach(this.addScheme);
-                }
-            });
+            buildConfig.allowedProtocols.forEach(this.addScheme);
         });
     }
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -105,6 +105,7 @@ export type BuildConfig = {
     enableServerManagement: boolean;
     enableAutoUpdater: boolean;
     managedResources: string[];
+    allowedProtocols: string[];
 }
 
 export type RegistryConfig = {


### PR DESCRIPTION
#### Summary
The use of the `electron-builder` to store our default allowed protocols was causing the install to think that we should be registering Mattermost as a potential default for opening these protocols.

This PR moves the defaults to the build config, so that the only one registered for our app is `mattermost`, and the others will be stored elsewhere.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46101

```release-note
Fixed an issue where an OS might register Mattermost as the default Web Browser/Mail app
```