### PR TITLE
[chore] Fix vscode debugger for E2E tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -43,8 +43,8 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "Mocha Tests",
-            "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+            "name": "E2E Tests",
+            "program": "${workspaceRoot}/node_modules/electron-mocha/bin/electron-mocha",
             "args": [
                 "-r",
                 "@babel/register",
@@ -52,10 +52,10 @@
                 "--timeout",
                 "999999",
                 "--colors",
-                "${workspaceRoot}/e2e/specs"
+                "${workspaceRoot}/dist/tests/e2e_bundle.js"
             ],
             "internalConsoleOptions": "openOnSessionStart",
-            "preLaunchTask": "Build sources"
+            "preLaunchTask": "prepare-e2e"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,6 +8,12 @@
             "type": "npm",
             "script": "build",
             "problemMatcher": []
+        },
+        {
+            "label": "prepare-e2e",
+            "type": "shell",
+            "command": "npm run build; npm run build-robotjs; npm run test:e2e:build",
+            "problemMatcher": []
         }
     ]
 }


### PR DESCRIPTION
#### Summary
Fix vscode debugger for E2E tests. The issue was the it didn't use `electron-mocha` and the correct entrypoint

#### Release Note
```release-note
NONE
```
