### PR TITLE
[MM-49082] Hide menu bar in calls popout window

### DIFF
--- a/src/main/windows/callsWidgetWindow.test.js
+++ b/src/main/windows/callsWidgetWindow.test.js
@@ -51,6 +51,9 @@ describe('main/windows/callsWidgetWindow', () => {
         baseWindow.setBackgroundColor = jest.fn();
         baseWindow.setMenuBarVisibility = jest.fn();
         baseWindow.setBounds = jest.fn();
+        baseWindow.webContents = {
+            setWindowOpenHandler: jest.fn(),
+        };
 
         beforeEach(() => {
             mainWindow.getBounds.mockImplementation(() => {
@@ -138,6 +141,7 @@ describe('main/windows/callsWidgetWindow', () => {
             });
 
             baseWindow.webContents = {
+                ...baseWindow.webContents,
                 openDevTools: jest.fn(),
             };
 
@@ -258,6 +262,7 @@ describe('main/windows/callsWidgetWindow', () => {
 
         it('onShareScreen', () => {
             baseWindow.webContents = {
+                ...baseWindow.webContents,
                 send: jest.fn(),
             };
 
@@ -272,6 +277,7 @@ describe('main/windows/callsWidgetWindow', () => {
 
         it('onJoinedCall', () => {
             baseWindow.webContents = {
+                ...baseWindow.webContents,
                 send: jest.fn(),
             };
 

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -82,6 +82,15 @@ export default class CallsWidgetWindow extends EventEmitter {
         ipcMain.on(CALLS_WIDGET_SHARE_SCREEN, this.onShareScreen);
         ipcMain.on(CALLS_JOINED_CALL, this.onJoinedCall);
 
+        this.win.webContents.setWindowOpenHandler(() => {
+            return {
+                action: 'allow',
+                overrideBrowserWindowOptions: {
+                    autoHideMenuBar: true,
+                },
+            };
+        });
+
         this.load();
     }
 


### PR DESCRIPTION
#### Summary

PR brings back the title bar to the calls popout window (when global widget is enabled, Desktop >= 5.3) which was originally removed to avoid showing the menu bar. 

At the time I wasn't aware that there was a simple way to customize a window opened from the renderer side but using [`webContents.setWindowOpenHandler()`](https://www.electronjs.org/docs/latest/api/web-contents#contentssetwindowopenhandlerhandler) is working nicely and allows us to hide the menu bar while retaining the title bar which is useful for easily resizing, closing and dragging the window.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49082

#### Related PR

https://github.com/mattermost/mattermost-plugin-calls/pull/282

#### Release Note

```release-note
NONE
```

