### PR TITLE
[MM-48142] Fix remaining call state issues in main window

### DIFF
--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -142,6 +142,7 @@ export const CALLS_LEAVE_CALL = 'calls-leave-call';
 export const CALLS_WIDGET_RESIZE = 'calls-widget-resize';
 export const CALLS_WIDGET_SHARE_SCREEN = 'calls-widget-share-screen';
 export const CALLS_WIDGET_CHANNEL_LINK_CLICK = 'calls-widget-channel-link-click';
+export const CALLS_JOINED_CALL = 'calls-joined-call';
 
 export const REQUEST_CLEAR_DOWNLOADS_DROPDOWN = 'request-clear-downloads-dropdown';
 export const CLOSE_DOWNLOADS_DROPDOWN = 'close-downloads-dropdown';

--- a/src/common/utils/constants.ts
+++ b/src/common/utils/constants.ts
@@ -26,8 +26,8 @@ export const MINIMUM_WINDOW_WIDTH = 700;
 export const MINIMUM_WINDOW_HEIGHT = 240;
 
 // Calls
-export const MINIMUM_CALLS_WIDGET_WIDTH = 280;
-export const MINIMUM_CALLS_WIDGET_HEIGHT = 86;
+export const MINIMUM_CALLS_WIDGET_WIDTH = 284;
+export const MINIMUM_CALLS_WIDGET_HEIGHT = 90;
 export const CALLS_PLUGIN_ID = 'com.mattermost.calls';
 
 export const DOWNLOADS_DROPDOWN_HEIGHT = 360;

