### PR TITLE
[MM-50948] Prevent popup windows from redirecting to internal URLs outside of the plugin/managed resource URLs

### DIFF
--- a/src/main/views/webContentEvents.ts
+++ b/src/main/views/webContentEvents.ts
@@ -187,6 +187,17 @@ export class WebContentsEventManager {
                             spellcheck: (typeof spellcheck === 'undefined' ? true : spellcheck),
                         },
                     });
+                    this.popupWindow.webContents.on('will-redirect', (event, url) => {
+                        const parsedURL = urlUtils.parseURL(url);
+                        if (!parsedURL) {
+                            event.preventDefault();
+                            return;
+                        }
+
+                        if (urlUtils.isInternalURL(serverURL, parsedURL) && !urlUtils.isPluginUrl(serverURL, parsedURL) && !urlUtils.isManagedResource(serverURL, parsedURL)) {
+                            event.preventDefault();
+                        }
+                    });
                     this.popupWindow.webContents.setWindowOpenHandler(this.denyNewWindow);
                     this.popupWindow.once('ready-to-show', () => {
                         this.popupWindow!.show();


### PR DESCRIPTION
#### Summary
There was a case where a user could click on a link that was able to trick the application into navigating to an arbitrary URL by having it prefixed with the path: `/plugins/..%2F`. From there any internal URL would open in the popup window which has some looser restrictions around navigating to external URLs. This was caused because our URL checker would note that the URL was a plugin URL, but Chrome would not evaluate it as such.

This PR adds a listener on the `will-redirect` event to ensure that those URLs cannot be exploited by making sure that any redirects to internal URLs need to go to the matching plugin/managed resource that is allowed by the application.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50948

```release-note
Fixed an issue where a certain URL form would allow the popup window to navigate to any arbitrary URL
```
