### PR TITLE
[MM-48167] Only grab the last extension from a filename during Save As

### DIFF
--- a/src/main/downloadsManager.ts
+++ b/src/main/downloadsManager.ts
@@ -401,7 +401,7 @@ export class DownloadsManager extends JsonFileManager<DownloadedItems> {
     private showSaveDialog = (item: DownloadItem) => {
         const filename = item.getFilename();
         const fileElements = filename.split('.');
-        const filters = this.getFileFilters(fileElements.slice(1));
+        const filters = this.getFileFilters(fileElements.slice(fileElements.length - 1));
 
         return dialog.showSaveDialog({
             title: filename,


### PR DESCRIPTION
#### Summary
When right-clicking a file and choosing Save As, if the filename had more than one `.`, the dialog would pick up each string seperated by a `.` and add it to the file extension list. Commonly reproducible when sharing macOS screenshots.

This PR ensures that we always get the actual file extension (ie. the last one) and use it for the dialog.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48167

```release-note
NONE
```
