### PR TITLE
[MM-47279] Upgrade to Electron v19.1.1 and other Electron dependency upgrades

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,11 @@
         "bootstrap": "4.6.1",
         "bootstrap-dark": "1.0.3",
         "classnames": "2.3.1",
-        "electron-context-menu": "3.1.2",
+        "electron-context-menu": "3.5.0",
         "electron-devtools-installer": "3.2.0",
         "electron-is-dev": "2.0.0",
-        "electron-log": "4.4.6",
-        "electron-updater": "5.0.0",
+        "electron-log": "4.4.8",
+        "electron-updater": "5.2.1",
         "fs-extra": "10.0.1",
         "joi": "17.6.0",
         "macos-notification-state": "2.0.1",
@@ -46,8 +46,8 @@
         "@babel/preset-react": "7.16.7",
         "@babel/register": "7.17.7",
         "@bloomberg/record-tuple-polyfill": "^0.0.4",
-        "@electron/fuses": "1.5.0",
-        "@electron/universal": "1.2.1",
+        "@electron/fuses": "1.6.0",
+        "@electron/universal": "1.3.1",
         "@storybook/addon-actions": "6.4.20",
         "@storybook/react": "6.4.20",
         "@types/auto-launch": "5.0.2",
@@ -68,12 +68,12 @@
         "copy-webpack-plugin": "10.2.4",
         "cross-env": "7.0.3",
         "css-loader": "6.7.1",
-        "electron": "19.0.6",
-        "electron-builder": "23.0.8",
+        "electron": "19.1.1",
+        "electron-builder": "23.3.3",
         "electron-connect": "0.6.3",
         "electron-mocha": "11.0.2",
         "electron-notarize": "1.2.1",
-        "electron-rebuild": "3.2.8",
+        "electron-rebuild": "3.2.9",
         "eslint": "7.29.0",
         "eslint-import-resolver-webpack": "0.13.2",
         "eslint-plugin-babel": "5.3.1",
@@ -2124,9 +2124,9 @@
       }
     },
     "node_modules/@electron/fuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.5.0.tgz",
-      "integrity": "sha512-2NPJdQTPoERxcIWsTAG9ZKay0KsORfs973dbkdksNEeBAfjdyPBNaUrh/DAlpUdAnFmPl+Cs9gIZibRYiOrvqQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.6.0.tgz",
+      "integrity": "sha512-UnZgLfVO1jf7QoYVEEB27CCP1JjT5plhbWU1U8ji1OaXnvNe5UT6KPuRJ3Z12mwa5ZBAASU2tgxVuI06/2x6nQ==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.1",
@@ -2256,9 +2256,9 @@
       }
     },
     "node_modules/@electron/universal": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.2.1.tgz",
-      "integrity": "sha512-7323HyMh7KBAl/nPDppdLsC87G6RwRU02dy5FPeGB1eS7rUePh55+WNWiDPLhFQqqVPHzh77M69uhmoT8XnwMQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.3.1.tgz",
+      "integrity": "sha512-y1r1dpiyrOa3EOxKgr2Rwsv69Dya2MC1LwM+9/QG5jeCetd2s73NTrpubBD6scv9sRNexYYik8or/Fo8sNtNbg==",
       "dev": true,
       "dependencies": {
         "@malept/cross-spawn-promise": "^1.1.0",
@@ -9277,9 +9277,9 @@
       "dev": true
     },
     "node_modules/@types/verror": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.5.tgz",
-      "integrity": "sha512-9UjMCHK5GPgQRoNbqdLIAvAy0EInuiqbW0PBMtVP6B5B2HQJlvoJHM+KodPZMEjOa5VkSc+5LH7xy+cUzQdmHw==",
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.6.tgz",
+      "integrity": "sha512-NNm+gdePAX1VGvPcGZCDKQZKYSiAWigKhKaz5KF94hG6f2s8de9Ow5+7AbXoeKxL8gavZfk4UquSAygOF2duEQ==",
       "dev": true,
       "optional": true
     },
