### PR TITLE
[MM-47682] Implement WebRequestManager

### DIFF
--- a/src/main/app/initialize.test.js
+++ b/src/main/app/initialize.test.js
@@ -142,6 +142,9 @@ jest.mock('main/UserActivityMonitor', () => ({
     on: jest.fn(),
     startMonitoring: jest.fn(),
 }));
+jest.mock('main/webRequest/webRequestManager', () => ({
+    initialize: jest.fn(),
+}));
 jest.mock('main/windows/windowManager', () => ({
     getMainWindow: jest.fn(),
     showMainWindow: jest.fn(),

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -56,6 +56,7 @@ import TrustedOriginsStore from 'main/trustedOrigins';
 import {refreshTrayImages, setupTray} from 'main/tray/tray';
 import UserActivityMonitor from 'main/UserActivityMonitor';
 import WindowManager from 'main/windows/windowManager';
+import WebRequestManager from 'main/webRequest/webRequestManager';
 
 import {protocols} from '../../../electron-builder.json';
 
@@ -269,6 +270,8 @@ function initializeAfterAppReady() {
     updateServerInfos(Config.teams);
     app.setAppUserModelId('Mattermost.Desktop'); // Use explicit AppUserModelID
     const defaultSession = session.defaultSession;
+
+    WebRequestManager.initialize();
 
     if (process.platform !== 'darwin') {
         defaultSession.on('spellcheck-dictionary-download-failure', (event, lang) => {

--- a/src/main/downloadsManager.ts
+++ b/src/main/downloadsManager.ts
@@ -110,7 +110,7 @@ export class DownloadsManager extends JsonFileManager<DownloadedItems> {
      * This function monitors webRequests and retrieves the total file size (of files being downloaded)
      * from the custom HTTP header "x-uncompressed-content-length".
      */
-    webRequestOnHeadersReceivedHandler = (details: Electron.OnHeadersReceivedListenerDetails, cb: (headersReceivedResponse: Electron.HeadersReceivedResponse) => void) => {
+    webRequestOnHeadersReceivedHandler = (details: Electron.OnHeadersReceivedListenerDetails) => {
         const headers = details.responseHeaders ?? {};
 
         if (headers?.['content-encoding']?.includes('gzip') && headers?.['x-uncompressed-content-length'] && headers?.['content-disposition'].join(';')?.includes('filename=')) {
@@ -122,7 +122,7 @@ export class DownloadsManager extends JsonFileManager<DownloadedItems> {
         }
 
         // With no arguments it uses the same headers
-        cb({});
+        return {};
     };
 
     checkForDeletedFiles = () => {

--- a/src/main/views/downloadsDropdownView.ts
+++ b/src/main/views/downloadsDropdownView.ts
@@ -23,6 +23,7 @@ import {getLocalPreload, getLocalURLString} from 'main/utils';
 
 import WindowManager from '../windows/windowManager';
 import downloadsManager from 'main/downloadsManager';
+import WebRequestManager from 'main/webRequest/webRequestManager';
 
 export default class DownloadsDropdownView {
     bounds?: Electron.Rectangle;
@@ -55,7 +56,7 @@ export default class DownloadsDropdownView {
         this.view.webContents.loadURL(getLocalURLString('downloadsDropdown.html'));
         this.window.addBrowserView(this.view);
 
-        this.view.webContents.session.webRequest.onHeadersReceived(downloadsManager.webRequestOnHeadersReceivedHandler);
+        WebRequestManager.onHeadersReceived.setListener('downloadsDropdownView', downloadsManager.webRequestOnHeadersReceivedHandler);
 
         ipcMain.on(OPEN_DOWNLOADS_DROPDOWN, this.handleOpen);
         ipcMain.on(CLOSE_DOWNLOADS_DROPDOWN, this.handleClose);

--- a/src/main/views/downloadsDropdownView.ts
+++ b/src/main/views/downloadsDropdownView.ts
@@ -56,7 +56,7 @@ export default class DownloadsDropdownView {
         this.view.webContents.loadURL(getLocalURLString('downloadsDropdown.html'));
         this.window.addBrowserView(this.view);
 
-        WebRequestManager.onHeadersReceived.setListener('downloadsDropdownView', downloadsManager.webRequestOnHeadersReceivedHandler);
+        WebRequestManager.onHeadersReceived.on('downloadsDropdownView', downloadsManager.webRequestOnHeadersReceivedHandler);
 
         ipcMain.on(OPEN_DOWNLOADS_DROPDOWN, this.handleOpen);
         ipcMain.on(CLOSE_DOWNLOADS_DROPDOWN, this.handleClose);

--- a/src/main/webRequest/webRequestHandler.test.js
+++ b/src/main/webRequest/webRequestHandler.test.js
@@ -8,27 +8,6 @@ jest.mock('electron-log', () => ({
 }));
 
 describe('main/webRequest/webRequestHandler', () => {
-    it('should not iterate through listeners when size is < 1', () => {
-        const handler = new WebRequestHandler();
-        handler.listeners = {
-            size: 0,
-            keys: jest.fn(),
-        };
-
-        const callback = jest.fn();
-        handler.handle({}, callback);
-        expect(handler.listeners.keys).not.toBeCalled();
-        expect(callback).toBeCalledWith({});
-
-        handler.listeners = {
-            size: 1,
-            keys: jest.fn().mockReturnValue([]),
-        };
-
-        handler.handle();
-        expect(handler.listeners.keys).toBeCalled();
-    });
-
     it('should call each listener in the sequence they were added', () => {
         const modifyCallbackObject = jest.fn();
         const handler = new WebRequestHandler(modifyCallbackObject);
@@ -38,15 +17,15 @@ describe('main/webRequest/webRequestHandler', () => {
         const listener1 = jest.fn().mockImplementation(() => {
             result += 'listener1';
         });
-        handler.setListener('listener1', listener1);
+        handler.on('listener1', listener1);
         const listener2 = jest.fn().mockImplementation(() => {
             result += 'listener2';
         });
-        handler.setListener('listener2', listener2);
+        handler.on('listener2', listener2);
         const listener3 = jest.fn().mockImplementation(() => {
             result += 'listener3';
         });
-        handler.setListener('listener3', listener3);
+        handler.on('listener3', listener3);
 
         const details = {some: 'detail'};
         const callback = jest.fn();
@@ -66,11 +45,11 @@ describe('main/webRequest/webRequestHandler', () => {
         const handler = new WebRequestHandler(modifyCallbackObject);
 
         const listener1 = jest.fn().mockImplementation(() => ({listener1: true}));
-        handler.setListener('listener1', listener1);
+        handler.on('listener1', listener1);
         const listener2 = jest.fn().mockImplementation(() => ({listener2: true}));
-        handler.setListener('listener2', listener2);
+        handler.on('listener2', listener2);
         const listener3 = jest.fn().mockImplementation(() => ({listener3: false}));
-        handler.setListener('listener3', listener3);
+        handler.on('listener3', listener3);
 
         const details = {some: 'detail'};
         const callback = jest.fn();

--- a/src/main/webRequest/webRequestHandler.test.js
+++ b/src/main/webRequest/webRequestHandler.test.js
@@ -1,0 +1,85 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {WebRequestHandler} from './webRequestHandler';
+
+jest.mock('electron-log', () => ({
+    silly: jest.fn(),
+}));
+
+describe('main/webRequest/webRequestHandler', () => {
+    it('should not iterate through listeners when size is < 1', () => {
+        const handler = new WebRequestHandler();
+        handler.listeners = {
+            size: 0,
+            keys: jest.fn(),
+        };
+
+        const callback = jest.fn();
+        handler.handle({}, callback);
+        expect(handler.listeners.keys).not.toBeCalled();
+        expect(callback).toBeCalledWith({});
+
+        handler.listeners = {
+            size: 1,
+            keys: jest.fn().mockReturnValue([]),
+        };
+
+        handler.handle();
+        expect(handler.listeners.keys).toBeCalled();
+    });
+
+    it('should call each listener in the sequence they were added', () => {
+        const modifyCallbackObject = jest.fn();
+        const handler = new WebRequestHandler(modifyCallbackObject);
+
+        let result = '';
+
+        const listener1 = jest.fn().mockImplementation(() => {
+            result += 'listener1';
+        });
+        handler.setListener('listener1', listener1);
+        const listener2 = jest.fn().mockImplementation(() => {
+            result += 'listener2';
+        });
+        handler.setListener('listener2', listener2);
+        const listener3 = jest.fn().mockImplementation(() => {
+            result += 'listener3';
+        });
+        handler.setListener('listener3', listener3);
+
+        const details = {some: 'detail'};
+        const callback = jest.fn();
+        handler.handle(details, callback);
+
+        expect(listener1).toHaveBeenCalledWith(details);
+        expect(listener2).toHaveBeenCalledWith(details);
+        expect(listener3).toHaveBeenCalledWith(details);
+        expect(result).toBe('listener1listener2listener3');
+    });
+
+    it('should modify the callback object and call the webRequest with the compiled object', () => {
+        const modifyCallbackObject = jest.fn().mockImplementation((details, callbackObject, result) => ({
+            ...callbackObject,
+            ...result,
+        }));
+        const handler = new WebRequestHandler(modifyCallbackObject);
+
+        const listener1 = jest.fn().mockImplementation(() => ({listener1: true}));
+        handler.setListener('listener1', listener1);
+        const listener2 = jest.fn().mockImplementation(() => ({listener2: true}));
+        handler.setListener('listener2', listener2);
+        const listener3 = jest.fn().mockImplementation(() => ({listener3: false}));
+        handler.setListener('listener3', listener3);
+
+        const details = {some: 'detail'};
+        const callback = jest.fn();
+        handler.handle(details, callback);
+
+        expect(callback).toHaveBeenCalledWith({
+            listener1: true,
+            listener2: true,
+            listener3: false,
+        });
+    });
+});

--- a/src/main/webRequest/webRequestHandler.ts
+++ b/src/main/webRequest/webRequestHandler.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import log from 'electron-log';
+
+export class WebRequestHandler<T, T2> {
+    listeners: Map<string, (details: T) => T2>;
+    modifyCallbackObject: (details: T, callbackObject: T2, result: T2) => T2;
+
+    constructor(modifyCallbackObject: (details: T, callbackObject: T2, result: T2) => T2) {
+        this.listeners = new Map();
+        this.modifyCallbackObject = modifyCallbackObject;
+    }
+
+    setListener = (
+        id: string,
+        listener: (details: T) => T2,
+    ) => {
+        this.listeners.set(id, listener);
+    }
+
+    removeListener = (id: string) => {
+        this.listeners.delete(id);
+    }
+
+    handle = (details: T, callback?: (response: T2) => void) => {
+        log.silly('webRequestHandler.handle', details);
+
+        if (!this.listeners.size) {
+            callback?.({} as T2);
+            return;
+        }
+
+        let callbackObject = {} as T2;
+
+        for (const id of this.listeners.keys()) {
+            if (this.listeners.has(id)) {
+                const listener = this.listeners.get(id)!;
+                const result = listener(details);
+
+                callbackObject = this.modifyCallbackObject(details, callbackObject, result);
+            }
+        }
+
+        log.silly('webRequestHandler.handle result', callbackObject);
+
+        callback?.(callbackObject);
+    }
+}

--- a/src/main/webRequest/webRequestHandler.ts
+++ b/src/main/webRequest/webRequestHandler.ts
@@ -1,41 +1,25 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {EventEmitter} from 'events';
+
 import log from 'electron-log';
 
-export class WebRequestHandler<T, T2> {
-    listeners: Map<string, (details: T) => T2>;
+export class WebRequestHandler<T, T2> extends EventEmitter {
     modifyCallbackObject: (details: T, callbackObject: T2, result: T2) => T2;
 
     constructor(modifyCallbackObject: (details: T, callbackObject: T2, result: T2) => T2) {
-        this.listeners = new Map();
+        super();
         this.modifyCallbackObject = modifyCallbackObject;
-    }
-
-    setListener = (
-        id: string,
-        listener: (details: T) => T2,
-    ) => {
-        this.listeners.set(id, listener);
-    }
-
-    removeListener = (id: string) => {
-        this.listeners.delete(id);
     }
 
     handle = (details: T, callback?: (response: T2) => void) => {
         log.silly('webRequestHandler.handle', details);
 
-        if (!this.listeners.size) {
-            callback?.({} as T2);
-            return;
-        }
-
         let callbackObject = {} as T2;
 
-        for (const id of this.listeners.keys()) {
-            if (this.listeners.has(id)) {
-                const listener = this.listeners.get(id)!;
+        for (const id of this.eventNames()) {
+            for (const listener of this.listeners(id)) {
                 const result = listener(details);
 
                 callbackObject = this.modifyCallbackObject(details, callbackObject, result);

--- a/src/main/webRequest/webRequestManager.test.js
+++ b/src/main/webRequest/webRequestManager.test.js
@@ -1,0 +1,85 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {WebRequestManager} from './webRequestManager';
+
+describe('main/webRequest/webRequestManager', () => {
+    describe('onBeforeRequestCallback', () => {
+        it('should throw an error when more than one listener provides a redirect url', () => {
+            const manager = new WebRequestManager();
+            expect(() => {
+                manager.onBeforeRequestCallback(
+                    {url: 'http://some-url.com'},
+                    {redirectURL: 'http://some-other-url.com'},
+                    {redirectURL: 'http://some-even-more-other-url.com'},
+                );
+            }).toThrow(Error);
+        });
+
+        it('should override cancel behaviour if any one listener cancels the request', () => {
+            const manager = new WebRequestManager();
+            expect(manager.onBeforeRequestCallback(
+                {url: 'http://some-url.com'},
+                {cancel: false},
+                {cancel: true},
+            )).toStrictEqual({cancel: true});
+        });
+
+        it('should add redirect url', () => {
+            const manager = new WebRequestManager();
+            expect(manager.onBeforeRequestCallback(
+                {url: 'http://some-url.com'},
+                {},
+                {redirectURL: 'http://some-other-url.com'},
+            )).toStrictEqual({redirectURL: 'http://some-other-url.com'});
+        });
+    });
+
+    describe('onBeforeSendHeadersCallback', () => {
+        it('should override cancel behaviour if any one listener cancels the request', () => {
+            const manager = new WebRequestManager();
+            expect(manager.onBeforeSendHeadersCallback(
+                {url: 'http://some-url.com', requestHeaders: {some_header: 'value1'}},
+                {cancel: false},
+                {cancel: true},
+            )).toStrictEqual({cancel: true, requestHeaders: {some_header: 'value1'}});
+        });
+
+        it('should add and overwrite request headers', () => {
+            const manager = new WebRequestManager();
+            expect(manager.onBeforeSendHeadersCallback(
+                {url: 'http://some-url.com', requestHeaders: {some_header: 'value1'}},
+                {requestHeaders: {some_other_header: 'value2'}},
+                {requestHeaders: {some_other_header: 'value3', some_other_other_header: 'value4'}},
+            )).toStrictEqual({requestHeaders: {
+                some_header: 'value1',
+                some_other_header: 'value3',
+                some_other_other_header: 'value4',
+            }});
+        });
+    });
+
+    describe('onHeadersReceivedCallback', () => {
+        it('should override cancel behaviour if any one listener cancels the request', () => {
+            const manager = new WebRequestManager();
+            expect(manager.onHeadersReceivedCallback(
+                {url: 'http://some-url.com', responseHeaders: {some_header: 'value1'}},
+                {cancel: false},
+                {cancel: true},
+            )).toStrictEqual({cancel: true, responseHeaders: {some_header: 'value1'}});
+        });
+
+        it('should add and overwrite response headers', () => {
+            const manager = new WebRequestManager();
+            expect(manager.onHeadersReceivedCallback(
+                {url: 'http://some-url.com', responseHeaders: {some_header: 'value1'}},
+                {responseHeaders: {some_other_header: 'value2'}},
+                {responseHeaders: {some_other_header: 'value3', some_other_other_header: 'value4'}},
+            )).toStrictEqual({responseHeaders: {
+                some_header: 'value1',
+                some_other_header: 'value3',
+                some_other_other_header: 'value4',
+            }});
+        });
+    });
+});

--- a/src/main/webRequest/webRequestManager.ts
+++ b/src/main/webRequest/webRequestManager.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {
+    BeforeSendResponse,
+    CallbackResponse,
+    HeadersReceivedResponse,
+    OnBeforeRequestListenerDetails,
+    OnBeforeSendHeadersListenerDetails,
+    OnHeadersReceivedListenerDetails,
+    session,
+} from 'electron';
+
+import {WebRequestHandler} from 'main/webRequest/webRequestHandler';
+
+export class WebRequestManager {
+    onBeforeRequest: WebRequestHandler<OnBeforeRequestListenerDetails, CallbackResponse>;
+    onBeforeSendHeaders: WebRequestHandler<OnBeforeSendHeadersListenerDetails, BeforeSendResponse>;
+    onHeadersReceived: WebRequestHandler<OnHeadersReceivedListenerDetails, HeadersReceivedResponse>;
+
+    constructor() {
+        this.onBeforeRequest = new WebRequestHandler(this.onBeforeRequestCallback);
+        this.onBeforeSendHeaders = new WebRequestHandler(this.onBeforeSendHeadersCallback);
+        this.onHeadersReceived = new WebRequestHandler(this.onHeadersReceivedCallback);
+    }
+
+    initialize = () => {
+        session.defaultSession.webRequest.onBeforeRequest(this.onBeforeRequest.handle);
+        session.defaultSession.webRequest.onBeforeSendHeaders(this.onBeforeSendHeaders.handle);
+        session.defaultSession.webRequest.onHeadersReceived(this.onHeadersReceived.handle);
+    }
+
+    onBeforeRequestCallback = (
+        details: OnBeforeRequestListenerDetails,
+        callbackObject: CallbackResponse,
+        result: CallbackResponse,
+    ): CallbackResponse => {
+        if (result.redirectURL && callbackObject.redirectURL) {
+            throw new Error(`Listeners produced more than one redirect URL: ${result.redirectURL} ${callbackObject.redirectURL}`);
+        }
+        const modifiedCallbackObject: CallbackResponse = {};
+        if (result.cancel) {
+            modifiedCallbackObject.cancel = result.cancel;
+        }
+        if (result.redirectURL) {
+            modifiedCallbackObject.redirectURL = result.redirectURL;
+        }
+        return modifiedCallbackObject;
+    }
+
+    onBeforeSendHeadersCallback = (
+        details: OnBeforeSendHeadersListenerDetails,
+        callbackObject: BeforeSendResponse,
+        result: BeforeSendResponse,
+    ): BeforeSendResponse => {
+        const modifiedCallbackObject: BeforeSendResponse = {
+            requestHeaders: {
+                ...details.requestHeaders,
+                ...callbackObject.requestHeaders,
+                ...result.requestHeaders,
+            },
+        };
+        if (result.cancel) {
+            modifiedCallbackObject.cancel = result.cancel;
+        }
+        return modifiedCallbackObject;
+    }
+
+    onHeadersReceivedCallback = (
+        details: OnHeadersReceivedListenerDetails,
+        callbackObject: HeadersReceivedResponse,
+        result: HeadersReceivedResponse,
+    ): HeadersReceivedResponse => {
+        const modifiedCallbackObject: HeadersReceivedResponse = {
+            responseHeaders: {
+                ...details.responseHeaders,
+                ...callbackObject.responseHeaders,
+                ...result.responseHeaders,
+            },
+        };
+        if (result.cancel) {
+            modifiedCallbackObject.cancel = result.cancel;
+        }
+        return modifiedCallbackObject;
+    }
+}
+
+const webRequestManager = new WebRequestManager();
+export default webRequestManager;


### PR DESCRIPTION
#### Summary
In order to support URL rewriting from many different listeners, we need a manager that will allow us to bind as many listeners to the web requests as possible. This PR adds a manage for the WebRequest handlers and allows the app to bind as many listeners as we want.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47682

```release-note
NONE
```
