### PR TITLE
Change order of fields in add server modal to match the one in mobile v2

### DIFF
--- a/src/renderer/components/NewTeamModal.tsx
+++ b/src/renderer/components/NewTeamModal.tsx
@@ -34,7 +34,7 @@ type State = {
 
 class NewTeamModal extends React.PureComponent<Props, State> {
     wasShown?: boolean;
-    teamNameInputRef?: HTMLInputElement;
+    teamUrlInputRef?: HTMLInputElement;
 
     static defaultProps = {
         restoreFocus: true,
@@ -262,7 +262,7 @@ class NewTeamModal extends React.PureComponent<Props, State> {
                 show={this.props.show}
                 id='newServerModal'
                 enforceFocus={true}
-                onEntered={() => this.teamNameInputRef?.focus()}
+                onEntered={() => this.teamUrlInputRef?.focus()}
                 onHide={this.props.onClose}
                 restoreFocus={this.props.restoreFocus}
                 onKeyDown={(e: React.KeyboardEvent) => {
@@ -289,41 +289,6 @@ class NewTeamModal extends React.PureComponent<Props, State> {
                         <FormGroup>
                             <FormLabel>
                                 <FormattedMessage
-                                    id='renderer.components.newTeamModal.serverDisplayName'
-                                    defaultMessage='Server Display Name'
-                                />
-                            </FormLabel>
-                            <FormControl
-                                id='teamNameInput'
-                                type='text'
-                                value={this.state.teamName}
-                                placeholder={this.props.intl.formatMessage({id: 'renderer.components.newTeamModal.serverDisplayName', defaultMessage: 'Server Display Name'})}
-                                onChange={this.handleTeamNameChange}
-                                ref={(ref: HTMLInputElement) => {
-                                    this.teamNameInputRef = ref;
-                                    if (this.props.setInputRef) {
-                                        this.props.setInputRef(ref);
-                                    }
-                                }}
-                                onClick={(e: React.MouseEvent<HTMLInputElement>) => {
-                                    e.stopPropagation();
-                                }}
-                                autoFocus={true}
-                                isInvalid={Boolean(this.getTeamNameValidationState())}
-                            />
-                            <FormControl.Feedback/>
-                            <FormText>
-                                <FormattedMessage
-                                    id='renderer.components.newTeamModal.serverDisplayName.description'
-                                    defaultMessage='The name of the server displayed on your desktop app tab bar.'
-                                />
-                            </FormText>
-                        </FormGroup>
-                        <FormGroup
-                            className='NewTeamModal-noBottomSpace'
-                        >
-                            <FormLabel>
-                                <FormattedMessage
                                     id='renderer.components.newTeamModal.serverURL'
                                     defaultMessage='Server URL'
                                 />
@@ -337,13 +302,46 @@ class NewTeamModal extends React.PureComponent<Props, State> {
                                 onClick={(e: React.MouseEvent<HTMLInputElement>) => {
                                     e.stopPropagation();
                                 }}
+                                ref={(ref: HTMLInputElement) => {
+                                    this.teamUrlInputRef = ref;
+                                    if (this.props.setInputRef) {
+                                        this.props.setInputRef(ref);
+                                    }
+                                }}
                                 isInvalid={Boolean(this.getTeamUrlValidationState())}
+                                autoFocus={true}
+                            />
+                            <FormControl.Feedback/>
+                            <FormText>
+                                <FormattedMessage
+                                    id='renderer.components.newTeamModal.serverURL.description'
+                                    defaultMessage='The URL of your Mattermost server. Must start with http:// or https://.'
+                                />
+                            </FormText>
+                        </FormGroup>
+                        <FormGroup className='NewTeamModal-noBottomSpace'>
+                            <FormLabel>
+                                <FormattedMessage
+                                    id='renderer.components.newTeamModal.serverDisplayName'
+                                    defaultMessage='Server Display Name'
+                                />
+                            </FormLabel>
+                            <FormControl
+                                id='teamNameInput'
+                                type='text'
+                                value={this.state.teamName}
+                                placeholder={this.props.intl.formatMessage({id: 'renderer.components.newTeamModal.serverDisplayName', defaultMessage: 'Server Display Name'})}
+                                onChange={this.handleTeamNameChange}
+                                onClick={(e: React.MouseEvent<HTMLInputElement>) => {
+                                    e.stopPropagation();
+                                }}
+                                isInvalid={Boolean(this.getTeamNameValidationState())}
                             />
                             <FormControl.Feedback/>
                             <FormText className='NewTeamModal-noBottomSpace'>
                                 <FormattedMessage
-                                    id='renderer.components.newTeamModal.serverURL.description'
-                                    defaultMessage='The URL of your Mattermost server. Must start with http:// or https://.'
+                                    id='renderer.components.newTeamModal.serverDisplayName.description'
+                                    defaultMessage='The name of the server displayed on your desktop app tab bar.'
                                 />
                             </FormText>
                         </FormGroup>


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
In order to be consistent with mobile v2, the add server modal fields order is changed (asking for server URL first and display name after).

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/desktop/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Improvement: https://mattermost.atlassian.net/browse/MM-45058

#### Device Information
This PR was tested on: Laptop running Linux (Ubuntu)<!-- Device name(s), OS version(s) -->

#### Screenshots

The new UI after the change:

![image](https://user-images.githubusercontent.com/812886/185385808-e3d074be-533e-4293-8d79-55fc4ede3398.png)

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