@@ -10261,9 +10261,9 @@
       "dev": true
     },
     "node_modules/app-builder-lib": {
-      "version": "23.0.8",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-23.0.8.tgz",
-      "integrity": "sha512-IObTdRc/0TQsfGn9IvaEXULE/QacgyFgpz3+vmlpZgHHjQ6V1c/T4pKlzNTsNHGjJBuEg2FvTvYi9ZVFfhyWow==",
+      "version": "23.3.3",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-23.3.3.tgz",
+      "integrity": "sha512-m0+M53+HYMzqKxwNQZT143K7WwXEGUy9LY31l8dJphXx2P/FQod615mVbxHyqbDCG4J5bHdWm21qZ0e2DVY6CQ==",
       "dev": true,
       "dependencies": {
         "@develar/schema-utils": "~2.6.5",
@@ -10272,13 +10272,13 @@
         "7zip-bin": "~5.1.1",
         "async-exit-hook": "^2.0.1",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "23.0.8",
-        "builder-util-runtime": "9.0.2",
+        "builder-util": "23.3.3",
+        "builder-util-runtime": "9.0.3",
         "chromium-pickle-js": "^0.2.0",
         "debug": "^4.3.4",
         "ejs": "^3.1.7",
         "electron-osx-sign": "^0.6.0",
-        "electron-publish": "23.0.8",
+        "electron-publish": "23.3.3",
         "form-data": "^4.0.0",
         "fs-extra": "^10.1.0",
         "hosted-git-info": "^4.1.0",
@@ -10303,23 +10303,10 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
-    "node_modules/app-builder-lib/node_modules/builder-util-runtime": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.2.tgz",
-      "integrity": "sha512-xF55W/8mgfT6+sMbX0TeiJkTusA5GMOzckM4rajN4KirFcUIuLTH8oEaTYmM86YwVCZaTwa/7GyFhauXaEICwA==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.3.4",
-        "sax": "^1.2.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/app-builder-lib/node_modules/ci-info": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
-      "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
+      "integrity": "sha512-t5QdPT5jq3o262DOQ8zA6E1tlH2upmUc4Hlvrbx1pGYJuiiHl7O7rvVNI+l8HTVhd/q3Qc9vqimkNk5yiXsAug==",
       "dev": true
     },
     "node_modules/app-builder-lib/node_modules/debug": {
@@ -10428,9 +10415,9 @@
       }
     },
     "node_modules/app-builder-lib/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -12149,9 +12136,9 @@
       }
     },
     "node_modules/builder-util": {
-      "version": "23.0.8",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.0.8.tgz",
-      "integrity": "sha512-xPpnoLLAEPx5oxxzRFINRnxmLNQDn+FddU7QRvCJDQi0jvUJ7UjdoGoM+UPy9yh+p9O82/nC7MHGuUptJkOXyQ==",
+      "version": "23.3.3",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.3.3.tgz",
+      "integrity": "sha512-MJZlUiq2PY5hjYv9+XNaoYdsITqvLgRDoHSFg/4nzpInbNxNjLQOolL04Zsyp+hgfcbFvMC4h0KkR1CMPHLWbA==",
       "dev": true,
       "dependencies": {
         "@types/debug": "^4.1.6",
@@ -12159,7 +12146,7 @@
         "7zip-bin": "~5.1.1",
         "app-builder-bin": "4.0.0",
         "bluebird-lst": "^1.0.9",
-        "builder-util-runtime": "9.0.2",
+        "builder-util-runtime": "9.0.3",
         "chalk": "^4.1.1",
         "cross-spawn": "^7.0.3",
         "debug": "^4.3.4",
@@ -12174,15 +12161,31 @@
       }
     },
     "node_modules/builder-util-runtime": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.0.tgz",
-      "integrity": "sha512-SkpEtSmTkREDHRJnxKEv43aAYp8sYWY8fxYBhGLBLOBIRXeaIp6Kv3lBgSD7uR8jQtC7CA659sqJrpSV6zNvSA==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.3.tgz",
+      "integrity": "sha512-SfG2wnyjpUbbdtpnqDpWwklujofC6GarGpvdWrEkg9p5AD/xJmTF2buTNaqs3qtsNBEVQDDjZz9xc2GGpVyMfA==",
       "dependencies": {
-        "debug": "^4.3.2",
+        "debug": "^4.3.4",
         "sax": "^1.2.4"
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/builder-util-runtime/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/builder-util/node_modules/@tootallnate/once": {
@@ -12199,19 +12202,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
-    },
-    "node_modules/builder-util/node_modules/builder-util-runtime": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.2.tgz",
-      "integrity": "sha512-xF55W/8mgfT6+sMbX0TeiJkTusA5GMOzckM4rajN4KirFcUIuLTH8oEaTYmM86YwVCZaTwa/7GyFhauXaEICwA==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.3.4",
-        "sax": "^1.2.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/builder-util/node_modules/chalk": {
       "version": "4.1.2",
@@ -12230,9 +12220,9 @@
       }
     },
     "node_modules/builder-util/node_modules/ci-info": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
