### PR TITLE
[MM-50042] Detect Boards using the BuildBoards flag in the client config

### DIFF
--- a/src/main/server/serverAPI.test.js
+++ b/src/main/server/serverAPI.test.js
@@ -23,6 +23,9 @@ jest.mock('electron', () => ({
                         if (event === 'data') {
                             responseCallback(url === badDataURL ? '98&H09986t&(*6BV789RhN^t97rb6Ev^*e5v89 re5bg^&' : JSON.stringify(testData));
                         }
+                        if (event === 'end') {
+                            responseCallback();
+                        }
                     }),
                     statusCode: (url === validURL || url === badDataURL) ? 200 : 404,
                 });

--- a/src/main/server/serverAPI.ts
+++ b/src/main/server/serverAPI.ts
@@ -38,9 +38,12 @@ export async function getServerAPI<T>(url: URL, isAuthenticated: boolean, onSucc
         req.on('response', (response: Electron.IncomingMessage) => {
             log.silly('getServerAPI.response', response);
             if (response.statusCode === 200) {
+                let raw = '';
                 response.on('data', (chunk: Buffer) => {
                     log.silly('getServerAPI.response.data', `${chunk}`);
-                    const raw = `${chunk}`;
+                    raw += `${chunk}`;
+                });
+                response.on('end', () => {
                     try {
                         const data = JSON.parse(raw) as T;
                         onSuccess(data);

--- a/src/main/server/serverInfo.ts
+++ b/src/main/server/serverInfo.ts
@@ -44,12 +44,13 @@ export class ServerInfo {
     onGetConfig = (data: ClientConfig) => {
         this.remoteInfo.serverVersion = data.Version;
         this.remoteInfo.siteURL = data.SiteURL;
+        this.remoteInfo.hasFocalboard = this.remoteInfo.hasFocalboard || data.BuildBoards === 'true';
 
         this.trySendRemoteInfo();
     }
 
     onGetPlugins = (data: Array<{id: string; version: string}>) => {
-        this.remoteInfo.hasFocalboard = data.some((plugin) => plugin.id === 'focalboard');
+        this.remoteInfo.hasFocalboard = this.remoteInfo.hasFocalboard || data.some((plugin) => plugin.id === 'focalboard');
         this.remoteInfo.hasPlaybooks = data.some((plugin) => plugin.id === 'playbooks');
 
         this.trySendRemoteInfo();

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -12,4 +12,5 @@ export type RemoteInfo = {
 export type ClientConfig = {
     Version: string;
     SiteURL: string;
+    BuildBoards: string;
 }


### PR DESCRIPTION
#### Summary
With the changes to allow Boards to function as a product, newer server versions won't have the Boards plugins installed anymore, thus when the server is added to the Desktop App the Boards tab wouldn't be automatically added.

This PR changes the logic to check for the `BuildBoards` flag in the `ClientConfig` object. If it set to `true` then we show the Boards tab.

Also, made a fix to the API to allow for chunked responses, since `community.mattermost.com` was sending those.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50042

```release-note
Fixed an issue where sometimes the Boards/Playbooks tabs wouldn't appear automatically when a server was added.
```
