### PR TITLE
[MM-47779] Prevent crash when either URL view or main window was destroyed first

### DIFF
--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -373,7 +373,11 @@ export class ViewManager {
 
             const hideView = () => {
                 delete this.urlViewCancel;
-                this.mainWindow.removeBrowserView(urlView);
+                try {
+                    this.mainWindow.removeBrowserView(urlView);
+                } catch (e) {
+                    log.error('Failed to remove URL view', e);
+                }
 
                 // workaround to eliminate zombie processes
                 // https://github.com/mattermost/desktop/pull/1519


### PR DESCRIPTION
#### Summary
There's a potential race condition that can crash the app when the app reloads. If a URL view was supposed to disappear as the computer was being locked, on wake the window may not yet be fully re-rendered causing a crash.

This PR just catches that so that the app doesn't crash.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47779

```release-note
Fixed an issue where the app could crash when logging back in.
```