-      "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
+      "integrity": "sha512-t5QdPT5jq3o262DOQ8zA6E1tlH2upmUc4Hlvrbx1pGYJuiiHl7O7rvVNI+l8HTVhd/q3Qc9vqimkNk5yiXsAug==",
       "dev": true
     },
     "node_modules/builder-util/node_modules/cross-spawn": {
@@ -14517,6 +14507,7 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
       "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "devOptional": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -14920,14 +14911,14 @@
       }
     },
     "node_modules/dmg-builder": {
-      "version": "23.0.8",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-23.0.8.tgz",
-      "integrity": "sha512-dXguxjekxY70hzgAW+0NPCI7bagQ2ZrLDwYf1bvHSwlVfVizyJ/EC+e71U/NUgiWlXU5nogbWcGC3H74mFu0iw==",
+      "version": "23.3.3",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-23.3.3.tgz",
+      "integrity": "sha512-ECwAjt+ZWyOvddrkDx1xRD6IVUCZb5SV6vSMHZd+Va3G2sUXHrnglR1cGDKRF4oYRQm8SYVrpLZKbi8npyDcAQ==",
       "dev": true,
       "dependencies": {
-        "app-builder-lib": "23.0.8",
-        "builder-util": "23.0.8",
-        "builder-util-runtime": "9.0.2",
+        "app-builder-lib": "23.3.3",
+        "builder-util": "23.3.3",
+        "builder-util-runtime": "9.0.3",
         "fs-extra": "^10.0.0",
         "iconv-lite": "^0.6.2",
         "js-yaml": "^4.1.0"
@@ -14941,36 +14932,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
-    },
-    "node_modules/dmg-builder/node_modules/builder-util-runtime": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.2.tgz",
-      "integrity": "sha512-xF55W/8mgfT6+sMbX0TeiJkTusA5GMOzckM4rajN4KirFcUIuLTH8oEaTYmM86YwVCZaTwa/7GyFhauXaEICwA==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.3.4",
-        "sax": "^1.2.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/dmg-builder/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
     },
     "node_modules/dmg-builder/node_modules/js-yaml": {
       "version": "4.1.0",
@@ -15244,9 +15205,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "19.0.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.6.tgz",
-      "integrity": "sha512-S9Yud32nKhB0iWC0lGl2JXz4FQnCiLCnP5Vehm1/CqyeICcQGmgQaZl2HYpCJ2pesKIsYL9nsgmku/10cxm/gg==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.1.1.tgz",
+      "integrity": "sha512-cVjX+vYH431iNdIpDXU1cfx83heS/lkPVorpaiERSPcycwiZYFtE5xjL8XAARV11TG+AmN4gxBFMSb9R7DhStw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -15262,17 +15223,17 @@
       }
     },
     "node_modules/electron-builder": {
-      "version": "23.0.8",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-23.0.8.tgz",
-      "integrity": "sha512-7WxdR4+l+VL4QN/K6NdqRQg7+cbIka4By1+4eN8odMPySSTI5d6nrV8R+SSRt9MXeWVdWlW8RCX5Pk6L0oaRug==",
+      "version": "23.3.3",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-23.3.3.tgz",
+      "integrity": "sha512-mFYYdhoFPKevP6y5uaaF3dusmB2OtQ/HnwwpyOePeU7QDS0SEIAUokQsHUanAiJAZcBqtY7iyLBgX18QybdFFw==",
       "dev": true,
       "dependencies": {
         "@types/yargs": "^17.0.1",
-        "app-builder-lib": "23.0.8",
-        "builder-util": "23.0.8",
-        "builder-util-runtime": "9.0.2",
+        "app-builder-lib": "23.3.3",
+        "builder-util": "23.3.3",
+        "builder-util-runtime": "9.0.3",
         "chalk": "^4.1.1",
-        "dmg-builder": "23.0.8",
+        "dmg-builder": "23.3.3",
         "fs-extra": "^10.0.0",
         "is-ci": "^3.0.0",
         "lazy-val": "^1.0.5",
@@ -15297,19 +15258,6 @@
         "@types/yargs-parser": "*"
       }
     },
-    "node_modules/electron-builder/node_modules/builder-util-runtime": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.2.tgz",
-      "integrity": "sha512-xF55W/8mgfT6+sMbX0TeiJkTusA5GMOzckM4rajN4KirFcUIuLTH8oEaTYmM86YwVCZaTwa/7GyFhauXaEICwA==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.3.4",
-        "sax": "^1.2.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/electron-builder/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -15331,23 +15279,6 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
       "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
       "dev": true
-    },
-    "node_modules/electron-builder/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
     },
     "node_modules/electron-builder/node_modules/has-flag": {
       "version": "4.0.0",
@@ -15395,9 +15326,9 @@
       }
     },
     "node_modules/electron-context-menu": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/electron-context-menu/-/electron-context-menu-3.1.2.tgz",
-      "integrity": "sha512-nNzu4w14n7mOR+4cLjRC9cEFqGUsAY76seOm0sw3f4OxEfX/d75m7HYekyp5b+0m7Ixy2KN/Mrljw1zLmpyV2w==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/electron-context-menu/-/electron-context-menu-3.5.0.tgz",
+      "integrity": "sha512-z4agpok6YnXlGFs66zU9EBFft4llUFJ41NYFEMMS0fnprMKBztJUCHBA6LMAqJgjabfqsYC7kxlvjvepxodOqg==",
       "dependencies": {
         "cli-truncate": "^2.1.0",
         "electron-dl": "^3.2.1",
@@ -15453,9 +15384,9 @@
       "integrity": "sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA=="
     },
     "node_modules/electron-log": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.4.6.tgz",
