### PR TITLE
[MM-46980] Improve screensharing permissions flow

### DIFF
--- a/src/main/preload/callsWidget.js
+++ b/src/main/preload/callsWidget.js
@@ -15,7 +15,6 @@ import {
     CALLS_ERROR,
     DESKTOP_SOURCES_RESULT,
     DESKTOP_SOURCES_MODAL_REQUEST,
-    DISPATCH_GET_DESKTOP_SOURCES,
 } from 'common/communication';
 
 window.addEventListener('message', ({origin, data = {}} = {}) => {
@@ -39,10 +38,6 @@ window.addEventListener('message', ({origin, data = {}} = {}) => {
                 window.location.origin,
             );
         });
-        break;
-    }
-    case 'get-desktop-sources': {
-        ipcRenderer.send(DISPATCH_GET_DESKTOP_SOURCES, 'widget', message);
         break;
     }
     case DESKTOP_SOURCES_MODAL_REQUEST:

--- a/src/main/preload/callsWidget.js
+++ b/src/main/preload/callsWidget.js
@@ -45,6 +45,7 @@ window.addEventListener('message', ({origin, data = {}} = {}) => {
     case CALLS_WIDGET_RESIZE:
     case CALLS_JOINED_CALL:
     case CALLS_POPOUT_FOCUS:
+    case CALLS_ERROR:
     case CALLS_LEAVE_CALL: {
         ipcRenderer.send(type, message);
         break;

--- a/src/main/preload/mattermost.js
+++ b/src/main/preload/mattermost.js
@@ -36,6 +36,7 @@ import {
     DESKTOP_SOURCES_MODAL_REQUEST,
     CALLS_WIDGET_SHARE_SCREEN,
     CLOSE_DOWNLOADS_DROPDOWN,
+    CALLS_ERROR,
 } from 'common/communication';
 
 const UNREAD_COUNT_INTERVAL = 1000;
@@ -337,6 +338,16 @@ ipcRenderer.on(CALLS_JOINED_CALL, (event, message) => {
     window.postMessage(
         {
             type: CALLS_JOINED_CALL,
+            message,
+        },
+        window.location.origin,
+    );
+});
+
+ipcRenderer.on(CALLS_ERROR, (event, message) => {
+    window.postMessage(
+        {
+            type: CALLS_ERROR,
             message,
         },
         window.location.origin,

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -5,6 +5,11 @@
 import path from 'path';
 import fs from 'fs';
 
+import {exec as execOriginal} from 'child_process';
+
+import {promisify} from 'util';
+const exec = promisify(execOriginal);
+
 import {app, BrowserWindow} from 'electron';
 
 import {Args} from 'types/args';
@@ -135,4 +140,20 @@ export function shouldIncrementFilename(filepath: string, increment = 0): string
         return shouldIncrementFilename(filepath, increment + 1);
     }
     return filename;
+}
+
+export function resetScreensharePermissionsMacOS() {
+    if (process.platform !== 'darwin') {
+        return Promise.resolve();
+    }
+    return exec('tccutil reset ScreenCapture Mattermost.Desktop',
+        {timeout: 1000});
+}
+
+export function openScreensharePermissionsSettingsMacOS() {
+    if (process.platform !== 'darwin') {
+        return Promise.resolve();
+    }
+    return exec('open "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"',
+        {timeout: 1000});
 }

--- a/src/main/windows/callsWidgetWindow.test.js
+++ b/src/main/windows/callsWidgetWindow.test.js
@@ -379,5 +379,10 @@ describe('main/windows/callsWidgetWindow', () => {
             const widgetWindow = new CallsWidgetWindow(mainWindow, mainView, widgetConfig);
             expect(widgetWindow.getURL().toString()).toBe('http://localhost:8065/');
         });
+
+        it('getMainView', () => {
+            const widgetWindow = new CallsWidgetWindow(mainWindow, mainView, widgetConfig);
+            expect(widgetWindow.getMainView()).toEqual(mainView);
+        });
     });
 });

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -219,5 +219,9 @@ export default class CallsWidgetWindow extends EventEmitter {
     public getURL() {
         return urlUtils.parseURL(this.win.webContents.getURL());
     }
+
+    public getMainView() {
+        return this.mainView;
+    }
 }
 

--- a/src/main/windows/windowManager.test.js
+++ b/src/main/windows/windowManager.test.js
@@ -1368,6 +1368,42 @@ describe('main/windows/windowManager', () => {
         });
     });
 
+    describe('handleCallsError', () => {
+        const windowManager = new WindowManager();
+        windowManager.switchServer = jest.fn();
+        windowManager.mainWindow = {
+            focus: jest.fn(),
+        };
+
+        beforeEach(() => {
+            CallsWidgetWindow.mockImplementation(() => {
+                return {
+                    getServerName: () => 'server-2',
+                    getMainView: jest.fn().mockReturnValue({
+                        view: {
+                            webContents: {
+                                send: jest.fn(),
+                            },
+                        },
+                    }),
+                };
+            });
+        });
+
+        afterEach(() => {
+            jest.resetAllMocks();
+            Config.teams = [];
+        });
+
+        it('should focus view and propagate error to main view', () => {
+            windowManager.callsWidgetWindow = new CallsWidgetWindow();
+            windowManager.handleCallsError(null, {err: 'client-error'});
+            expect(windowManager.switchServer).toHaveBeenCalledWith('server-2');
+            expect(windowManager.mainWindow.focus).toHaveBeenCalled();
+            expect(windowManager.callsWidgetWindow.getMainView().view.webContents.send).toHaveBeenCalledWith('calls-error', {err: 'client-error'});
+        });
+    });
+
     describe('getServerURLFromWebContentsId', () => {
         const view = {
             name: 'server-1_tab-messaging',

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -139,7 +139,7 @@ export class WindowManager {
         log.debug('WindowManager.handleDesktopSourcesModalRequest');
 
         if (this.callsWidgetWindow) {
-            this.switchServer(this.callsWidgetWindow?.getServerName());
+            this.switchServer(this.callsWidgetWindow.getServerName());
             this.mainWindow?.focus();
             const currentView = this.viewManager?.getCurrentView();
             currentView?.view.webContents.send(DESKTOP_SOURCES_MODAL_REQUEST);
@@ -834,6 +834,7 @@ export class WindowManager {
 
         const view = this.viewManager?.views.get(viewName);
         if (!view) {
+            log.error('WindowManager.handleGetDesktopSources: view not found');
             return Promise.resolve();
         }
 

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -9,6 +9,7 @@ import log from 'electron-log';
 
 import {
     CallsJoinCallMessage,
+    CallsErrorMessage,
 } from 'types/calls';
 
 import {
@@ -101,6 +102,7 @@ export class WindowManager {
         ipcMain.on(CALLS_LEAVE_CALL, () => this.callsWidgetWindow?.close());
         ipcMain.on(DESKTOP_SOURCES_MODAL_REQUEST, this.handleDesktopSourcesModalRequest);
         ipcMain.on(CALLS_WIDGET_CHANNEL_LINK_CLICK, this.handleCallsWidgetChannelLinkClick);
+        ipcMain.on(CALLS_ERROR, this.handleCallsError);
     }
 
     handleUpdateConfig = () => {
@@ -153,6 +155,14 @@ export class WindowManager {
             this.mainWindow?.focus();
             const currentView = this.viewManager?.getCurrentView();
             currentView?.view.webContents.send(BROWSER_HISTORY_PUSH, this.callsWidgetWindow.getChannelURL());
+        }
+    }
+
+    handleCallsError = (event: IpcMainEvent, msg: CallsErrorMessage) => {
+        if (this.callsWidgetWindow) {
+            this.switchServer(this.callsWidgetWindow.getServerName());
+            this.mainWindow?.focus();
+            this.callsWidgetWindow.getMainView().view.webContents.send(CALLS_ERROR, msg);
         }
     }
 

--- a/src/types/calls.ts
+++ b/src/types/calls.ts
@@ -28,3 +28,9 @@ export type CallsWidgetShareScreenMessage = {
 export type CallsJoinedCallMessage = {
     callID: string;
 }
+
+export type CallsErrorMessage = {
+    err: string;
+    callID?: string;
+    errMsg?: string;
+};


### PR DESCRIPTION
#### Summary

PR addresses a couple of outstanding issues with screen sharing:

1. After https://github.com/mattermost/desktop/pull/2554 there was still an issue preventing the error message from surfacing up again if dismissed and permissions were missing after the first attempt to share.
2. Since macOS 10.15 Catalina screen permissions need to be explicitly (and manually) granted to an app through the system settings. This has caused a lot of confusion for users on why screen sharing isn't working (see ticket below). On top of that the system isn't really helping since permissions require an app restart to take effect and the prompt to fix them is only showed once per app execution. To help with this we reset permissions on a share request if missing and also open the related system setting pane in an attempt to make it easier for the user (see video below).

#### Video

https://user-images.githubusercontent.com/1832946/219493880-7fc7f30f-faf9-46de-ac0f-8521b19fea99.mov

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46980

#### Related PR

https://github.com/mattermost/mattermost-plugin-calls/pull/338

#### Release Note

```release-note
NONE
```
