### PR TITLE
[MM-50973] Harden Calls windows URL navigation checks

### DIFF
--- a/src/common/utils/url.test.js
+++ b/src/common/utils/url.test.js
@@ -275,4 +275,58 @@ describe('common/utils/url', () => {
             )).toBe(false);
         });
     });
+
+    describe('isCallsPopOutURL', () => {
+        it('should match correct URL', () => {
+            expect(urlUtils.isCallsPopOutURL(
+                'http://example.org',
+                'http://example.org/team/com.mattermost.calls/expanded/callid',
+                'callid',
+            )).toBe(true);
+        });
+
+        it('should match with subpath', () => {
+            expect(urlUtils.isCallsPopOutURL(
+                'http://example.org/subpath',
+                'http://example.org/subpath/team/com.mattermost.calls/expanded/callid',
+                'callid',
+            )).toBe(true);
+        });
+
+        it('should match with teamname with dash', () => {
+            expect(urlUtils.isCallsPopOutURL(
+                'http://example.org',
+                'http://example.org/team-name/com.mattermost.calls/expanded/callid',
+                'callid',
+            )).toBe(true);
+        });
+
+        it('should not match with invalid team name', () => {
+            expect(urlUtils.isCallsPopOutURL(
+                'http://example.org',
+                'http://example.org/invalid$team/com.mattermost.calls/expanded/othercallid',
+                'callid',
+            )).toBe(false);
+        });
+
+        it('should not match with incorrect callid', () => {
+            expect(urlUtils.isCallsPopOutURL(
+                'http://example.org',
+                'http://example.org/team/com.mattermost.calls/expanded/othercallid',
+                'callid',
+            )).toBe(false);
+        });
+
+        it('should not match with incorrect origin', () => {
+            expect(urlUtils.isCallsPopOutURL(
+                'http://example.com',
+                'http://example.org/team/com.mattermost.calls/expanded/callid',
+                'callid',
+            )).toBe(false);
+        });
+
+        it('should not match with missing arguments', () => {
+            expect(urlUtils.isCallsPopOutURL()).toBe(false);
+        });
+    });
 });

--- a/src/common/utils/url.ts
+++ b/src/common/utils/url.ts
@@ -4,7 +4,7 @@
 import {isHttpsUri, isHttpUri, isUri} from 'valid-url';
 
 import buildConfig from 'common/config/buildConfig';
