### PR TITLE
Fixed URL rewrite for Boards

### DIFF
--- a/src/main/views/MattermostView.ts
+++ b/src/main/views/MattermostView.ts
@@ -77,6 +77,12 @@ export class MattermostView extends EventEmitter {
             this.view.webContents.id,
         );
 
+        WebRequestManager.rewriteURL(
+            new RegExp(`file://${this.tab.server.url.pathname}/plugins/focalboard/(.+)`, 'g'),
+            `${this.tab.server.url}/plugins/focalboard/$1`,
+            this.view.webContents.id,
+        );
+
         // Cookies
         this.cookies = [];
         ipcMain.handle(SETUP_INITIAL_COOKIES, this.setupCookies);


### PR DESCRIPTION
#### Summary
Since Boards uses it's own web request module that resolves differently that the web app one does, we had to add an extra override specifically for Boards to make sure that it can access its API.

```release-note
NONE
```
