### PR TITLE
FIx E2E test util method

### DIFF
--- a/e2e/modules/utils.js
+++ b/e2e/modules/utils.js
@@ -30,15 +30,17 @@ function dirExistsAsync(path) {
 function mkDirAsync(path) {
     return new Promise((resolve, reject) => {
         dirExistsAsync(path).then((exists) => {
-            if (!exists) {
-                fs.mkdir(path, {recursive: true}, (error) => {
-                    if (error) {
-                        reject(error);
-                        return;
-                    }
-                    resolve();
-                });
+            if (exists) {
+                resolve();
+                return;
             }
+            fs.mkdir(path, {recursive: true}, (error) => {
+                if (error) {
+                    reject(error);
+                    return;
+                }
+                resolve();
+            });
         }).catch((err) => {
             reject(err);
         });


### PR DESCRIPTION
One of the util methods was hanging the tests if a directory already existed.

```release-note
NONE
```