### PR TITLE
Add webContents listeners to modals

### DIFF
--- a/src/main/views/modalManager.test.js
+++ b/src/main/views/modalManager.test.js
@@ -15,6 +15,14 @@ jest.mock('electron', () => ({
     },
 }));
 
+jest.mock('common/config', () => ({
+    teams: [],
+}));
+
+jest.mock('main/views/webContentEvents', () => ({
+    addWebContentsEventListeners: jest.fn(),
+}));
+
 jest.mock('./modalView', () => ({
     ModalView: jest.fn(),
 }));

--- a/src/main/views/modalManager.ts
+++ b/src/main/views/modalManager.ts
@@ -19,8 +19,10 @@ import {
     GET_MODAL_UNCLOSEABLE,
     RESIZE_MODAL,
 } from 'common/communication';
+import Config from 'common/config';
 
 import {getAdjustedWindowBoundaries} from 'main/utils';
+import WebContentsEventManager from 'main/views/webContentEvents';
 import WindowManager from 'main/windows/windowManager';
 
 import {ModalView} from './modalView';
@@ -87,6 +89,7 @@ export class ModalManager {
             if (index === 0) {
                 WindowManager.sendToRenderer(MODAL_OPEN);
                 modal.show(undefined, Boolean(withDevTools));
+                WebContentsEventManager.addWebContentsEventListeners(modal.view.webContents, () => Config.teams.concat());
             } else {
                 WindowManager.sendToRenderer(MODAL_CLOSE);
                 modal.hide();

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -277,7 +277,7 @@ export class ViewManager {
             log.error(`Couldn't find a view with the name ${viewName}`);
             return;
         }
-        WebContentsEventManager.addWebContentsEventListeners(view, this.getServers);
+        WebContentsEventManager.addMattermostViewEventListeners(view, this.getServers);
     }
 
     finishLoading = (server: string) => {

--- a/src/main/views/webContentEvents.test.js
+++ b/src/main/views/webContentEvents.test.js
@@ -32,6 +32,10 @@ jest.mock('../windows/windowManager', () => ({
     showMainWindow: jest.fn(),
 }));
 
+jest.mock('common/config', () => ({
+    spellcheck: true,
+}));
+
 jest.mock('common/utils/url', () => ({
     parseURL: (url) => {
         try {


### PR DESCRIPTION
#### Summary
I noticed that our modals don't handle external links at all, since we've never had them before. However, now that we might want to do that, it would make sense to have similar handling around our links.

```release-note
NONE
```
