### PR TITLE
[MM-48483] Remove invalid files from downloads list on startup

### DIFF
--- a/src/main/downloadsManager.test.js
+++ b/src/main/downloadsManager.test.js
@@ -193,5 +193,32 @@ describe('main/downloadsManager', () => {
         dl.showFileInFolder(item1);
         expect(shell.showItemInFolder).toHaveBeenCalledWith(locationMock1);
     });
+
+    it('MM-48483 - should remove an invalid file from the list on startup', () => {
+        const dl = new DownloadsManager(JSON.stringify({
+            ...downloadsJson,
+            'invalid_file1.txt': undefined,
+            'invalid_file2.txt': {},
+            'invalid_file3.txt': {invalidProperty: 'something'},
+            'invalid_file4.txt': {
+                state: 'completed',
+                type: 'file',
+            },
+            'invalid_file5.txt': {
+                filename: 'invalid_file5.txt',
+                type: 'file',
+            },
+            'invalid_file6.txt': {
+                filename: 'invalid_file5.txt',
+                state: 'completed',
+            },
+        }));
+        expect(Object.keys(dl.downloads).includes('invalid_file1.txt')).toBe(false);
+        expect(Object.keys(dl.downloads).includes('invalid_file2.txt')).toBe(false);
+        expect(Object.keys(dl.downloads).includes('invalid_file3.txt')).toBe(false);
+        expect(Object.keys(dl.downloads).includes('invalid_file4.txt')).toBe(false);
+        expect(Object.keys(dl.downloads).includes('invalid_file5.txt')).toBe(false);
+        expect(Object.keys(dl.downloads).includes('invalid_file6.txt')).toBe(false);
+    });
 });
 

--- a/src/main/downloadsManager.ts
+++ b/src/main/downloadsManager.ts
@@ -174,16 +174,25 @@ export class DownloadsManager extends JsonFileManager<DownloadedItems> {
 
         for (const fileId in downloads) {
             if (Object.prototype.hasOwnProperty.call(downloads, fileId)) {
+                const file = downloads[fileId];
+
+                if (this.isInvalidFile(file)) {
+                    delete downloads[fileId];
+                    modified = true;
+                    continue;
+                }
+
                 // Remove update if app was updated and restarted
                 if (fileId === APP_UPDATE_KEY) {
-                    if (appVersionManager.lastAppVersion === downloads[APP_UPDATE_KEY].filename) {
+                    if (appVersionManager.lastAppVersion === file.filename) {
                         delete downloads[APP_UPDATE_KEY];
                         modified = true;
+                        continue;
                     } else {
                         continue;
                     }
                 }
-                const file = downloads[fileId];
+
                 if (file.state === 'completed') {
                     if (!file.location || !fs.existsSync(file.location)) {
                         downloads[fileId].state = 'deleted';
@@ -632,6 +641,13 @@ export class DownloadsManager extends JsonFileManager<DownloadedItems> {
     private isAppUpdate = (item: DownloadedItem): boolean => {
         return item.type === DownloadItemTypeEnum.UPDATE;
     };
+
+    private isInvalidFile(file: DownloadedItem) {
+        return (typeof file !== 'object') ||
+            !file.filename ||
+            !file.state ||
+            !file.type;
+    }
 }
 
 let downloadsManager = new DownloadsManager(downloadsJson);

--- a/src/main/notifications/index.test.js
+++ b/src/main/notifications/index.test.js
@@ -240,6 +240,20 @@ describe('main/notifications', () => {
     });
 
     describe('getLinuxDoNotDisturb', () => {
+        let originalPlatform;
+        beforeAll(() => {
+            originalPlatform = process.platform;
+            Object.defineProperty(process, 'platform', {
+                value: 'linux',
+            });
+        });
+
+        afterAll(() => {
+            Object.defineProperty(process, 'platform', {
+                value: originalPlatform,
+            });
+        });
+
         it('should return false', () => {
             cp.execSync.mockReturnValue('true');
             expect(getLinuxDoNotDisturb()).toBe(false);


### PR DESCRIPTION
#### Summary
When the application starts, the downloads manager checks if any files were deleted and then updates their state. If there is a corrupt file in the list (write to file was interrupted by closing the application for example) it would cause the application to crash during startup. 

I added a check for invalid files that should eliminate this issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48483
Closes #2400

#### Release Note
```release-note
Fix possible crash when download list includes corrupt data
```
