### PR TITLE
[MM-50410] Allow any unhandled target=_blank links to open in the browser

### DIFF
--- a/src/main/views/webContentEvents.test.js
+++ b/src/main/views/webContentEvents.test.js
@@ -250,5 +250,11 @@ describe('main/views/webContentsEvents', () => {
             expect(newWindow({url: 'http://server-1.com/trusted/login'})).toStrictEqual({action: 'deny'});
             expect(webContentsEventManager.popupWindow).toBeTruthy();
         });
+
+        it('should open external URIs in browser', () => {
+            urlUtils.isValidURI.mockReturnValue(false);
+            expect(newWindow({url: 'https://google.com'})).toStrictEqual({action: 'deny'});
+            expect(shell.openExternal).toBeCalledWith('https://google.com');
+        });
     });
 });

--- a/src/main/views/webContentEvents.ts
+++ b/src/main/views/webContentEvents.ts
@@ -133,7 +133,6 @@ export class WebContentsEventManager {
             }
 
             const serverURL = WindowManager.getServerURLFromWebContentsId(webContentsId);
-
             if (!serverURL) {
                 shell.openExternal(details.url);
                 return {action: 'deny'};
@@ -206,8 +205,12 @@ export class WebContentsEventManager {
 
                 const contextMenu = new ContextMenu({}, this.popupWindow);
                 contextMenu.reload();
+
+                return {action: 'deny'};
             }
 
+            // If all else fails, just open externally
+            shell.openExternal(details.url);
             return {action: 'deny'};
         };
     };


### PR DESCRIPTION
#### Summary
With my recent changes [here](https://github.com/mattermost/desktop/pull/2544), I neglected to account for the case in which the URL doesn't match any of our specifically handled cases, which also happened to be the default external links case. Our previous method specifically checked if the URL matched an active view, but since the new one does not, we can just allow it to fall through and open uncaught cases in the browser.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50410

```release-note
NONE
```
