### PR TITLE
[MM-46993] Implement CallsWidgetWindow

### DIFF
--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -131,7 +131,7 @@ export const VIEW_FINISHED_RESIZING = 'view-finished-resizing';
 export const DISPATCH_GET_DESKTOP_SOURCES = 'dispatch-get-desktop-sources';
 export const DESKTOP_SOURCES_RESULT = 'desktop-sources-result';
 
-export const CALLS_CLIENT_CONNECT = 'calls-client-connect';
 export const CALLS_JOIN_CALL = 'calls-join-call';
 export const CALLS_LEAVE_CALL = 'calls-leave-call';
+export const CALLS_WIDGET_RESIZE = 'calls-widget-resize';
 

--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -130,8 +130,10 @@ export const VIEW_FINISHED_RESIZING = 'view-finished-resizing';
 // Calls
 export const DISPATCH_GET_DESKTOP_SOURCES = 'dispatch-get-desktop-sources';
 export const DESKTOP_SOURCES_RESULT = 'desktop-sources-result';
+export const DESKTOP_SOURCES_MODAL_REQUEST = 'desktop-sources-modal-request';
 
 export const CALLS_JOIN_CALL = 'calls-join-call';
 export const CALLS_LEAVE_CALL = 'calls-leave-call';
 export const CALLS_WIDGET_RESIZE = 'calls-widget-resize';
+export const CALLS_WIDGET_SHARE_SCREEN = 'calls-widget-share-screen';
 

--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -116,9 +116,6 @@ export const UPDATE_PATHS = 'update-paths';
 
 export const UPDATE_URL_VIEW_WIDTH = 'update-url-view-width';
 
-export const DISPATCH_GET_DESKTOP_SOURCES = 'dispatch-get-desktop-sources';
-export const DESKTOP_SOURCES_RESULT = 'desktop-sources-result';
-
 export const RELOAD_CURRENT_VIEW = 'reload-current-view';
 
 export const PING_DOMAIN = 'ping-domain';
@@ -129,3 +126,12 @@ export const RETRIEVED_LANGUAGE_INFORMATION = 'retrieved-language-information';
 export const GET_AVAILABLE_LANGUAGES = 'get-available-languages';
 
 export const VIEW_FINISHED_RESIZING = 'view-finished-resizing';
+
+// Calls
+export const DISPATCH_GET_DESKTOP_SOURCES = 'dispatch-get-desktop-sources';
+export const DESKTOP_SOURCES_RESULT = 'desktop-sources-result';
+
+export const CALLS_CLIENT_CONNECT = 'calls-client-connect';
+export const CALLS_JOIN_CALL = 'calls-join-call';
+export const CALLS_LEAVE_CALL = 'calls-leave-call';
+

--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -136,4 +136,5 @@ export const CALLS_JOIN_CALL = 'calls-join-call';
 export const CALLS_LEAVE_CALL = 'calls-leave-call';
 export const CALLS_WIDGET_RESIZE = 'calls-widget-resize';
 export const CALLS_WIDGET_SHARE_SCREEN = 'calls-widget-share-screen';
+export const CALLS_WIDGET_CHANNEL_LINK_CLICK = 'calls-widget-channel-link-click';
 

