### PR TITLE
[MM-49739] Set parent window on calls expanded popout view

### DIFF
--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -143,6 +143,7 @@ export const CALLS_WIDGET_RESIZE = 'calls-widget-resize';
 export const CALLS_WIDGET_SHARE_SCREEN = 'calls-widget-share-screen';
 export const CALLS_WIDGET_CHANNEL_LINK_CLICK = 'calls-widget-channel-link-click';
 export const CALLS_JOINED_CALL = 'calls-joined-call';
+export const CALLS_POPOUT_FOCUS = 'calls-popout-focus';
 
 export const REQUEST_CLEAR_DOWNLOADS_DROPDOWN = 'request-clear-downloads-dropdown';
 export const CLOSE_DOWNLOADS_DROPDOWN = 'close-downloads-dropdown';

--- a/src/main/preload/callsWidget.js
+++ b/src/main/preload/callsWidget.js
@@ -8,6 +8,7 @@ import {ipcRenderer} from 'electron';
 import {
     CALLS_LEAVE_CALL,
     CALLS_JOINED_CALL,
+    CALLS_POPOUT_FOCUS,
     CALLS_WIDGET_RESIZE,
     CALLS_WIDGET_SHARE_SCREEN,
     CALLS_WIDGET_CHANNEL_LINK_CLICK,
@@ -47,6 +48,7 @@ window.addEventListener('message', ({origin, data = {}} = {}) => {
     case CALLS_WIDGET_CHANNEL_LINK_CLICK:
     case CALLS_WIDGET_RESIZE:
     case CALLS_JOINED_CALL:
+    case CALLS_POPOUT_FOCUS:
     case CALLS_LEAVE_CALL: {
         ipcRenderer.send(type, message);
         break;

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -122,6 +122,7 @@ export default class CallsWidgetWindow extends EventEmitter {
         ipcMain.off(CALLS_WIDGET_RESIZE, this.onResize);
         ipcMain.off(CALLS_WIDGET_SHARE_SCREEN, this.onShareScreen);
         ipcMain.off(CALLS_JOINED_CALL, this.onJoinedCall);
+        ipcMain.off(CALLS_POPOUT_FOCUS, this.onPopOutFocus);
     }
 
     private getWidgetURL() {

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -86,6 +86,7 @@ export default class CallsWidgetWindow extends EventEmitter {
             return {
                 action: 'allow',
                 overrideBrowserWindowOptions: {
+                    parent: this.win,
                     autoHideMenuBar: true,
                 },
             };


### PR DESCRIPTION
#### Summary

Setting the parent seems to do the trick and now the expanded view should be focused and brought on top when clicking on the icon.

@tboulis It would be great if you could give it a quick try and let me know if it works as expected now. Thanks!

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49739

#### Release Note

```release-note
NONE
```

