### PR TITLE
[MM-45565] Check if View->Page is destroyed before sending ipc message

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,7 @@
         "chromedriver",
         "chromedriverlog",
         "deauthorize",
+        "deeplink",
         "deeplinking",
         "diskimage",
         "dont",

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -549,6 +549,10 @@ export class ViewManager {
     };
 
     sendToAllViews = (channel: string, ...args: unknown[]) => {
-        this.views.forEach((view) => view.view.webContents.send(channel, ...args));
+        this.views.forEach((view) => {
+            if (!view.view.webContents.isDestroyed()) {
+                view.view.webContents.send(channel, ...args);
+            }
+        });
     }
 }


### PR DESCRIPTION
#### Summary
It seems that this is an [issue of electron](https://github.com/electron/electron/issues/15725). Despite that, I added check if the view is destroyed before sending any messages to it. 
I couldn't repro so I'm not so sure about the resolution but, [based on the logs](https://mattermost.atlassian.net/browse/MM-45565?focusedCommentId=131683) (main.log) this error seems to be triggered by a destroyed view. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45565

#### Release Note
```release-note
NONE
```
