### PR TITLE
[MM-47778] Remove Sign into another Server menu item when no servers exist

### DIFF
--- a/src/main/menus/app.test.js
+++ b/src/main/menus/app.test.js
@@ -213,6 +213,27 @@ describe('main/menus/app', () => {
         expect(signInOption).not.toBe(undefined);
     });
 
+    it('should not show `Sign in to Another Server` if no teams are configured', () => {
+        localizeMessage.mockImplementation((id) => {
+            switch (id) {
+            case 'main.menus.app.file':
+                return '&File';
+            case 'main.menus.app.file.signInToAnotherServer':
+                return 'Sign in to Another Server';
+            default:
+                return '';
+            }
+        });
+        const modifiedConfig = {
+            ...config,
+            teams: [],
+        };
+        const menu = createTemplate(modifiedConfig);
+        const fileMenu = menu.find((item) => item.label === '&AppName' || item.label === '&File');
+        const signInOption = fileMenu.submenu.find((item) => item.label === 'Sign in to Another Server');
+        expect(signInOption).not.toBe(undefined);
+    });
+
     it('should show the first 9 servers (using order) in the Window menu', () => {
         localizeMessage.mockImplementation((id) => {
             if (id === 'main.menus.app.window') {

--- a/src/main/menus/app.ts
+++ b/src/main/menus/app.ts
@@ -45,7 +45,7 @@ export function createTemplate(config: Config, updateManager: UpdateManager) {
         },
     });
 
-    if (config.data?.enableServerManagement === true) {
+    if (config.data?.enableServerManagement === true && config.data?.teams.length > 0) {
         platformAppMenu.push({
             label: localizeMessage('main.menus.app.file.signInToAnotherServer', 'Sign in to Another Server'),
             click() {


### PR DESCRIPTION
#### Summary
When no servers exist, you can still pop the Add Server Modal when the Getting Started screen is there. This causes some confusion as it pops after the screen is finished, and you can't dismiss it since it thinks when it is queued that there's no servers.

This PR just removes the menu item to show it so that it can't be added while the Getting Started screen exists.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47778

```release-note
NONE
```