-      "integrity": "sha512-nirYgRdY+F+vclr8ijdwy2vW03IzFpDHTaKNWu76dEN21Y76+smcES5knS7cgHUUB0qNLOi8vZO36taakjbSXA=="
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.4.8.tgz",
+      "integrity": "sha512-QQ4GvrXO+HkgqqEOYbi+DHL7hj5JM+nHi/j+qrN9zeeXVKy8ZABgbu4CnG+BBqDZ2+tbeq9tUC4DZfIWFU5AZA=="
     },
     "node_modules/electron-mocha": {
       "version": "11.0.2",
@@ -15787,6 +15718,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.6.0.tgz",
       "integrity": "sha512-+hiIEb2Xxk6eDKJ2FFlpofCnemCbjbT5jz+BKGpVBrRNT3kWTGs4DfNX6IzGwgi33hUcXF+kFs9JW+r6Wc1LRg==",
+      "deprecated": "Please use @electron/osx-sign moving forward. Be aware the API is slightly different",
       "dev": true,
       "dependencies": {
         "bluebird": "^3.5.0",
@@ -15832,31 +15764,18 @@
       "dev": true
     },
     "node_modules/electron-publish": {
-      "version": "23.0.8",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-23.0.8.tgz",
-      "integrity": "sha512-GnqJH7Wh8LnapN4npl1Xs2Er/486/qxE3dV42WxXHX2VeoKAJTOuCzOVWCxpajaR3Msji4SkS0p81R018uK6Mg==",
+      "version": "23.3.3",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-23.3.3.tgz",
+      "integrity": "sha512-1dX17eE5xVXedTxjC+gjsP74oC0+sIHgqysp0ryTlF9+yfQUyXjBk6kcK+zhtBA2SsHMSglDtM+JPxDD/WpPTQ==",
       "dev": true,
       "dependencies": {
         "@types/fs-extra": "^9.0.11",
-        "builder-util": "23.0.8",
-        "builder-util-runtime": "9.0.2",
+        "builder-util": "23.3.3",
+        "builder-util-runtime": "9.0.3",
         "chalk": "^4.1.1",
         "fs-extra": "^10.0.0",
         "lazy-val": "^1.0.5",
         "mime": "^2.5.2"
-      }
-    },
-    "node_modules/electron-publish/node_modules/builder-util-runtime": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.2.tgz",
-      "integrity": "sha512-xF55W/8mgfT6+sMbX0TeiJkTusA5GMOzckM4rajN4KirFcUIuLTH8oEaTYmM86YwVCZaTwa/7GyFhauXaEICwA==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.3.4",
-        "sax": "^1.2.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/electron-publish/node_modules/chalk": {
@@ -15873,23 +15792,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/electron-publish/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/electron-publish/node_modules/has-flag": {
@@ -15926,9 +15828,9 @@
       }
     },
     "node_modules/electron-rebuild": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-3.2.8.tgz",
-      "integrity": "sha512-+U/G5ZH9RNfvPQsEHevC3yDlgSB+wliNXnG6haqUeZBEq061pEgSTWK9ZBEfqMEq+PKxvniMNxfou/h6079s3A==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-3.2.9.tgz",
+      "integrity": "sha512-FkEZNFViUem3P0RLYbZkUjC8LUFIK+wKq09GHoOITSJjfDAVQv964hwaNseTTWt58sITQX3/5fHNYcTefqaCWw==",
       "dev": true,
       "dependencies": {
         "@malept/cross-spawn-promise": "^2.0.0",
@@ -16272,18 +16174,19 @@
       "devOptional": true
     },
     "node_modules/electron-updater": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-5.0.0.tgz",
-      "integrity": "sha512-SC3sw92ewjrJFZIJamVOHqxW3yzFin/Q/Swf2FZodqm9xd4s8hCbPCfptpD/xBIcvQmAv2BAggbprwWq/fyp6w==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-5.2.1.tgz",
+      "integrity": "sha512-OQZVIvqcK8j03HjT07uVPgvguP/r8RY2wZcwCM26+fcDOjtrm01Dfz3G8Eru+69znbrR+F9pDzr98ewMavBrWQ==",
       "dependencies": {
         "@types/semver": "^7.3.6",
-        "builder-util-runtime": "9.0.0",
+        "builder-util-runtime": "9.0.3",
         "fs-extra": "^10.0.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
         "lodash.escaperegexp": "^4.1.2",
         "lodash.isequal": "^4.5.0",
-        "semver": "^7.3.5"
+        "semver": "^7.3.5",
+        "typed-emitter": "^2.1.0"
       }
     },
     "node_modules/electron-updater/node_modules/argparse": {
@@ -28525,6 +28428,21 @@
         "aproba": "^1.1.1"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "optional": true
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -30830,6 +30748,14 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "optionalDependencies": {
+        "rxjs": "*"
       }
     },
     "node_modules/typedarray": {
@@ -34270,9 +34196,9 @@
       "dev": true
     },
     "@electron/fuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.5.0.tgz",
