### PR TITLE
Replace deprecated "gpu-process-crashed" with "child-process-gone"

### DIFF
--- a/src/main/app/app.ts
+++ b/src/main/app/app.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {app, BrowserWindow, Event, dialog, WebContents, Certificate} from 'electron';
+import {app, BrowserWindow, Event, dialog, WebContents, Certificate, Details} from 'electron';
 import log from 'electron-log';
 
 import urlUtils from 'common/utils/url';
@@ -178,6 +178,6 @@ export async function handleAppCertificateError(event: Event, webContents: WebCo
     }
 }
 
-export function handleAppGPUProcessCrashed(event: Event, killed: boolean) {
-    log.error(`The GPU process has crashed (killed = ${killed})`);
+export function handleChildProcessGone(event: Event, details: Details) {
+    log.error('"child-process-gone" The child process has crashed. Details: ', details);
 }

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -63,10 +63,10 @@ import {
     handleAppBeforeQuit,
     handleAppBrowserWindowCreated,
     handleAppCertificateError,
-    handleAppGPUProcessCrashed,
     handleAppSecondInstance,
     handleAppWillFinishLaunching,
     handleAppWindowAllClosed,
+    handleChildProcessGone,
 } from './app';
 import {handleConfigUpdate, handleDarkModeChange} from './config';
 import {
@@ -183,7 +183,7 @@ function initializeAppEventListeners() {
     app.on('before-quit', handleAppBeforeQuit);
     app.on('certificate-error', handleAppCertificateError);
     app.on('select-client-certificate', CertificateManager.handleSelectCertificate);
-    app.on('gpu-process-crashed', handleAppGPUProcessCrashed);
+    app.on('child-process-gone', handleChildProcessGone);
     app.on('login', AuthManager.handleAppLogin);
     app.on('will-finish-launching', handleAppWillFinishLaunching);
 }


### PR DESCRIPTION
#### Summary
I also passed the details as an argument and not concat them in the string in order to be displayed in the logs

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49039

#### Screenshots
![5497A918-364C-4750-8CC4-119D4567749F](https://user-images.githubusercontent.com/24255041/207349339-30ab9796-452d-4937-a833-b58ec682484b.png)

#### Release Note
```release-note
NONE
```
