### PR TITLE
[MM-48766] - Check if url is a plugin url when calculating the window bounds

### DIFF
--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -58,7 +58,7 @@ export function shouldHaveBackBar(serverUrl: URL | string, inputURL: URL | strin
 
         return false;
     }
-    return !UrlUtils.isTeamUrl(serverUrl, inputURL) && !UrlUtils.isAdminUrl(serverUrl, inputURL);
+    return !UrlUtils.isTeamUrl(serverUrl, inputURL) && !UrlUtils.isAdminUrl(serverUrl, inputURL) && !UrlUtils.isPluginUrl(serverUrl, inputURL);
 }
 
 export function getLocalURLString(urlPath: string, query?: Map<string, string>, isMain?: boolean) {


### PR DESCRIPTION
#### Summary
When the desktop app would navigate into a plugins UI and/or when resizing the window while in that UI, it would display a white bar between the UI and the Desktop application bar which is intended to be used with the "Back" bar but, it had no elements inside it.

The solution is to also check if the url of the UI is not a plugin url when calculating the window height. 

Issue for reference: https://github.com/mattermost/desktop/issues/2415 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48766

#### Device Information
This PR was tested on: PC, Ubuntu 22

#### Screenshots

Before:
[Screencast from 02-12-2022 06:25:30 ΜΜ.webm](https://user-images.githubusercontent.com/24255041/205339739-ab97319e-96a6-4502-ad88-0b02b471cfba.webm)

After:
[Screencast from 02-12-2022 06:26:46 ΜΜ.webm](https://user-images.githubusercontent.com/24255041/205339759-f8213c26-5b4b-40a3-8168-5eec1d6292f0.webm)

#### Release Note
```release-note
Fixed issue with plugin navigation displaying white empty bar
```
