### PR TITLE
[MM-50527] Explicitly allow the Mattermost views access to write to the clipboard using Copy Link

### DIFF
--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -407,7 +407,7 @@ function initializeAfterAppReady() {
                 callback(true);
                 return;
             }
-            if (callsWidgetWindow.popOut && webContents.id === callsWidgetWindow.win.webContents.id) {
+            if (callsWidgetWindow.popOut && webContents.id === callsWidgetWindow.popOut.webContents.id) {
                 callback(true);
                 return;
             }

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -380,12 +380,15 @@ function initializeAfterAppReady() {
         'notifications',
         'fullscreen',
         'openExternal',
+        'clipboard-sanitized-write',
     ];
 
     // handle permission requests
     // - approve if a supported permission type and the request comes from the renderer or one of the defined servers
     defaultSession.setPermissionRequestHandler((webContents, permission, callback) => {
-    // is the requested permission type supported?
+        log.debug('permission requested', webContents.id, permission);
+
+        // is the requested permission type supported?
         if (!supportedPermissionTypes.includes(permission)) {
             callback(false);
             return;

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -386,7 +386,7 @@ function initializeAfterAppReady() {
     // handle permission requests
     // - approve if a supported permission type and the request comes from the renderer or one of the defined servers
     defaultSession.setPermissionRequestHandler((webContents, permission, callback) => {
-        log.debug('permission requested', webContents.id, permission);
+        log.debug('permission requested', webContents.getURL(), permission);
 
         // is the requested permission type supported?
         if (!supportedPermissionTypes.includes(permission)) {
@@ -397,6 +397,12 @@ function initializeAfterAppReady() {
         // is the request coming from the renderer?
         const mainWindow = WindowManager.getMainWindow();
         if (mainWindow && webContents.id === mainWindow.webContents.id) {
+            callback(true);
+            return;
+        }
+
+        const callsWidgetWindow = WindowManager.callsWidgetWindow;
+        if (callsWidgetWindow && webContents.id === callsWidgetWindow.win.webContents.id) {
             callback(true);
             return;
         }

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -402,9 +402,15 @@ function initializeAfterAppReady() {
         }
 
         const callsWidgetWindow = WindowManager.callsWidgetWindow;
-        if (callsWidgetWindow && webContents.id === callsWidgetWindow.win.webContents.id) {
-            callback(true);
-            return;
+        if (callsWidgetWindow) {
+            if (webContents.id === callsWidgetWindow.win.webContents.id) {
+                callback(true);
+                return;
+            }
+            if (callsWidgetWindow.popOut && webContents.id === callsWidgetWindow.win.webContents.id) {
+                callback(true);
+                return;
+            }
         }
 
         const requestingURL = webContents.getURL();

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -40,7 +40,7 @@ type LoadURLOpts = {
 export default class CallsWidgetWindow extends EventEmitter {
     public win: BrowserWindow;
     private main: BrowserWindow;
-    private popOut: BrowserWindow | null = null;
+    public popOut: BrowserWindow | null = null;
     private mainView: MattermostView;
     private config: CallsWidgetWindowConfig;
     private boundsErr: Rectangle = {


### PR DESCRIPTION
#### Summary
When upgrading to Electron v23, it seems that a new permission was added to check if we were allowed to write to the clipboard using the Clipboard API. I think the permission has existed for a while (since it didn't come up in the Breaking Changes) but it must have been recently enforced (or a bug was fixed)

This PR makes sure that we allowed that permission when coming from a trusted source. I've also added the calls widget window as a trusted source since it asks to play media sometimes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50527

```release-note
NONE
```