-      "integrity": "sha512-2NPJdQTPoERxcIWsTAG9ZKay0KsORfs973dbkdksNEeBAfjdyPBNaUrh/DAlpUdAnFmPl+Cs9gIZibRYiOrvqQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.6.0.tgz",
+      "integrity": "sha512-UnZgLfVO1jf7QoYVEEB27CCP1JjT5plhbWU1U8ji1OaXnvNe5UT6KPuRJ3Z12mwa5ZBAASU2tgxVuI06/2x6nQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.1",
@@ -34372,9 +34298,9 @@
       }
     },
     "@electron/universal": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.2.1.tgz",
-      "integrity": "sha512-7323HyMh7KBAl/nPDppdLsC87G6RwRU02dy5FPeGB1eS7rUePh55+WNWiDPLhFQqqVPHzh77M69uhmoT8XnwMQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.3.1.tgz",
+      "integrity": "sha512-y1r1dpiyrOa3EOxKgr2Rwsv69Dya2MC1LwM+9/QG5jeCetd2s73NTrpubBD6scv9sRNexYYik8or/Fo8sNtNbg==",
       "dev": true,
       "requires": {
         "@malept/cross-spawn-promise": "^1.1.0",
@@ -39985,9 +39911,9 @@
       "dev": true
     },
     "@types/verror": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.5.tgz",
-      "integrity": "sha512-9UjMCHK5GPgQRoNbqdLIAvAy0EInuiqbW0PBMtVP6B5B2HQJlvoJHM+KodPZMEjOa5VkSc+5LH7xy+cUzQdmHw==",
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.6.tgz",
+      "integrity": "sha512-NNm+gdePAX1VGvPcGZCDKQZKYSiAWigKhKaz5KF94hG6f2s8de9Ow5+7AbXoeKxL8gavZfk4UquSAygOF2duEQ==",
       "dev": true,
       "optional": true
     },
@@ -40778,24 +40704,24 @@
       "dev": true
     },
     "app-builder-lib": {
-      "version": "23.0.8",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-23.0.8.tgz",
-      "integrity": "sha512-IObTdRc/0TQsfGn9IvaEXULE/QacgyFgpz3+vmlpZgHHjQ6V1c/T4pKlzNTsNHGjJBuEg2FvTvYi9ZVFfhyWow==",
+      "version": "23.3.3",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-23.3.3.tgz",
+      "integrity": "sha512-m0+M53+HYMzqKxwNQZT143K7WwXEGUy9LY31l8dJphXx2P/FQod615mVbxHyqbDCG4J5bHdWm21qZ0e2DVY6CQ==",
       "dev": true,
       "requires": {
         "@develar/schema-utils": "~2.6.5",
-        "@electron/universal": "1.2.1",
+        "@electron/universal": "1.3.1",
         "@malept/flatpak-bundler": "^0.4.0",
         "7zip-bin": "~5.1.1",
         "async-exit-hook": "^2.0.1",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "23.0.8",
-        "builder-util-runtime": "9.0.2",
+        "builder-util": "23.3.3",
+        "builder-util-runtime": "9.0.3",
         "chromium-pickle-js": "^0.2.0",
         "debug": "^4.3.4",
         "ejs": "^3.1.7",
         "electron-osx-sign": "^0.6.0",
-        "electron-publish": "23.0.8",
+        "electron-publish": "23.3.3",
         "form-data": "^4.0.0",
         "fs-extra": "^10.1.0",
         "hosted-git-info": "^4.1.0",
@@ -40817,20 +40743,10 @@
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
           "dev": true
         },
-        "builder-util-runtime": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.2.tgz",
-          "integrity": "sha512-xF55W/8mgfT6+sMbX0TeiJkTusA5GMOzckM4rajN4KirFcUIuLTH8oEaTYmM86YwVCZaTwa/7GyFhauXaEICwA==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.3.4",
-            "sax": "^1.2.4"
-          }
-        },
         "ci-info": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
