### PR TITLE
Fix for some flaky E2E tests

### DIFF
--- a/e2e/modules/environment.js
+++ b/e2e/modules/environment.js
@@ -217,6 +217,13 @@ module.exports = {
         await window.waitForSelector('#input_loginId');
         await window.waitForSelector('#input_password-input');
         await window.waitForSelector('#saveSetting');
+
+        // Do this twice because sometimes the app likes to load the login screen, then go to Loading... again
+        await asyncSleep(1000);
+        await window.waitForSelector('#input_loginId');
+        await window.waitForSelector('#input_password-input');
+        await window.waitForSelector('#saveSetting');
+
         await window.type('#input_loginId', 'user-1');
         await window.type('#input_password-input', 'SampleUs@r-1');
         await window.click('#saveSetting');


### PR DESCRIPTION
#### Summary
Sometimes, test servers like to switch back to the Loading screen after the login screen has shown. This change asks the tester to expect that so that it doesn't miss the login prompt.

```release-note
NONE
```
