### PR TITLE
Disabled "Clear All" button when downloads include only the update

### DIFF
--- a/src/main/downloadsManager.ts
+++ b/src/main/downloadsManager.ts
@@ -157,10 +157,16 @@ export class DownloadsManager extends JsonFileManager<DownloadedItems> {
     clearDownloadsDropDown = () => {
         log.debug('DownloadsManager.clearDownloadsDropDown');
 
-        this.saveAll({});
-        this.fileSizes = new Map();
+        if (this.hasUpdate()) {
+            this.saveAll({
+                [APP_UPDATE_KEY]: this.downloads[APP_UPDATE_KEY],
+            });
+        } else {
+            this.saveAll({});
+            this.toggleAppMenuDownloadsEnabled(false);
+        }
         this.closeDownloadsDropdown();
-        this.toggleAppMenuDownloadsEnabled(false);
+        this.fileSizes = new Map();
     }
 
     showFileInFolder = (item?: DownloadedItem) => {
@@ -280,6 +286,10 @@ export class DownloadsManager extends JsonFileManager<DownloadedItems> {
         this.open = true;
         ipcMain.emit(OPEN_DOWNLOADS_DROPDOWN);
         WindowManager.sendToRenderer(HIDE_DOWNLOADS_DROPDOWN_BUTTON_BADGE);
+    }
+
+    hasUpdate = () => {
+        return Boolean(this.downloads[APP_UPDATE_KEY]?.type === DownloadItemTypeEnum.UPDATE);
     }
 
     private markFileAsDeleted = (item: DownloadedItem) => {

--- a/src/renderer/css/downloadsDropdown.scss
+++ b/src/renderer/css/downloadsDropdown.scss
@@ -158,6 +158,7 @@ body {
                     }
 
                     &.disabled {
+                        background: transparent;
                         cursor: default;
                         color: rgba(63, 67, 80, 0.32);
                     }
@@ -438,8 +439,15 @@ body {
                 background: #1f1f1f;
                 border: 1px solid rgba(221, 223, 228, 0.16);
 
-                .DownloadsDropdown__header .DownloadsDropdown__Downloads {
-                    color: #DDD;
+                .DownloadsDropdown__header {
+                    .DownloadsDropdown__Downloads {
+                        color: #DDD;
+                    }
+                    .DownloadsDropdown__clearAllButton {
+                        &.disabled {
+                            color: rgba(63, 67, 80, 0.52);
+                        }
+                    }
                 }
 
                 .DownloadsDropdown__divider {

--- a/src/renderer/downloadsDropdown.tsx
+++ b/src/renderer/downloadsDropdown.tsx
@@ -74,7 +74,13 @@ class DownloadsDropdown extends React.PureComponent<Record<string, never>, State
     }
 
     clearAll = () => {
-        window.postMessage({type: REQUEST_CLEAR_DOWNLOADS_DROPDOWN}, window.location.href);
+        if (!this.clearAllButtonDisabled()) {
+            window.postMessage({type: REQUEST_CLEAR_DOWNLOADS_DROPDOWN}, window.location.href);
+        }
+    }
+
+    clearAllButtonDisabled = () => {
+        return this.state.downloads?.length === 1 && this.state.downloads[0]?.type === 'update';
     }
 
     render() {
@@ -93,7 +99,9 @@ class DownloadsDropdown extends React.PureComponent<Record<string, never>, State
                             />
                         </div>
                         <div
-                            className={'DownloadsDropdown__clearAllButton'}
+                            className={classNames('DownloadsDropdown__clearAllButton', {
+                                disabled: this.clearAllButtonDisabled(),
+                            })}
                             onClick={this.clearAll}
                         >
                             <FormattedMessage


### PR DESCRIPTION
#### Summary
- Disable "Clear All" button in Downloads when only the application update is included
- When Downloads include files and application update, the "Clear All" button will only remove the files, not the update

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47784

#### Release Note

```release-note
NONE
```