-          "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
+          "integrity": "sha512-t5QdPT5jq3o262DOQ8zA6E1tlH2upmUc4Hlvrbx1pGYJuiiHl7O7rvVNI+l8HTVhd/q3Qc9vqimkNk5yiXsAug==",
           "dev": true
         },
         "debug": {
@@ -40911,9 +40827,9 @@
           }
         },
         "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -42287,9 +42203,9 @@
       "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
     },
     "builder-util": {
-      "version": "23.0.8",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.0.8.tgz",
-      "integrity": "sha512-xPpnoLLAEPx5oxxzRFINRnxmLNQDn+FddU7QRvCJDQi0jvUJ7UjdoGoM+UPy9yh+p9O82/nC7MHGuUptJkOXyQ==",
+      "version": "23.3.3",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.3.3.tgz",
+      "integrity": "sha512-MJZlUiq2PY5hjYv9+XNaoYdsITqvLgRDoHSFg/4nzpInbNxNjLQOolL04Zsyp+hgfcbFvMC4h0KkR1CMPHLWbA==",
       "dev": true,
       "requires": {
         "@types/debug": "^4.1.6",
@@ -42297,7 +42213,7 @@
         "7zip-bin": "~5.1.1",
         "app-builder-bin": "4.0.0",
         "bluebird-lst": "^1.0.9",
-        "builder-util-runtime": "9.0.2",
+        "builder-util-runtime": "9.0.3",
         "chalk": "^4.1.1",
         "cross-spawn": "^7.0.3",
         "debug": "^4.3.4",
@@ -42323,16 +42239,6 @@
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
           "dev": true
         },
-        "builder-util-runtime": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.2.tgz",
-          "integrity": "sha512-xF55W/8mgfT6+sMbX0TeiJkTusA5GMOzckM4rajN4KirFcUIuLTH8oEaTYmM86YwVCZaTwa/7GyFhauXaEICwA==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.3.4",
-            "sax": "^1.2.4"
-          }
-        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -42344,9 +42250,9 @@
           }
         },
         "ci-info": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
-          "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
+          "integrity": "sha512-t5QdPT5jq3o262DOQ8zA6E1tlH2upmUc4Hlvrbx1pGYJuiiHl7O7rvVNI+l8HTVhd/q3Qc9vqimkNk5yiXsAug==",
           "dev": true
         },
         "cross-spawn": {
@@ -42446,12 +42352,22 @@
       }
     },
     "builder-util-runtime": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.0.tgz",
-      "integrity": "sha512-SkpEtSmTkREDHRJnxKEv43aAYp8sYWY8fxYBhGLBLOBIRXeaIp6Kv3lBgSD7uR8jQtC7CA659sqJrpSV6zNvSA==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.3.tgz",
+      "integrity": "sha512-SfG2wnyjpUbbdtpnqDpWwklujofC6GarGpvdWrEkg9p5AD/xJmTF2buTNaqs3qtsNBEVQDDjZz9xc2GGpVyMfA==",
       "requires": {
-        "debug": "^4.3.2",
+        "debug": "^4.3.4",
         "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
       }
     },
     "builtin-status-codes": {
@@ -44081,6 +43997,7 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
       "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "devOptional": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -44395,14 +44312,14 @@
       }
     },
     "dmg-builder": {
-      "version": "23.0.8",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-23.0.8.tgz",
-      "integrity": "sha512-dXguxjekxY70hzgAW+0NPCI7bagQ2ZrLDwYf1bvHSwlVfVizyJ/EC+e71U/NUgiWlXU5nogbWcGC3H74mFu0iw==",
+      "version": "23.3.3",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-23.3.3.tgz",
+      "integrity": "sha512-ECwAjt+ZWyOvddrkDx1xRD6IVUCZb5SV6vSMHZd+Va3G2sUXHrnglR1cGDKRF4oYRQm8SYVrpLZKbi8npyDcAQ==",
       "dev": true,
       "requires": {
-        "app-builder-lib": "23.0.8",
-        "builder-util": "23.0.8",
-        "builder-util-runtime": "9.0.2",
+        "app-builder-lib": "23.3.3",
+        "builder-util": "23.3.3",
+        "builder-util-runtime": "9.0.3",
         "dmg-license": "^1.0.11",
         "fs-extra": "^10.0.0",
         "iconv-lite": "^0.6.2",
@@ -44414,25 +44331,6 @@
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
           "dev": true
-        },
-        "builder-util-runtime": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.2.tgz",
-          "integrity": "sha512-xF55W/8mgfT6+sMbX0TeiJkTusA5GMOzckM4rajN4KirFcUIuLTH8oEaTYmM86YwVCZaTwa/7GyFhauXaEICwA==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.3.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
         },
         "js-yaml": {
           "version": "4.1.0",
@@ -44652,9 +44550,9 @@
       }
     },
     "electron": {
-      "version": "19.0.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.6.tgz",
-      "integrity": "sha512-S9Yud32nKhB0iWC0lGl2JXz4FQnCiLCnP5Vehm1/CqyeICcQGmgQaZl2HYpCJ2pesKIsYL9nsgmku/10cxm/gg==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.1.1.tgz",
+      "integrity": "sha512-cVjX+vYH431iNdIpDXU1cfx83heS/lkPVorpaiERSPcycwiZYFtE5xjL8XAARV11TG+AmN4gxBFMSb9R7DhStw==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.14.1",
@@ -44671,17 +44569,17 @@
       }
     },
     "electron-builder": {
-      "version": "23.0.8",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-23.0.8.tgz",
-      "integrity": "sha512-7WxdR4+l+VL4QN/K6NdqRQg7+cbIka4By1+4eN8odMPySSTI5d6nrV8R+SSRt9MXeWVdWlW8RCX5Pk6L0oaRug==",
+      "version": "23.3.3",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-23.3.3.tgz",
+      "integrity": "sha512-mFYYdhoFPKevP6y5uaaF3dusmB2OtQ/HnwwpyOePeU7QDS0SEIAUokQsHUanAiJAZcBqtY7iyLBgX18QybdFFw==",
       "dev": true,
       "requires": {
         "@types/yargs": "^17.0.1",
-        "app-builder-lib": "23.0.8",
-        "builder-util": "23.0.8",
-        "builder-util-runtime": "9.0.2",
+        "app-builder-lib": "23.3.3",
+        "builder-util": "23.3.3",
+        "builder-util-runtime": "9.0.3",
         "chalk": "^4.1.1",
-        "dmg-builder": "23.0.8",
+        "dmg-builder": "23.3.3",
         "fs-extra": "^10.0.0",
         "is-ci": "^3.0.0",
         "lazy-val": "^1.0.5",
@@ -44699,16 +44597,6 @@
             "@types/yargs-parser": "*"
           }
         },