--- a/src/main/preload/callsWidget.js
+++ b/src/main/preload/callsWidget.js
@@ -7,6 +7,7 @@ import {ipcRenderer} from 'electron';
 
 import {
     CALLS_LEAVE_CALL,
+    CALLS_JOINED_CALL,
     CALLS_WIDGET_RESIZE,
     CALLS_WIDGET_SHARE_SCREEN,
     CALLS_WIDGET_CHANNEL_LINK_CLICK,
@@ -45,6 +46,7 @@ window.addEventListener('message', ({origin, data = {}} = {}) => {
     case DESKTOP_SOURCES_MODAL_REQUEST:
     case CALLS_WIDGET_CHANNEL_LINK_CLICK:
     case CALLS_WIDGET_RESIZE:
+    case CALLS_JOINED_CALL:
     case CALLS_LEAVE_CALL: {
         ipcRenderer.send(type, message);
         break;

--- a/src/main/preload/mattermost.js
+++ b/src/main/preload/mattermost.js
@@ -31,6 +31,8 @@ import {
     DESKTOP_SOURCES_RESULT,
     VIEW_FINISHED_RESIZING,
     CALLS_JOIN_CALL,
+    CALLS_JOINED_CALL,
+    CALLS_LEAVE_CALL,
     DESKTOP_SOURCES_MODAL_REQUEST,
     CALLS_WIDGET_SHARE_SCREEN,
     CLOSE_DOWNLOADS_DROPDOWN,
@@ -166,6 +168,10 @@ window.addEventListener('message', ({origin, data = {}} = {}) => {
     }
     case CALLS_WIDGET_SHARE_SCREEN: {
         ipcRenderer.send(CALLS_WIDGET_SHARE_SCREEN, viewName, message);
+        break;
+    }
+    case CALLS_LEAVE_CALL: {
+        ipcRenderer.send(CALLS_LEAVE_CALL, viewName, message);
         break;
     }
     }
@@ -322,6 +328,16 @@ ipcRenderer.on(DESKTOP_SOURCES_MODAL_REQUEST, () => {
     window.postMessage(
         {
             type: DESKTOP_SOURCES_MODAL_REQUEST,
+        },
+        window.location.origin,
+    );
+});
+
+ipcRenderer.on(CALLS_JOINED_CALL, (event, message) => {
+    window.postMessage(
+        {
+            type: CALLS_JOINED_CALL,
+            message,
         },
         window.location.origin,
     );

--- a/src/main/windows/callsWidgetWindow.test.js
+++ b/src/main/windows/callsWidgetWindow.test.js
@@ -8,6 +8,7 @@ import {CALLS_WIDGET_SHARE_SCREEN} from 'common/communication';
 import {
     MINIMUM_CALLS_WIDGET_WIDTH,
     MINIMUM_CALLS_WIDGET_HEIGHT,
+    CALLS_PLUGIN_ID,
 } from 'common/utils/constants';
 
 import CallsWidgetWindow from './callsWidgetWindow';
@@ -57,8 +58,8 @@ describe('main/windows/callsWidgetWindow', () => {
                 return {
                     x: 0,
                     y: 0,
-                    width: 280,
-                    height: 86,
+                    width: MINIMUM_CALLS_WIDGET_WIDTH,
+                    height: MINIMUM_CALLS_WIDGET_HEIGHT,
                 };
             });
 
@@ -102,9 +103,9 @@ describe('main/windows/callsWidgetWindow', () => {
             expect(widgetWindow.win.setAlwaysOnTop).toHaveBeenCalled();
             expect(widgetWindow.win.setBounds).toHaveBeenCalledWith({
                 x: 12,
-                y: 622,
-                width: 280,
-                height: 86,
+                y: 618,
+                width: MINIMUM_CALLS_WIDGET_WIDTH,
+                height: MINIMUM_CALLS_WIDGET_HEIGHT,
             });
         });
 
@@ -156,8 +157,8 @@ describe('main/windows/callsWidgetWindow', () => {
             let winBounds = {
                 x: 0,
                 y: 0,
-                width: 280,
-                height: 86,
+                width: MINIMUM_CALLS_WIDGET_WIDTH,
+                height: MINIMUM_CALLS_WIDGET_HEIGHT,
             };
             baseWindow.getBounds = jest.fn(() => {
                 return winBounds;
@@ -179,9 +180,9 @@ describe('main/windows/callsWidgetWindow', () => {
 
             expect(baseWindow.setBounds).toHaveBeenCalledWith({
                 x: 12,
-                y: 522,
-                width: 280,
-                height: 186,
+                y: 518,
+                width: MINIMUM_CALLS_WIDGET_WIDTH,
+                height: MINIMUM_CALLS_WIDGET_HEIGHT + 100,
             });
 
             widgetWindow.onResize(null, {
@@ -191,9 +192,9 @@ describe('main/windows/callsWidgetWindow', () => {
 
             expect(baseWindow.setBounds).toHaveBeenCalledWith({
                 x: 12,
-                y: 522,
-                width: 380,
-                height: 186,
+                y: 518,
+                width: MINIMUM_CALLS_WIDGET_WIDTH + 100,
+                height: MINIMUM_CALLS_WIDGET_HEIGHT + 100,
             });
 
             widgetWindow.onResize(null, {
@@ -203,9 +204,9 @@ describe('main/windows/callsWidgetWindow', () => {
 
             expect(baseWindow.setBounds).toHaveBeenCalledWith({
                 x: 12,
-                y: 522,
-                width: 280,
-                height: 186,
+                y: 518,
+                width: MINIMUM_CALLS_WIDGET_WIDTH,
+                height: MINIMUM_CALLS_WIDGET_HEIGHT + 100,
             });
 
             widgetWindow.onResize(null, {
@@ -215,9 +216,9 @@ describe('main/windows/callsWidgetWindow', () => {
 
             expect(baseWindow.setBounds).toHaveBeenCalledWith({
                 x: 12,
-                y: 622,
-                width: 280,
-                height: 86,
+                y: 618,
+                width: MINIMUM_CALLS_WIDGET_WIDTH,
+                height: MINIMUM_CALLS_WIDGET_HEIGHT,
             });
         });
 
@@ -238,7 +239,7 @@ describe('main/windows/callsWidgetWindow', () => {
                 title: 'call test title #/&',
             };
             const widgetWindow = new CallsWidgetWindow(mainWindow, config);
-            const expected = `${config.siteURL}/plugins/com.mattermost.calls/widget/widget.html?call_id=${config.callID}&title=call+test+title+%23%2F%26`;
+            const expected = `${config.siteURL}/plugins/${CALLS_PLUGIN_ID}/standalone/widget.html?call_id=${config.callID}&title=call+test+title+%23%2F%26`;
             expect(widgetWindow.getWidgetURL()).toBe(expected);
         });
 

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -11,7 +11,10 @@ import {
     CallsWidgetWindowConfig,
     CallsWidgetResizeMessage,
     CallsWidgetShareScreenMessage,
+    CallsJoinedCallMessage,
 } from 'types/calls';
+
+import {MattermostView} from 'main/views/MattermostView';
 
 import {getLocalPreload} from 'main/utils';
 
@@ -24,6 +27,7 @@ import Utils from 'common/utils/util';
 import {
     CALLS_WIDGET_RESIZE,
     CALLS_WIDGET_SHARE_SCREEN,
+    CALLS_JOINED_CALL,
 } from 'common/communication';
 
 type LoadURLOpts = {
@@ -33,6 +37,7 @@ type LoadURLOpts = {
 export default class CallsWidgetWindow extends EventEmitter {
     public win: BrowserWindow;
     private main: BrowserWindow;
+    private mainView: MattermostView;
     private config: CallsWidgetWindowConfig;
     private boundsErr: Rectangle = {
         x: 0,
@@ -46,11 +51,12 @@ export default class CallsWidgetWindow extends EventEmitter {
         },
     };
 
-    constructor(mainWindow: BrowserWindow, config: CallsWidgetWindowConfig) {
+    constructor(mainWindow: BrowserWindow, mainView: MattermostView, config: CallsWidgetWindowConfig) {
         super();
 
         this.config = config;
         this.main = mainWindow;
+        this.mainView = mainView;
         this.win = new BrowserWindow({
             width: MINIMUM_CALLS_WIDGET_WIDTH,
             height: MINIMUM_CALLS_WIDGET_HEIGHT,
@@ -74,6 +80,7 @@ export default class CallsWidgetWindow extends EventEmitter {
         this.win.on('closed', this.onClosed);
         ipcMain.on(CALLS_WIDGET_RESIZE, this.onResize);
         ipcMain.on(CALLS_WIDGET_SHARE_SCREEN, this.onShareScreen);
+        ipcMain.on(CALLS_JOINED_CALL, this.onJoinedCall);
 
         this.load();
     }
@@ -91,6 +98,10 @@ export default class CallsWidgetWindow extends EventEmitter {
         return this.config.channelURL;
     }
 
+    public getCallID() {
+        return this.config.callID;
+    }
+
     private load() {
         const opts = {} as LoadURLOpts;
         this.win.loadURL(this.getWidgetURL(), opts).catch((reason) => {
@@ -104,6 +115,7 @@ export default class CallsWidgetWindow extends EventEmitter {
         this.removeAllListeners('closed');
         ipcMain.off(CALLS_WIDGET_RESIZE, this.onResize);
         ipcMain.off(CALLS_WIDGET_SHARE_SCREEN, this.onShareScreen);
+        ipcMain.off(CALLS_JOINED_CALL, this.onJoinedCall);
     }
 
     private getWidgetURL() {
@@ -156,6 +168,10 @@ export default class CallsWidgetWindow extends EventEmitter {
 
     private onShareScreen = (ev: IpcMainEvent, viewName: string, message: CallsWidgetShareScreenMessage) => {
         this.win.webContents.send(CALLS_WIDGET_SHARE_SCREEN, message);
+    }
+
+    private onJoinedCall = (ev: IpcMainEvent, message: CallsJoinedCallMessage) => {
+        this.mainView.view.webContents.send(CALLS_JOINED_CALL, message);
     }
 
     private setBounds(bounds: Rectangle) {

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -108,7 +108,7 @@ export default class CallsWidgetWindow extends EventEmitter {
 
     private getWidgetURL() {
         const u = new url.URL(this.config.siteURL);
-        u.pathname += `/plugins/${CALLS_PLUGIN_ID}/widget/widget.html`;
+        u.pathname += `/plugins/${CALLS_PLUGIN_ID}/standalone/widget.html`;
         u.searchParams.append('call_id', this.config.callID);
         if (this.config.title) {
             u.searchParams.append('title', this.config.title);

--- a/src/main/windows/windowManager.test.js
+++ b/src/main/windows/windowManager.test.js
@@ -1017,6 +1017,22 @@ describe('main/windows/windowManager', () => {
             windowManager.createCallsWidgetWindow(null, 'server-1_tab-messaging', {callID: 'test'});
             expect(windowManager.callsWidgetWindow).toBeDefined();
         });
+
+        it('should not create a new window if call is the same', () => {
+            const widgetWindow = windowManager.callsWidgetWindow;
+            expect(widgetWindow).toBeDefined();
+            widgetWindow.getCallID = jest.fn(() => 'test');
+            windowManager.createCallsWidgetWindow(null, 'server-1_tab-messaging', {callID: 'test'});
+            expect(windowManager.callsWidgetWindow).toEqual(widgetWindow);
+        });
+
+        it('should create a new window if switching calls', () => {
+            const widgetWindow = windowManager.callsWidgetWindow;
+            expect(widgetWindow).toBeDefined();
+            widgetWindow.getCallID = jest.fn(() => 'test');
+            windowManager.createCallsWidgetWindow(null, 'server-1_tab-messaging', {callID: 'test2'});
+            expect(windowManager.callsWidgetWindow).not.toEqual(widgetWindow);
+        });
     });
 
     describe('handleDesktopSourcesModalRequest', () => {

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -107,7 +107,11 @@ export class WindowManager {
     createCallsWidgetWindow = (event: IpcMainEvent, viewName: string, msg: CallsJoinCallMessage) => {
         log.debug('WindowManager.createCallsWidgetWindow');
         if (this.callsWidgetWindow) {
-            return;
+            // trying to join again the call we are already in should not be allowed.
+            if (this.callsWidgetWindow.getCallID() === msg.callID) {
+                return;
+            }
+            this.callsWidgetWindow.close();
         }
         const currentView = this.viewManager?.views.get(viewName);
         if (!currentView) {
@@ -115,7 +119,7 @@ export class WindowManager {
             return;
         }
 
-        this.callsWidgetWindow = new CallsWidgetWindow(this.mainWindow!, {
+        this.callsWidgetWindow = new CallsWidgetWindow(this.mainWindow!, currentView, {
             siteURL: currentView.serverInfo.remoteInfo.siteURL!,
             callID: msg.callID,
             title: msg.title,

--- a/src/types/calls.ts
+++ b/src/types/calls.ts
@@ -24,3 +24,7 @@ export type CallsWidgetShareScreenMessage = {
     sourceID: string;
     withAudio: boolean;
 }
+
+export type CallsJoinedCallMessage = {
+    callID: string;
+}


### PR DESCRIPTION
#### Summary

PR fixes some outstanding issues with the call state in the main window, namely:

- Channel toast should not show in the channel after joining the call.
- Leave button should render in the post card.
- Leaving the call from the post card should be allowed, as well as through slash command.
- Switching calls from the post card should work as in web version.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-48142

#### Related PR

https://github.com/mattermost/mattermost-plugin-calls/pull/235

#### Release Note

```release-note
NONE
```
