### PR TITLE
Corrected grammar for unresponsive.dialog.message in en.json

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -42,7 +42,7 @@
   "main.CriticalErrorHandler.uncaughtException.button.reopen": "Reopen",
   "main.CriticalErrorHandler.uncaughtException.button.showDetails": "Show Details",
   "main.CriticalErrorHandler.uncaughtException.dialog.message": "The {appName} app quit unexpectedly. Click \"{showDetails}\" to learn more or \"{reopen}\" to open the application again.\n\nInternal error: {err}",
-  "main.CriticalErrorHandler.unresponsive.dialog.message": "The window is no longer responsive.\nDo you wait until the window becomes responsive again?",
+  "main.CriticalErrorHandler.unresponsive.dialog.message": "The window is no longer responsive.\nDo you want to wait until the window becomes responsive again?",
   "main.menus.app.edit": "&Edit",
   "main.menus.app.edit.copy": "Copy",
   "main.menus.app.edit.cut": "Cut",


### PR DESCRIPTION
#### Summary
Fixes a grammatical error in one of the error messages in en.json



#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)


#### Release Note
* Bug fixes and fixes of previous known issues
```release-note
Corrected grammar for unresponsive.dialog.message in en.json
```