-        "builder-util-runtime": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.2.tgz",
-          "integrity": "sha512-xF55W/8mgfT6+sMbX0TeiJkTusA5GMOzckM4rajN4KirFcUIuLTH8oEaTYmM86YwVCZaTwa/7GyFhauXaEICwA==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.3.4",
-            "sax": "^1.2.4"
-          }
-        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -44724,15 +44612,6 @@
           "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
           "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
           "dev": true
-        },
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
         },
         "has-flag": {
           "version": "4.0.0",
@@ -44773,9 +44652,9 @@
       }
     },
     "electron-context-menu": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/electron-context-menu/-/electron-context-menu-3.1.2.tgz",
-      "integrity": "sha512-nNzu4w14n7mOR+4cLjRC9cEFqGUsAY76seOm0sw3f4OxEfX/d75m7HYekyp5b+0m7Ixy2KN/Mrljw1zLmpyV2w==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/electron-context-menu/-/electron-context-menu-3.5.0.tgz",
+      "integrity": "sha512-z4agpok6YnXlGFs66zU9EBFft4llUFJ41NYFEMMS0fnprMKBztJUCHBA6LMAqJgjabfqsYC7kxlvjvepxodOqg==",
       "requires": {
         "cli-truncate": "^2.1.0",
         "electron-dl": "^3.2.1",
@@ -44824,9 +44703,9 @@
       "integrity": "sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA=="
     },
     "electron-log": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.4.6.tgz",
-      "integrity": "sha512-nirYgRdY+F+vclr8ijdwy2vW03IzFpDHTaKNWu76dEN21Y76+smcES5knS7cgHUUB0qNLOi8vZO36taakjbSXA=="
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.4.8.tgz",
+      "integrity": "sha512-QQ4GvrXO+HkgqqEOYbi+DHL7hj5JM+nHi/j+qrN9zeeXVKy8ZABgbu4CnG+BBqDZ2+tbeq9tUC4DZfIWFU5AZA=="
     },
     "electron-mocha": {
       "version": "11.0.2",
@@ -45099,30 +44978,20 @@
       }
     },
     "electron-publish": {
-      "version": "23.0.8",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-23.0.8.tgz",
-      "integrity": "sha512-GnqJH7Wh8LnapN4npl1Xs2Er/486/qxE3dV42WxXHX2VeoKAJTOuCzOVWCxpajaR3Msji4SkS0p81R018uK6Mg==",
+      "version": "23.3.3",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-23.3.3.tgz",
+      "integrity": "sha512-1dX17eE5xVXedTxjC+gjsP74oC0+sIHgqysp0ryTlF9+yfQUyXjBk6kcK+zhtBA2SsHMSglDtM+JPxDD/WpPTQ==",
       "dev": true,
       "requires": {
         "@types/fs-extra": "^9.0.11",
-        "builder-util": "23.0.8",
-        "builder-util-runtime": "9.0.2",
+        "builder-util": "23.3.3",
+        "builder-util-runtime": "9.0.3",
         "chalk": "^4.1.1",
         "fs-extra": "^10.0.0",
         "lazy-val": "^1.0.5",
         "mime": "^2.5.2"
       },
       "dependencies": {
-        "builder-util-runtime": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.2.tgz",
-          "integrity": "sha512-xF55W/8mgfT6+sMbX0TeiJkTusA5GMOzckM4rajN4KirFcUIuLTH8oEaTYmM86YwVCZaTwa/7GyFhauXaEICwA==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.3.4",
-            "sax": "^1.2.4"
-          }
-        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -45131,15 +45000,6 @@
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
-          }
-        },
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
           }
         },
         "has-flag": {
@@ -45166,9 +45026,9 @@
       }
     },
     "electron-rebuild": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-3.2.8.tgz",
