### PR TITLE
Escape server name when used inside regex

### DIFF
--- a/src/common/utils/util.test.js
+++ b/src/common/utils/util.test.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import Utils from 'common/utils/util';
+import Utils, {escapeRegex} from 'common/utils/util';
 
 describe('common/utils/util', () => {
     describe('shorten', () => {
@@ -113,6 +113,14 @@ describe('common/utils/util', () => {
             };
 
             expect(Utils.boundsDiff(base, actual)).toEqual(diff);
+        });
+    });
+
+    describe('escapeRegex', () => {
+        it('should escape special chars in string when used inside regex', () => {
+            const str = 'Language C++';
+            const regex = `${escapeRegex(str)}___TAB_[A-Z]+`;
+            expect(new RegExp(regex).test('Language C++___TAB_ABCDEF')).toBe(true);
         });
     });
 });

--- a/src/common/utils/util.ts
+++ b/src/common/utils/util.ts
@@ -58,9 +58,18 @@ function boundsDiff(base: Rectangle, actual: Rectangle) {
     };
 }
 
+// MM-48463 - https://stackoverflow.com/a/3561711/5605822
+export const escapeRegex = (s?: string) => {
+    if (typeof s !== 'string') {
+        return '';
+    }
+    return s.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
+};
+
 export default {
     runMode,
     shorten,
     isVersionGreaterThanOrEqualTo,
     boundsDiff,
+    escapeRegex,
 };

--- a/src/renderer/components/MainPage.tsx
+++ b/src/renderer/components/MainPage.tsx
@@ -14,7 +14,7 @@ import {TeamWithTabs} from 'types/config';
 import {DownloadedItems} from 'types/downloads';
 
 import {getTabViewName} from 'common/tabs/TabView';
-import {escapeRegex} from 'renderer/utils';
+import {escapeRegex} from 'common/utils/util';
 
 import restoreButton from '../../assets/titlebar/chrome-restore.svg';
 import maximizeButton from '../../assets/titlebar/chrome-maximize.svg';

--- a/src/renderer/utils.ts
+++ b/src/renderer/utils.ts
@@ -85,19 +85,10 @@ const prettyETA = (ms = 0, intl: IntlShape) => {
     return `${eta} ${intl.formatMessage({id: 'renderer.downloadsDropdown.remaining', defaultMessage: 'remaining'})}`;
 };
 
-// MM-48463 - https://stackoverflow.com/a/3561711/5605822
-const escapeRegex = (s?: string) => {
-    if (typeof s !== 'string') {
-        return '';
-    }
-    return s.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
-};
-
 export {
     getDownloadingFileStatus,
     getFileSizeOrBytesProgress,
     getIconClassName,
     isImageFile,
     prettyETA,
-    escapeRegex,
 };


### PR DESCRIPTION
#### Summary
If the name included any special character, it could cause a regex validation to fail. Escaping the `teamName` fixes the issue. Perhaps we could allow only specific characters inside the team name when entered, but it's not necessary at this moment in my opinion. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48463
https://github.com/mattermost/desktop/issues/2388

#### Screenshots
https://recordit.co/u1Pp8fTAxj

#### Release Note
```release-note
Fixed issue with special characters in server name causing the top bar to disappear
```
