### PR TITLE
[MM-50220] Fix issue with rpm build conflicting with other electron applications

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -167,5 +167,8 @@
   },
   "nsis": {
     "artifactName": "${version}/${name}-setup-${version}-win.${ext}"
+  },
+  "rpm": {
+    "fpm": ["--rpm-rpmbuild-define", "_build_id_links none"]
   }
 }


### PR DESCRIPTION
#### Summary
This will basically prevent the creation of symlinks in /usr/lib/.build_id to avoid conflicts with other electron applications

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50220
and
https://github.com/mattermost/desktop/issues/2461

#### Release Note
```release-note
Fix RPM conflict with other electron based applications
```
