### PR TITLE
Fixed an issue where opening the app with a deeplink may cause the app not to redirect to the correct URL

### DIFF
--- a/src/main/views/MattermostView.ts
+++ b/src/main/views/MattermostView.ts
@@ -174,6 +174,10 @@ export class MattermostView extends EventEmitter {
                 this.status = Status.ERROR;
                 return;
             }
+            if (err.code && err.code.startsWith('ERR_ABORTED')) {
+                // If the loading was aborted, we shouldn't be retrying
+                return;
+            }
             this.loadRetry(loadURL, err);
         });
     }


### PR DESCRIPTION
#### Summary
Found this when running E2E tests on my local VM. When we start the app and specify a deep linking URL, the first thing we do is start all the views and have them load their default URLs. On some machines, what would happen is that the initial URL wouldn't be finished loading and the app would throw an `ERR_ABORTED` error on the initial URL and start the retry logic.

The deeplink URL would then finish loading, but it would then try to retry the original URL after 5 seconds and forward you back to the original URL, which isn't ideal. This wouldn't reproduce on my local Windows machine, but my Windows VM was a bit slower and showed this behaviour, causing the E2E test to fail pretty reliably.

This PR catches the `ERR_ABORTED` error and ignores the retry logic, since an `ERR_ABORTED` is always due to user input, or the app specifically changing URLs. If it pops up, we should be aborting the initial load and starting whatever the new one is.

```release-note
Fixed an issue where opening the app with a deeplink may cause the app not to redirect to the correct URL
```
