### PR TITLE
[MM-46405] Drop support for asterisk-based unreads

### DIFF
--- a/src/main/views/MattermostView.test.js
+++ b/src/main/views/MattermostView.test.js
@@ -342,17 +342,12 @@ describe('main/views/MattermostView', () => {
 
         it('should parse mentions from title', () => {
             mattermostView.updateMentionsFromTitle('(7) Mattermost');
-            expect(appState.updateMentions).toHaveBeenCalledWith(mattermostView.tab.name, 7, undefined);
+            expect(appState.updateMentions).toHaveBeenCalledWith(mattermostView.tab.name, 7);
         });
 
         it('should parse unreads from title', () => {
             mattermostView.updateMentionsFromTitle('* Mattermost');
-            expect(appState.updateMentions).toHaveBeenCalledWith(mattermostView.tab.name, 0, true);
-        });
-
-        it('should not parse unreads when title is on a channel with an asterisk before it', () => {
-            mattermostView.updateMentionsFromTitle('*testChannel - Mattermost');
-            expect(appState.updateMentions).toHaveBeenCalledWith(mattermostView.tab.name, 0, false);
+            expect(appState.updateMentions).toHaveBeenCalledWith(mattermostView.tab.name, 0);
         });
     });
 });


### PR DESCRIPTION
#### Summary
Old version of Mattermost (<5.28) used an asterisk in the page title to show whether they had unread messages or not. Later versions uses the favicon, which is what the Desktop App prefers.

The asterisk is still used for session expiry, and we ran into a strange issue where the view would get stuck in the asterisk mode if the session expired, thus stopping notifications from happening.

Since v5.28 and earlier have been out of support for almost 2 years now, it seems to make sense to drop support for this since it's causing issues with newer versions.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46405

```release-note
Drop support for asterisk-based unreads in Mattermost versions <5.28
```
