### PR TITLE
Update release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -22,9 +22,9 @@ function tag {
 }
 
 function write_package_version {
-    temp_file="$(mktemp -t package.json)"
+    temp_file="$(mktemp -t package.json.XXXX)"
     jq ".version = \"${1}\"" ./package.json > "${temp_file}" && mv "${temp_file}" ./package.json
-    temp_file="$(mktemp -t package-lock.json)"
+    temp_file="$(mktemp -t package-lock.json.XXXX)"
     jq ".version = \"${1}\"" ./package-lock.json > "${temp_file}" && mv "${temp_file}" ./package-lock.json
 
     git add ./package.json ./package-lock.json
@@ -39,8 +39,8 @@ trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
 trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
 
 # mattermost repo might not be the origin one, we don't want to enforce that.
-org="github.com:mattermost"
-git_origin="$(git remote -v | grep ${org} | grep push | awk '{print $1}')"
+org="github.com:mattermost|https://github.com/mattermost"
+git_origin="$(git remote -v | grep -E ${org} | grep push | awk '{print $1}')"
 if [[ -z "${git_origin}" ]]; then
     print_warning "Can't find a mattermost remote, defaulting to origin"
     git_origin="origin"


### PR DESCRIPTION
#### Summary
There was a couple things annoying me about our release script:
- `mktemp` would fail on MinGW (which I use) with the error: `mktemp: too few X's in template ‘package.json’`. Apparently `mktemp` needs Xs to generate dummy files on some distributions so I've added those.
- The check for which remote to push to always failed for me because I use HTTPS to push/pull from GitHub, which the script wasn't checking for. Added that too.

```release-note
NONE
```
