### PR TITLE
Extend npm run package:* context deadline to 60m

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ commands:
       - run: 
           name: npn run
           command: npm run package:<< parameters.os >>
-          no_output_timeout: 30m
+          no_output_timeout: 60m
       - run: bash -x ./scripts/patch_updater_yml.sh
       - run: mkdir -p << parameters.path >>
       - run: bash -x ./scripts/cp_artifacts.sh release << parameters.path >>


### PR DESCRIPTION
#### Summary
The mac_installer build is taking a lot longer than expected, likely due to some issues with Apple during notarization.
I've extended the time to 60 minutes to hopefully cover this.

```release-note
NONE
```
