### PR TITLE
Make writeToFile return a Promise in JsonFileManager

### DIFF
--- a/src/common/JsonFileManager.ts
+++ b/src/common/JsonFileManager.ts
@@ -24,6 +24,7 @@ export default class JsonFileManager<T> {
                     // eslint-disable-next-line no-console
                     console.error(err);
                     reject(err);
+                    return;
                 }
                 resolve();
             });

--- a/src/common/JsonFileManager.ts
+++ b/src/common/JsonFileManager.ts
@@ -16,13 +16,17 @@ export default class JsonFileManager<T> {
         }
     }
 
-    writeToFile(): void {
-        fs.writeFile(this.jsonFile, JSON.stringify(this.json, undefined, 2), (err) => {
-            if (err) {
-                // No real point in bringing electron-log into this otherwise electron-free file
-                // eslint-disable-next-line no-console
-                console.error(err);
-            }
+    writeToFile(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            fs.writeFile(this.jsonFile, JSON.stringify(this.json, undefined, 2), (err) => {
+                if (err) {
+                    // No real point in bringing electron-log into this otherwise electron-free file
+                    // eslint-disable-next-line no-console
+                    console.error(err);
+                    reject(err);
+                }
+                resolve();
+            });
         });
     }
 


### PR DESCRIPTION
#### Summary
Make `JsonFileManager.writeToFile()` return a Promise instead of void. 

#### Release Note
```release-note
NONE
```
