### PR TITLE
Fix MAS build

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -118,7 +118,8 @@
     "provisioningProfile": "./mas.provisionprofile",
     "extendInfo": {
       "ITSAppUsesNonExemptEncryption": false
-    }
+    },
+    "singleArchFiles": "*"
   },
   "masDev": {
     "provisioningProfile": "./mas-dev.provisionprofile"


### PR DESCRIPTION
#### Summary
MAS build was failing due to the addition of native modules that were conflicting.