### PR TITLE
[MM-47801][MM-45980] Added support for security-scoped bookmarks to allow the MAS build to save files wherever needed

### DIFF
--- a/entitlements.mas.plist
+++ b/entitlements.mas.plist
@@ -38,5 +38,9 @@
 	<string>UQ8HT4Q2XM.Mattermost.Desktop</string>
 	<key>com.apple.developer.team-identifier</key>
 	<string>UQ8HT4Q2XM</string>
+	<key>com.apple.security.files.bookmarks.app-scope</key>
+	<true/>
+	<key>com.apple.security.files.bookmarks.document-scope</key>
+	<true/>
 </dict>
 </plist>

--- a/scripts/patch_macos_notification_state.js
+++ b/scripts/patch_macos_notification_state.js
@@ -1,8 +1,9 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-const jq = require('node-jq');
 const fs = require('fs');
+
+const jq = require('node-jq');
 
 jq.run(
     '.scripts.install = "node-gyp rebuild"',

--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -148,6 +148,7 @@ export const REQUEST_HAS_DOWNLOADS = 'request-has-downloads';
 export const DOWNLOADS_DROPDOWN_FOCUSED = 'downloads-dropdown-focused';
 export const RECEIVE_DOWNLOADS_DROPDOWN_SIZE = 'receive-downloads-dropdown-size';
 export const SEND_DOWNLOADS_DROPDOWN_SIZE = 'send-downloads-dropdown-size';
+export const GET_DOWNLOADED_IMAGE_THUMBNAIL_LOCATION = 'get-downloaded-image-thumbnail-location';
 
 export const OPEN_DOWNLOADS_DROPDOWN_MENU = 'open-downloads-dropdown-menu';
 export const CLOSE_DOWNLOADS_DROPDOWN_MENU = 'close-downloads-dropdown-menu';

--- a/src/main/Validator.ts
+++ b/src/main/Validator.ts
@@ -58,6 +58,7 @@ const downloadsSchema = Joi.object<DownloadedItems>().pattern(
         addedAt: Joi.number().min(0),
         receivedBytes: Joi.number().min(0),
         totalBytes: Joi.number().min(0),
+        bookmark: Joi.string(),
     });
 
 const configDataSchemaV0 = Joi.object<ConfigV0>({

--- a/src/main/downloadsManager.test.js
+++ b/src/main/downloadsManager.test.js
@@ -117,6 +117,7 @@ const item = {
     getStartTime: () => nowSeconds,
     getTotalBytes: () => 4242,
     getSavePath: () => locationMock,
+    getURL: () => 'http://some-url.com/some-text.txt',
     hasUserGesture: jest.fn().mockReturnValue(true),
     setSavePath: jest.fn(),
     on: jest.fn(),
@@ -144,7 +145,8 @@ describe('main/downloadsManager', () => {
     it('should handle a new download', () => {
         const dl = new DownloadsManager({});
         path.parse.mockImplementation(() => ({base: 'file.txt'}));
-        dl.handleNewDownload({}, item, {id: 0, getURL: jest.fn()});
+        dl.willDownloadURLs.set('http://some-url.com/some-text.txt', {filePath: locationMock});
+        dl.handleNewDownload({preventDefault: jest.fn()}, item, {id: 0, getURL: jest.fn(), downloadURL: jest.fn()});
         expect(dl).toHaveProperty('downloads', {'file.txt': {
             addedAt: nowSeconds * 1000,
             filename: 'file.txt',

--- a/src/main/preload/downloadsDropdown.js
+++ b/src/main/preload/downloadsDropdown.js
@@ -20,12 +20,17 @@ import {
     START_UPGRADE,
     TOGGLE_DOWNLOADS_DROPDOWN_MENU,
     UPDATE_DOWNLOADS_DROPDOWN,
+    GET_DOWNLOADED_IMAGE_THUMBNAIL_LOCATION,
 } from 'common/communication';
 
 console.log('preloaded for the downloadsDropdown!');
 
 contextBridge.exposeInMainWorld('process', {
     platform: process.platform,
+});
+
+contextBridge.exposeInMainWorld('mas', {
+    getThumbnailLocation: (location) => ipcRenderer.invoke(GET_DOWNLOADED_IMAGE_THUMBNAIL_LOCATION, location),
 });
 
 window.addEventListener('click', () => {

--- a/src/main/views/downloadsDropdownView.ts
+++ b/src/main/views/downloadsDropdownView.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import {BrowserView, BrowserWindow, ipcMain, IpcMainEvent} from 'electron';
+import path from 'path';
+
+import {app, BrowserView, BrowserWindow, ipcMain, IpcMainEvent, IpcMainInvokeEvent} from 'electron';
 
 import log from 'electron-log';
 
@@ -17,6 +19,7 @@ import {
     REQUEST_DOWNLOADS_DROPDOWN_INFO,
     UPDATE_DOWNLOADS_DROPDOWN,
     UPDATE_DOWNLOADS_DROPDOWN_MENU_ITEM,
+    GET_DOWNLOADED_IMAGE_THUMBNAIL_LOCATION,
 } from 'common/communication';
 import {TAB_BAR_HEIGHT, DOWNLOADS_DROPDOWN_WIDTH, DOWNLOADS_DROPDOWN_HEIGHT, DOWNLOADS_DROPDOWN_FULL_WIDTH} from 'common/utils/constants';
 import {getLocalPreload, getLocalURLString} from 'main/utils';
@@ -66,6 +69,7 @@ export default class DownloadsDropdownView {
         ipcMain.on(DOWNLOADS_DROPDOWN_SHOW_FILE_IN_FOLDER, this.showFileInFolder);
         ipcMain.on(UPDATE_DOWNLOADS_DROPDOWN, this.updateDownloads);
         ipcMain.on(UPDATE_DOWNLOADS_DROPDOWN_MENU_ITEM, this.updateDownloadsDropdownMenuItem);
+        ipcMain.handle(GET_DOWNLOADED_IMAGE_THUMBNAIL_LOCATION, this.getDownloadImageThumbnailLocation);
     }
 
     updateDownloads = (event: IpcMainEvent, downloads: DownloadedItems) => {
@@ -197,5 +201,16 @@ export default class DownloadsDropdownView {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         this.view.webContents.destroy();
+    }
+
+    getDownloadImageThumbnailLocation = (event: IpcMainInvokeEvent, location: string) => {
+        // eslint-disable-next-line no-undef
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        if (!__IS_MAC_APP_STORE__) {
+            return location;
+        }
+
+        return path.resolve(app.getPath('temp'), path.basename(location));
     }
 }

--- a/src/renderer/components/DownloadsDropdown/Thumbnail.tsx
+++ b/src/renderer/components/DownloadsDropdown/Thumbnail.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import {DownloadedItem} from 'types/downloads';
 
 import {CheckCircleIcon, CloseCircleIcon} from '@mattermost/compass-icons/components';
@@ -19,6 +19,8 @@ const colorRed = '#D24B4E';
 const isWin = window.process.platform === 'win32';
 
 const Thumbnail = ({item}: OwnProps) => {
+    const [imageUrl, setImageUrl] = useState<string | undefined>();
+
     const showBadge = (state: DownloadedItem['state']) => {
         switch (state) {
         case 'completed':
@@ -42,15 +44,27 @@ const Thumbnail = ({item}: OwnProps) => {
         }
     };
 
+    useEffect(() => {
+        const fetchThumbnail = async () => {
+            const imageUrl = await window.mas.getThumbnailLocation(item.location);
+            setImageUrl(imageUrl);
+        };
+
+        fetchThumbnail();
+    }, [item]);
+
     const showImagePreview = isImageFile(item) && item.state === 'completed';
+    if (showImagePreview && !imageUrl) {
+        return null;
+    }
 
     return (
         <div className='DownloadsDropdown__Thumbnail__Container'>
-            {showImagePreview ?
+            {showImagePreview && imageUrl ?
                 <div
                     className='DownloadsDropdown__Thumbnail preview'
                     style={{
-                        backgroundImage: `url("${isWin ? `file:///${item.location.replaceAll('\\', '/')}` : item.location}")`,
+                        backgroundImage: `url("${isWin ? `file:///${imageUrl.replaceAll('\\', '/')}` : imageUrl}")`,
                         backgroundSize: 'cover',
                     }}
                 /> :

--- a/src/types/downloads.ts
+++ b/src/types/downloads.ts
@@ -17,6 +17,7 @@ export type DownloadedItem = {
     addedAt: number;
     receivedBytes: number;
     totalBytes: number;
+    bookmark?: string;
 }
 
 export type DownloadedItems = Record<string, DownloadedItem>;

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -20,5 +20,8 @@ declare global {
         timers: {
             setImmediate: typeof setImmediate;
         };
+        mas: {
+            getThumbnailLocation: (location: string) => Promise<string>;
+        };
     }
 }


### PR DESCRIPTION
#### Summary
Because of Apple's App Sandbox, saving files in any location other than the Downloads directory causes a number of issues. In order to resolve these, Apple provides an API called "security-scoped bookmarks" that allows an app to temporarily gain access to a file in the same way that the user would normally pick one using the dialog box and do some work on it.

This PR converts the downloads code to allow for these bookmarks to be created and stored in a persistent manner so that MAS build users can access and save files as normal. This approach conveniently also fixes the issue where users couldn't replace files.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47801
https://mattermost.atlassian.net/browse/MM-45980
Closes https://github.com/mattermost/desktop/issues/2199

```release-note
Fixed an issue where MAS users couldn't easily replace files.
```
