### PR TITLE
[MM-50409] Stop the main window from creating its own uncontrolled child windows

### DIFF
--- a/src/main/windows/windowManager.test.js
+++ b/src/main/windows/windowManager.test.js
@@ -165,17 +165,24 @@ describe('main/windows/windowManager', () => {
             const window = {
                 on: jest.fn(),
                 once: jest.fn(),
+                webContents: {
+                    setWindowOpenHandler: jest.fn(),
+                },
             };
             createMainWindow.mockReturnValue(window);
             windowManager.showMainWindow();
             expect(windowManager.mainWindow).toBe(window);
             expect(window.on).toHaveBeenCalled();
+            expect(window.webContents.setWindowOpenHandler).toHaveBeenCalled();
         });
 
         it('should open deep link when provided', () => {
             const window = {
                 on: jest.fn(),
                 once: jest.fn(),
+                webContents: {
+                    setWindowOpenHandler: jest.fn(),
+                },
             };
             createMainWindow.mockReturnValue(window);
             windowManager.showMainWindow('mattermost://server-1.com/subpath');

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -215,6 +215,9 @@ export class WindowManager {
             this.mainWindow.on('enter-full-screen', () => this.sendToRenderer('enter-full-screen'));
             this.mainWindow.on('leave-full-screen', () => this.sendToRenderer('leave-full-screen'));
 
+            // Should not allow the main window to generate a window of its own
+            this.mainWindow.webContents.setWindowOpenHandler(() => ({action: 'deny'}));
+
             if (process.env.MM_DEBUG_SETTINGS) {
                 this.mainWindow.webContents.openDevTools({mode: 'detach'});
             }


### PR DESCRIPTION
#### Summary
There were a couple cases in which a user could open a child window using links on the main window (easiest way to reproduce was to middle click one of the products tabs at the top)

This PR adds a `new-window` listener to deny the main window from opening any of its own child windows, other than ones we explicitly do using other methods.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50409

```release-note
Fixed an issue where a user could open a blank Electron window using the main window
```
