### PR TITLE
Allow ai.moda's RFC3161 load balancer to use any Microsoft trusted TSA

### DIFF
--- a/scripts/Makefile.ps1
+++ b/scripts/Makefile.ps1
@@ -543,13 +543,13 @@ function Run-BuildForceSignature {
             # correct signature from Microsoft. Windows doesn't seem to complain, but we
             # don't know whether this is authorized by the Microsoft EULA.
             Get-ChildItem -Path $archPath -recurse "*.dll" | ForEach-Object {
-                signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "https://rfc3161.ai.moda" /fd sha1 /td sha1 "$($_.FullName)"
-                signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "https://rfc3161.ai.moda" /fd sha256 /td sha256 /as "$($_.FullName)"
+                signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "https://rfc3161.ai.moda/microsoft" /fd sha1 /td sha1 "$($_.FullName)"
+                signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "https://rfc3161.ai.moda/microsoft" /fd sha256 /td sha256 /as "$($_.FullName)"
             }
 
             Print-Info "Signing Mattermost.exe..."
-            signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "https://rfc3161.ai.moda" /fd sha1 /td sha1 "$archPath\Mattermost.exe"
-            signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "https://rfc3161.ai.moda" /fd sha256 /td sha256 /as "$archPath\Mattermost.exe"
+            signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "https://rfc3161.ai.moda/microsoft" /fd sha1 /td sha1 "$archPath\Mattermost.exe"
+            signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "https://rfc3161.ai.moda/microsoft" /fd sha256 /td sha256 /as "$archPath\Mattermost.exe"
         }
     } else {
         Print-Info "Certificate file not found, DLLs and executable won't be signed."
@@ -627,10 +627,10 @@ function Run-BuildMsi {
         # Dual signing is not supported on msi files. Is it recommended to sign with 256 hash.
         # src.: https://security.stackexchange.com/a/124685/84134
         # src.: https://social.msdn.microsoft.com/Forums/windowsdesktop/en-us/d4b70ecd-a883-4289-8047-cc9cde28b492#0b3e3b80-6b3b-463f-ac1e-1bf0dc831952
-        signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "https://rfc3161.ai.moda" /fd sha256 /td sha256 /d "release\$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x86.msi" "release\$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x86.msi"
+        signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "https://rfc3161.ai.moda/microsoft" /fd sha256 /td sha256 /d "release\$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x86.msi" "release\$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x86.msi"
 
         Print-Info "Signing mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x64.msi..."
-        signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "https://rfc3161.ai.moda" /fd sha256 /td sha256 /d "release\$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x64.msi" "release\$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x64.msi"
+        signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "https://rfc3161.ai.moda/microsoft" /fd sha256 /td sha256 /d "release\$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x64.msi" "release\$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x64.msi"
     } else {
         Print-Info "Certificate file not found, the msi installers won't be signed."
     }

--- a/scripts/Makefile.ps1
+++ b/scripts/Makefile.ps1
@@ -543,23 +543,13 @@ function Run-BuildForceSignature {
             # correct signature from Microsoft. Windows doesn't seem to complain, but we
             # don't know whether this is authorized by the Microsoft EULA.
             Get-ChildItem -Path $archPath -recurse "*.dll" | ForEach-Object {
-                Print-Info "Signing $($_.Name) (waiting for 2 * 15 seconds)..."
-                # Waiting for at least 15 seconds is needed because these time
-                # servers usually have rate limits and signtool can fail with the
-                # following error message:
-                # "SignTool Error: The specified timestamp server either could not be reached or returned an invalid response.
-                # src.: https://web.archive.org/web/20190306223053/https://github.com/electron-userland/electron-builder/issues/2795#issuecomment-466831315
-                Start-Sleep -s 15
-                signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "http://timestamp.digicert.com" /fd sha1 /td sha1 "$($_.FullName)"
-                Start-Sleep -s 15
-                signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "http://timestamp.digicert.com" /fd sha256 /td sha256 /as "$($_.FullName)"
+                signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "https://rfc3161.ai.moda" /fd sha1 /td sha1 "$($_.FullName)"
+                signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "https://rfc3161.ai.moda" /fd sha256 /td sha256 /as "$($_.FullName)"
             }
 
-            Print-Info "Signing Mattermost.exe (waiting for 2 * 15 seconds)..."
-            Start-Sleep -s 15
-            signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "http://timestamp.digicert.com" /fd sha1 /td sha1 "$archPath\Mattermost.exe"
-            Start-Sleep -s 15
-            signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "http://timestamp.digicert.com" /fd sha256 /td sha256 /as "$archPath\Mattermost.exe"
+            Print-Info "Signing Mattermost.exe..."
+            signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "https://rfc3161.ai.moda" /fd sha1 /td sha1 "$archPath\Mattermost.exe"
+            signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "https://rfc3161.ai.moda" /fd sha256 /td sha256 /as "$archPath\Mattermost.exe"
         }
     } else {
         Print-Info "Certificate file not found, DLLs and executable won't be signed."
@@ -633,16 +623,14 @@ function Run-BuildMsi {
     # Only sign the executable and .dll if this is a release and not a pull request
     # check.
     if (Test-Path 'env:PFX') {
-        Print-Info "Signing mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x86.msi (waiting for 15 seconds)..."
-        Start-Sleep -s 15
+        Print-Info "Signing mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x86.msi..."
         # Dual signing is not supported on msi files. Is it recommended to sign with 256 hash.
         # src.: https://security.stackexchange.com/a/124685/84134
         # src.: https://social.msdn.microsoft.com/Forums/windowsdesktop/en-us/d4b70ecd-a883-4289-8047-cc9cde28b492#0b3e3b80-6b3b-463f-ac1e-1bf0dc831952
-        signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "http://timestamp.digicert.com" /fd sha256 /td sha256 /d "release\$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x86.msi" "release\$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x86.msi"
+        signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "https://rfc3161.ai.moda" /fd sha256 /td sha256 /d "release\$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x86.msi" "release\$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x86.msi"
 
-        Print-Info "Signing mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x64.msi (waiting for 15 seconds)..."
-        Start-Sleep -s 15
-        signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "http://timestamp.digicert.com" /fd sha256 /td sha256 /d "release\$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x64.msi" "release\$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x64.msi"
+        Print-Info "Signing mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x64.msi..."
+        signtool.exe sign /f "./mattermost-desktop-windows.pfx" /p "$env:PFX_KEY" /tr "https://rfc3161.ai.moda" /fd sha256 /td sha256 /d "release\$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x64.msi" "release\$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)\mattermost-desktop-$($env:COM_MATTERMOST_MAKEFILE_BUILD_ID)-x64.msi"
     } else {
         Print-Info "Certificate file not found, the msi installers won't be signed."
     }


### PR DESCRIPTION
#### Release Note

```release-note
Allow ai.moda's RFC3161 load balancer to use any Microsoft trusted TSA. This should improve build times slightly in theory.
```

This should be merged in after #2523 is deemed acceptable and tested more for a few days/weeks.