### PR TITLE
[MM-47710] Override CSP header including allowances for the Web App and Desktop App

### DIFF
--- a/src/common/utils/constants.ts
+++ b/src/common/utils/constants.ts
@@ -39,6 +39,8 @@ export const DOWNLOADS_DROPDOWN_MENU_FULL_HEIGHT = DOWNLOADS_DROPDOWN_MENU_HEIGH
 export const DOWNLOADS_DROPDOWN_MAX_ITEMS = 50;
 export const DOWNLOADS_DROPDOWN_AUTOCLOSE_TIMEOUT = 4000; // 4 sec
 
+export const DEFAULT_CSP_HEADER = 'script-src \'self\'; style-src \'self\' \'unsafe-inline\'; media-src data:';
+
 // supported custom login paths (oath, saml)
 export const customLoginRegexPaths = [
     /^\/oauth\/authorize$/i,

--- a/src/common/utils/constants.ts
+++ b/src/common/utils/constants.ts
@@ -39,7 +39,7 @@ export const DOWNLOADS_DROPDOWN_MENU_FULL_HEIGHT = DOWNLOADS_DROPDOWN_MENU_HEIGH
 export const DOWNLOADS_DROPDOWN_MAX_ITEMS = 50;
 export const DOWNLOADS_DROPDOWN_AUTOCLOSE_TIMEOUT = 4000; // 4 sec
 
-export const DEFAULT_CSP_HEADER = 'script-src \'self\'; style-src \'self\' \'unsafe-inline\'; media-src data:';
+export const DEFAULT_CSP_HEADER = "script-src 'self'; style-src 'self' 'unsafe-inline'; media-src data:";
 
 // supported custom login paths (oath, saml)
 export const customLoginRegexPaths = [

--- a/src/main/downloadsManager.test.js
+++ b/src/main/downloadsManager.test.js
@@ -167,7 +167,7 @@ describe('main/downloadsManager', () => {
             'x-uncompressed-content-length': ['4242'],
             'content-disposition': ['attachment; filename="file.txt"; foobar'],
         };
-        dl.webRequestOnHeadersReceivedHandler(responseHeaders);
+        dl.webRequestOnHeadersReceivedHandler({responseHeaders});
         expect(dl.fileSizes.get('file.txt')).toBe('4242');
     });
 

--- a/src/main/downloadsManager.ts
+++ b/src/main/downloadsManager.ts
@@ -3,12 +3,11 @@
 import path from 'path';
 import fs from 'fs';
 
-import {DownloadItem, Event, WebContents, FileFilter, ipcMain, dialog, shell, Menu, app} from 'electron';
+import {DownloadItem, Event, WebContents, FileFilter, ipcMain, dialog, shell, Menu, app, OnHeadersReceivedListenerDetails} from 'electron';
 import log from 'electron-log';
 import {ProgressInfo} from 'electron-updater';
 
 import {DownloadedItem, DownloadItemDoneEventState, DownloadedItems, DownloadItemState, DownloadItemUpdatedEventState} from 'types/downloads';
-import {ResponseHeaders} from 'types/webRequest';
 
 import {
     CANCEL_UPDATE_DOWNLOAD,
@@ -133,10 +132,10 @@ export class DownloadsManager extends JsonFileManager<DownloadedItems> {
      * This function monitors webRequests and retrieves the total file size (of files being downloaded)
      * from the custom HTTP header "x-uncompressed-content-length".
      */
-    webRequestOnHeadersReceivedHandler = (headers: ResponseHeaders) => {
-        if (headers?.['content-encoding']?.includes('gzip') && headers?.['x-uncompressed-content-length'] && headers?.['content-disposition'].join(';')?.includes('filename=')) {
-            const filename = readFilenameFromContentDispositionHeader(headers['content-disposition']);
-            const fileSize = headers['x-uncompressed-content-length']?.[0] || '0';
+    webRequestOnHeadersReceivedHandler = (details: OnHeadersReceivedListenerDetails) => {
+        if (details.responseHeaders?.['content-encoding']?.includes('gzip') && details.responseHeaders?.['x-uncompressed-content-length'] && details.responseHeaders?.['content-disposition'].join(';')?.includes('filename=')) {
+            const filename = readFilenameFromContentDispositionHeader(details.responseHeaders['content-disposition']);
+            const fileSize = details.responseHeaders['x-uncompressed-content-length']?.[0] || '0';
             if (filename && (!this.fileSizes.has(filename) || this.fileSizes.get(filename)?.toString() !== fileSize)) {
                 this.fileSizes.set(filename, fileSize);
             }

--- a/src/main/server/serverAPI.test.js
+++ b/src/main/server/serverAPI.test.js
@@ -58,6 +58,7 @@ describe('main/server/serverAPI', () => {
             false,
             successFn,
             null,
+            null,
             errorFn,
         );
         expect(successFn).not.toHaveBeenCalled();
@@ -71,6 +72,7 @@ describe('main/server/serverAPI', () => {
             badDataURL,
             false,
             successFn,
+            null,
             null,
             errorFn,
         );
@@ -100,6 +102,7 @@ describe('main/server/serverAPI', () => {
             false,
             successFn,
             null,
+            null,
             errorFn,
         );
         expect(errorFn).toHaveBeenCalled();
@@ -121,6 +124,7 @@ describe('main/server/serverAPI', () => {
             validURL,
             false,
             successFn,
+            null,
             abortFn,
             null,
         );
@@ -144,6 +148,7 @@ describe('main/server/serverAPI', () => {
             false,
             successFn,
             null,
+            null,
             errorFn,
         );
         expect(errorFn).toHaveBeenCalled();
@@ -154,6 +159,7 @@ describe('main/server/serverAPI', () => {
         await getServerAPI(
             validURL,
             true,
+            undefined,
             successFn,
         );
         expect(net.request).not.toBeCalled();

--- a/src/main/server/serverInfo.ts
+++ b/src/main/server/serverInfo.ts
@@ -26,17 +26,27 @@ export class ServerInfo {
     }
 
     getRemoteInfo = () => {
+        getServerAPI<void>(
+            new URL(`${this.server.url}`),
+            false,
+            undefined,
+            this.onGetIndexHeaders,
+            this.onRetrievedRemoteInfo,
+            this.onRetrievedRemoteInfo);
+
         getServerAPI<ClientConfig>(
-            new URL(`${this.server.url.toString()}/api/v4/config/client?format=old`),
+            new URL(`${this.server.url}/api/v4/config/client?format=old`),
             false,
             this.onGetConfig,
+            undefined,
             this.onRetrievedRemoteInfo,
             this.onRetrievedRemoteInfo);
 
         getServerAPI<Array<{id: string; version: string}>>(
-            new URL(`${this.server.url.toString()}/api/v4/plugins/webapp`),
+            new URL(`${this.server.url}/api/v4/plugins/webapp`),
             false,
             this.onGetPlugins,
+            undefined,
             this.onRetrievedRemoteInfo,
             this.onRetrievedRemoteInfo);
     }
@@ -44,6 +54,12 @@ export class ServerInfo {
     onGetConfig = (data: ClientConfig) => {
         this.remoteInfo.serverVersion = data.Version;
         this.remoteInfo.siteURL = data.SiteURL;
+
+        this.trySendRemoteInfo();
+    }
+
+    onGetIndexHeaders = (headers: Record<string, string | string[]>) => {
+        this.remoteInfo.cspHeader = headers['content-security-policy'] as string;
 
         this.trySendRemoteInfo();
     }
@@ -65,6 +81,7 @@ export class ServerInfo {
 
     isRemoteInfoRetrieved = () => {
         return !(
+            typeof this.remoteInfo.cspHeader === 'undefined' ||
             typeof this.remoteInfo.serverVersion === 'undefined' ||
             typeof this.remoteInfo.hasFocalboard === 'undefined' ||
             typeof this.remoteInfo.hasPlaybooks === 'undefined'

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -9,7 +9,7 @@ import {app, BrowserWindow} from 'electron';
 
 import {Args} from 'types/args';
 
-import {BACK_BAR_HEIGHT, customLoginRegexPaths, PRODUCTION, TAB_BAR_HEIGHT} from 'common/utils/constants';
+import {BACK_BAR_HEIGHT, customLoginRegexPaths, PRODUCTION, TAB_BAR_HEIGHT, DEFAULT_CSP_HEADER} from 'common/utils/constants';
 import UrlUtils from 'common/utils/url';
 import Utils from 'common/utils/util';
 
@@ -135,4 +135,39 @@ export function shouldIncrementFilename(filepath: string, increment = 0): string
         return shouldIncrementFilename(filepath, increment + 1);
     }
     return filename;
+}
+
+export function makeCSPHeader(serverURL: URL, remoteCSPHeader?: string) {
+    if (!remoteCSPHeader) {
+        return DEFAULT_CSP_HEADER;
+    }
+
+    let headerMap = addToCSPMap(new Map(), DEFAULT_CSP_HEADER);
+    headerMap = addToCSPMap(headerMap, remoteCSPHeader, (piece) => {
+        if (piece === '\'self\'') {
+            return serverURL.origin;
+        }
+        return piece;
+    });
+
+    const subheaders = [...headerMap.keys()];
+    const header = subheaders.map((sub) => `${sub} ${headerMap.get(sub)?.join(' ')}`).join('; ');
+    return header;
+}
+
+function addToCSPMap(cspMap: Map<string, string[]>, header: string, ...filters: Array<(x: string) => string>) {
+    header.split('; ').forEach((section) => {
+        const pieces = section.split(' ');
+        let existingPieces = (cspMap.get(pieces[0]) ?? []);
+
+        let newPieces = pieces.slice(1);
+        filters.forEach((func) => {
+            newPieces = newPieces.map(func) as string[];
+        });
+
+        existingPieces = existingPieces.concat(newPieces);
+        existingPieces = existingPieces.filter((value, index, self) => index === self.findIndex((t) => (t === value)));
+        cspMap.set(pieces[0], existingPieces);
+    });
+    return cspMap;
 }

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -144,7 +144,7 @@ export function makeCSPHeader(serverURL: URL, remoteCSPHeader?: string) {
 
     let headerMap = addToCSPMap(new Map(), DEFAULT_CSP_HEADER);
     headerMap = addToCSPMap(headerMap, remoteCSPHeader, (piece) => {
-        if (piece === '\'self\'') {
+        if (piece === "'self'") {
             return serverURL.origin;
         }
         return piece;

--- a/src/main/views/MattermostView.ts
+++ b/src/main/views/MattermostView.ts
@@ -57,8 +57,6 @@ export class MattermostView extends EventEmitter {
         );
 
         WebRequestManager.onResponseHeaders(this.addCSPHeader, this.view.webContents.id);
-
-        this.view.webContents.openDevTools({mode: 'detach'});
     }
 
     addCSPHeader = (details: OnHeadersReceivedListenerDetails) => {

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -85,10 +85,12 @@ export class ViewManager {
         const tabView = getServerView(srv, tab);
         const view = new MattermostView(tabView, serverInfo, this.mainWindow, this.viewOptions);
         view.once(LOAD_SUCCESS, this.activateView);
-        view.load(url);
         view.on(UPDATE_TARGET_URL, this.showURLView);
         view.on(LOADSCREEN_END, this.finishLoading);
         view.on(LOAD_FAILED, this.failLoading);
+        serverInfo.promise.then(() => {
+            view.load(url);
+        });
         return view;
     }
 

--- a/src/main/webRequest/webRequestManager.ts
+++ b/src/main/webRequest/webRequestManager.ts
@@ -12,7 +12,7 @@ import {
 } from 'electron';
 import log from 'electron-log';
 
-import {RequestHeaders, ResponseHeaders} from 'types/webRequest';
+import {Headers} from 'types/webRequest';
 
 import {WebRequestHandler} from 'main/webRequest/webRequestHandler';
 
@@ -56,7 +56,7 @@ export class WebRequestManager {
         });
     }
 
-    onRequestHeaders = (listener: (headers: RequestHeaders) => RequestHeaders, webContentsId?: number) => {
+    onRequestHeaders = (listener: (headers: OnBeforeSendHeadersListenerDetails) => Headers, webContentsId?: number) => {
         log.debug('WebRequestManager.onRequestHeaders', webContentsId);
 
         this.onBeforeSendHeaders.addWebRequestListener(`onRequestHeaders_${webContentsId ?? '*'}`, (details) => {
@@ -68,11 +68,11 @@ export class WebRequestManager {
                 return {};
             }
 
-            return {requestHeaders: listener(details.requestHeaders)};
+            return {requestHeaders: listener(details)};
         });
     };
 
-    onResponseHeaders = (listener: (headers: ResponseHeaders) => ResponseHeaders, webContentsId?: number) => {
+    onResponseHeaders = (listener: (details: OnHeadersReceivedListenerDetails) => Headers, webContentsId?: number) => {
         log.debug('WebRequestManager.onResponseHeaders', webContentsId);
 
         this.onHeadersReceived.addWebRequestListener(`onResponseHeaders_${webContentsId ?? '*'}`, (details) => {
@@ -84,7 +84,7 @@ export class WebRequestManager {
                 return {};
             }
 
-            return {responseHeaders: listener(details.responseHeaders)};
+            return {responseHeaders: listener(details)};
         });
     };
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -2,8 +2,6 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <!--TODO-->
-        <!--meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; media-src data:"-->
         <title><%= htmlWebpackPlugin.options.title %></title>
     </head>
     <body>

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -7,6 +7,7 @@ export type RemoteInfo = {
     siteURL?: string;
     hasFocalboard?: boolean;
     hasPlaybooks?: boolean;
+    cspHeader?: string;
 };
 
 export type ClientConfig = {

--- a/src/types/webRequest.ts
+++ b/src/types/webRequest.ts
@@ -1,5 +1,4 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-export type RequestHeaders = Record<string, string>;
-export type ResponseHeaders = Record<string, string[]>;
+export type Headers = Record<string, string | string[]>;

--- a/webpack.config.renderer.js
+++ b/webpack.config.renderer.js
@@ -17,8 +17,6 @@ const base = require('./webpack.config.base');
 
 const WEBSERVER_PORT = process.env.WEBSERVER_PORT ?? 9001;
 
-const deps = require('./package.json').dependencies;
-
 const getRemoteEntry = (resolve) => {
     const script = document.createElement('script');
     window.mattermost.getUrl.then((url) => {


### PR DESCRIPTION
#### Summary
This PR adds the logic to insert the correct CSP header when the app is loaded. It takes information from the web app's CSP header and adds in a few fields to allow for Desktop App modules to run.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47710

```release-note
NONE
```
