### PR TITLE
[MM-46857] Remove misleading console error about tab status when servers don't exist

### DIFF
--- a/e2e/specs/settings.test.js
+++ b/e2e/specs/settings.test.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const fs = require('fs');
-const path = require('path');
 
 const {SHOW_SETTINGS_WINDOW} = require('../../src/common/communication');
 

--- a/src/renderer/components/MainPage.tsx
+++ b/src/renderer/components/MainPage.tsx
@@ -2,6 +2,8 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+/* eslint-disable max-lines */
+
 import classNames from 'classnames';
 import React, {Fragment} from 'react';
 import {Container, Row} from 'react-bootstrap';
@@ -553,13 +555,14 @@ class MainPage extends React.PureComponent<Props, State> {
         );
 
         const views = () => {
+            if (!this.props.teams.length) {
+                return null;
+            }
             let component;
             const tabStatus = this.getTabViewStatus();
             if (!tabStatus) {
-                if (this.state.activeTabName) {
+                if (this.state.activeTabName || this.state.activeServerName) {
                     console.error(`Not tabStatus for ${this.state.activeTabName}`);
-                } else {
-                    console.error('No tab status, tab doesn\'t exist anymore');
                 }
                 return null;
             }


### PR DESCRIPTION
#### Summary
There was a misleading error about tab status that was coming up when no servers were configured. This was a relic of older BrowserView/WebView architecture stuff where it was possible that we were missing tab statuses for certain tabs, which doesn't happen anymore. So we've removed that log entry.

Also fixed a couple lint headaches.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46857

```release-note
NONE
```
