### PR TITLE
[MM-49724] More robust check for startup before starting E2E tests

### DIFF
--- a/e2e/modules/environment.js
+++ b/e2e/modules/environment.js
@@ -214,16 +214,16 @@ module.exports = {
         //     // this changes the default debugging port so chromedriver can run without issues.
         //     options.chromeDriverArgs.push('remote-debugging-port=9222');
         //}
-        return electron.launch(options).then(async (app) => {
-            // Make sure the app has time to fully load and that the window is focused
-            await asyncSleep(1000);
-            const mainWindow = app.windows().find((window) => window.url().includes('index'));
-            const browserWindow = await app.browserWindow(mainWindow);
-            await browserWindow.evaluate((win) => {
-                win.show();
-                return true;
+        return electron.launch(options).then(async (eapp) => {
+            await eapp.evaluate(async ({app}) => {
+                const promise = new Promise((resolve) => {
+                    app.on('e2e-app-loaded', () => {
+                        resolve();
+                    });
+                });
+                return promise;
             });
-            return app;
+            return eapp;
         });
     },
 

--- a/e2e/specs/popup.test.js
+++ b/e2e/specs/popup.test.js
@@ -44,7 +44,7 @@ describe('popup', function desc() {
             await firstServer.click('#sidebarItem_suscipit-4');
             await firstServer.click('#post_textbox');
             await firstServer.type('#post_textbox', '/github connect ');
-            await firstServer.press('#post_textbox', 'Enter');
+            await firstServer.click('button[data-testid="SendMessageButton"]');
 
             const githubLink = await firstServer.waitForSelector('a.theme.markdown__link:has-text("GitHub account")');
             githubLink.click();
@@ -100,7 +100,7 @@ describe('popup', function desc() {
         await firstServer.click('#sidebarItem_suscipit-4');
         await firstServer.click('#post_textbox');
         await firstServer.type('#post_textbox', '/github connect ');
-        await firstServer.press('#post_textbox', 'Enter');
+        await firstServer.click('button[data-testid="SendMessageButton"]');
 
         const githubLink = await firstServer.waitForSelector('a.theme.markdown__link:has-text("GitHub account")');
         githubLink.click();

--- a/src/main/app/intercom.ts
+++ b/src/main/app/intercom.ts
@@ -92,6 +92,18 @@ export function handleShowOnboardingScreens(showWelcomeScreen: boolean, showNewS
     const showWelcomeScreenFunc = () => {
         if (showWelcomeScreen) {
             handleWelcomeScreenModal();
+
+            if (process.env.NODE_ENV === 'test') {
+                const welcomeScreen = ModalManager.modalQueue.find((modal) => modal.key === 'welcomeScreen');
+                if (welcomeScreen?.view.webContents.isLoading()) {
+                    welcomeScreen?.view.webContents.once('did-finish-load', () => {
+                        app.emit('e2e-app-loaded');
+                    });
+                } else {
+                    app.emit('e2e-app-loaded');
+                }
+            }
+
             return;
         }
         if (showNewServerModal) {

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -667,6 +667,10 @@ export class WindowManager {
         if (this.viewManager) {
             this.viewManager.hideLoadingScreen();
         }
+
+        if (process.env.NODE_ENV === 'test') {
+            app.emit('e2e-app-loaded');
+        }
     }
 
     updateLoadingScreenDarkMode = (darkMode: boolean) => {


### PR DESCRIPTION
#### Summary
I changed the way we setup the Electron app in E2E tests by explicitly having a call back in two locations in the Electron app specifically for the E2E tests: one when the loading screen hides, and another when the welcome screen loads.

This gives us a much more robust way of checking when the app has finished loading and we can pull the correct windows without running into errors.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49724

```release-note
NONE
```
