### PR TITLE
Fixed full screen E2E test for smaller displays

### DIFF
--- a/e2e/specs/menu_bar/full_screen.test.js
+++ b/e2e/specs/menu_bar/full_screen.test.js
@@ -1,0 +1,66 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+'use strict';
+
+const fs = require('fs');
+
+const robot = require('robotjs');
+
+const env = require('../../modules/environment');
+const {asyncSleep} = require('../../modules/utils');
+
+describe('menu/view', function desc() {
+    this.timeout(30000);
+
+    const config = env.demoMattermostConfig;
+
+    beforeEach(async () => {
+        env.cleanDataDir();
+        env.createTestUserDataDir();
+        env.cleanTestConfig();
+        fs.writeFileSync(env.configFilePath, JSON.stringify(config));
+        fs.writeFileSync(env.boundsInfoPath, JSON.stringify({x: 0, y: 0, width: 700, height: 240, maximized: false, fullscreen: false}));
+        await asyncSleep(1000);
+        this.app = await env.getApp();
+        this.serverMap = await env.getServerMap(this.app);
+    });
+
+    afterEach(async () => {
+        if (this.app) {
+            await this.app.close();
+        }
+        await env.clearElectronInstances();
+    });
+
+    // TODO: No keyboard shortcut for macOS
+    if (process.platform !== 'darwin') {
+        it('MM-T816 Toggle Full Screen in the Menu Bar', async () => {
+            const mainWindow = this.app.windows().find((window) => window.url().includes('index'));
+            const loadingScreen = this.app.windows().find((window) => window.url().includes('loadingScreen'));
+            await loadingScreen.waitForSelector('.LoadingScreen', {state: 'hidden'});
+            const firstServer = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].win;
+            await env.loginToMattermost(firstServer);
+            await firstServer.waitForSelector('#searchBox');
+            let currentWidth = await firstServer.evaluate('window.outerWidth');
+            let currentHeight = await firstServer.evaluate('window.outerHeight');
+            await mainWindow.click('button.three-dot-menu');
+            robot.keyTap('v');
+            robot.keyTap('t');
+            robot.keyTap('enter');
+            await asyncSleep(1000);
+            const fullScreenWidth = await firstServer.evaluate('window.outerWidth');
+            const fullScreenHeight = await firstServer.evaluate('window.outerHeight');
+            fullScreenWidth.should.be.greaterThan(currentWidth);
+            fullScreenHeight.should.be.greaterThan(currentHeight);
+            await mainWindow.click('button.three-dot-menu');
+            robot.keyTap('v');
+            robot.keyTap('t');
+            robot.keyTap('enter');
+            await asyncSleep(1000);
+            currentWidth = await firstServer.evaluate('window.outerWidth');
+            currentHeight = await firstServer.evaluate('window.outerHeight');
+            currentWidth.should.be.lessThan(fullScreenWidth);
+            currentHeight.should.be.lessThan(fullScreenHeight);
+        });
+    }
+});

--- a/e2e/specs/menu_bar/full_screen.test.js
+++ b/e2e/specs/menu_bar/full_screen.test.js
@@ -40,7 +40,7 @@ describe('menu/view', function desc() {
             await loadingScreen.waitForSelector('.LoadingScreen', {state: 'hidden'});
             const firstServer = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].win;
             await env.loginToMattermost(firstServer);
-            await firstServer.waitForSelector('#searchBox');
+            await firstServer.waitForSelector('#post_textbox');
             let currentWidth = await firstServer.evaluate('window.outerWidth');
             let currentHeight = await firstServer.evaluate('window.outerHeight');
             await mainWindow.click('button.three-dot-menu');

--- a/e2e/specs/menu_bar/view_menu.test.js
+++ b/e2e/specs/menu_bar/view_menu.test.js
@@ -70,38 +70,6 @@ describe('menu/view', function desc() {
         text.should.include('in:');
     });
 
-    // TODO: No keyboard shortcut for macOS
-    if (process.platform !== 'darwin') {
-        it('MM-T816 Toggle Full Screen in the Menu Bar', async () => {
-            const mainWindow = this.app.windows().find((window) => window.url().includes('index'));
-            const loadingScreen = this.app.windows().find((window) => window.url().includes('loadingScreen'));
-            await loadingScreen.waitForSelector('.LoadingScreen', {state: 'hidden'});
-            const firstServer = this.serverMap[`${config.teams[0].name}___TAB_MESSAGING`].win;
-            await env.loginToMattermost(firstServer);
-            await firstServer.waitForSelector('#searchBox');
-            let currentWidth = await firstServer.evaluate('window.outerWidth');
-            let currentHeight = await firstServer.evaluate('window.outerHeight');
-            await mainWindow.click('button.three-dot-menu');
-            robot.keyTap('v');
-            robot.keyTap('t');
-            robot.keyTap('enter');
-            await asyncSleep(1000);
-            const fullScreenWidth = await firstServer.evaluate('window.outerWidth');
-            const fullScreenHeight = await firstServer.evaluate('window.outerHeight');
-            fullScreenWidth.should.be.greaterThan(currentWidth);
-            fullScreenHeight.should.be.greaterThan(currentHeight);
-            await mainWindow.click('button.three-dot-menu');
-            robot.keyTap('v');
-            robot.keyTap('t');
-            robot.keyTap('enter');
-            await asyncSleep(1000);
-            currentWidth = await firstServer.evaluate('window.outerWidth');
-            currentHeight = await firstServer.evaluate('window.outerHeight');
-            currentWidth.should.be.lessThan(fullScreenWidth);
-            currentHeight.should.be.lessThan(fullScreenHeight);
-        });
-    }
-
     it('MM-T817 Actual Size Zoom in the menu bar', async () => {
         const mainWindow = this.app.windows().find((window) => window.url().includes('index'));
         const browserWindow = await this.app.browserWindow(mainWindow);


### PR DESCRIPTION
#### Summary
One of the E2E tests was failing on CI due to the size of the display we were using, which was lower than the default size.
This PR changes the size of the window for that test to the minimum size, so that it should always be possible to full screen.

```release-note
NONE
```
