### PR TITLE
[MM-48404] Exclude unnecessary binaries for native modules

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -17,7 +17,12 @@
   "files": [
     "node_modules/bootstrap/dist/**",
     "node_modules/font-awesome/{css,fonts}/**",
-    "!**/node_modules/macos-notification-state/build/Release/.forge-meta",
+    "!**/node_modules/macos-notification-state/bin/**/*",
+    "!**/node_modules/macos-notification-state/build/**/*",
+    "!**/node_modules/windows-focus-assist/bin/**/*",
+    "!**/node_modules/windows-focus-assist/build/**/*",
+    "node_modules/macos-notification-state/build/**/*.node",
+    "node_modules/windows-focus-assist/build/Release/**/*.node",
     {
       "from": "dist",
       "to": ".",
@@ -49,8 +54,8 @@
     "priority": "optional"
   },
   "asarUnpack": [
-    "./node_modules/macos-notification-state/**/*",
-    "./node_modules/windows-focus-assist/**/*"
+    "./node_modules/macos-notification-state/build/Release/**/*.node",
+    "./node_modules/windows-focus-assist/build/Release/**/*.node"
   ],
   "linux": {
     "category": "Network;InstantMessaging",


### PR DESCRIPTION
#### Summary
We were rejected from the Mac App Store for having a deprecated API. I believe this was being caused by the inclusion of a bunch of unnecessary binaries from the native modules. I've restricted `electron-builder` from including these in the future.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48404
Closes https://github.com/mattermost/desktop/issues/2374

```release-note
NONE
```
