### PR TITLE
[MM-47682] Add helpers for URL rewriting, header replacement

### DIFF
--- a/src/main/downloadsManager.test.js
+++ b/src/main/downloadsManager.test.js
@@ -160,14 +160,12 @@ describe('main/downloadsManager', () => {
 
     it('should monitor network to retrieve the file size of downloading items', () => {
         const dl = new DownloadsManager({});
-        const details = {
-            responseHeaders: {
-                'content-encoding': ['gzip'],
-                'x-uncompressed-content-length': ['4242'],
-                'content-disposition': ['attachment; filename="file.txt"; foobar'],
-            },
+        const responseHeaders = {
+            'content-encoding': ['gzip'],
+            'x-uncompressed-content-length': ['4242'],
+            'content-disposition': ['attachment; filename="file.txt"; foobar'],
         };
-        dl.webRequestOnHeadersReceivedHandler(details, jest.fn());
+        dl.webRequestOnHeadersReceivedHandler(responseHeaders);
         expect(dl.fileSizes.get('file.txt')).toBe('4242');
     });
 

--- a/src/main/downloadsManager.ts
+++ b/src/main/downloadsManager.ts
@@ -110,9 +110,7 @@ export class DownloadsManager extends JsonFileManager<DownloadedItems> {
      * This function monitors webRequests and retrieves the total file size (of files being downloaded)
      * from the custom HTTP header "x-uncompressed-content-length".
      */
-    webRequestOnHeadersReceivedHandler = (details: Electron.OnHeadersReceivedListenerDetails) => {
-        const headers = details.responseHeaders ?? {};
-
+    webRequestOnHeadersReceivedHandler = (headers: Record<string, string[]>) => {
         if (headers?.['content-encoding']?.includes('gzip') && headers?.['x-uncompressed-content-length'] && headers?.['content-disposition'].join(';')?.includes('filename=')) {
             const filename = readFilenameFromContentDispositionHeader(headers['content-disposition']);
             const fileSize = headers['x-uncompressed-content-length']?.[0] || '0';

--- a/src/main/downloadsManager.ts
+++ b/src/main/downloadsManager.ts
@@ -8,6 +8,7 @@ import log from 'electron-log';
 import {ProgressInfo} from 'electron-updater';
 
 import {DownloadedItem, DownloadItemDoneEventState, DownloadedItems, DownloadItemState, DownloadItemUpdatedEventState} from 'types/downloads';
+import {ResponseHeaders} from 'types/webRequest';
 
 import {
     CANCEL_UPDATE_DOWNLOAD,
@@ -32,12 +33,10 @@ import WindowManager from 'main/windows/windowManager';
 import {doubleSecToMs, getPercentage, isStringWithLength, readFilenameFromContentDispositionHeader, shouldIncrementFilename} from 'main/utils';
 import {DOWNLOADS_DROPDOWN_AUTOCLOSE_TIMEOUT, DOWNLOADS_DROPDOWN_MAX_ITEMS} from 'common/utils/constants';
 import JsonFileManager from 'common/JsonFileManager';
-
 import {APP_UPDATE_KEY} from 'common/constants';
 
 import {downloadsJson} from './constants';
 import * as Validator from './Validator';
-
 export enum DownloadItemTypeEnum {
     FILE = 'file',
     UPDATE = 'update',
@@ -110,7 +109,7 @@ export class DownloadsManager extends JsonFileManager<DownloadedItems> {
      * This function monitors webRequests and retrieves the total file size (of files being downloaded)
      * from the custom HTTP header "x-uncompressed-content-length".
      */
-    webRequestOnHeadersReceivedHandler = (headers: Record<string, string[]>) => {
+    webRequestOnHeadersReceivedHandler = (headers: ResponseHeaders) => {
         if (headers?.['content-encoding']?.includes('gzip') && headers?.['x-uncompressed-content-length'] && headers?.['content-disposition'].join(';')?.includes('filename=')) {
             const filename = readFilenameFromContentDispositionHeader(headers['content-disposition']);
             const fileSize = headers['x-uncompressed-content-length']?.[0] || '0';

--- a/src/main/views/downloadsDropdownView.ts
+++ b/src/main/views/downloadsDropdownView.ts
@@ -56,7 +56,7 @@ export default class DownloadsDropdownView {
         this.view.webContents.loadURL(getLocalURLString('downloadsDropdown.html'));
         this.window.addBrowserView(this.view);
 
-        WebRequestManager.onHeadersReceived.on('downloadsDropdownView', downloadsManager.webRequestOnHeadersReceivedHandler);
+        WebRequestManager.onHeadersReceived.addWebRequestListener('downloadsDropdownView', downloadsManager.webRequestOnHeadersReceivedHandler);
 
         ipcMain.on(OPEN_DOWNLOADS_DROPDOWN, this.handleOpen);
         ipcMain.on(CLOSE_DOWNLOADS_DROPDOWN, this.handleClose);

--- a/src/main/views/downloadsDropdownView.ts
+++ b/src/main/views/downloadsDropdownView.ts
@@ -56,7 +56,7 @@ export default class DownloadsDropdownView {
         this.view.webContents.loadURL(getLocalURLString('downloadsDropdown.html'));
         this.window.addBrowserView(this.view);
 
-        WebRequestManager.onHeadersReceived.addWebRequestListener('downloadsDropdownView', downloadsManager.webRequestOnHeadersReceivedHandler);
+        WebRequestManager.onResponseHeaders(downloadsManager.webRequestOnHeadersReceivedHandler);
 
         ipcMain.on(OPEN_DOWNLOADS_DROPDOWN, this.handleOpen);
         ipcMain.on(CLOSE_DOWNLOADS_DROPDOWN, this.handleClose);

--- a/src/main/webRequest/webRequestHandler.test.js
+++ b/src/main/webRequest/webRequestHandler.test.js
@@ -17,19 +17,19 @@ describe('main/webRequest/webRequestHandler', () => {
         const listener1 = jest.fn().mockImplementation(() => {
             result += 'listener1';
         });
-        handler.on('listener1', listener1);
+        handler.addWebRequestListener('listener1', listener1);
         const listener2 = jest.fn().mockImplementation(() => {
             result += 'listener2';
         });
-        handler.on('listener2', listener2);
+        handler.addWebRequestListener('listener2', listener2);
         const listener3 = jest.fn().mockImplementation(() => {
             result += 'listener3';
         });
-        handler.on('listener3', listener3);
+        handler.addWebRequestListener('listener3', listener3);
 
         const details = {some: 'detail'};
         const callback = jest.fn();
-        handler.handle(details, callback);
+        handler.handleWebRequest(details, callback);
 
         expect(listener1).toHaveBeenCalledWith(details);
         expect(listener2).toHaveBeenCalledWith(details);
@@ -45,15 +45,15 @@ describe('main/webRequest/webRequestHandler', () => {
         const handler = new WebRequestHandler(modifyCallbackObject);
 
         const listener1 = jest.fn().mockImplementation(() => ({listener1: true}));
-        handler.on('listener1', listener1);
+        handler.addWebRequestListener('listener1', listener1);
         const listener2 = jest.fn().mockImplementation(() => ({listener2: true}));
-        handler.on('listener2', listener2);
+        handler.addWebRequestListener('listener2', listener2);
         const listener3 = jest.fn().mockImplementation(() => ({listener3: false}));
-        handler.on('listener3', listener3);
+        handler.addWebRequestListener('listener3', listener3);
 
         const details = {some: 'detail'};
         const callback = jest.fn();
-        handler.handle(details, callback);
+        handler.handleWebRequest(details, callback);
 
         expect(callback).toHaveBeenCalledWith({
             listener1: true,

--- a/src/main/webRequest/webRequestHandler.ts
+++ b/src/main/webRequest/webRequestHandler.ts
@@ -13,21 +13,24 @@ export class WebRequestHandler<T, T2> extends EventEmitter {
         this.modifyCallbackObject = modifyCallbackObject;
     }
 
-    handle = (details: T, callback?: (response: T2) => void) => {
+    handleWebRequest = (details: T, callback?: (response: T2) => void) => {
         log.silly('webRequestHandler.handle', details);
 
         let callbackObject = {} as T2;
+        const modify = (result: T2) => {
+            callbackObject = this.modifyCallbackObject(details, callbackObject, result);
+        };
 
         for (const id of this.eventNames()) {
-            for (const listener of this.listeners(id)) {
-                const result = listener(details);
-
-                callbackObject = this.modifyCallbackObject(details, callbackObject, result);
-            }
+            this.emit(id, details, (result: T2) => modify(result));
         }
 
         log.silly('webRequestHandler.handle result', callbackObject);
 
         callback?.(callbackObject);
     }
+
+    addWebRequestListener = (name: string, listener: (details: T) => T2) => {
+        this.on(name, (details: T, callback: (result: T2) => void) => callback(listener(details)));
+    };
 }

--- a/src/main/webRequest/webRequestHandler.ts
+++ b/src/main/webRequest/webRequestHandler.ts
@@ -6,7 +6,7 @@ import {EventEmitter} from 'events';
 import log from 'electron-log';
 
 export class WebRequestHandler<T, T2> extends EventEmitter {
-    modifyCallbackObject: (details: T, callbackObject: T2, result: T2) => T2;
+    protected modifyCallbackObject: (details: T, callbackObject: T2, result: T2) => T2;
 
     constructor(modifyCallbackObject: (details: T, callbackObject: T2, result: T2) => T2) {
         super();

--- a/src/main/webRequest/webRequestManager.test.js
+++ b/src/main/webRequest/webRequestManager.test.js
@@ -1,8 +1,6 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {WebRequestHandler} from 'main/webRequest/webRequestHandler';
-
 import {WebRequestManager} from './webRequestManager';
 
 jest.mock('electron-log', () => ({

--- a/src/main/webRequest/webRequestManager.test.js
+++ b/src/main/webRequest/webRequestManager.test.js
@@ -1,7 +1,21 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {WebRequestHandler} from 'main/webRequest/webRequestHandler';
+
 import {WebRequestManager} from './webRequestManager';
+
+jest.mock('electron-log', () => ({
+    debug: jest.fn(),
+}));
+
+jest.mock('main/webRequest/webRequestHandler', () => ({
+    WebRequestHandler: jest.fn().mockImplementation(() => ({
+        addWebRequestListener: jest.fn(),
+        eventNames: jest.fn().mockReturnValue([]),
+        removeAllListeners: jest.fn(),
+    })),
+}));
 
 describe('main/webRequest/webRequestManager', () => {
     describe('onBeforeRequestCallback', () => {
@@ -80,6 +94,69 @@ describe('main/webRequest/webRequestManager', () => {
                 some_other_header: 'value3',
                 some_other_other_header: 'value4',
             }});
+        });
+    });
+
+    describe('rewriteURL', () => {
+        it('should overwrite old listeners with new ones if the regex matches', () => {
+            const manager = new WebRequestManager();
+            manager.onBeforeRequest.eventNames = jest.fn().mockReturnValue(['rewriteURL_/file:\\/\\/\\/*/_4']);
+            manager.rewriteURL(/file:\/\/\/*/, 'http:', 4);
+            expect(manager.onBeforeRequest.removeAllListeners).toHaveBeenCalled();
+        });
+
+        it('should not rewrite URLs if the request does not match the web contents id', () => {
+            const manager = new WebRequestManager();
+            let result = {};
+            manager.onBeforeRequest.addWebRequestListener.mockImplementation((name, fn) => {
+                result = fn({url: 'file:///some/file/path', webContentsId: 1});
+            });
+            manager.rewriteURL(/file:\/\/\/*/, 'http://', 2);
+            expect(result).not.toHaveProperty('redirectURL');
+        });
+
+        it('should not rewrite URLs if the request does not match the regex', () => {
+            const manager = new WebRequestManager();
+            let result = {};
+            manager.onBeforeRequest.addWebRequestListener.mockImplementation((name, fn) => {
+                result = fn({url: 'http://some/file/path', webContentsId: 1});
+            });
+            manager.rewriteURL(/file:\/\/\/*/, 'http://', 1);
+            expect(result).not.toHaveProperty('redirectURL');
+        });
+
+        it('should rewrite URL correctly', () => {
+            const manager = new WebRequestManager();
+            let result = {};
+            manager.onBeforeRequest.addWebRequestListener.mockImplementation((name, fn) => {
+                result = fn({url: 'file:///some/file/path', webContentsId: 1});
+            });
+            manager.rewriteURL(/file:\/\/\/*/, 'http://', 1);
+            expect(result).toHaveProperty('redirectURL', 'http://some/file/path');
+        });
+    });
+
+    describe('onRequestHeaders', () => {
+        it('should not call listener if the web contents id does not match', () => {
+            const manager = new WebRequestManager();
+            const listener = jest.fn();
+            manager.onBeforeSendHeaders.addWebRequestListener.mockImplementation((name, fn) => {
+                fn({requestHeaders: {}, webContentsId: 1});
+            });
+            manager.onRequestHeaders(listener, 2);
+            expect(listener).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('onResponseHeaders', () => {
+        it('should not call listener if the web contents id does not match', () => {
+            const manager = new WebRequestManager();
+            const listener = jest.fn();
+            manager.onHeadersReceived.addWebRequestListener.mockImplementation((name, fn) => {
+                fn({responseHeaders: {}, webContentsId: 1});
+            });
+            manager.onResponseHeaders(listener, 2);
+            expect(listener).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/main/webRequest/webRequestManager.ts
+++ b/src/main/webRequest/webRequestManager.ts
@@ -25,12 +25,12 @@ export class WebRequestManager {
     }
 
     initialize = () => {
-        session.defaultSession.webRequest.onBeforeRequest(this.onBeforeRequest.handle);
-        session.defaultSession.webRequest.onBeforeSendHeaders(this.onBeforeSendHeaders.handle);
-        session.defaultSession.webRequest.onHeadersReceived(this.onHeadersReceived.handle);
+        session.defaultSession.webRequest.onBeforeRequest(this.onBeforeRequest.handleWebRequest);
+        session.defaultSession.webRequest.onBeforeSendHeaders(this.onBeforeSendHeaders.handleWebRequest);
+        session.defaultSession.webRequest.onHeadersReceived(this.onHeadersReceived.handleWebRequest);
     }
 
-    onBeforeRequestCallback = (
+    private onBeforeRequestCallback = (
         details: OnBeforeRequestListenerDetails,
         callbackObject: CallbackResponse,
         result: CallbackResponse,
@@ -48,7 +48,7 @@ export class WebRequestManager {
         return modifiedCallbackObject;
     }
 
-    onBeforeSendHeadersCallback = (
+    private onBeforeSendHeadersCallback = (
         details: OnBeforeSendHeadersListenerDetails,
         callbackObject: BeforeSendResponse,
         result: BeforeSendResponse,
@@ -66,7 +66,7 @@ export class WebRequestManager {
         return modifiedCallbackObject;
     }
 
-    onHeadersReceivedCallback = (
+    private onHeadersReceivedCallback = (
         details: OnHeadersReceivedListenerDetails,
         callbackObject: HeadersReceivedResponse,
         result: HeadersReceivedResponse,

--- a/src/main/webRequest/webRequestManager.ts
+++ b/src/main/webRequest/webRequestManager.ts
@@ -12,6 +12,8 @@ import {
 } from 'electron';
 import log from 'electron-log';
 
+import {RequestHeaders, ResponseHeaders} from 'types/webRequest';
+
 import {WebRequestHandler} from 'main/webRequest/webRequestHandler';
 
 export class WebRequestManager {
@@ -53,7 +55,7 @@ export class WebRequestManager {
         });
     }
 
-    onRequestHeaders = (listener: (headers: Record<string, string>) => Record<string, string>, webContentsId?: number) => {
+    onRequestHeaders = (listener: (headers: RequestHeaders) => RequestHeaders, webContentsId?: number) => {
         log.debug('WebRequestManager.onRequestHeaders', webContentsId);
 
         this.onBeforeSendHeaders.addWebRequestListener(`onRequestHeaders_${webContentsId ?? '*'}`, (details) => {
@@ -69,7 +71,7 @@ export class WebRequestManager {
         });
     };
 
-    onResponseHeaders = (listener: (headers: Record<string, string[]>) => Record<string, string[]>, webContentsId?: number) => {
+    onResponseHeaders = (listener: (headers: ResponseHeaders) => ResponseHeaders, webContentsId?: number) => {
         log.debug('WebRequestManager.onResponseHeaders', webContentsId);
 
         this.onHeadersReceived.addWebRequestListener(`onResponseHeaders_${webContentsId ?? '*'}`, (details) => {

--- a/src/types/webRequest.ts
+++ b/src/types/webRequest.ts
@@ -1,0 +1,5 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export type RequestHeaders = Record<string, string>;
+export type ResponseHeaders = Record<string, string[]>;


### PR DESCRIPTION
#### Summary
The main features we'll need out of the new WebRequestManager will be to faciliate URL rewrite and header replacement. I've since locked down the access to the other handlers and I'm letting the manager be in charge of adding those listeners.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47682

```release-note
NONE
```