--- a/src/main/preload/callsWidget.js
+++ b/src/main/preload/callsWidget.js
@@ -8,6 +8,10 @@ import {ipcRenderer} from 'electron';
 import {
     CALLS_LEAVE_CALL,
     CALLS_WIDGET_RESIZE,
+    CALLS_WIDGET_SHARE_SCREEN,
+    DESKTOP_SOURCES_RESULT,
+    DESKTOP_SOURCES_MODAL_REQUEST,
+    DISPATCH_GET_DESKTOP_SOURCES,
 } from 'common/communication';
 
 window.addEventListener('message', ({origin, data = {}} = {}) => {
@@ -18,10 +22,50 @@ window.addEventListener('message', ({origin, data = {}} = {}) => {
     }
 
     switch (type) {
+    case 'get-app-version': {
+        ipcRenderer.invoke('get-app-version').then(({name, version}) => {
+            window.postMessage(
+                {
+                    type: 'register-desktop',
+                    message: {
+                        name,
+                        version,
+                    },
+                },
+                window.location.origin,
+            );
+        });
+        break;
+    }
+    case 'get-desktop-sources': {
+        ipcRenderer.send(DISPATCH_GET_DESKTOP_SOURCES, 'widget', message);
+        break;
+    }
+    case DESKTOP_SOURCES_MODAL_REQUEST:
     case CALLS_WIDGET_RESIZE:
     case CALLS_LEAVE_CALL: {
         ipcRenderer.send(type, message);
         break;
     }
     }
+});
+
+ipcRenderer.on(DESKTOP_SOURCES_RESULT, (event, sources) => {
+    window.postMessage(
+        {
+            type: DESKTOP_SOURCES_RESULT,
+            message: sources,
+        },
+        window.location.origin,
+    );
+});
+
+ipcRenderer.on(CALLS_WIDGET_SHARE_SCREEN, (event, message) => {
+    window.postMessage(
+        {
+            type: CALLS_WIDGET_SHARE_SCREEN,
+            message,
+        },
+        window.location.origin,
+    );
 });

--- a/src/main/preload/callsWidget.js
+++ b/src/main/preload/callsWidget.js
@@ -9,6 +9,7 @@ import {
     CALLS_LEAVE_CALL,
     CALLS_WIDGET_RESIZE,
     CALLS_WIDGET_SHARE_SCREEN,
+    CALLS_WIDGET_CHANNEL_LINK_CLICK,
     DESKTOP_SOURCES_RESULT,
     DESKTOP_SOURCES_MODAL_REQUEST,
     DISPATCH_GET_DESKTOP_SOURCES,
@@ -42,6 +43,7 @@ window.addEventListener('message', ({origin, data = {}} = {}) => {
         break;
     }
     case DESKTOP_SOURCES_MODAL_REQUEST:
+    case CALLS_WIDGET_CHANNEL_LINK_CLICK:
     case CALLS_WIDGET_RESIZE:
     case CALLS_LEAVE_CALL: {
         ipcRenderer.send(type, message);

--- a/src/main/preload/callsWidget.js
+++ b/src/main/preload/callsWidget.js
@@ -3,18 +3,12 @@
 
 'use strict';
 
-import {ipcRenderer, contextBridge} from 'electron';
+import {ipcRenderer} from 'electron';
 
 import {
-    CALLS_CLIENT_CONNECT,
     CALLS_LEAVE_CALL,
+    CALLS_WIDGET_RESIZE,
 } from 'common/communication';
-
-contextBridge.exposeInMainWorld('ipcRenderer', {
-    send: ipcRenderer.send,
-    on: (channel, listener) => ipcRenderer.on(channel, (_, ...args) => listener(null, ...args)),
-    invoke: ipcRenderer.invoke,
-});
 
 window.addEventListener('message', ({origin, data = {}} = {}) => {
     const {type, message = {}} = data;
@@ -24,11 +18,10 @@ window.addEventListener('message', ({origin, data = {}} = {}) => {
     }
 
     switch (type) {
-    case CALLS_CLIENT_CONNECT:
+    case CALLS_WIDGET_RESIZE:
     case CALLS_LEAVE_CALL: {
         ipcRenderer.send(type, message);
         break;
     }
     }
 });
-

--- a/src/main/preload/callsWidget.js
+++ b/src/main/preload/callsWidget.js
@@ -1,0 +1,34 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+'use strict';
+
+import {ipcRenderer, contextBridge} from 'electron';
+
+import {
+    CALLS_CLIENT_CONNECT,
+    CALLS_LEAVE_CALL,
+} from 'common/communication';
+
+contextBridge.exposeInMainWorld('ipcRenderer', {
+    send: ipcRenderer.send,
+    on: (channel, listener) => ipcRenderer.on(channel, (_, ...args) => listener(null, ...args)),
+    invoke: ipcRenderer.invoke,
+});
+
+window.addEventListener('message', ({origin, data = {}} = {}) => {
+    const {type, message = {}} = data;
+
+    if (origin !== window.location.origin) {
+        return;
+    }
+
+    switch (type) {
+    case CALLS_CLIENT_CONNECT:
+    case CALLS_LEAVE_CALL: {
+        ipcRenderer.send(type, message);
+        break;
+    }
+    }
+});
+

--- a/src/main/preload/mattermost.js
+++ b/src/main/preload/mattermost.js
@@ -30,6 +30,8 @@ import {
     DISPATCH_GET_DESKTOP_SOURCES,
     DESKTOP_SOURCES_RESULT,
     VIEW_FINISHED_RESIZING,
+    CALLS_JOIN_CALL,
+    CALLS_LEAVE_CALL,
 } from 'common/communication';
 
 const UNREAD_COUNT_INTERVAL = 1000;
@@ -154,6 +156,14 @@ window.addEventListener('message', ({origin, data = {}} = {}) => {
     }
     case 'get-desktop-sources': {
         ipcRenderer.send(DISPATCH_GET_DESKTOP_SOURCES, viewName, message);
+        break;
+    }
+    case 'calls-join-call': {
+        ipcRenderer.send(CALLS_JOIN_CALL, viewName, message);
+        break;
+    }
+    case 'calls-client-close': {
+        ipcRenderer.send(CALLS_LEAVE_CALL, viewName, message);
         break;
     }
     }

--- a/src/main/preload/mattermost.js
+++ b/src/main/preload/mattermost.js
@@ -31,6 +31,8 @@ import {
     DESKTOP_SOURCES_RESULT,
     VIEW_FINISHED_RESIZING,
     CALLS_JOIN_CALL,
+    DESKTOP_SOURCES_MODAL_REQUEST,
+    CALLS_WIDGET_SHARE_SCREEN,
 } from 'common/communication';
 
 const UNREAD_COUNT_INTERVAL = 1000;
@@ -159,6 +161,10 @@ window.addEventListener('message', ({origin, data = {}} = {}) => {
     }
     case CALLS_JOIN_CALL: {
         ipcRenderer.send(CALLS_JOIN_CALL, viewName, message);
+        break;
+    }
+    case CALLS_WIDGET_SHARE_SCREEN: {
+        ipcRenderer.send(CALLS_WIDGET_SHARE_SCREEN, viewName, message);
         break;
     }
     }
@@ -291,6 +297,15 @@ ipcRenderer.on(DESKTOP_SOURCES_RESULT, (event, sources) => {
         {
             type: 'desktop-sources-result',
             message: sources,
+        },
+        window.location.origin,
+    );
+});
+
+ipcRenderer.on(DESKTOP_SOURCES_MODAL_REQUEST, () => {
+    window.postMessage(
+        {
+            type: DESKTOP_SOURCES_MODAL_REQUEST,
         },
         window.location.origin,
     );

--- a/src/main/preload/mattermost.js
+++ b/src/main/preload/mattermost.js
@@ -31,7 +31,6 @@ import {
     DESKTOP_SOURCES_RESULT,
     VIEW_FINISHED_RESIZING,
     CALLS_JOIN_CALL,
-    CALLS_LEAVE_CALL,
 } from 'common/communication';
 
 const UNREAD_COUNT_INTERVAL = 1000;
@@ -158,12 +157,8 @@ window.addEventListener('message', ({origin, data = {}} = {}) => {
         ipcRenderer.send(DISPATCH_GET_DESKTOP_SOURCES, viewName, message);
         break;
     }
-    case 'calls-join-call': {
+    case CALLS_JOIN_CALL: {
         ipcRenderer.send(CALLS_JOIN_CALL, viewName, message);
-        break;
-    }
-    case 'calls-client-close': {
-        ipcRenderer.send(CALLS_LEAVE_CALL, viewName, message);
         break;
     }
     }

--- a/src/main/windows/callsWidgetWindow.test.js
+++ b/src/main/windows/callsWidgetWindow.test.js
@@ -1,0 +1,214 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {EventEmitter} from 'events';
+import {BrowserWindow} from 'electron';
+
+import CallsWidgetWindow from './callsWidgetWindow';
+
+jest.mock('electron', () => ({
+    BrowserWindow: jest.fn(),
+    ipcMain: {
+        on: jest.fn(),
+        off: jest.fn(),
+    },
+}));
+
+describe('main/windows/callsWidgetWindow', () => {
+    describe('create CallsWidgetWindow', () => {
+        const widgetConfig = {
+            callID: 'test',
+            siteURL: 'http://localhost:8065',
+            title: '',
+        };
+
+        const mainWindow = {
+            getBounds: jest.fn(),
+        };
+
+        const baseWindow = new EventEmitter();
+        baseWindow.loadURL = jest.fn();
+        baseWindow.focus = jest.fn();
+        baseWindow.setVisibleOnAllWorkspaces = jest.fn();
+        baseWindow.setAlwaysOnTop = jest.fn();
+        baseWindow.setBackgroundColor = jest.fn();
+        baseWindow.setMenuBarVisibility = jest.fn();
+        baseWindow.setBounds = jest.fn();
+
+        beforeEach(() => {
+            mainWindow.getBounds.mockImplementation(() => {
+                return {
+                    x: 0,
+                    y: 0,
+                    width: 1280,
+                    height: 720,
+                };
+            });
+
+            baseWindow.getBounds = jest.fn(() => {
+                return {
+                    x: 0,
+                    y: 0,
+                    width: 280,
+                    height: 86,
+                };
+            });
+
+            baseWindow.loadURL.mockImplementation(() => ({
+                catch: jest.fn(),
+            }));
+            BrowserWindow.mockImplementation(() => baseWindow);
+        });
+
+        afterEach(() => {
+            jest.resetAllMocks();
+        });
+
+        it('verify initial configuration', () => {
+            const widgetWindow = new CallsWidgetWindow(mainWindow, widgetConfig);
+            expect(BrowserWindow).toHaveBeenCalledWith(expect.objectContaining({
+                width: widgetWindow.minWidth,
+                height: widgetWindow.minHeight,
+                minWidth: widgetWindow.minWidth,
+                minHeight: widgetWindow.minHeight,
+                fullscreen: false,
+                resizable: false,
+                frame: false,
+                transparent: true,
+                show: false,
+                alwaysOnTop: true,
+            }));
+        });
+
+        it('showing window', () => {
+            baseWindow.show = jest.fn(() => {
+                baseWindow.emit('show');
+            });
+
+            const widgetWindow = new CallsWidgetWindow(mainWindow, widgetConfig);
+            widgetWindow.win.emit('ready-to-show');
+
+            expect(widgetWindow.win.show).toHaveBeenCalled();
+            expect(widgetWindow.win.setAlwaysOnTop).toHaveBeenCalled();
+            expect(widgetWindow.win.setBounds).toHaveBeenCalledWith({
+                x: 12,
+                y: 622,
+                width: 280,
+                height: 86,
+            });
+        });
+
+        it('loadURL error', () => {
+            baseWindow.show = jest.fn(() => {
+                baseWindow.emit('show');
+            });
+
+            baseWindow.loadURL = jest.fn(() => {
+                return Promise.reject(new Error('failed to load URL'));
+            });
+
+            const widgetWindow = new CallsWidgetWindow(mainWindow, widgetConfig);
+            expect(widgetWindow.win.loadURL).toHaveBeenCalled();
+        });
+
+        it('open devTools', () => {
+            process.env.MM_DEBUG_CALLS_WIDGET = 'true';
+
+            baseWindow.show = jest.fn(() => {
+                baseWindow.emit('show');
+            });
+
+            baseWindow.webContents = {
+                openDevTools: jest.fn(),
+            };
+
+            const widgetWindow = new CallsWidgetWindow(mainWindow, widgetConfig);
+            widgetWindow.win.emit('ready-to-show');
+
+            expect(widgetWindow.win.webContents.openDevTools).toHaveBeenCalled();
+        });
+
+        it('closing window', () => {
+            baseWindow.close = jest.fn(() => {
+                baseWindow.emit('closed');
+            });
+
+            const widgetWindow = new CallsWidgetWindow(mainWindow, widgetConfig);
+            widgetWindow.close();
+            expect(widgetWindow.win.close).toHaveBeenCalled();
+        });
+
+        it('resize', () => {
+            baseWindow.show = jest.fn(() => {
+                baseWindow.emit('show');
+            });
+
+            let winBounds = {
+                x: 0,
+                y: 0,
+                width: 280,
+                height: 86,
+            };
+            baseWindow.getBounds = jest.fn(() => {
+                return winBounds;
+            });
+
+            baseWindow.setBounds = jest.fn((bounds) => {
+                winBounds = bounds;
+            });
+
+            const widgetWindow = new CallsWidgetWindow(mainWindow, widgetConfig);
+            widgetWindow.win.emit('ready-to-show');
+
+            expect(baseWindow.setBounds).toHaveBeenCalledTimes(2);
+
+            widgetWindow.onResize(null, {
+                element: 'calls-widget-menu',
+                height: 100,
+            });
+
+            expect(baseWindow.setBounds).toHaveBeenCalledWith({
+                x: 12,
+                y: 522,
+                width: 280,
+                height: 186,
+            });
+
+            widgetWindow.onResize(null, {
+                element: 'calls-widget-audio-menu',
+                width: 100,
+            });
+
+            expect(baseWindow.setBounds).toHaveBeenCalledWith({
+                x: 12,
+                y: 522,
+                width: 380,
+                height: 186,
+            });
+
+            widgetWindow.onResize(null, {
+                element: 'calls-widget-audio-menu',
+                width: 0,
+            });
+
+            expect(baseWindow.setBounds).toHaveBeenCalledWith({
+                x: 12,
+                y: 522,
+                width: 280,
+                height: 186,
+            });
+
+            widgetWindow.onResize(null, {
+                element: 'calls-widget-menu',
+                height: 0,
+            });
+
+            expect(baseWindow.setBounds).toHaveBeenCalledWith({
+                x: 12,
+                y: 622,
+                width: 280,
+                height: 86,
+            });
+        });
+    });
+});

--- a/src/main/windows/callsWidgetWindow.test.js
+++ b/src/main/windows/callsWidgetWindow.test.js
@@ -4,6 +4,8 @@
 import {EventEmitter} from 'events';
 import {BrowserWindow} from 'electron';
 
+import {CALLS_WIDGET_SHARE_SCREEN} from 'common/communication';
+
 import CallsWidgetWindow from './callsWidgetWindow';
 
 jest.mock('electron', () => ({
@@ -20,6 +22,7 @@ describe('main/windows/callsWidgetWindow', () => {
             callID: 'test',
             siteURL: 'http://localhost:8065',
             title: '',
+            serverName: 'test',
         };
 
         const mainWindow = {
@@ -209,6 +212,25 @@ describe('main/windows/callsWidgetWindow', () => {
                 width: 280,
                 height: 86,
             });
+        });
+
+        it('getServerName', () => {
+            const widgetWindow = new CallsWidgetWindow(mainWindow, widgetConfig);
+            expect(widgetWindow.getServerName()).toBe('test');
+        });
+
+        it('onShareScreen', () => {
+            baseWindow.webContents = {
+                send: jest.fn(),
+            };
+
+            const widgetWindow = new CallsWidgetWindow(mainWindow, widgetConfig);
+            const message = {
+                sourceID: 'test',
+                withAudio: false,
+            };
+            widgetWindow.onShareScreen(null, '', message);
+            expect(widgetWindow.win.webContents.send).toHaveBeenCalledWith(CALLS_WIDGET_SHARE_SCREEN, message);
         });
     });
 });

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -1,55 +1,180 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {BrowserWindow} from 'electron';
+import {EventEmitter} from 'events';
+import {BrowserWindow, Rectangle, ipcMain, IpcMainEvent} from 'electron';
 import log from 'electron-log';
 
-import {CallsWidgetWindowConfig} from 'types/calls';
+import {CallsWidgetWindowConfig, CallsWidgetResizeMessage} from 'types/calls';
 
 import {getLocalPreload} from 'main/utils';
 
-export default function createCallsWidgetWindow(mainWindow: BrowserWindow, config: CallsWidgetWindowConfig) {
-    const preload = getLocalPreload('callsWidget.js');
-    const win = new BrowserWindow({
-        parent: mainWindow,
-        width: 274,
-        height: 82,
-        title: 'Calls Widget', // TODO: possibly add channel name?
-        fullscreen: false,
-        resizable: false,
-        frame: false,
-        transparent: true,
-        show: false,
-        alwaysOnTop: true,
-        webPreferences: {
-            preload,
+import {PRODUCTION} from 'common/utils/constants';
+import Utils from 'common/utils/util';
+import {
+    CALLS_WIDGET_RESIZE,
+} from 'common/communication';
 
-            // Workaround for this issue: https://github.com/electron/electron/issues/30993
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
+type LoadURLOpts = {
+    extraHeaders: string;
+}
+
+function boundsDiff(base: Rectangle, actual: Rectangle) {
+    return {
+        x: base.x - actual.x,
+        y: base.y - actual.y,
+        width: base.width - actual.width,
+        height: base.height - actual.height,
+    };
+}
+
+export default class CallsWidgetWindow extends EventEmitter {
+    private win: BrowserWindow;
+    private main: BrowserWindow;
+    private config: CallsWidgetWindowConfig;
+    private minWidth = 280;
+    private minHeight = 86;
+    private pluginID = 'com.mattermost.calls';
+    private boundsErr: Rectangle = {
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+    };
+    private offsetsMap = {
+        'calls-widget-menu': {
+            height: 0,
+        },
+    };
+
+    constructor(mainWindow: BrowserWindow, config: CallsWidgetWindowConfig) {
+        super();
+
+        this.config = config;
+        this.main = mainWindow;
+        this.win = new BrowserWindow({
+            width: this.minWidth,
+            height: this.minHeight,
+            minWidth: this.minWidth,
+            minHeight: this.minHeight,
+            title: 'Calls Widget',
+            fullscreen: false,
+            resizable: false,
+            frame: false,
             transparent: true,
-        }});
-
-    win.once('ready-to-show', () => {
-        win.show();
-    });
-
-    const size = win.getSize();
-    const mainPos = mainWindow.getPosition();
-    const mainSize = mainWindow.getSize();
-    win.setPosition(mainPos[0] + 12, (mainPos[1] + mainSize[1]) - size[1] - 12);
-    win.setBackgroundColor('#00ffffff');
-    win.setMenuBarVisibility(false);
-
-    win.webContents.openDevTools({mode: 'detach'});
-
-    const pluginID = 'com.mattermost.calls';
-    const widgetURL = `${config.siteURL}/static/plugins/${pluginID}/widget/widget.html?call_id=${config.channelID}`;
-    win.loadURL(widgetURL).catch(
-        (reason) => {
-            log.error(`Calls window failed to load: ${reason}`);
+            show: false,
+            alwaysOnTop: true,
+            webPreferences: {
+                preload: getLocalPreload('callsWidget.js'),
+            },
         });
 
-    return win;
+        this.win.once('ready-to-show', () => this.win.show());
+        this.win.once('show', this.onShow);
+        this.win.on('closed', this.onClosed);
+        ipcMain.on(CALLS_WIDGET_RESIZE, this.onResize);
+
+        this.load();
+    }
+
+    public close() {
+        log.debug('CallsWidgetWindow.close');
+        this.win.close();
+    }
+
+    private load() {
+        const opts = {} as LoadURLOpts;
+        if (Utils.runMode() !== PRODUCTION) {
+            opts.extraHeaders = 'pragma: no-cache\n';
+        }
+        this.win.loadURL(this.getWidgetURL(), opts).catch((reason) => {
+            log.error(`Calls widget window failed to load: ${reason}`);
+        });
+    }
+
+    private onClosed = () => {
+        log.debug('CallsWidgetWindow.onClosed');
+        this.emit('closed');
+        this.removeAllListeners('closed');
+        ipcMain.off(CALLS_WIDGET_RESIZE, this.onResize);
+    }
+
+    private getWidgetURL() {
+        return `${this.config.siteURL}/static/plugins/${this.pluginID}/widget/widget.html?call_id=${this.config.callID}`;
+    }
+
+    private onResize = (event: IpcMainEvent, msg: CallsWidgetResizeMessage) => {
+        log.debug('CallsWidgetWindow.onResize');
+
+        const currBounds = this.win.getBounds();
+
+        switch (msg.element) {
+        case 'calls-widget-audio-menu': {
+            const newBounds = {
+                x: currBounds.x,
+                y: currBounds.y,
+                width: msg.width > 0 ? currBounds.width + msg.width : this.minWidth,
+                height: currBounds.height,
+            };
+
+            this.setBounds(newBounds);
+
+            break;
+        }
+        case 'calls-widget-menu': {
+            const hOff = this.offsetsMap[msg.element].height;
+
+            const newBounds = {
+                x: currBounds.x,
+                y: msg.height === 0 ? currBounds.y + hOff : currBounds.y - (msg.height - hOff),
+                width: this.minWidth,
+                height: this.minHeight + msg.height,
+            };
+
+            this.setBounds(newBounds);
+
+            this.offsetsMap[msg.element].height = msg.height;
+
+            break;
+        }
+        }
+    }
+
+    private setBounds(bounds: Rectangle) {
+        // NOTE: this hack is needed to fix positioning on certain systems where
+        // BrowserWindow.setBounds() is not consistent.
+        bounds.x += this.boundsErr.x;
+        bounds.y += this.boundsErr.y;
+        bounds.height += this.boundsErr.height;
+        bounds.width += this.boundsErr.width;
+
+        this.win.setBounds(bounds);
+        this.boundsErr = boundsDiff(bounds, this.win.getBounds());
+    }
+
+    private onShow = () => {
+        log.debug('CallsWidgetWindow.onShow');
+
+        this.win.focus();
+        this.win.setVisibleOnAllWorkspaces(true, {visibleOnFullScreen: true});
+        this.win.setAlwaysOnTop(true, 'screen-saver');
+
+        const bounds = this.win.getBounds();
+        const mainBounds = this.main.getBounds();
+        const initialBounds = {
+            x: mainBounds.x + 12,
+            y: (mainBounds.y + mainBounds.height) - bounds.height - 12,
+            width: this.minWidth,
+            height: this.minHeight,
+        };
+        this.win.setBackgroundColor('#00ffffff');
+        this.win.setMenuBarVisibility(false);
+
+        if (process.env.MM_DEBUG_CALLS_WIDGET) {
+            this.win.webContents.openDevTools({mode: 'detach'});
+        }
+
+        this.setBounds(initialBounds);
+    }
 }
 

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {BrowserWindow} from 'electron';
+import log from 'electron-log';
+
+import {CallsWidgetWindowConfig} from 'types/calls';
+
+import {getLocalPreload} from 'main/utils';
+
+export default function createCallsWidgetWindow(mainWindow: BrowserWindow, config: CallsWidgetWindowConfig) {
+    const preload = getLocalPreload('callsWidget.js');
+    const win = new BrowserWindow({
+        parent: mainWindow,
+        width: 274,
+        height: 82,
+        title: 'Calls Widget', // TODO: possibly add channel name?
+        fullscreen: false,
+        resizable: false,
+        frame: false,
+        transparent: true,
+        show: false,
+        alwaysOnTop: true,
+        webPreferences: {
+            preload,
+
+            // Workaround for this issue: https://github.com/electron/electron/issues/30993
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            transparent: true,
+        }});
+
+    win.once('ready-to-show', () => {
+        win.show();
+    });
+
+    const size = win.getSize();
+    const mainPos = mainWindow.getPosition();
+    const mainSize = mainWindow.getSize();
+    win.setPosition(mainPos[0] + 12, (mainPos[1] + mainSize[1]) - size[1] - 12);
+    win.setBackgroundColor('#00ffffff');
+    win.setMenuBarVisibility(false);
+
+    win.webContents.openDevTools({mode: 'detach'});
+
+    const pluginID = 'com.mattermost.calls';
+    const widgetURL = `${config.siteURL}/static/plugins/${pluginID}/widget/widget.html?call_id=${config.channelID}`;
+    win.loadURL(widgetURL).catch(
+        (reason) => {
+            log.error(`Calls window failed to load: ${reason}`);
+        });
+
+    return win;
+}
+

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -7,7 +7,10 @@ import path from 'path';
 import {app, BrowserWindow, nativeImage, systemPreferences, ipcMain, IpcMainEvent, IpcMainInvokeEvent, desktopCapturer} from 'electron';
 import log from 'electron-log';
 
-import {CallsJoinCallMessage} from 'types/calls';
+import {
+    CallsJoinCallMessage,
+    CallsWidgetChannelLinkClickMessage,
+} from 'types/calls';
 
 import {
     MAXIMIZE_CHANGE,
@@ -32,6 +35,7 @@ import {
     CALLS_JOIN_CALL,
     CALLS_LEAVE_CALL,
     DESKTOP_SOURCES_MODAL_REQUEST,
+    CALLS_WIDGET_CHANNEL_LINK_CLICK,
 } from 'common/communication';
 import urlUtils from 'common/utils/url';
 import {SECOND} from 'common/utils/constants';
@@ -86,6 +90,7 @@ export class WindowManager {
         ipcMain.on(CALLS_JOIN_CALL, this.createCallsWidgetWindow);
         ipcMain.on(CALLS_LEAVE_CALL, () => this.callsWidgetWindow?.close());
         ipcMain.on(DESKTOP_SOURCES_MODAL_REQUEST, this.handleDesktopSourcesModalRequest);
+        ipcMain.on(CALLS_WIDGET_CHANNEL_LINK_CLICK, this.handleCallsWidgetChannelLinkClick);
     }
 
     handleUpdateConfig = () => {
@@ -123,6 +128,16 @@ export class WindowManager {
             this.mainWindow?.focus();
             const currentView = this.viewManager?.getCurrentView();
             currentView?.view.webContents.send(DESKTOP_SOURCES_MODAL_REQUEST);
+        }
+    }
+
+    handleCallsWidgetChannelLinkClick = (ev: IpcMainEvent, msg: CallsWidgetChannelLinkClickMessage) => {
+        log.debug('WindowManager.handleCallsWidgetChannelLinkClick');
+        if (this.callsWidgetWindow) {
+            this.switchServer(this.callsWidgetWindow?.getServerName());
+            this.mainWindow?.focus();
+            const currentView = this.viewManager?.getCurrentView();
+            currentView?.view.webContents.send(BROWSER_HISTORY_PUSH, msg.pathName);
         }
     }
 

--- a/src/types/calls.ts
+++ b/src/types/calls.ts
@@ -1,0 +1,12 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+export type CallsWidgetWindowConfig = {
+    siteURL: string;
+    channelID: string;
+    title: string;
+}
+
+export type CallsJoinCallMessage = {
+    channelID: string;
+    title: string;
+}

--- a/src/types/calls.ts
+++ b/src/types/calls.ts
@@ -4,6 +4,7 @@ export type CallsWidgetWindowConfig = {
     siteURL: string;
     callID: string;
     title: string;
+    serverName: string;
 }
 
 export type CallsJoinCallMessage = {
@@ -15,4 +16,9 @@ export type CallsWidgetResizeMessage = {
     element: string;
     width: number;
     height: number;
+}
+
+export type CallsWidgetShareScreenMessage = {
+    sourceID: string;
+    withAudio: boolean;
 }

--- a/src/types/calls.ts
+++ b/src/types/calls.ts
@@ -2,11 +2,17 @@
 // See LICENSE.txt for license information.
 export type CallsWidgetWindowConfig = {
     siteURL: string;
-    channelID: string;
+    callID: string;
     title: string;
 }
 
 export type CallsJoinCallMessage = {
-    channelID: string;
+    callID: string;
     title: string;
+}
+
+export type CallsWidgetResizeMessage = {
+    element: string;
+    width: number;
+    height: number;
 }

--- a/src/types/calls.ts
+++ b/src/types/calls.ts
@@ -22,3 +22,7 @@ export type CallsWidgetShareScreenMessage = {
     sourceID: string;
     withAudio: boolean;
 }
+
+export type CallsWidgetChannelLinkClickMessage = {
+    pathName: string;
+}

--- a/webpack.config.main.js
+++ b/webpack.config.main.js
@@ -21,6 +21,7 @@ module.exports = merge(base, {
         modalPreload: './src/main/preload/modalPreload.js',
         loadingScreenPreload: './src/main/preload/loadingScreenPreload.js',
         urlView: './src/main/preload/urlView.js',
+        callsWidget: './src/main/preload/callsWidget.js',
     },
     externals: {
         'macos-notification-state': 'require("macos-notification-state")',


### PR DESCRIPTION
#### Summary

PR adds the initial implementation of a floating desktop widget for Calls. Technically speaking this is a frameless and transparent window that loads a standalone react app that purely renders the widget component (option 2 of the [design proposal](https://docs.google.com/document/d/1axYeHZeGbQWwsQPKHGYbdoyEkRTx0nbwxUEHWfk0FMA/edit)).

While ready for initial review I expect a few changes to get added on top as we start testing this a bit. I am using the [MM-46971-global-widget](https://github.com/mattermost/desktop/tree/MM-46971-global-widget) feature branch as base for this and any subsequent PRs.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46993

#### Related PRs

https://github.com/mattermost/mattermost-plugin-calls/pull/213

#### Screenshots

<img width="100%" src="https://user-images.githubusercontent.com/1832946/192771408-315e2e39-8ff1-4bd8-b73b-e87168a7bb63.png">

#### Release Note

```release-note
NONE
```