### PR TITLE
MM-49079 - Calls: process link clicks from Calls popout

### DIFF
--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -135,6 +135,7 @@ export const CALLS_LEAVE_CALL = 'calls-leave-call';
 export const CALLS_WIDGET_RESIZE = 'calls-widget-resize';
 export const CALLS_WIDGET_SHARE_SCREEN = 'calls-widget-share-screen';
 export const CALLS_WIDGET_CHANNEL_LINK_CLICK = 'calls-widget-channel-link-click';
+export const CALLS_LINK_CLICK = 'calls-link-click';
 export const CALLS_JOINED_CALL = 'calls-joined-call';
 export const CALLS_POPOUT_FOCUS = 'calls-popout-focus';
 export const CALLS_ERROR = 'calls-error';

--- a/src/main/preload/callsWidget.js
+++ b/src/main/preload/callsWidget.js
@@ -16,6 +16,7 @@ import {
     DESKTOP_SOURCES_RESULT,
     DESKTOP_SOURCES_MODAL_REQUEST,
     DISPATCH_GET_DESKTOP_SOURCES,
+    CALLS_LINK_CLICK,
 } from 'common/communication';
 
 window.addEventListener('message', ({origin, data = {}} = {}) => {
@@ -47,6 +48,7 @@ window.addEventListener('message', ({origin, data = {}} = {}) => {
     }
     case DESKTOP_SOURCES_MODAL_REQUEST:
     case CALLS_WIDGET_CHANNEL_LINK_CLICK:
+    case CALLS_LINK_CLICK:
     case CALLS_WIDGET_RESIZE:
     case CALLS_JOINED_CALL:
     case CALLS_POPOUT_FOCUS:

--- a/src/main/windows/callsWidgetWindow.test.js
+++ b/src/main/windows/callsWidgetWindow.test.js
@@ -15,6 +15,9 @@ import WebContentsEventManager from '../views/webContentEvents';
 import CallsWidgetWindow from './callsWidgetWindow';
 
 jest.mock('electron', () => ({
+    app: {
+        getAppPath: () => '/path/to/app',
+    },
     BrowserWindow: jest.fn(),
     ipcMain: {
         on: jest.fn(),

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 import url from 'url';
-
 import {EventEmitter} from 'events';
 import {BrowserWindow, Rectangle, ipcMain, IpcMainEvent} from 'electron';
 import log from 'electron-log';
@@ -31,6 +30,8 @@ import {
     CALLS_WIDGET_RESIZE,
     CALLS_WIDGET_SHARE_SCREEN,
 } from 'common/communication';
+import webContentsEventManager from 'main/views/webContentEvents';
+import Config from 'common/config';
 
 type LoadURLOpts = {
     extraHeaders: string;
@@ -200,6 +201,11 @@ export default class CallsWidgetWindow extends EventEmitter {
 
     private onPopOutCreate = (win: BrowserWindow) => {
         this.popOut = win;
+
+        // Let the webContentsEventManager handle links that try to open a new window
+        const spellcheck = Config.useSpellChecker;
+        const newWindow = webContentsEventManager.generateNewWindowListener(this.popOut.webContents.id, spellcheck);
+        this.popOut.webContents.setWindowOpenHandler(newWindow);
     }
 
     private onPopOutFocus = () => {

--- a/src/main/windows/windowManager.test.js
+++ b/src/main/windows/windowManager.test.js
@@ -80,6 +80,7 @@ jest.mock('../downloadsManager', () => ({
 }));
 
 jest.mock('./callsWidgetWindow');
+jest.mock('main/views/webContentEvents', () => ({}));
 
 describe('main/windows/windowManager', () => {
     describe('handleUpdateConfig', () => {
@@ -1263,6 +1264,29 @@ describe('main/windows/windowManager', () => {
             windowManager.callsWidgetWindow = new CallsWidgetWindow();
             windowManager.handleCallsWidgetChannelLinkClick();
             expect(windowManager.switchServer).toHaveBeenCalledWith('server-2');
+        });
+    });
+
+    describe('handleCallsLinkClick', () => {
+        const windowManager = new WindowManager();
+        const view1 = {
+            view: {
+                webContents: {
+                    send: jest.fn(),
+                },
+            },
+        };
+        windowManager.viewManager = {
+            views: new Map([
+                ['server-1_tab-messaging', view1],
+            ]),
+            getCurrentView: jest.fn(),
+        };
+
+        it('should pass through the click link to browser history push', () => {
+            windowManager.viewManager.getCurrentView.mockReturnValue(view1);
+            windowManager.handleCallsLinkClick(null, {link: '/other/subpath'});
+            expect(view1.view.webContents.send).toBeCalledWith('browser-history-push', '/other/subpath');
         });
     });
 

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -7,9 +7,7 @@ import path from 'path';
 import {app, BrowserWindow, nativeImage, systemPreferences, ipcMain, IpcMainEvent, IpcMainInvokeEvent, desktopCapturer} from 'electron';
 import log from 'electron-log';
 
-import {
-    CallsJoinCallMessage,
-} from 'types/calls';
+import {CallsJoinCallMessage, CallsLinkClickMessage} from 'types/calls';
 
 import {
     MAXIMIZE_CHANGE,
@@ -35,6 +33,7 @@ import {
     DESKTOP_SOURCES_MODAL_REQUEST,
     CALLS_WIDGET_CHANNEL_LINK_CLICK,
     CALLS_ERROR,
+    CALLS_LINK_CLICK,
 } from 'common/communication';
 import urlUtils from 'common/utils/url';
 import {SECOND} from 'common/utils/constants';
@@ -95,6 +94,7 @@ export class WindowManager {
         ipcMain.on(CALLS_LEAVE_CALL, () => this.callsWidgetWindow?.close());
         ipcMain.on(DESKTOP_SOURCES_MODAL_REQUEST, this.handleDesktopSourcesModalRequest);
         ipcMain.on(CALLS_WIDGET_CHANNEL_LINK_CLICK, this.handleCallsWidgetChannelLinkClick);
+        ipcMain.on(CALLS_LINK_CLICK, this.handleCallsLinkClick);
     }
 
     handleUpdateConfig = () => {
@@ -148,6 +148,13 @@ export class WindowManager {
             const currentView = this.viewManager?.getCurrentView();
             currentView?.view.webContents.send(BROWSER_HISTORY_PUSH, this.callsWidgetWindow.getChannelURL());
         }
+    }
+
+    handleCallsLinkClick = (_: IpcMainEvent, msg: CallsLinkClickMessage) => {
+        log.debug('WindowManager.handleCallsLinkClick with linkURL', msg.link);
+        this.mainWindow?.focus();
+        const currentView = this.viewManager?.getCurrentView();
+        currentView?.view.webContents.send(BROWSER_HISTORY_PUSH, msg.link);
     }
 
     showSettingsWindow = () => {

--- a/src/types/calls.ts
+++ b/src/types/calls.ts
@@ -28,3 +28,7 @@ export type CallsWidgetShareScreenMessage = {
 export type CallsJoinedCallMessage = {
     callID: string;
 }
+
+export type CallsLinkClickMessage = {
+    link: string | URL;
+}


### PR DESCRIPTION
#### Summary
- This allows the Calls popout to:
  - Send internal links to the Desktop to be processed as any other link would
  - Capture link clicks that would open a separate window, and process them as those clicks would normally be processed.
- More detail as to what that looked like here: https://github.com/mattermost/mattermost-plugin-calls/pull/340

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-49079

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [x] executed `npm run lint:js` for proper code formatting

#### Device Information
macOS 12.5 Monterey

#### Release Note

```release-note
Calls: Handle call thread links correctly
```
