### PR TITLE
[MM-47929] Switch to using mm-desktop:// protocol for navigating through the app

### DIFF
--- a/src/main/webRequest/webRequestHandler.ts
+++ b/src/main/webRequest/webRequestHandler.ts
@@ -18,7 +18,7 @@ export class WebRequestHandler<T, T2> extends EventEmitter {
 
         let callbackObject = {} as T2;
         const modify = (result: T2) => {
-            callbackObject = this.modifyCallbackObject(details, callbackObject, result);
+            callbackObject = {...callbackObject, ...this.modifyCallbackObject(details, callbackObject, result)};
         };
 
         for (const id of this.eventNames()) {


### PR DESCRIPTION
#### Summary
In order to effectively separate any origin-based storage system with the integration, I've added a special new protocol to the app called "mm-desktop" that it used as a substitute for the local `file:///` URL we've been using.

It will prefix the files with `mm-desktop://<server-host-name>`, so that Chrome knows that anything loaded under the URL should use it as its origin.

In order to facilitate this, we've had to do some CORS magic in the main process as well, effectively adding a proxy that the renderer process will hit and verify on behalf of the server that any cross-origin requests between the `mm-desktop` origin and the server are okay.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47929

```release-note
NONE
```
