### PR TITLE
[MM-50411] Fix media permissions failure on Calls window

### DIFF
--- a/src/main/windows/callsWidgetWindow.test.js
+++ b/src/main/windows/callsWidgetWindow.test.js
@@ -358,5 +358,26 @@ describe('main/windows/callsWidgetWindow', () => {
             expect(popOut.focus).toHaveBeenCalled();
             expect(popOut.restore).toHaveBeenCalled();
         });
+
+        it('getWebContentsId', () => {
+            baseWindow.webContents = {
+                ...baseWindow.webContents,
+                id: 'testID',
+            };
+
+            const widgetWindow = new CallsWidgetWindow(mainWindow, mainView, widgetConfig);
+            expect(widgetWindow.getWebContentsId()).toBe('testID');
+        });
+
+        it('getURL', () => {
+            baseWindow.webContents = {
+                ...baseWindow.webContents,
+                id: 'testID',
+                getURL: jest.fn(() => 'http://localhost:8065/'),
+            };
+
+            const widgetWindow = new CallsWidgetWindow(mainWindow, mainView, widgetConfig);
+            expect(widgetWindow.getURL().toString()).toBe('http://localhost:8065/');
+        });
     });
 });

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -24,6 +24,7 @@ import {
     CALLS_PLUGIN_ID,
 } from 'common/utils/constants';
 import Utils from 'common/utils/util';
+import urlUtils from 'common/utils/url';
 import {
     CALLS_JOINED_CALL,
     CALLS_POPOUT_FOCUS,
@@ -209,6 +210,14 @@ export default class CallsWidgetWindow extends EventEmitter {
             this.popOut.restore();
         }
         this.popOut.focus();
+    }
+
+    public getWebContentsId() {
+        return this.win.webContents.id;
+    }
+
+    public getURL() {
+        return urlUtils.parseURL(this.win.webContents.getURL());
     }
 }
 

--- a/src/main/windows/windowManager.test.js
+++ b/src/main/windows/windowManager.test.js
@@ -1183,4 +1183,35 @@ describe('main/windows/windowManager', () => {
             expect(windowManager.switchServer).toHaveBeenCalledWith('server-2');
         });
     });
+
+    describe('getServerURLFromWebContentsId', () => {
+        const view = {
+            name: 'server-1_tab-messaging',
+            serverInfo: {
+                remoteInfo: {
+                    siteURL: 'http://server-1.com',
+                },
+            },
+        };
+        const windowManager = new WindowManager();
+        windowManager.viewManager = {
+            views: new Map([
+                ['server-1_tab-messaging', view],
+            ]),
+            findViewByWebContent: jest.fn(),
+        };
+
+        it('should return calls widget URL', () => {
+            CallsWidgetWindow.mockImplementation(() => {
+                return {
+                    on: jest.fn(),
+                    getURL: jest.fn(() => 'http://localhost:8065'),
+                    getWebContentsId: jest.fn(() => 'callsID'),
+                };
+            });
+
+            windowManager.createCallsWidgetWindow(null, 'server-1_tab-messaging', {callID: 'test'});
+            expect(windowManager.getServerURLFromWebContentsId('callsID')).toBe(windowManager.callsWidgetWindow.getURL());
+        });
+    });
 });

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -862,6 +862,10 @@ export class WindowManager {
     }
 
     getServerURLFromWebContentsId = (id: number) => {
+        if (this.callsWidgetWindow && id === this.callsWidgetWindow.getWebContentsId()) {
+            return this.callsWidgetWindow.getURL();
+        }
+
         const viewName = this.getViewNameByWebContentsId(id);
         if (!viewName) {
             return undefined;


### PR DESCRIPTION
#### Summary

With changes in https://github.com/mattermost/desktop/pull/2544, `WindowManager.getServerURLFromWebContentsId()` wasn't taking into account the Calls widget window which doesn't really have a view so it would return undefined and eventually fail during a permission check for media in `setPermissionRequestHandler()`.

PR adds a check to make sure that we also match against the web contents id for the calls window, if present.

@cpoile Could you give this a quick try on your system as well?

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-50411

#### Release Note

```release-note
NONE
```
