### PR TITLE
Downloads - Remove duplicate handler for showing file in folder

### DIFF
--- a/src/main/views/downloadsDropdownMenuView.ts
+++ b/src/main/views/downloadsDropdownMenuView.ts
@@ -12,7 +12,6 @@ import {
     DOWNLOADS_DROPDOWN_MENU_CANCEL_DOWNLOAD,
     DOWNLOADS_DROPDOWN_MENU_CLEAR_FILE,
     DOWNLOADS_DROPDOWN_MENU_OPEN_FILE,
-    DOWNLOADS_DROPDOWN_SHOW_FILE_IN_FOLDER,
     EMIT_CONFIGURATION,
     OPEN_DOWNLOADS_DROPDOWN_MENU,
     REQUEST_DOWNLOADS_DROPDOWN_MENU_INFO,
@@ -70,7 +69,6 @@ export default class DownloadsDropdownMenuView {
         ipcMain.on(EMIT_CONFIGURATION, this.updateConfig);
         ipcMain.on(REQUEST_DOWNLOADS_DROPDOWN_MENU_INFO, this.updateDownloadsDropdownMenu);
         ipcMain.on(DOWNLOADS_DROPDOWN_MENU_OPEN_FILE, this.openFile);
-        ipcMain.on(DOWNLOADS_DROPDOWN_SHOW_FILE_IN_FOLDER, this.showFileInFolder);
         ipcMain.on(DOWNLOADS_DROPDOWN_MENU_CANCEL_DOWNLOAD, this.cancelDownload);
         ipcMain.on(DOWNLOADS_DROPDOWN_MENU_CLEAR_FILE, this.clearFile);
         ipcMain.on(UPDATE_DOWNLOADS_DROPDOWN_MENU, this.updateItem);
@@ -173,13 +171,6 @@ export default class DownloadsDropdownMenuView {
 
     cancelDownload = () => {
         downloadsManager.cancelDownload(this.item);
-        this.handleClose();
-    }
-
-    showFileInFolder = (e: IpcMainEvent, item: DownloadedItem) => {
-        log.debug('DownloadsDropdownMenuView.showFileInFolder', {item});
-
-        downloadsManager.showFileInFolder(item);
         this.handleClose();
     }
 


### PR DESCRIPTION
I noticed this on ubuntu.
If you clicked a file from the downloads list it would open the downloads folder twice. On mac it would not open a second Finder window, that's why I missed it

```release-note
NONE
```

