### PR TITLE
Reduce the number of writes to the config

### DIFF
--- a/src/common/config/index.ts
+++ b/src/common/config/index.ts
@@ -219,6 +219,8 @@ export class Config extends EventEmitter {
             return;
         }
 
+        log.info('Saving config data to file...');
+
         try {
             this.writeFile(this.configFilePath, this.localConfigData, (error: NodeJS.ErrnoException | null) => {
                 if (error) {

--- a/src/common/config/index.ts
+++ b/src/common/config/index.ts
@@ -160,7 +160,7 @@ export class Config extends EventEmitter {
 
         if (properties.length) {
             const newData = properties.reduce((obj, data) => {
-                obj[data.key] = data.data;
+                (obj as any)[data.key] = data.data;
                 return obj;
             }, {} as Partial<ConfigType>);
             this.setMultiple(newData);

--- a/src/common/config/index.ts
+++ b/src/common/config/index.ts
@@ -102,7 +102,7 @@ export class Config extends EventEmitter {
         ipcMain.handle(GET_CONFIGURATION, this.handleGetConfiguration);
         ipcMain.handle(GET_LOCAL_CONFIGURATION, this.handleGetLocalConfiguration);
         ipcMain.handle(UPDATE_TEAMS, this.handleUpdateTeams);
-        ipcMain.on(UPDATE_CONFIGURATION, this.setMultiple);
+        ipcMain.on(UPDATE_CONFIGURATION, this.updateConfiguration);
         if (process.platform === 'darwin' || process.platform === 'win32') {
             nativeTheme.on('updated', this.handleUpdateTheme);
         }
@@ -151,16 +151,22 @@ export class Config extends EventEmitter {
      * @param {*} data value to save for provided key
      */
     set = (key: keyof ConfigType, data: ConfigType[keyof ConfigType]): void => {
-        if (key && this.localConfigData) {
-            if (key === 'teams') {
-                this.localConfigData.teams = this.filterOutPredefinedTeams(data as TeamWithTabs[]);
-                this.predefinedTeams = this.filterInPredefinedTeams(data as TeamWithTabs[]);
-            } else {
-                this.localConfigData = Object.assign({}, this.localConfigData, {[key]: data});
-            }
-            this.regenerateCombinedConfigData();
-            this.saveLocalConfigData();
+        log.debug('Config.set');
+        this.setMultiple({[key]: data});
+    }
+
+    updateConfiguration = (event: Electron.IpcMainEvent, properties: Array<{key: keyof ConfigType; data: ConfigType[keyof ConfigType]}> = []): Partial<ConfigType> | undefined => {
+        log.debug('Config.updateConfiguration', properties);
+
+        if (properties.length) {
+            const newData = properties.reduce((obj, data) => {
+                obj[data.key] = data.data;
+                return obj;
+            }, {} as Partial<ConfigType>);
+            this.setMultiple(newData);
         }
+
+        return this.localConfigData;
     }
 
     /**
@@ -168,14 +174,16 @@ export class Config extends EventEmitter {
      *
      * @param {array} properties an array of config properties to save
      */
-    setMultiple = (event: Electron.IpcMainEvent, properties: Array<{key: keyof ConfigType; data: ConfigType[keyof ConfigType]}> = []): Partial<ConfigType> | undefined => {
-        log.debug('Config.setMultiple', properties);
+    setMultiple = (newData: Partial<ConfigType>) => {
+        log.debug('Config.setMultiple', newData);
 
-        if (properties.length) {
-            this.localConfigData = Object.assign({}, this.localConfigData, ...properties.map(({key, data}) => ({[key]: data})));
-            this.regenerateCombinedConfigData();
-            this.saveLocalConfigData();
+        this.localConfigData = Object.assign({}, this.localConfigData, newData);
+        if (newData.teams && this.localConfigData) {
+            this.localConfigData.teams = this.filterOutPredefinedTeams(newData.teams as TeamWithTabs[]);
+            this.predefinedTeams = this.filterInPredefinedTeams(newData.teams as TeamWithTabs[]);
         }
+        this.regenerateCombinedConfigData();
+        this.saveLocalConfigData();
 
         return this.localConfigData; //this is the only part that changes
     }

--- a/src/main/app/config.ts
+++ b/src/main/app/config.ts
@@ -24,6 +24,13 @@ let didCheckForAddServerModal = false;
 //
 
 export function handleConfigUpdate(newConfig: CombinedConfig) {
+    if (log.transports.file.level !== newConfig.logLevel) {
+        log.error('Log level set to:', newConfig.logLevel);
+    }
+    if (newConfig.logLevel) {
+        setLoggingLevel(newConfig.logLevel as LogLevel);
+    }
+
     log.debug('App.Config.handleConfigUpdate');
     log.silly('App.Config.handleConfigUpdate', newConfig);
 
@@ -62,9 +69,6 @@ export function handleConfigUpdate(newConfig: CombinedConfig) {
         WindowManager.initializeCurrentServerName();
         handleMainWindowIsShown();
     }
-
-    log.info('Log level set to:', newConfig.logLevel);
-    setLoggingLevel(newConfig.logLevel as LogLevel);
 
     handleUpdateMenuEvent();
     if (newConfig.trayIconTheme) {

--- a/src/main/app/intercom.ts
+++ b/src/main/app/intercom.ts
@@ -321,8 +321,10 @@ export function handleUpdateLastActive(event: IpcMainEvent, serverName: string, 
             team.lastActiveTab = viewOrder;
         }
     });
-    Config.set('teams', teams);
-    Config.set('lastActiveTeam', teams.find((team) => team.name === serverName)?.order || 0);
+    Config.setMultiple({
+        teams,
+        lastActiveTeam: teams.find((team) => team.name === serverName)?.order || 0,
+    });
 }
 
 export function handlePingDomain(event: IpcMainInvokeEvent, url: string): Promise<string> {

--- a/src/main/app/utils.ts
+++ b/src/main/app/utils.ts
@@ -50,6 +50,7 @@ export function updateSpellCheckerLocales() {
 }
 
 export function updateServerInfos(teams: TeamWithTabs[]) {
+    log.silly('app.utils.updateServerInfos');
     const serverInfos: Array<Promise<RemoteInfo | string | undefined>> = [];
     teams.forEach((team) => {
         const serverInfo = new ServerInfo(new MattermostServer(team.name, team.url));

--- a/src/main/views/MattermostView.ts
+++ b/src/main/views/MattermostView.ts
@@ -85,7 +85,7 @@ export class MattermostView extends EventEmitter {
         this.view = new BrowserView(this.options);
         this.resetLoadingStatus();
 
-        log.info(`BrowserView created for server ${this.tab.name}`);
+        log.verbose(`BrowserView created for server ${this.tab.name}`);
 
         this.hasBeenShown = false;
 
@@ -164,7 +164,7 @@ export class MattermostView extends EventEmitter {
         } else {
             loadURL = this.tab.url.toString();
         }
-        log.info(`[${Util.shorten(this.tab.name)}] Loading ${loadURL}`);
+        log.verbose(`[${Util.shorten(this.tab.name)}] Loading ${loadURL}`);
         const loading = this.view.webContents.loadURL(loadURL, {userAgent: composeUserAgent()});
         loading.then(this.loadSuccess(loadURL)).catch((err) => {
             if (err.code && err.code.startsWith('ERR_CERT')) {
@@ -220,7 +220,7 @@ export class MattermostView extends EventEmitter {
 
     loadSuccess = (loadURL: string) => {
         return () => {
-            log.info(`[${Util.shorten(this.tab.name)}] finished loading ${loadURL}`);
+            log.verbose(`[${Util.shorten(this.tab.name)}] finished loading ${loadURL}`);
             WindowManager.sendToRenderer(LOAD_SUCCESS, this.tab.name);
             this.maxRetries = MAX_SERVER_RETRIES;
             if (this.status === Status.LOADING) {

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -127,6 +127,8 @@ export class ViewManager {
      * close, open, or reload tabs, taking care to reuse tabs and
      * preserve focus on the currently selected tab. */
     reloadConfiguration = (configServers: TeamWithTabs[]) => {
+        log.debug('viewManager.reloadConfiguration');
+
         const focusedTuple: TabTuple | undefined = this.views.get(this.currentView as string)?.urlTypeTuple;
 
         const current: Map<TabTuple, MattermostView> = new Map();
@@ -199,6 +201,8 @@ export class ViewManager {
     }
 
     showInitial = () => {
+        log.verbose('viewManager.showInitial');
+
         const servers = this.getServers();
         if (servers.length) {
             const element = servers.find((e) => e.order === this.lastActiveServer) || servers.find((e) => e.order === 0);

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -590,6 +590,7 @@ export class WindowManager {
     }
 
     switchServer = (serverName: string, waitForViewToExist = false) => {
+        log.debug('windowManager.switchServer');
         this.showMainWindow();
         const server = Config.teams.find((team) => team.name === serverName);
         if (!server) {
@@ -617,6 +618,7 @@ export class WindowManager {
     }
 
     switchTab = (serverName: string, tabName: string) => {
+        log.debug('windowManager.switchTab');
         this.showMainWindow();
         const tabViewName = getTabViewName(serverName, tabName);
         this.viewManager?.showByName(tabViewName);


### PR DESCRIPTION
#### Summary
One thing I noticed during the integration development was that the number of writes we do to the config file that aren't properly debounced is high. So I took some time to review how we were writing to the config and fixed a few issues:
- `Config.setMultiple` can now be used externally and calling `Config.set` is no longer necessary for repeated changes
- When updating server info, we're only writing out to the config when there's a change from now on

I also changed up the logging a bit to avoid a bunch of redundant lines.

```release-note
NONE
```
