### PR TITLE
[MM-48557] Fix AppImage shortcut

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -83,6 +83,9 @@
       }
     ]
   },
+  "appImage": {
+    "executableArgs": [" "]
+  },
   "mac": {
     "category": "public.app-category.productivity",
     "target": [


### PR DESCRIPTION
#### Summary
Apparently we never fixed the AppImage shortcuts once the fix to `electron-builder` was merged. The issue with the `--no-sandbox` flag causing the app to crash is resolved by this fix.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48557

```release-note
Fixed an issue where the Applmage when added with the AppImageLauncher would not allow the app to launch correctly
```
