### PR TITLE
[MM-48156] Include config in diagnostics

### DIFF
--- a/src/main/diagnostics/index.test.js
+++ b/src/main/diagnostics/index.test.js
@@ -20,6 +20,6 @@ describe('main/diagnostics/index', () => {
 
     it('should count the steps correctly', () => {
         const d = Diagnostics;
-        expect(d.getStepCount()).toBe(9);
+        expect(d.getStepCount()).toBe(10);
     });
 });

--- a/src/main/diagnostics/index.ts
+++ b/src/main/diagnostics/index.ts
@@ -16,6 +16,7 @@ import Step5 from './steps/step5.browserWindows';
 import Step6 from './steps/step6.permissions';
 import Step7 from './steps/step7.performance';
 import Step8 from './steps/step8.logHeuristics';
+import Step9 from './steps/step9.config';
 
 const SORTED_STEPS: DiagnosticsStep[] = [
     Step0,
@@ -27,6 +28,7 @@ const SORTED_STEPS: DiagnosticsStep[] = [
     Step6,
     Step7,
     Step8,
+    Step9,
 ];
 
 class DiagnosticsModule {
@@ -80,7 +82,7 @@ class DiagnosticsModule {
                 this.addToReport({
                     ...stepResult,
                     ...reportStep,
-                    payload: JSON.stringify(stepResult.payload, null, 4),
+                    payload: stepResult.payload,
                 });
                 this.logger.debug('Diagnostics executeSteps StepCompleted', {index, name: step.name, retries: step.retries, stepResult});
             } else {

--- a/src/main/diagnostics/steps/step9.config.ts
+++ b/src/main/diagnostics/steps/step9.config.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {ElectronLog} from 'electron-log';
+import {DiagnosticStepResponse} from 'types/diagnostics';
+
+import config from 'common/config';
+
+import DiagnosticsStep from '../DiagnosticStep';
+
+const stepName = 'Step-9';
+const stepDescriptiveName = 'Config';
+
+const run = async (logger: ElectronLog): Promise<DiagnosticStepResponse> => {
+    try {
+        logger.debug(`Diagnostics ${stepName} run`);
+
+        const payload = config.data;
+
+        return {
+            message: `${stepName} finished successfully`,
+            succeeded: true,
+            payload,
+        };
+    } catch (error) {
+        logger.warn(`Diagnostics ${stepName} Failure`, {error});
+        return {
+            message: `${stepName} failed`,
+            succeeded: false,
+            payload: error,
+        };
+    }
+};
+
+const Step9 = new DiagnosticsStep({
+    name: `diagnostic-${stepName}/${stepDescriptiveName}`,
+    retries: 0,
+    run,
+});
+
+export default Step9;


### PR DESCRIPTION
#### Summary
Log the Config with the diagnostics logger. It is obfuscated by default (logger hooks)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48156

#### Release Note
```release-note
NONE
```
