### PR TITLE
Fix for mac unit tests

### DIFF
--- a/src/main/notifications/index.test.js
+++ b/src/main/notifications/index.test.js
@@ -80,6 +80,7 @@ describe('main/notifications', () => {
         beforeEach(() => {
             Notification.isSupported.mockImplementation(() => true);
             getFocusAssist.mockReturnValue({value: false});
+            getDarwinDoNotDisturb.mockReturnValue(false);
         });
 
         it('should do nothing when Notification is not supported', () => {
@@ -218,6 +219,7 @@ describe('main/notifications', () => {
 
     describe('displayDownloadCompleted', () => {
         it('should open file when clicked', () => {
+            getDarwinDoNotDisturb.mockReturnValue(false);
             localizeMessage.mockReturnValue('test_filename');
             displayDownloadCompleted(
                 'test_filename',


### PR DESCRIPTION
#### Summary
Unit tests were failing on macOS due to missing mocks for notification libraries. Thanks to @saturninoabril for pointing this out :)

```release-note
NONE
```
