### PR TITLE
MM-46445_Add a way to bypass Desktop App onboarding to `buildConfig`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,13 @@ commands:
         type: string
         default: "./linux/"
     steps:
+      - when:
+          condition: << pipeline.parameters.run_nightly >>
+          steps:
+            - run:
+                name: Patch buildConfig file for run nightly
+                command: |
+                  sed -i "" "s/skipOnboardingScreens:[[:blank:]]*false/skipOnboardingScreens: true/" ./src/common/config/buildConfig.ts;
       - run: 
           name: npn run
           command: npm run package:<< parameters.os >>

--- a/src/common/config/buildConfig.ts
+++ b/src/common/config/buildConfig.ts
@@ -37,6 +37,7 @@ const buildConfig: BuildConfig = {
         'mailto',
         'tel',
     ],
+    skipOnboardingScreens: false,
 };
 
 export default buildConfig;

--- a/src/common/config/defaultPreferences.ts
+++ b/src/common/config/defaultPreferences.ts
@@ -43,6 +43,7 @@ const defaultPreferences: ConfigV3 = {
     lastActiveTeam: 0,
     downloadLocation: getDefaultDownloadLocation(),
     startInFullscreen: false,
+    skipOnboardingScreens: false,
 };
 
 export default defaultPreferences;

--- a/src/common/config/index.ts
+++ b/src/common/config/index.ts
@@ -332,6 +332,10 @@ export class Config extends EventEmitter {
         return this.combinedData?.appLanguage;
     }
 
+    get skipOnboardingScreens() {
+        return this.combinedData?.skipOnboardingScreens ?? defaultPreferences.skipOnboardingScreens;
+    }
+
     // initialization/processing methods
 
     /**

--- a/src/main/Validator.test.js
+++ b/src/main/Validator.test.js
@@ -150,6 +150,7 @@ describe('main/Validator', () => {
             ],
             trayIconTheme: 'use_system',
             useSpellChecker: true,
+            skipOnboardingScreens: false,
             version: 3,
         };
 

--- a/src/main/Validator.ts
+++ b/src/main/Validator.ts
@@ -132,6 +132,7 @@ const configDataSchemaV3 = Joi.object<ConfigV3>({
     alwaysClose: Joi.boolean(),
     logLevel: Joi.string().default('info'),
     appLanguage: Joi.string().allow(''),
+    skipOnboardingScreens: Joi.boolean().default(false),
 });
 
 // eg. data['community.mattermost.com'] = { data: 'certificate data', issuerName: 'COMODO RSA Domain Validation Secure Server CA'};

--- a/src/main/app/intercom.ts
+++ b/src/main/app/intercom.ts
@@ -86,7 +86,7 @@ export function handleOpenTab(event: IpcMainEvent, serverName: string, tabName: 
 }
 
 export function handleMainWindowIsShown() {
-    const showWelcomeScreen = !Config.teams.length;
+    const showWelcomeScreen = !Config.skipOnboardingScreens && !Config.teams.length;
     const mainWindow = WindowManager.getMainWindow();
 
     if (mainWindow) {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -46,6 +46,7 @@ export type ConfigV3 = {
     alwaysClose?: boolean;
     logLevel?: string;
     appLanguage?: string;
+    skipOnboardingScreens: boolean;
 }
 
 export type ConfigV2 = {
@@ -106,6 +107,7 @@ export type BuildConfig = {
     enableAutoUpdater: boolean;
     managedResources: string[];
     allowedProtocols: string[];
+    skipOnboardingScreens: boolean;
 }
 
 export type RegistryConfig = {


### PR DESCRIPTION
#### Summary
Implemented a way to bypass the onboarding screens for nightly run builds.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46445

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [x] executed `npm run lint:js` for proper code formatting

#### Device Information
This PR was tested on: macOs Big Sur 11.6.6

#### Release Note
```release-note
NONE
```
