### PR TITLE
#2262 Fix notifications on linux in default configuration

### DIFF
--- a/src/common/config/defaultPreferences.ts
+++ b/src/common/config/defaultPreferences.ts
@@ -29,7 +29,7 @@ const defaultPreferences: ConfigV3 = {
     trayIconTheme: 'use_system',
     minimizeToTray: process.platform !== 'linux',
     notifications: {
-        flashWindow: 2,
+        flashWindow: process.platform === 'linux' ? 0 : 2,
         bounceIcon: true,
         bounceIconType: 'informational',
     },


### PR DESCRIPTION
#### Summary
Change default configuration on Linux to not flash the window on new messages.

With the option enabled, when using Linux, the first notification would render without message content and just say "Mattermost desktop app is ready". Disabling this option by default under Linux makes the desktop app work fine out of the box.

Also under Linux the flash window feature doesn't work anyway. See linked ticket for more details.

#### Ticket Link
Fixes https://github.com/mattermost/desktop/issues/2262

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [x] read and understood our [Contributing Guidelines]
- [x] completed [Mattermost Contributor Agreement]
- [x] executed `npm run lint:js` for proper code formatting

#### Device Information
This PR was tested on: Ubuntu 22.04

#### Release Note

```release-note
Changed default for config setting notifications.flashWindow to 0 under Linux (fixes notifications for Linux users)
```