### PR TITLE
E2E omnibus fixes

### DIFF
--- a/e2e/modules/environment.js
+++ b/e2e/modules/environment.js
@@ -30,7 +30,7 @@ const userDataDir = path.join(sourceRootDir, 'e2e/testUserData/');
 const configFilePath = path.join(userDataDir, 'config.json');
 const boundsInfoPath = path.join(userDataDir, 'bounds-info.json');
 const exampleURL = 'http://example.com/';
-const mattermostURL = 'http://localhost:8065/';
+const mattermostURL = process.env.MM_TEST_SERVER_URL || 'http://localhost:8065/';
 
 const exampleTeam = {
     name: 'example',

--- a/e2e/modules/environment.js
+++ b/e2e/modules/environment.js
@@ -33,7 +33,7 @@ const appUpdatePath = path.join(userDataDir, 'app-update.yml');
 const exampleURL = 'http://example.com/';
 const mattermostURL = process.env.MM_TEST_SERVER_URL || 'http://localhost:8065/';
 
-if (process.platform === 'windows') {
+if (process.platform === 'win32') {
     const robot = require('robotjs');
     robot.mouseClick();
 }

--- a/e2e/modules/environment.js
+++ b/e2e/modules/environment.js
@@ -124,10 +124,6 @@ module.exports = {
     cmdOrCtrl,
 
     async clearElectronInstances() {
-        if (process.platform !== 'win32' && process.platform !== 'darwin') {
-            return Promise.resolve();
-        }
-
         return new Promise((resolve, reject) => {
             ps.lookup({
                 command: process.platform === 'darwin' ? 'Electron' : 'electron',

--- a/e2e/modules/environment.js
+++ b/e2e/modules/environment.js
@@ -190,8 +190,15 @@ module.exports = {
         //     options.chromeDriverArgs.push('remote-debugging-port=9222');
         //}
         return electron.launch(options).then(async (app) => {
-            // Make sure the app has time to fully load
+            // Make sure the app has time to fully load and that the window is focused
             await asyncSleep(1000);
+            const mainWindow = app.windows().find((window) => window.url().includes('index'));
+            await mainWindow.bringToFront();
+            const browserWindow = await app.browserWindow(mainWindow);
+            await browserWindow.evaluate((win) => {
+                win.focus();
+                return true;
+            });
             return app;
         });
     },

--- a/e2e/modules/environment.js
+++ b/e2e/modules/environment.js
@@ -124,13 +124,13 @@ module.exports = {
     cmdOrCtrl,
 
     async clearElectronInstances() {
-        if (process.platform !== 'win32') {
+        if (process.platform !== 'win32' && process.platform !== 'darwin') {
             return Promise.resolve();
         }
 
         return new Promise((resolve, reject) => {
             ps.lookup({
-                command: 'electron',
+                command: process.platform === 'darwin' ? 'Electron.app' : 'electron',
             }, (err, resultList) => {
                 if (err) {
                     reject(err);

--- a/e2e/modules/environment.js
+++ b/e2e/modules/environment.js
@@ -130,7 +130,7 @@ module.exports = {
 
         return new Promise((resolve, reject) => {
             ps.lookup({
-                command: process.platform === 'darwin' ? 'Electron.app' : 'electron',
+                command: process.platform === 'darwin' ? 'Electron' : 'electron',
             }, (err, resultList) => {
                 if (err) {
                     reject(err);

--- a/e2e/modules/environment.js
+++ b/e2e/modules/environment.js
@@ -29,6 +29,7 @@ const electronBinaryPath = (() => {
 const userDataDir = path.join(sourceRootDir, 'e2e/testUserData/');
 const configFilePath = path.join(userDataDir, 'config.json');
 const boundsInfoPath = path.join(userDataDir, 'bounds-info.json');
+const appUpdatePath = path.join(userDataDir, 'app-update.yml');
 const exampleURL = 'http://example.com/';
 const mattermostURL = process.env.MM_TEST_SERVER_URL || 'http://localhost:8065/';
 
@@ -115,6 +116,7 @@ module.exports = {
     configFilePath,
     userDataDir,
     boundsInfoPath,
+    appUpdatePath,
     exampleURL,
     mattermostURL,
     demoConfig,
@@ -175,6 +177,10 @@ module.exports = {
 
     async getApp(args = []) {
         const options = {
+            env: {
+                ...process.env,
+                RESOURCES_PATH: userDataDir,
+            },
             executablePath: electronBinaryPath,
             args: [`${path.join(sourceRootDir, 'dist')}`, `--data-dir=${userDataDir}`, '--disable-dev-mode', ...args],
         };

--- a/e2e/modules/environment.js
+++ b/e2e/modules/environment.js
@@ -193,10 +193,9 @@ module.exports = {
             // Make sure the app has time to fully load and that the window is focused
             await asyncSleep(1000);
             const mainWindow = app.windows().find((window) => window.url().includes('index'));
-            await mainWindow.bringToFront();
             const browserWindow = await app.browserWindow(mainWindow);
             await browserWindow.evaluate((win) => {
-                win.focus();
+                win.show();
                 return true;
             });
             return app;

--- a/e2e/modules/environment.js
+++ b/e2e/modules/environment.js
@@ -33,6 +33,11 @@ const appUpdatePath = path.join(userDataDir, 'app-update.yml');
 const exampleURL = 'http://example.com/';
 const mattermostURL = process.env.MM_TEST_SERVER_URL || 'http://localhost:8065/';
 
+if (process.platform === 'windows') {
+    const robot = require('robotjs');
+    robot.mouseClick();
+}
+
 const exampleTeam = {
     name: 'example',
     url: exampleURL,

--- a/e2e/specs/popup.test.js
+++ b/e2e/specs/popup.test.js
@@ -105,7 +105,7 @@ describe('popup', function desc() {
         const githubLink = await firstServer.waitForSelector('a.theme.markdown__link:has-text("GitHub account")');
         githubLink.click();
         const popupWindow = await this.app.waitForEvent('window');
-        popupWindow.focus();
+        await popupWindow.bringToFront();
         const currentURL = popupWindow.url();
 
         // Try and go back

--- a/e2e/specs/settings.test.js
+++ b/e2e/specs/settings.test.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 
 const {SHOW_SETTINGS_WINDOW} = require('../../src/common/communication');
 
@@ -20,6 +21,7 @@ describe('Settings', function desc() {
         env.createTestUserDataDir();
         env.cleanTestConfig();
         fs.writeFileSync(env.configFilePath, JSON.stringify(config));
+        fs.writeFileSync(env.appUpdatePath, '');
         await asyncSleep(1000);
         this.app = await env.getApp();
     });

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -13,17 +13,21 @@ const webpack = require('webpack');
 
 const VERSION = childProcess.execSync('git rev-parse --short HEAD').toString();
 const isProduction = process.env.NODE_ENV === 'production';
+const isTest = process.env.NODE_ENV === 'test';
 const isRelease = process.env.CIRCLE_BRANCH && process.env.CIRCLE_BRANCH.startsWith('release-');
 
 const codeDefinitions = {
     __HASH_VERSION__: !isRelease && JSON.stringify(VERSION),
-    __CAN_UPGRADE__: JSON.stringify(process.env.CAN_UPGRADE === 'true'),
+    __CAN_UPGRADE__: isTest || JSON.stringify(process.env.CAN_UPGRADE === 'true'),
     __IS_NIGHTLY_BUILD__: JSON.stringify(process.env.CIRCLE_BRANCH === 'nightly'),
     __IS_MAC_APP_STORE__: JSON.stringify(process.env.IS_MAC_APP_STORE === 'true'),
     __SKIP_ONBOARDING_SCREENS__: JSON.stringify(process.env.MM_DESKTOP_BUILD_SKIPONBOARDINGSCREENS === 'true'),
     __DISABLE_GPU__: JSON.stringify(process.env.MM_DESKTOP_BUILD_DISABLEGPU === 'true'),
 };
 codeDefinitions['process.env.NODE_ENV'] = JSON.stringify(process.env.NODE_ENV);
+if (isTest) {
+    codeDefinitions['process.resourcesPath'] = 'process.env.RESOURCES_PATH';
+}
 
 module.exports = {
 


### PR DESCRIPTION
#### Summary
A bunch of E2E test fixes listed here:
- Add an environment variable `MM_TEST_SERVER_URL` to specify where the test Mattermost server is located
- Fixed the auto updater test where the `app-update.yml` file didn't exist
- Force Electron processes to stop on all OSes after each test

```release-note
NONE
```
