### PR TITLE
Remove buildConfig patch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,13 +108,6 @@ commands:
         type: string
         default: "./linux/"
     steps:
-      - when:
-          condition: << pipeline.parameters.run_nightly >>
-          steps:
-            - run:
-                name: Patch buildConfig file for run nightly
-                command: |
-                  sed -i "" "s/skipOnboardingScreens:[[:blank:]]*false/skipOnboardingScreens: true/" ./src/common/config/buildConfig.ts;
       - run: 
           name: npn run
           command: npm run package:<< parameters.os >>


### PR DESCRIPTION
#### Summary
This patch isn't needed right now and is breaking the build. Removing it for now and will add the changes for Rainforest in a separate PR.

```release-note
NONE
```