-      "integrity": "sha512-+U/G5ZH9RNfvPQsEHevC3yDlgSB+wliNXnG6haqUeZBEq061pEgSTWK9ZBEfqMEq+PKxvniMNxfou/h6079s3A==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-3.2.9.tgz",
+      "integrity": "sha512-FkEZNFViUem3P0RLYbZkUjC8LUFIK+wKq09GHoOITSJjfDAVQv964hwaNseTTWt58sITQX3/5fHNYcTefqaCWw==",
       "dev": true,
       "requires": {
         "@malept/cross-spawn-promise": "^2.0.0",
@@ -45408,18 +45268,19 @@
       "devOptional": true
     },
     "electron-updater": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-5.0.0.tgz",
-      "integrity": "sha512-SC3sw92ewjrJFZIJamVOHqxW3yzFin/Q/Swf2FZodqm9xd4s8hCbPCfptpD/xBIcvQmAv2BAggbprwWq/fyp6w==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-5.2.1.tgz",
+      "integrity": "sha512-OQZVIvqcK8j03HjT07uVPgvguP/r8RY2wZcwCM26+fcDOjtrm01Dfz3G8Eru+69znbrR+F9pDzr98ewMavBrWQ==",
       "requires": {
         "@types/semver": "^7.3.6",
-        "builder-util-runtime": "9.0.0",
+        "builder-util-runtime": "9.0.3",
         "fs-extra": "^10.0.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
         "lodash.escaperegexp": "^4.1.2",
         "lodash.isequal": "^4.5.0",
-        "semver": "^7.3.5"
+        "semver": "^7.3.5",
+        "typed-emitter": "^2.1.0"
       },
       "dependencies": {
         "argparse": {
@@ -54973,6 +54834,23 @@
         "aproba": "^1.1.1"
       }
     },
+    "rxjs": {
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "optional": true
+        }
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -56817,6 +56695,14 @@
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
+      }
+    },
+    "typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "requires": {
+        "rxjs": "*"
       }
     },
     "typedarray": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/mattermost/desktop.git"
   },
   "config": {
-    "target": "19.0.6",
+    "target": "19.1.2",
     "arch": "x64",
     "target_arch": "x64",
     "disturl": "https://electronjs.org/headers",
@@ -27,7 +27,7 @@
     "build": "npm-run-all build:*",
     "build:main": "webpack-cli --config webpack.config.main.js",
     "build:renderer": "webpack-cli --config webpack.config.renderer.js",
-    "build-robotjs": "electron-rebuild -v 19.0.6 -m ./node_modules/robotjs",
+    "build-robotjs": "electron-rebuild -v 19.1.2 -m ./node_modules/robotjs",
     "start": "electron dist/ --disable-dev-mode",
     "restart": "npm run build && npm run start",
     "storybook": "start-storybook -p 9001 -c src/.storybook",
@@ -129,8 +129,8 @@
     "@babel/preset-react": "7.16.7",
     "@babel/register": "7.17.7",
     "@bloomberg/record-tuple-polyfill": "^0.0.4",
-    "@electron/fuses": "1.5.0",
-    "@electron/universal": "1.2.1",
+    "@electron/fuses": "1.6.0",
+    "@electron/universal": "1.3.1",
     "@storybook/addon-actions": "6.4.20",
     "@storybook/react": "6.4.20",
     "@types/auto-launch": "5.0.2",
@@ -151,12 +151,12 @@
     "copy-webpack-plugin": "10.2.4",
     "cross-env": "7.0.3",
     "css-loader": "6.7.1",
-    "electron": "19.0.6",
-    "electron-builder": "23.0.8",
+    "electron": "19.1.1",
+    "electron-builder": "23.3.3",
     "electron-connect": "0.6.3",
     "electron-mocha": "11.0.2",
     "electron-notarize": "1.2.1",
-    "electron-rebuild": "3.2.8",
+    "electron-rebuild": "3.2.9",
     "eslint": "7.29.0",
     "eslint-import-resolver-webpack": "0.13.2",
     "eslint-plugin-babel": "5.3.1",
@@ -195,11 +195,11 @@
     "bootstrap": "4.6.1",
     "bootstrap-dark": "1.0.3",
     "classnames": "2.3.1",
-    "electron-context-menu": "3.1.2",
+    "electron-context-menu": "3.5.0",
     "electron-devtools-installer": "3.2.0",
     "electron-is-dev": "2.0.0",
-    "electron-log": "4.4.6",
-    "electron-updater": "5.0.0",
+    "electron-log": "4.4.8",
+    "electron-updater": "5.2.1",
     "fs-extra": "10.0.1",
     "joi": "17.6.0",
     "macos-notification-state": "2.0.1",
@@ -218,6 +218,6 @@
     "yargs": "17.4.0"
   },
   "overrides": {
-    "@electron/universal": "1.2.1"
+    "@electron/universal": "1.3.1"
   }
 }


### PR DESCRIPTION
#### Summary
In lieu of the issues with upgrading to Electron v20+ (see here: https://github.com/mattermost/desktop/pull/2270), for now I've elected to upgrade to the latest Electron v19 patch and upgraded some of its dependencies as well.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47279

```release-note
Upgrade to Electron v19.1.1
```
