### PR TITLE
[MM-45003] Fix the infinite redirect caused by MFA sending the login signal repeatedly

### DIFF
--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -698,7 +698,7 @@ export class WindowManager {
         log.debug('WindowManager.handleAppLoggedIn', viewName);
 
         const view = this.viewManager?.views.get(viewName);
-        if (view) {
+        if (view && !view.isLoggedIn) {
             view.isLoggedIn = true;
             this.viewManager?.reloadViewIfNeeded(viewName);
         }
@@ -708,7 +708,7 @@ export class WindowManager {
         log.debug('WindowManager.handleAppLoggedOut', viewName);
 
         const view = this.viewManager?.views.get(viewName);
-        if (view) {
+        if (view && view) {
             view.isLoggedIn = false;
         }
     }

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -708,7 +708,7 @@ export class WindowManager {
         log.debug('WindowManager.handleAppLoggedOut', viewName);
 
         const view = this.viewManager?.views.get(viewName);
-        if (view && view) {
+        if (view && view.isLoggedIn) {
             view.isLoggedIn = false;
         }
     }


### PR DESCRIPTION
#### Summary
If `localStorage` sends the `__login__` signal more than once, we end up with an infinite redirect. This PR makes sure not to reload the view if we already know the view is logged in. It will now only reset if the `__logout__` signal is sent.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45003

```release-note
Fixed an issue where tabs will infinitely redirect to each other on multiple `__login__` signals.
```
