### PR TITLE
[MM-49689] Force `/api/v4/files` links to not open a new window and download correctly

### DIFF
--- a/src/main/views/webContentEvents.test.js
+++ b/src/main/views/webContentEvents.test.js
@@ -30,7 +30,7 @@ jest.mock('electron', () => ({
 }));
 
 jest.mock('../allowProtocolDialog', () => ({}));
-jest.mock('../windows/windowManager', () => ({
+jest.mock('main/windows/windowManager', () => ({
     showMainWindow: jest.fn(),
     getViewNameByWebContentsId: jest.fn(),
     viewManager: {
@@ -38,6 +38,9 @@ jest.mock('../windows/windowManager', () => ({
             get: jest.fn(),
         },
     },
+}));
+jest.mock('main/downloadsManager', () => ({
+    downloadURLInMattermostView: jest.fn(),
 }));
 
 jest.mock('common/config', () => ({


### PR DESCRIPTION
#### Summary
With the changing over to using the `mm-desktop` protocol, we end up a cross-origin request when trying to download files from the server. Thus, it will try to open all files in a new window, which isn't ideal.

This PR forces them through the `DownloadsManager` manually, by denying the `new-window` request and manually calling `downloadURL` on the corresponding `webContents`.

@tboulis I'm honestly not totally happy with the way I've done this, but it's the best I could come up with for now. Feel free to provide suggestions to improve.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49689

```release-note
NONE
```
