### PR TITLE
[MM-38369] Exit process with code 1 if afterPack throws error

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
         "source.fixAll.eslint": true
     },
     "cSpell.words": [
+        "appimage",
         "automations",
         "Autoupgrade",
         "browserview",

--- a/scripts/afterpack.js
+++ b/scripts/afterpack.js
@@ -37,14 +37,20 @@ function getAppFileName(context) {
 }
 
 exports.default = async function afterPack(context) {
-    await flipFuses(
-        `${context.appOutDir}/${getAppFileName(context)}`, // Returns the path to the electron binary
-        {
-            version: FuseVersion.V1,
-            [FuseV1Options.RunAsNode]: false, // Disables ELECTRON_RUN_AS_NODE
-        });
+    try {
+        await flipFuses(
+            `${context.appOutDir}/${getAppFileName(context)}`, // Returns the path to the electron binary
+            {
+                version: FuseVersion.V1,
+                [FuseV1Options.RunAsNode]: false, // Disables ELECTRON_RUN_AS_NODE
+            });
 
-    if (context.electronPlatformName === 'linux') {
-        context.targets.forEach(fixSetuid(context));
+        if (context.electronPlatformName === 'linux') {
+            context.targets.forEach(fixSetuid(context));
+        }
+    } catch (error) {
+        console.error('afterPack error: ', error);
+        // eslint-disable-next-line no-process-exit
+        process.exit(1);
     }
 };


### PR DESCRIPTION
#### Summary
Use `process.exit(1)` to handle errors inside afterPack script of `electron-builder`

I think the related code in `electron-builder` is [here](https://github.com/electron-userland/electron-builder/blob/master/packages/app-builder-lib/src/packager.ts#L533-L535)
but it's unclear to me if this would propagate the error upwards.
I tried to investigate but the compiler throws the error when defining the promise, not on runtime:
![5A3E085B-FC44-4EA0-831C-57DC90F69826](https://user-images.githubusercontent.com/24255041/216961571-313284a7-5481-44f1-90ba-906543400cec.png)


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38369

#### Release Note
```release-note
NONE
```
