### PR TITLE
[MM-46696] Send error to global widget if missing screen sharing permissions

### DIFF
--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -137,6 +137,7 @@ export const CALLS_WIDGET_SHARE_SCREEN = 'calls-widget-share-screen';
 export const CALLS_WIDGET_CHANNEL_LINK_CLICK = 'calls-widget-channel-link-click';
 export const CALLS_JOINED_CALL = 'calls-joined-call';
 export const CALLS_POPOUT_FOCUS = 'calls-popout-focus';
+export const CALLS_ERROR = 'calls-error';
 
 export const REQUEST_CLEAR_DOWNLOADS_DROPDOWN = 'request-clear-downloads-dropdown';
 export const CLOSE_DOWNLOADS_DROPDOWN = 'close-downloads-dropdown';

--- a/src/main/preload/callsWidget.js
+++ b/src/main/preload/callsWidget.js
@@ -12,6 +12,7 @@ import {
     CALLS_WIDGET_RESIZE,
     CALLS_WIDGET_SHARE_SCREEN,
     CALLS_WIDGET_CHANNEL_LINK_CLICK,
+    CALLS_ERROR,
     DESKTOP_SOURCES_RESULT,
     DESKTOP_SOURCES_MODAL_REQUEST,
     DISPATCH_GET_DESKTOP_SOURCES,
@@ -70,6 +71,16 @@ ipcRenderer.on(CALLS_WIDGET_SHARE_SCREEN, (event, message) => {
     window.postMessage(
         {
             type: CALLS_WIDGET_SHARE_SCREEN,
+            message,
+        },
+        window.location.origin,
+    );
+});
+
+ipcRenderer.on(CALLS_ERROR, (event, message) => {
+    window.postMessage(
+        {
+            type: CALLS_ERROR,
             message,
         },
         window.location.origin,


### PR DESCRIPTION
#### Summary

PR implements some logic to surface errors from desktop to global widget. In this PR we are handling missing screen sharing permissions. 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46696

#### Video

https://user-images.githubusercontent.com/1832946/219226766-009f4145-ba92-4eea-941f-d256207c3911.mov

#### Related PR

https://github.com/mattermost/mattermost-plugin-calls/pull/337

#### Release Note

```release-note
NONE
```


