### PR TITLE
[MM-49690] Set currentView to `undefined` instead of using `delete`

### DIFF
--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -180,7 +180,7 @@ export class ViewManager {
 
         if ((focusedTuple && closed.has(focusedTuple)) || (this.currentView && this.closedViews.has(this.currentView))) {
             if (configServers.length) {
-                delete this.currentView;
+                this.currentView = undefined;
                 this.showInitial();
             } else {
                 this.mainWindow.webContents.send(SET_ACTIVE_VIEW);


### PR DESCRIPTION
#### Summary
When reloading the configuration, if we have deleted a server and thus a view, we need to make sure that we unset the value of `currentView` so that other tasks working with the views aren't expecting a view to be visible. We were clearing the value using `delete`, which apparently sets the `string` to `null`, which of course evaluates to `true`.

This PR changes the operation to explicitly set the value to `undefined`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49690

```release-note
NONE
```
