### PR TITLE
[MM-49586] Use location as is when displaying thumbnails inside downloads

### DIFF
--- a/src/main/views/downloadsDropdownView.ts
+++ b/src/main/views/downloadsDropdownView.ts
@@ -1,8 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import path from 'path';
 
-import {app, BrowserView, BrowserWindow, ipcMain, IpcMainEvent, IpcMainInvokeEvent} from 'electron';
+import {BrowserView, BrowserWindow, ipcMain, IpcMainEvent, IpcMainInvokeEvent} from 'electron';
 
 import log from 'electron-log';
 
@@ -212,13 +211,6 @@ export default class DownloadsDropdownView {
     }
 
     getDownloadImageThumbnailLocation = (event: IpcMainInvokeEvent, location: string) => {
-        // eslint-disable-next-line no-undef
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        if (!__IS_MAC_APP_STORE__) {
-            return location;
-        }
-
-        return path.resolve(app.getPath('temp'), path.basename(location));
+        return location;
     }
 }


### PR DESCRIPTION
#### Summary
Using the `temp` folder of the sandboxed app would cause issues with MAS builds. I tested it by changing the downloads location, replacing files, restarting the app and it seems to work. 
We should test it again once released through Testflight

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49586

#### Release Note
```release-note
Fixed issue with image thumbnails not always displayed in downloads for MAS builds
```

