### PR TITLE
[MM-47709] Implement cookie handling

### DIFF
--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -161,3 +161,5 @@ export const DOWNLOADS_DROPDOWN_MENU_CLEAR_FILE = 'downloads-dropdown-menu-clear
 export const DOWNLOADS_DROPDOWN_MENU_OPEN_FILE = 'downloads-dropdown-menu-open-file';
 
 export const GET_CURRENT_SERVER_URL = 'get-current-server-url';
+export const SETUP_INITIAL_COOKIES = 'setup-initial-cookies';
+export const CLEAR_COOKIES = 'clear-cookies';

--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -162,4 +162,4 @@ export const DOWNLOADS_DROPDOWN_MENU_OPEN_FILE = 'downloads-dropdown-menu-open-f
 
 export const GET_CURRENT_SERVER_URL = 'get-current-server-url';
 export const SETUP_INITIAL_COOKIES = 'setup-initial-cookies';
-export const CLEAR_COOKIES = 'clear-cookies';
+export const SET_COOKIE = 'set-cookie';

--- a/src/main/preload/mainWindow.js
+++ b/src/main/preload/mainWindow.js
@@ -10,6 +10,8 @@ import {
     GET_LANGUAGE_INFORMATION,
     RETRIEVED_LANGUAGE_INFORMATION,
     GET_CURRENT_SERVER_URL,
+    SETUP_INITIAL_COOKIES,
+    CLEAR_COOKIES,
 } from 'common/communication';
 
 contextBridge.exposeInMainWorld('ipcRenderer', {
@@ -32,6 +34,8 @@ contextBridge.exposeInMainWorld('timers', {
 
 contextBridge.exposeInMainWorld('mattermost', {
     getUrl: ipcRenderer.invoke(GET_CURRENT_SERVER_URL),
+    setupCookies: ipcRenderer.invoke(SETUP_INITIAL_COOKIES),
+    clearCookies: () => ipcRenderer.send(CLEAR_COOKIES),
 });
 
 window.addEventListener('message', async (event) => {

--- a/src/main/preload/mainWindow.js
+++ b/src/main/preload/mainWindow.js
@@ -11,7 +11,7 @@ import {
     RETRIEVED_LANGUAGE_INFORMATION,
     GET_CURRENT_SERVER_URL,
     SETUP_INITIAL_COOKIES,
-    CLEAR_COOKIES,
+    SET_COOKIE,
 } from 'common/communication';
 
 contextBridge.exposeInMainWorld('ipcRenderer', {
@@ -35,7 +35,7 @@ contextBridge.exposeInMainWorld('timers', {
 contextBridge.exposeInMainWorld('mattermost', {
     getUrl: ipcRenderer.invoke(GET_CURRENT_SERVER_URL),
     setupCookies: ipcRenderer.invoke(SETUP_INITIAL_COOKIES),
-    clearCookies: () => ipcRenderer.send(CLEAR_COOKIES),
+    setCookie: (cookie) => ipcRenderer.send(SET_COOKIE, cookie),
 });
 
 window.addEventListener('message', async (event) => {

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -148,8 +148,7 @@ function parseCookieString(cookie: string) {
 
 export function createCookieSetDetailsFromCookieString(cookie: string, url: string, domain: string) {
     const parsedCookie = cookie.split('; ')[0];
-    const cookieName = parsedCookie.split('=')[0];
-    const cookieValue = parsedCookie.split('=')[1];
+    const [cookieName, cookieValue] = parsedCookie.split('=');
     const cookieObject = parseCookieString(cookie);
     return {
         url,

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -136,3 +136,29 @@ export function shouldIncrementFilename(filepath: string, increment = 0): string
     }
     return filename;
 }
+
+function parseCookieString(cookie: string) {
+    const output: any = {};
+    cookie.split(/\s*;\s*/).forEach((value) => {
+        const kvp = value.split(/\s*=\s*/);
+        output[kvp[0]] = kvp.splice(1).join('=');
+    });
+    return output;
+}
+
+export function createCookieSetDetailsFromCookieString(cookie: string, url: string, domain: string) {
+    const parsedCookie = cookie.split('; ')[0];
+    const cookieName = parsedCookie.split('=')[0];
+    const cookieValue = parsedCookie.split('=')[1];
+    const cookieObject = parseCookieString(cookie);
+    return {
+        url,
+        name: cookieName,
+        value: cookieValue,
+        domain,
+        path: cookieObject.Path,
+        secure: Object.hasOwn(cookieObject, 'Secure'),
+        httpOnly: Object.hasOwn(cookieObject, 'HttpOnly'),
+        expirationDate: new Date(cookieObject.Expires).valueOf(),
+    };
+}

--- a/src/main/views/MattermostView.ts
+++ b/src/main/views/MattermostView.ts
@@ -86,7 +86,7 @@ export class MattermostView extends EventEmitter {
     }
 
     private setCookie = async (event: IpcMainEvent, cookie: string) => {
-        log.info('Mattermost.setCookie', cookie);
+        log.debug('Mattermost.setCookie', cookie);
         const cookieSetDetails = createCookieSetDetailsFromCookieString(cookie, `${this.tab.server.url}`, this.tab.server.url.host);
         await session.defaultSession.cookies.set(cookieSetDetails);
         this.cookies.push(cookieSetDetails);

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -56,6 +56,7 @@ class Root extends React.PureComponent<Record<string, never>, State> {
                 if (!cookie) {
                     return '';
                 }
+                window.mattermost.setCookie(cookie);
                 const cutoff = cookie.indexOf(';');
                 const pair = cookie.substring(0, cutoff >= 0 ? cutoff : cookie.length);
                 const bits = pair.split('=');
@@ -76,11 +77,6 @@ class Root extends React.PureComponent<Record<string, never>, State> {
         });
         cookies.forEach((cookie) => {
             document.cookie = `${cookie.name}=${cookie.value}`;
-        });
-        this.registry?.setModule<() => void>('actions/views/cookie/clearUserCookie', () => {
-            window.mattermost.clearCookies();
-            const defaultFunc = this.registry?.getModule<() => void>('actions/views/cookie/default');
-            defaultFunc?.();
         });
 
         await this.setInitialConfig();

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -46,6 +46,43 @@ class Root extends React.PureComponent<Record<string, never>, State> {
         this.registry = await import('mattermost_webapp/registry');
         this.registry?.setModule<History>('utils/browser_history', createHashHistory());
 
+        // Cookie handling
+        const cookies = await window.mattermost.setupCookies;
+        Object.defineProperty(document, 'cookie', {
+            get() {
+                return this.value || '';
+            },
+            set(cookie) {
+                if (!cookie) {
+                    return '';
+                }
+                const cutoff = cookie.indexOf(';');
+                const pair = cookie.substring(0, cutoff >= 0 ? cutoff : cookie.length);
+                const bits = pair.split('=');
+                const cookies = this.value ? this.value.split('; ') : [];
+
+                // look for an existing cookie and remove it if it exists
+                for (let i = 0; i < cookies.length; i++) {
+                    const cookieBits = cookies[i].split('=');
+                    if (cookieBits[0] === bits[0]) {
+                        cookies.splice(i, 1);
+                        break;
+                    }
+                }
+                cookies.push(pair);
+                this.value = cookies.join('; ');
+                return this.value;
+            },
+        });
+        cookies.forEach((cookie) => {
+            document.cookie = `${cookie.name}=${cookie.value}`;
+        });
+        this.registry?.setModule<() => void>('actions/views/cookie/clearUserCookie', () => {
+            window.mattermost.clearCookies();
+            const defaultFunc = this.registry?.getModule<() => void>('actions/views/cookie/default');
+            defaultFunc?.();
+        });
+
         await this.setInitialConfig();
 
         window.ipcRenderer.on('synchronize-config', () => {

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -25,7 +25,7 @@ declare global {
         };
         mattermost: {
             setupCookies: Promise<CookiesSetDetails[]>;
-            clearCookies: () => void;
+            setCookie: (cookie: string) => Promise<void>;
         };
     }
 }

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {ipcRenderer} from 'electron/renderer';
+import {CookiesSetDetails, ipcRenderer} from 'electron/renderer';
 
 declare global {
     interface Window {
@@ -22,6 +22,10 @@ declare global {
         };
         mas: {
             getThumbnailLocation: (location: string) => Promise<string>;
+        };
+        mattermost: {
+            setupCookies: Promise<CookiesSetDetails[]>;
+            clearCookies: () => void;
         };
     }
 }

--- a/webpack.config.renderer.js
+++ b/webpack.config.renderer.js
@@ -17,8 +17,6 @@ const base = require('./webpack.config.base');
 
 const WEBSERVER_PORT = process.env.WEBSERVER_PORT ?? 9001;
 
-const deps = require('./package.json').dependencies;
-
 const getRemoteEntry = (resolve) => {
     const script = document.createElement('script');
     window.mattermost.getUrl.then((url) => {


### PR DESCRIPTION
#### Summary
This PR includes the handler for the cookie manager. This involves a system in which we strip the cookie out of the response headers and store it internally, then make sure that it's passed up with every request where it's necessary.

We also override the locally provided `document.cookie` property to make sure the local webapp has access to the cookie as needed (since it won't be allowed otherwise being on a locally hosted app).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47709

```release-note
NONE
```
