### PR TITLE
Bump macos-notification-state to 2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "macos-notification-state": "2.0.1",
+        "macos-notification-state": "2.0.2",
         "windows-focus-assist": "1.3.0"
       },
       "devDependencies": {
@@ -24234,9 +24234,9 @@
       }
     },
     "node_modules/macos-notification-state": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/macos-notification-state/-/macos-notification-state-2.0.1.tgz",
-      "integrity": "sha512-FBaaSdqws2R6RCqIq9CqG+QnZicJu00vayc88LM+iII4P72b1bXeGdZpxgXeIeKzwdlP0xHsq1PfOImJH3GOAg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/macos-notification-state/-/macos-notification-state-2.0.2.tgz",
+      "integrity": "sha512-rTKda+694hvxXm4s00I5LEwlQxGwwCZKaCXogxEXyGagmsP7mGfLiyoI6MX360GQ0V6lmHOCqivg4LLQPFYb6A==",
       "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0"
@@ -52732,9 +52732,9 @@
       }
     },
     "macos-notification-state": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/macos-notification-state/-/macos-notification-state-2.0.1.tgz",
-      "integrity": "sha512-FBaaSdqws2R6RCqIq9CqG+QnZicJu00vayc88LM+iII4P72b1bXeGdZpxgXeIeKzwdlP0xHsq1PfOImJH3GOAg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/macos-notification-state/-/macos-notification-state-2.0.2.tgz",
+      "integrity": "sha512-rTKda+694hvxXm4s00I5LEwlQxGwwCZKaCXogxEXyGagmsP7mGfLiyoI6MX360GQ0V6lmHOCqivg4LLQPFYb6A==",
       "requires": {
         "bindings": "^1.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "yargs": "17.4.0"
   },
   "dependencies": {
-    "macos-notification-state": "2.0.1",
+    "macos-notification-state": "2.0.2",
     "windows-focus-assist": "1.3.0"
   },
   "overrides": {


### PR DESCRIPTION
#### Summary
New patch version (2.0.2) for macos-notification-state.

[CHANGELOG
](https://github.com/felixrieseberg/macos-notification-state/commit/836e2cd97fef061358cb072fe54d86d5b9c52e33)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48350

#### Device Information
This PR was tested on: Macbook Pro, Macos Ventura 13.0.1

#### Release Note
```release-note
NONE
```


[MM-48350]: https://mattermost.atlassian.net/browse/MM-48350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