### PR TITLE
Allow MAS build to be repeated more easily

### DIFF
--- a/scripts/patch_mas_version.sh
+++ b/scripts/patch_mas_version.sh
@@ -9,8 +9,8 @@ if [ "$BUILD_VERSION" == "" ]; then
     BUILD_VERSION=$STABLE_VERSION
 fi
 
-if [ "$CIRCLE_BUILD_NUM" != "" ]; then
-    BUILD_VERSION=$CIRCLE_BUILD_NUM
+if [ "$GITHUB_RUN_ID" != "" ]; then
+    BUILD_VERSION="${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}"
 fi
 
 temp_file="$(mktemp -t electron-builder.json)"


### PR DESCRIPTION
#### Summary
The old patcher was based on CircleCI and wasn't grabbing a unique ID for GitHub Actions. This PR should make sure it always has a unique id.

```release-note
NONE
```
