### PR TITLE
[MM-51222] Fix race condition on switching calls

### DIFF
--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -89,9 +89,16 @@ export default class CallsWidgetWindow extends EventEmitter {
         this.load();
     }
 
-    public close() {
+    public async close() {
         log.debug('CallsWidgetWindow.close');
-        this.win.close();
+        return new Promise<void>((resolve) => {
+            if (this.win.isDestroyed()) {
+                resolve();
+                return;
+            }
+            this.once('closed', resolve);
+            this.win.close();
+        });
     }
 
     public getServerName() {

--- a/src/main/windows/windowManager.test.js
+++ b/src/main/windows/windowManager.test.js
@@ -1032,6 +1032,23 @@ describe('main/windows/windowManager', () => {
                 },
             },
         };
+
+        beforeEach(() => {
+            CallsWidgetWindow.mockImplementation(() => {
+                return {
+                    win: {
+                        isDestroyed: jest.fn(() => true),
+                    },
+                    on: jest.fn(),
+                    close: jest.fn(),
+                };
+            });
+        });
+
+        afterEach(() => {
+            jest.resetAllMocks();
+        });
+
         const windowManager = new WindowManager();
         windowManager.viewManager = {
             views: new Map([
@@ -1039,25 +1056,25 @@ describe('main/windows/windowManager', () => {
             ]),
         };
 
-        it('should create calls widget window', () => {
+        it('should create calls widget window', async () => {
             expect(windowManager.callsWidgetWindow).toBeUndefined();
-            windowManager.createCallsWidgetWindow('server-1_tab-messaging', {callID: 'test'});
+            await windowManager.createCallsWidgetWindow('server-1_tab-messaging', {callID: 'test'});
             expect(windowManager.callsWidgetWindow).toBeDefined();
         });
 
-        it('should not create a new window if call is the same', () => {
+        it('should not create a new window if call is the same', async () => {
             const widgetWindow = windowManager.callsWidgetWindow;
             expect(widgetWindow).toBeDefined();
             widgetWindow.getCallID = jest.fn(() => 'test');
-            windowManager.createCallsWidgetWindow('server-1_tab-messaging', {callID: 'test'});
+            await windowManager.createCallsWidgetWindow('server-1_tab-messaging', {callID: 'test'});
             expect(windowManager.callsWidgetWindow).toEqual(widgetWindow);
         });
 
-        it('should create a new window if switching calls', () => {
+        it('should create a new window if switching calls', async () => {
             const widgetWindow = windowManager.callsWidgetWindow;
             expect(widgetWindow).toBeDefined();
             widgetWindow.getCallID = jest.fn(() => 'test');
-            windowManager.createCallsWidgetWindow('server-1_tab-messaging', {callID: 'test2'});
+            await windowManager.createCallsWidgetWindow('server-1_tab-messaging', {callID: 'test2'});
             expect(windowManager.callsWidgetWindow).not.toEqual(widgetWindow);
         });
     });

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -127,14 +127,17 @@ export class WindowManager {
         };
     }
 
-    createCallsWidgetWindow = (viewName: string, msg: CallsJoinCallMessage) => {
+    createCallsWidgetWindow = async (viewName: string, msg: CallsJoinCallMessage) => {
         log.debug('WindowManager.createCallsWidgetWindow');
         if (this.callsWidgetWindow) {
             // trying to join again the call we are already in should not be allowed.
             if (this.callsWidgetWindow.getCallID() === msg.callID) {
                 return;
             }
-            this.callsWidgetWindow.close();
+
+            // to switch from one call to another we need to wait for the existing
+            // window to be fully closed.
+            await this.callsWidgetWindow.close();
         }
         const currentView = this.viewManager?.views.get(viewName);
         if (!currentView) {


### PR DESCRIPTION
#### Summary

PR fixes a race condition when switching from one call to another (or starting a new call when already in one). Having two Calls clients active at the same time even for just a few moments led to a permission error when accessing the microphone. I am not exactly sure why Electron would prevent that but it's a not a strong issue at the moment since we don't want to allow a user to be in more than one call at the same time. 

The fix here is to wait until the widget window is properly closed and only then proceed with creating a new one.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51222

#### Release Note

```release-note
Fixed a race condition leading to a permissions error when switching calls.
```

