### PR TITLE
[MM-48083] Add websocket overrides

### DIFF
--- a/src/main/views/MattermostView.ts
+++ b/src/main/views/MattermostView.ts
@@ -83,6 +83,25 @@ export class MattermostView extends EventEmitter {
         ipcMain.on(SET_COOKIE, this.setCookie);
         WebRequestManager.onRequestHeaders(this.appendCookies, this.view.webContents.id);
         WebRequestManager.onResponseHeaders(this.extractCookies, this.view.webContents.id);
+
+        // Websocket
+        WebRequestManager.onRequestHeaders(this.addOriginForWebsocket);
+    }
+
+    private addOriginForWebsocket = (details: OnBeforeSendHeadersListenerDetails) => {
+        log.silly('WindowManager.addOriginForWebsocket', details.requestHeaders);
+
+        if (!details.url.startsWith('ws')) {
+            return {} as Headers;
+        }
+
+        if (!(details.requestHeaders.Origin === 'file://')) {
+            return {};
+        }
+
+        return {
+            Origin: `${this.tab.server.url.protocol}//${this.tab.server.url.host}`,
+        };
     }
 
     private setCookie = async (event: IpcMainEvent, cookie: string) => {

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -46,6 +46,10 @@ class Root extends React.PureComponent<Record<string, never>, State> {
         this.registry = await import('mattermost_webapp/registry');
         this.registry?.setModule<History>('utils/browser_history', createHashHistory());
 
+        // Websocket site url handling
+        const currentURL = await window.mattermost.getUrl;
+        this.registry?.setModule<() => string>('utils/url/getSiteURL', () => currentURL);
+
         // Cookie handling
         const cookies = await window.mattermost.setupCookies;
         Object.defineProperty(document, 'cookie', {

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -24,6 +24,7 @@ declare global {
             getThumbnailLocation: (location: string) => Promise<string>;
         };
         mattermost: {
+            getUrl: Promise<string>;
             setupCookies: Promise<CookiesSetDetails[]>;
             setCookie: (cookie: string) => Promise<void>;
         };


### PR DESCRIPTION
#### Summary
This implements an override for the `getSiteURL` module, and overrides the origin when connecting to the websocket. These two changes allow the websocket to connect and pass information as normal without any issue.

Relevant webapp change: https://github.com/mattermost/mattermost-webapp/pull/11383/commits/d2699127df051cc22f680e81c4c996bf26acd415

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48083

```release-note
NONE
```
