### PR TITLE
[MM-49049] Fix main window disappering on call join

### DIFF
--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -190,7 +190,7 @@ export default class CallsWidgetWindow extends EventEmitter {
         log.debug('CallsWidgetWindow.onShow');
 
         this.win.focus();
-        this.win.setVisibleOnAllWorkspaces(true, {visibleOnFullScreen: true});
+        this.win.setVisibleOnAllWorkspaces(true, {visibleOnFullScreen: true, skipTransformProcessType: true});
         this.win.setAlwaysOnTop(true, 'screen-saver');
 
         const bounds = this.win.getBounds();


### PR DESCRIPTION
#### Summary

There's a side effect in calling [`window.setVisibleOnAllWorkspaces`](https://www.electronjs.org/docs/latest/api/browser-window#winsetvisibleonallworkspacesvisible-options-macos-linux) on macOS which makes the main window (Mattermost) disappear. Setting the `skipTransformProcessType` prevents this behaviour as suggested in https://github.com/electron/electron/issues/25368#issuecomment-914960930.

I am open to more suggestions as there could be better ways to handle this case but so far it seems this is the quickest fix.

@Willyfrog Would be nice if you could run this locally and let me know if the issues you were encountering are gone.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49049

#### Release Note

```release-note
NONE
```

