### PR TITLE
[MM-50537] Upgrade to Electron v23.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "copy-webpack-plugin": "10.2.4",
         "cross-env": "7.0.3",
         "css-loader": "6.7.1",
-        "electron": "23.0.0",
+        "electron": "23.1.2",
         "electron-builder": "23.3.3",
         "electron-connect": "0.6.3",
         "electron-context-menu": "3.5.0",
@@ -16299,9 +16299,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "23.0.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-23.0.0.tgz",
-      "integrity": "sha512-S6hVtTAjauMiiWP9sBVR5RpcUC464cNZ06I2EMUjeZBq+KooS6tLmNsfw0zLpAXDp1qosjlBP3v71NTZ3gd9iA==",
+      "version": "23.1.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-23.1.2.tgz",
+      "integrity": "sha512-ajE6xzIwH7swf8TlTU5WklDqpI3mPj4Am6690YrpCXzcp+E+dmMBXIajUUNt4joDrFhJC/lC6ZqDS2Q1BApKgQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -46742,9 +46742,9 @@
       }
     },
     "electron": {
-      "version": "23.0.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-23.0.0.tgz",
-      "integrity": "sha512-S6hVtTAjauMiiWP9sBVR5RpcUC464cNZ06I2EMUjeZBq+KooS6tLmNsfw0zLpAXDp1qosjlBP3v71NTZ3gd9iA==",
+      "version": "23.1.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-23.1.2.tgz",
+      "integrity": "sha512-ajE6xzIwH7swf8TlTU5WklDqpI3mPj4Am6690YrpCXzcp+E+dmMBXIajUUNt4joDrFhJC/lC6ZqDS2Q1BApKgQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/mattermost/desktop.git"
   },
   "config": {
-    "target": "23.0.0",
+    "target": "23.1.2",
     "arch": "x64",
     "target_arch": "x64",
     "disturl": "https://electronjs.org/headers",
@@ -168,7 +168,7 @@
     "copy-webpack-plugin": "10.2.4",
     "cross-env": "7.0.3",
     "css-loader": "6.7.1",
-    "electron": "23.0.0",
+    "electron": "23.1.2",
     "electron-builder": "23.3.3",
     "electron-connect": "0.6.3",
     "electron-context-menu": "3.5.0",


### PR DESCRIPTION
#### Summary
There was a bug in Electron v23 that was causing the calls widget not to be draggable on the MAS build. This PR upgrades to Electron v23.1.2 which includes a fix for this issue: https://github.com/electron/electron/pull/37466

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50537

```release-note
NONE
```
