### PR TITLE
Fix issue with windows-focus-assist returning truthy value on older windows versions

### DIFF
--- a/src/main/notifications/dnd-linux.ts
+++ b/src/main/notifications/dnd-linux.ts
@@ -9,6 +9,9 @@ const GNOME_READ_DND = 'gsettings get org.gnome.desktop.notifications show-banne
 
 function getLinuxDoNotDisturb() {
     try {
+        if (process.platform !== 'linux') {
+            return false;
+        }
         const showNotifications = execSync(GNOME_READ_DND).toString().replace('\n', '');
         log.debug('getLinuxDoNotDisturb', {showNotifications});
 

--- a/src/main/notifications/dnd-windows.ts
+++ b/src/main/notifications/dnd-windows.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {getFocusAssist, isPriority} from 'windows-focus-assist';
+
+/**
+    -2: NOT_SUPPORTED,
+    -1: FAILED,
+    0: Off,
+    1: PRIORITY_ONLY,
+    2: ALARMS_ONLY
+*/
+function getWindowsDoNotDisturb() {
+    if (process.platform !== 'win32') {
+        return false;
+    }
+
+    const focusAssistValue = getFocusAssist().value;
+    switch (focusAssistValue) {
+    case 2:
+        return true;
+    case 1:
+        return !isPriority('Mattermost.Desktop');
+    case 0:
+    case -1:
+    case -2:
+        return false;
+    default:
+        return focusAssistValue;
+    }
+}
+
+export default getWindowsDoNotDisturb;

--- a/src/main/notifications/index.ts
+++ b/src/main/notifications/index.ts
@@ -4,7 +4,6 @@
 import {shell, Notification} from 'electron';
 import log from 'electron-log';
 
-import {getFocusAssist, isPriority} from 'windows-focus-assist';
 import {getDoNotDisturb as getDarwinDoNotDisturb} from 'macos-notification-state';
 
 import {MentionData} from 'types/notification';
@@ -18,6 +17,7 @@ import {Mention} from './Mention';
 import {DownloadNotification} from './Download';
 import {NewVersionNotification, UpgradeNotification} from './Upgrade';
 import getLinuxDoNotDisturb from './dnd-linux';
+import getWindowsDoNotDisturb from './dnd-windows';
 
 export const currentNotifications = new Map();
 
@@ -140,13 +140,7 @@ export function displayRestartToUpgrade(version: string, handleUpgrade: () => vo
 
 function getDoNotDisturb() {
     if (process.platform === 'win32') {
-        const focusAssistValue = getFocusAssist().value;
-        switch (focusAssistValue) {
-        case 1:
-            return !isPriority('Mattermost.Desktop');
-        default:
-            return focusAssistValue;
-        }
+        return getWindowsDoNotDisturb();
     }
 
     if (process.platform === 'darwin') {


### PR DESCRIPTION
#### Summary
`windows-focus-assist` is intended to be used on win 10,11. On windows 8.1 it returns `-1` which is a truthy value in javascript.

![5E86FFAA-E22E-47AC-B09C-1436BC2B0755](https://user-images.githubusercontent.com/24255041/201964718-6a39d5e1-fe06-4428-965e-3919db7d40c9.png)

This causes the application to not display notifications by erroneously receiving `true` for the do-not-disturb mode.

More info on the return value here: https://github.com/bitdisaster/windows-focus-assist/blob/master/lib/focus-assist.cc#L5-L9

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48397
Closes https://github.com/mattermost/desktop/issues/2373

#### Device Information
This PR was tested on: VirtualBox, windows 8.1

#### Release Note
```release-note
Fix issue with notifications not displayed on windows 8
```
