### PR TITLE
[MM-47831] Reposition and display 3-dot menu only when it is open

### DIFF
--- a/src/main/views/downloadsDropdownMenuView.ts
+++ b/src/main/views/downloadsDropdownMenuView.ts
@@ -199,7 +199,7 @@ export default class DownloadsDropdownMenuView {
 
     repositionDownloadsDropdownMenu = () => {
         this.bounds = this.getBounds(DOWNLOADS_DROPDOWN_MENU_FULL_WIDTH, DOWNLOADS_DROPDOWN_MENU_FULL_HEIGHT);
-        if (downloadsManager.getIsOpen()) {
+        if (this.open) {
             this.view.setBounds(this.bounds);
         }
     }


### PR DESCRIPTION
#### Summary
3-dot menu gets displayed when Downloads is open while resizing the window

Steps to repro:
1. Open Downloads dropdown
2. Open 3-dot menu of one of the files
3. Close 3-dot menu
4. Resize the mattermost window
5. Observe the 3-dot menu being displayed behind the Downloads Dropdown

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47831

#### Device Information
This PR was tested on: 
- Macos
- Windows

#### Release Note

```release-note
NONE
```
