### PR TITLE
Add await to the dark mode toggle test for Linux

### DIFF
--- a/e2e/specs/linux_dark_mode.test.js
+++ b/e2e/specs/linux_dark_mode.test.js
@@ -37,7 +37,7 @@ describe('dark_mode', function desc() {
             mainWindow.should.not.be.null;
 
             // Toggle Dark Mode
-            toggleDarkMode();
+            await toggleDarkMode();
 
             const topBarElementWithDarkMode = await mainWindow.waitForSelector('.topBar');
             const topBarElementClassWithDarkMode = await topBarElementWithDarkMode.getAttribute('class');
@@ -45,7 +45,7 @@ describe('dark_mode', function desc() {
             topBarElementClassWithDarkMode.should.contain('topBar darkMode row');
 
             // Toggle Light Mode
-            toggleDarkMode();
+            await toggleDarkMode();
 
             const topBarElementWithLightMode = await mainWindow.waitForSelector('.topBar');
             const topBarElementClassWithLightMode = await topBarElementWithLightMode.getAttribute('class');
@@ -55,11 +55,12 @@ describe('dark_mode', function desc() {
     }
 });
 
-function toggleDarkMode() {
+async function toggleDarkMode() {
     robot.keyTap('alt');
     robot.keyTap('enter');
     robot.keyTap('v');
     robot.keyTap('t');
+    await asyncSleep(500);  // Add a sleep because sometimes the second 't' doesn't fire
     robot.keyTap('t'); // Click on "Toggle Dark Mode" menu item
     robot.keyTap('enter');
 }


### PR DESCRIPTION
#### Summary
The Linux Dark Mode test seems to be failing quite regularly in which instead of the dark mode toggle being hit, we hit the full screen one.

To try and fix this, I've added an await to wait for the next keystroke to be pushed, hopefully should fix things.

```release-note
NONE
```
