### PR TITLE
[MM-48682] Stop user from opening the servers menu when no servers are configured

### DIFF
--- a/src/main/app/intercom.test.js
+++ b/src/main/app/intercom.test.js
@@ -16,7 +16,6 @@ import {
     handleRemoveServerModal,
     handleWelcomeScreenModal,
     handleMainWindowIsShown,
-    handleShowOnboardingScreens,
 } from './intercom';
 
 jest.mock('common/config', () => ({
@@ -271,20 +270,15 @@ describe('main/app/intercom', () => {
             Config.set.mockImplementation((name, value) => {
                 Config[name] = value;
             });
-            Config.teams = JSON.parse(JSON.stringify([{
-                name: 'test-team',
-                order: 0,
-                url: 'https://someurl.here',
-            }]));
+            Config.registryConfigData = {
+                teams: JSON.parse(JSON.stringify([{
+                    name: 'test-team',
+                    order: 0,
+                    url: 'https://someurl.here',
+                }])),
+            };
 
             handleMainWindowIsShown();
-            expect(ModalManager.addModal).not.toHaveBeenCalled();
-        });
-    });
-
-    describe('handleShowOnboardingScreens', () => {
-        it('MM-48079 should not show onboarding screen or server screen if GPO server is pre-configured', () => {
-            handleShowOnboardingScreens(false, false, true);
             expect(ModalManager.addModal).not.toHaveBeenCalled();
         });
     });

--- a/src/main/menus/app.ts
+++ b/src/main/menus/app.ts
@@ -254,13 +254,15 @@ export function createTemplate(config: Config, updateManager: UpdateManager) {
             role: 'close',
             label: isMac ? localizeMessage('main.menus.app.window.closeWindow', 'Close Window') : localizeMessage('main.menus.app.window.close', 'Close'),
             accelerator: 'CmdOrCtrl+W',
-        }, separatorItem, {
+        }, separatorItem,
+        ...(config.data?.teams.length ? [{
             label: localizeMessage('main.menus.app.window.showServers', 'Show Servers'),
             accelerator: `${process.platform === 'darwin' ? 'Cmd+Ctrl' : 'Ctrl+Shift'}+S`,
             click() {
                 ipcMain.emit(OPEN_TEAMS_DROPDOWN);
             },
-        }, ...teams.sort((teamA, teamB) => teamA.order - teamB.order).slice(0, 9).map((team, i) => {
+        }] : []),
+        ...teams.sort((teamA, teamB) => teamA.order - teamB.order).slice(0, 9).map((team, i) => {
             const items = [];
             items.push({
                 label: team.name,


### PR DESCRIPTION
#### Summary
When the Getting Started modal is open, a user can open the servers dropdown using the menu or a keyboard shortcut and trigger the Add Server Modal to open after the Getting Started one does, causing them to get stuck and require a second server be added.

This PR stops users from opening the servers dropdown until a server has been added.
Also fixed a bad unit test.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48682

```release-note
Fixed an issue where users could get stuck after finished the Getting Started flow
```