-import {customLoginRegexPaths, nonTeamUrlPaths} from 'common/utils/constants';
+import {customLoginRegexPaths, nonTeamUrlPaths, CALLS_PLUGIN_ID} from 'common/utils/constants';
 
 function isValidURL(testURL: string) {
     return Boolean(isHttpUri(testURL) || isHttpsUri(testURL)) && Boolean(parseURL(testURL));
@@ -184,6 +184,22 @@ function cleanPathName(basePathName: string, pathName: string) {
     return pathName;
 }
 
+function isCallsPopOutURL(serverURL: URL | string, inputURL: URL | string, callID: string) {
+    if (!serverURL || !inputURL || !callID) {
+        return false;
+    }
+
+    const parsedURL = parseURL(inputURL);
+    const server = getServerInfo(serverURL);
+    if (!parsedURL || !server || (!equalUrlsIgnoringSubpath(server.url, parsedURL))) {
+        return false;
+    }
+
+    const regexRule = `^${server.subpath}[A-Za-z0-9-_]+/${CALLS_PLUGIN_ID}/expanded/${callID}$`;
+
+    return new RegExp(regexRule, 'i').test(parsedURL.pathname);
+}
+
 export default {
     isValidURL,
     isValidURI,
@@ -201,4 +217,5 @@ export default {
     isUrlType,
     cleanPathName,
     startsWithProtocol,
+    isCallsPopOutURL,
 };

--- a/src/common/utils/url.ts
+++ b/src/common/utils/url.ts
@@ -98,12 +98,6 @@ function isAdminUrl(serverUrl: URL | string, inputURL: URL | string) {
 }
 
 function isTeamUrl(serverUrl: URL | string, inputURL: URL | string, withApi?: boolean) {
-    const parsedURL = parseURL(inputURL);
-    const server = getServerInfo(serverUrl);
-    if (!parsedURL || !server || (!equalUrlsIgnoringSubpath(server.url, parsedURL))) {
-        return false;
-    }
-
     const paths = [...getManagedResources(), ...nonTeamUrlPaths];
 
     if (withApi) {
@@ -191,7 +185,7 @@ function isCallsPopOutURL(serverURL: URL | string, inputURL: URL | string, callI
 
     const parsedURL = parseURL(inputURL);
     const server = getServerInfo(serverURL);
-    if (!parsedURL || !server || (!equalUrlsIgnoringSubpath(server.url, parsedURL))) {
+    if (!server || !parsedURL) {
         return false;
     }
 

--- a/src/common/utils/url.ts
+++ b/src/common/utils/url.ts
@@ -195,9 +195,15 @@ function isCallsPopOutURL(serverURL: URL | string, inputURL: URL | string, callI
         return false;
     }
 
-    const regexRule = `^${server.subpath}[A-Za-z0-9-_]+/${CALLS_PLUGIN_ID}/expanded/${callID}$`;
+    const matches = parsedURL.pathname.match(new RegExp(`^${server.subpath}([A-Za-z0-9-_]+)/`, 'i'));
+    if (matches?.length !== 2) {
+        return false;
+    }
 
-    return new RegExp(regexRule, 'i').test(parsedURL.pathname);
+    const teamName = matches[1];
+    const subPath = `${teamName}/${CALLS_PLUGIN_ID}/expanded/${callID}`;
+
+    return isUrlType(subPath, serverURL, inputURL);
 }
 
 export default {

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -284,7 +284,7 @@ export class ViewManager {
             log.error(`Couldn't find a view with the name ${viewName}`);
             return;
         }
-        WebContentsEventManager.addMattermostViewEventListeners(view, this.getServers);
+        WebContentsEventManager.addMattermostViewEventListeners(view);
     }
 
     finishLoading = (server: string) => {

--- a/src/main/views/webContentEvents.ts
+++ b/src/main/views/webContentEvents.ts
@@ -4,8 +4,6 @@
 import {BrowserWindow, session, shell, WebContents} from 'electron';
 import log from 'electron-log';
 
-import {TeamWithTabs} from 'types/config';
-
 import Config from 'common/config';
 import urlUtils from 'common/utils/url';
 
@@ -71,6 +69,11 @@ export class WebContentsEventManager {
             }
             if (this.customLogins[contentID]?.inProgress) {
                 flushCookiesStore(session.defaultSession);
+                return;
+            }
+
+            const callID = WindowManager.callsWidgetWindow?.getCallID();
+            if (serverURL && callID && urlUtils.isCallsPopOutURL(serverURL, parsedURL, callID)) {
                 return;
             }
 
@@ -221,10 +224,9 @@ export class WebContentsEventManager {
         }
     };
 
-    addMattermostViewEventListeners = (mmview: MattermostView, getServersFunction: () => TeamWithTabs[]) => {
+    addMattermostViewEventListeners = (mmview: MattermostView) => {
         this.addWebContentsEventListeners(
             mmview.view.webContents,
-            getServersFunction,
             (contents: WebContents) => {
                 contents.on('page-title-updated', mmview.handleTitleUpdate);
                 contents.on('page-favicon-updated', mmview.handleFaviconUpdate);
@@ -242,7 +244,6 @@ export class WebContentsEventManager {
 
     addWebContentsEventListeners = (
         contents: WebContents,
-        getServersFunction: () => TeamWithTabs[],
         addListeners?: (contents: WebContents) => void,
         removeListeners?: (contents: WebContents) => void,
     ) => {

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -221,14 +221,17 @@ export default class CallsWidgetWindow extends EventEmitter {
     }
 
     private onPopOutOpen = ({url}: {url: string}) => {
-        if (!urlUtils.isCallsPopOutURL(this.mainView.serverInfo.server.url, url, this.config.callID)) {
-            log.warn(`CallsWidgetWindow.onPopOutOpen: prevented window open to ${url}`);
-            return {action: 'deny' as const};
+        if (urlUtils.isCallsPopOutURL(this.mainView.serverInfo.server.url, url, this.config.callID)) {
+            return {
+                action: 'allow' as const,
+                overrideBrowserWindowOptions: {
+                    autoHideMenuBar: true,
+                },
+            }
         }
-
-        return {
-            action: 'allow' as const,
-            overrideBrowserWindowOptions: {
+        
+        log.warn(`CallsWidgetWindow.onPopOutOpen: prevented window open to ${url}`);
+        return {action: 'deny' as const};
                 autoHideMenuBar: true,
             },
         };

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -227,9 +227,9 @@ export default class CallsWidgetWindow extends EventEmitter {
                 overrideBrowserWindowOptions: {
                     autoHideMenuBar: true,
                 },
-            }
+            };
         }
-        
+
         log.warn(`CallsWidgetWindow.onPopOutOpen: prevented window open to ${url}`);
         return {action: 'deny' as const};
     }

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -232,9 +232,6 @@ export default class CallsWidgetWindow extends EventEmitter {
         
         log.warn(`CallsWidgetWindow.onPopOutOpen: prevented window open to ${url}`);
         return {action: 'deny' as const};
-                autoHideMenuBar: true,
-            },
-        };
     }
 
     private onPopOutCreate = (win: BrowserWindow) => {

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -947,7 +947,7 @@ export class WindowManager {
     }
 
     getServerURLFromWebContentsId = (id: number) => {
-        if (this.callsWidgetWindow && id === this.callsWidgetWindow.getWebContentsId()) {
+        if (this.callsWidgetWindow && (id === this.callsWidgetWindow.getWebContentsId() || id === this.callsWidgetWindow.getPopOutWebContentsId())) {
             return this.callsWidgetWindow.getURL();
         }
 


### PR DESCRIPTION
#### Summary

PR adds some stricter checks on what can be opened/navigated from calls widget and popout windows.

- widget window should only navigate to the widget url and open the popout url.
- popout window should only navigate/open to allowed sources (using `webContentsEventManager.addWebContentsEventListeners`).

@amyblais Similarly to the previous one it would be good to include this in 5.3 as well.

@cpoile Could you give this a pass to make sure I didn't break anything link clicking related?

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-50973
https://mattermost.atlassian.net/browse/MM-50974

#### Release Note

```release-note
NONE
```

