### PR TITLE
Fix node-gyp build on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,8 +191,8 @@ jobs:
       - run:
           name: Install nodejs-lts
           command: choco install nodejs-lts -y
-      # ignoring scripts for windows due to issues with node-gyp
-      - run: $env:PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = 1; npm ci --ignore-scripts
+      - run: npm i -g node-gyp install; node-gyp-install
+      - run: $env:PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = 1; npm ci
       - build:
           os: windows
           path: ./build/win

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,7 @@ jobs:
       - run:
           name: Install nodejs-lts
           command: choco install nodejs-lts -y
-      - run: npm i -g node-gyp install; node-gyp-install
+      - run: npm i -g node-gyp-install; node-gyp-install
       - run: $env:PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = 1; npm ci
       - build:
           os: windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,7 +269,8 @@ jobs:
       - run:
           name: Install nodejs-lts
           command: choco install nodejs-lts -y
-      - run: $env:PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = 1; npm ci --ignore-scripts
+      - run: npm i -g node-gyp; node-gyp install
+      - run: $env:PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = 1; npm ci
       - build:
           os: windows
           path: ./build/win

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,7 @@ jobs:
       - run:
           name: Install nodejs-lts
           command: choco install nodejs-lts -y
-      - run: npm i -g node-gyp-install; node-gyp-install
+      - run: npm i -g node-gyp; node-gyp install
       - run: $env:PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = 1; npm ci
       - build:
           os: windows

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,6 @@
         "mmjstool": "github:mattermost/mattermost-utilities#3b4506b0f6b14fbb402f9f8ef932370e459e3773",
         "mocha-circleci-reporter": "0.0.3",
         "mochawesome": "7.1.3",
-        "node-gyp": "9.0.0",
         "node-loader": "2.0.0",
         "npm-run-all": "4.1.5",
         "playwright": "1.23.4",

--- a/package.json
+++ b/package.json
@@ -167,7 +167,6 @@
     "mmjstool": "github:mattermost/mattermost-utilities#3b4506b0f6b14fbb402f9f8ef932370e459e3773",
     "mocha-circleci-reporter": "0.0.3",
     "mochawesome": "7.1.3",
-    "node-gyp": "9.0.0",
     "node-loader": "2.0.0",
     "npm-run-all": "4.1.5",
     "playwright": "1.23.4",

--- a/scripts/Makefile.ps1
+++ b/scripts/Makefile.ps1
@@ -525,7 +525,9 @@ function Run-BuildChangelog {
 
 function Run-BuildElectron {
     Print-Info "Installing nodejs/electron dependencies (running npm ci)..."
-    npm ci --ignore-scripts
+    npm i -g node-gyp
+    node-gyp install
+    npm ci
     #npm install --prefix="$(Get-RootDir)" "$(Get-RootDir)"
     Print-Info "Building nodejs/electron code (running npm run build)..."
     npm run build


### PR DESCRIPTION
#### Summary
The issue with the Windows node-gyp build seems to be related to the headers not being properly downloaded/populated. This PR pre-populates them which seems to fix the issue.

```release-note
NONE
```
