### PR TITLE
[MM-50712] Fix local prototype pollution flaw

### DIFF
--- a/src/main/diagnostics/steps/internal/loggerHooks.test.js
+++ b/src/main/diagnostics/steps/internal/loggerHooks.test.js
@@ -4,7 +4,7 @@
 import {MASK_EMAIL, MASK_PATH} from 'common/constants';
 
 import {maskMessageDataHook} from './loggerHooks';
-import { obfuscateByType } from './obfuscators';
+import {obfuscateByType} from './obfuscators';
 
 const loggerMock = {
     transports: {

--- a/src/main/diagnostics/steps/internal/loggerHooks.test.js
+++ b/src/main/diagnostics/steps/internal/loggerHooks.test.js
@@ -4,6 +4,7 @@
 import {MASK_EMAIL, MASK_PATH} from 'common/constants';
 
 import {maskMessageDataHook} from './loggerHooks';
+import { obfuscateByType } from './obfuscators';
 
 const loggerMock = {
     transports: {
@@ -57,6 +58,13 @@ describe('main/diagnostics/loggerHooks', () => {
         };
         const result = maskMessageDataHook(loggerMock)(message, 'file').data[0];
         expect(URLs.some((url) => result.includes(url))).toBe(false);
+    });
+
+    it('should not allow local prototype pollution', () => {
+        const obj = JSON.parse('{"__proto__":["1","2","3","4"]}');
+        expect(obj instanceof Array).toBe(false);
+        const obf = obfuscateByType(obj);
+        expect(obf instanceof Array).toBe(false);
     });
 
     describe('should mask paths for all OSs', () => {

--- a/src/main/diagnostics/steps/internal/obfuscators.ts
+++ b/src/main/diagnostics/steps/internal/obfuscators.ts
@@ -60,7 +60,10 @@ function maskDataInArray(arr: unknown[]): unknown[] {
 
 function maskDataInObject(obj: Record<string, unknown>): Record<string, unknown> {
     return Object.keys(obj).reduce<Record<string, unknown>>((acc, key) => {
-        acc[key] = obfuscateByType(obj[key]);
+        // Avoid local prototype pollution
+        if (key !== '__proto__') {
+            acc[key] = obfuscateByType(obj[key]);
+        }
         return acc;
     }, {});
 }


### PR DESCRIPTION
#### Summary
We had a function that would allow an untrusted input to override the type of the object that was inputted via local prototype pollution. This PR explicitly disallows for an object with the key `__proto__` to be included in the obfuscated output.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50712

```release-note
NONE
```
