### PR TITLE
[MM-46533] Remove buildConfig item and add webpack flags for onboarding screens and GPU acceleration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -720,7 +720,6 @@ workflows:
           requires:
             - store_artifacts
   nightly_rainforest:
-    when: << pipeline.parameters.run_nightly >>
     jobs:
       - msi_installer:
           context: windows-codesign

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -715,14 +715,24 @@ workflows:
             - build-linux
             - msi_installer
             - mac_installer
-      - upload_to_s3_daily:
-          context: mattermost-desktop-daily-s3
-          requires:
-            - build-linux
-            - msi_installer
-            - mac_installer
       - share_to_channel:
           context: desktop_browserview
           requires:
             - store_artifacts
-
+  nightly_rainforest:
+    when: << pipeline.parameters.run_nightly >>
+    jobs:
+      - msi_installer:
+          context: windows-codesign
+          pre-steps: 
+            - run: $env:MM_DESKTOP_BUILD_SKIPONBOARDINGSCREENS="true"
+      - mac_installer:
+          context: codesign-certificates
+          pre-steps: 
+            - run: export MM_DESKTOP_BUILD_SKIPONBOARDINGSCREENS="true"
+            - run: export MM_DESKTOP_BUILD_DISABLEGPU="true"
+      - upload_to_s3_daily:
+          context: mattermost-desktop-daily-s3
+          requires:
+            - msi_installer
+            - mac_installer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -720,6 +720,7 @@ workflows:
           requires:
             - store_artifacts
   nightly_rainforest:
+    when: << pipeline.parameters.run_nightly >>
     jobs:
       - msi_installer:
           context: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -722,14 +722,13 @@ workflows:
   nightly_rainforest:
     jobs:
       - msi_installer:
-          context: windows-codesign
-          pre-steps: 
-            - run: $env:MM_DESKTOP_BUILD_SKIPONBOARDINGSCREENS="true"
+          context: 
+            - windows-codesign
+            - desktop-rainforest-build
       - mac_installer:
-          context: codesign-certificates
-          pre-steps: 
-            - run: export MM_DESKTOP_BUILD_SKIPONBOARDINGSCREENS="true"
-            - run: export MM_DESKTOP_BUILD_DISABLEGPU="true"
+          context: 
+            - codesign-certificates
+            - desktop-rainforest-build
       - upload_to_s3_daily:
           context: mattermost-desktop-daily-s3
           requires:

--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
       "__HASH_VERSION__": "5.0.0",
       "__CAN_UPGRADE__": false,
       "__IS_NIGHTLY_BUILD__": false,
-      "__IS_MAC_APP_STORE__": false
+      "__IS_MAC_APP_STORE__": false,
+      "__DISABLE_GPU__": false
     },
     "setupFiles": [
       "./src/jestSetup.js"

--- a/scripts/Makefile.ps1
+++ b/scripts/Makefile.ps1
@@ -678,7 +678,7 @@ function Run-Build {
     Prepare-Path
     Get-Cert
     Run-BuildId
-    Run-BuildChangelog
+    #Run-BuildChangelog
     Run-BuildElectron
     Run-BuildForceSignature
     Run-BuildLicense

--- a/scripts/Makefile.ps1
+++ b/scripts/Makefile.ps1
@@ -678,7 +678,7 @@ function Run-Build {
     Prepare-Path
     Get-Cert
     Run-BuildId
-    #Run-BuildChangelog
+    Run-BuildChangelog
     Run-BuildElectron
     Run-BuildForceSignature
     Run-BuildLicense

--- a/src/common/config/buildConfig.ts
+++ b/src/common/config/buildConfig.ts
@@ -37,7 +37,6 @@ const buildConfig: BuildConfig = {
         'mailto',
         'tel',
     ],
-    skipOnboardingScreens: false,
 };
 
 export default buildConfig;

--- a/src/common/config/defaultPreferences.ts
+++ b/src/common/config/defaultPreferences.ts
@@ -43,7 +43,6 @@ const defaultPreferences: ConfigV3 = {
     lastActiveTeam: 0,
     downloadLocation: getDefaultDownloadLocation(),
     startInFullscreen: false,
-    skipOnboardingScreens: false,
 };
 
 export default defaultPreferences;

--- a/src/common/config/index.ts
+++ b/src/common/config/index.ts
@@ -332,10 +332,6 @@ export class Config extends EventEmitter {
         return this.combinedData?.appLanguage;
     }
 
-    get skipOnboardingScreens() {
-        return this.combinedData?.skipOnboardingScreens ?? defaultPreferences.skipOnboardingScreens;
-    }
-
     // initialization/processing methods
 
     /**

--- a/src/main/Validator.test.js
+++ b/src/main/Validator.test.js
@@ -150,7 +150,6 @@ describe('main/Validator', () => {
             ],
             trayIconTheme: 'use_system',
             useSpellChecker: true,
-            skipOnboardingScreens: false,
             version: 3,
         };
 

--- a/src/main/Validator.ts
+++ b/src/main/Validator.ts
@@ -132,7 +132,6 @@ const configDataSchemaV3 = Joi.object<ConfigV3>({
     alwaysClose: Joi.boolean(),
     logLevel: Joi.string().default('info'),
     appLanguage: Joi.string().allow(''),
-    skipOnboardingScreens: Joi.boolean().default(false),
 });
 
 // eg. data['community.mattermost.com'] = { data: 'certificate data', issuerName: 'COMODO RSA Domain Validation Secure Server CA'};

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -161,7 +161,10 @@ async function initializeConfig() {
             handleConfigUpdate(configData);
 
             // can only call this before the app is ready
-            if (Config.enableHardwareAcceleration === false) {
+            // eslint-disable-next-line no-undef
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            if (Config.enableHardwareAcceleration === false || __DISABLE_GPU__) {
                 app.disableHardwareAcceleration();
             }
 

--- a/src/main/app/intercom.ts
+++ b/src/main/app/intercom.ts
@@ -86,7 +86,10 @@ export function handleOpenTab(event: IpcMainEvent, serverName: string, tabName: 
 }
 
 export function handleMainWindowIsShown() {
-    const showWelcomeScreen = !Config.skipOnboardingScreens && !Config.teams.length;
+    // eslint-disable-next-line no-undef
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const showWelcomeScreen = !(Boolean(__SKIP_ONBOARDING_SCREENS__) || Config.teams.length);
     const mainWindow = WindowManager.getMainWindow();
 
     if (mainWindow) {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -46,7 +46,6 @@ export type ConfigV3 = {
     alwaysClose?: boolean;
     logLevel?: string;
     appLanguage?: string;
-    skipOnboardingScreens: boolean;
 }
 
 export type ConfigV2 = {
@@ -107,7 +106,6 @@ export type BuildConfig = {
     enableAutoUpdater: boolean;
     managedResources: string[];
     allowedProtocols: string[];
-    skipOnboardingScreens: boolean;
 }
 
 export type RegistryConfig = {

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -20,6 +20,8 @@ const codeDefinitions = {
     __CAN_UPGRADE__: JSON.stringify(process.env.CAN_UPGRADE === 'true'),
     __IS_NIGHTLY_BUILD__: JSON.stringify(process.env.CIRCLE_BRANCH === 'nightly'),
     __IS_MAC_APP_STORE__: JSON.stringify(process.env.IS_MAC_APP_STORE === 'true'),
+    __SKIP_ONBOARDING_SCREENS__: JSON.stringify(process.env.MM_DESKTOP_BUILD_SKIPONBOARDINGSCREENS === 'true'),
+    __DISABLE_GPU__: JSON.stringify(process.env.MM_DESKTOP_BUILD_DISABLEGPU === 'true'),
 };
 codeDefinitions['process.env.NODE_ENV'] = JSON.stringify(process.env.NODE_ENV);
 


### PR DESCRIPTION
#### Summary
We are in need of a special build of the Desktop App for Rainforest to fix 2 issues:
- The onboarding screens are causing issues with the existing tests, so we'll be disabling it
- GPU acceleration causes macOS to crash in RF, so we are disabling that as well

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46553

```release-note
NONE
```
