### PR TITLE
[MM-49089] Propagate calls client errors

### DIFF
--- a/src/main/preload/callsWidget.js
+++ b/src/main/preload/callsWidget.js
@@ -45,6 +45,7 @@ window.addEventListener('message', ({origin, data = {}} = {}) => {
     case CALLS_WIDGET_RESIZE:
     case CALLS_JOINED_CALL:
     case CALLS_POPOUT_FOCUS:
+    case CALLS_ERROR:
     case CALLS_LEAVE_CALL: {
         ipcRenderer.send(type, message);
         break;

--- a/src/main/windows/callsWidgetWindow.test.js
+++ b/src/main/windows/callsWidgetWindow.test.js
@@ -379,5 +379,10 @@ describe('main/windows/callsWidgetWindow', () => {
             const widgetWindow = new CallsWidgetWindow(mainWindow, mainView, widgetConfig);
             expect(widgetWindow.getURL().toString()).toBe('http://localhost:8065/');
         });
+
+        it('getMainView', () => {
+            const widgetWindow = new CallsWidgetWindow(mainWindow, mainView, widgetConfig);
+            expect(widgetWindow.getMainView()).toEqual(mainView);
+        });
     });
 });

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -219,5 +219,9 @@ export default class CallsWidgetWindow extends EventEmitter {
     public getURL() {
         return urlUtils.parseURL(this.win.webContents.getURL());
     }
+
+    public getMainView() {
+        return this.mainView;
+    }
 }
 

--- a/src/main/windows/windowManager.test.js
+++ b/src/main/windows/windowManager.test.js
@@ -1368,6 +1368,42 @@ describe('main/windows/windowManager', () => {
         });
     });
 
+    describe('handleCallsError', () => {
+        const windowManager = new WindowManager();
+        windowManager.switchServer = jest.fn();
+        windowManager.mainWindow = {
+            focus: jest.fn(),
+        };
+
+        beforeEach(() => {
+            CallsWidgetWindow.mockImplementation(() => {
+                return {
+                    getServerName: () => 'server-2',
+                    getMainView: jest.fn().mockReturnValue({
+                        view: {
+                            webContents: {
+                                send: jest.fn(),
+                            },
+                        },
+                    }),
+                };
+            });
+        });
+
+        afterEach(() => {
+            jest.resetAllMocks();
+            Config.teams = [];
+        });
+
+        it('should focus view and propagate error to main view', () => {
+            windowManager.callsWidgetWindow = new CallsWidgetWindow();
+            windowManager.handleCallsError(null, {err: 'client-error'});
+            expect(windowManager.switchServer).toHaveBeenCalledWith('server-2');
+            expect(windowManager.mainWindow.focus).toHaveBeenCalled();
+            expect(windowManager.callsWidgetWindow.getMainView().view.webContents.send).toHaveBeenCalledWith('calls-error', {err: 'client-error'});
+        });
+    });
+
     describe('getServerURLFromWebContentsId', () => {
         const view = {
             name: 'server-1_tab-messaging',

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -9,6 +9,7 @@ import log from 'electron-log';
 
 import {
     CallsJoinCallMessage,
+    CallsErrorMessage,
 } from 'types/calls';
 
 import {
@@ -101,6 +102,7 @@ export class WindowManager {
         ipcMain.on(CALLS_LEAVE_CALL, () => this.callsWidgetWindow?.close());
         ipcMain.on(DESKTOP_SOURCES_MODAL_REQUEST, this.handleDesktopSourcesModalRequest);
         ipcMain.on(CALLS_WIDGET_CHANNEL_LINK_CLICK, this.handleCallsWidgetChannelLinkClick);
+        ipcMain.on(CALLS_ERROR, this.handleCallsError);
     }
 
     handleUpdateConfig = () => {
@@ -153,6 +155,14 @@ export class WindowManager {
             this.mainWindow?.focus();
             const currentView = this.viewManager?.getCurrentView();
             currentView?.view.webContents.send(BROWSER_HISTORY_PUSH, this.callsWidgetWindow.getChannelURL());
+        }
+    }
+
+    handleCallsError = (event: IpcMainEvent, msg: CallsErrorMessage) => {
+        if (this.callsWidgetWindow) {
+            this.switchServer(this.callsWidgetWindow.getServerName());
+            this.mainWindow?.focus();
+            this.callsWidgetWindow.getMainView().view.webContents.send(CALLS_ERROR, msg);
         }
     }
 

--- a/src/types/calls.ts
+++ b/src/types/calls.ts
@@ -28,3 +28,9 @@ export type CallsWidgetShareScreenMessage = {
 export type CallsJoinedCallMessage = {
     callID: string;
 }
+
+export type CallsErrorMessage = {
+    err: string;
+    callID?: string;
+    errMsg?: string;
+};


### PR DESCRIPTION
#### Summary

PR implements some missing logic which is needed to surface clients errors (e.g. connection failure) from global widget to main window.

#### Videos

https://user-images.githubusercontent.com/1832946/219517628-49503970-a862-4cbc-ae52-2f1a864e7ff2.mov

https://user-images.githubusercontent.com/1832946/219517633-412ff76c-c4ea-40ee-980f-beb116944ae0.mov

https://user-images.githubusercontent.com/1832946/219517636-e898bd50-10a9-4e94-8027-ea7366eca94a.mov

#### Related PR

https://github.com/mattermost/mattermost-plugin-calls/pull/339

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49089

#### Release Note

```release-note
NONE
```
