### PR TITLE
Add MM_WIN_INSTALLERS for nightly builds

### DIFF
--- a/.github/workflows/nightly-browser-view.yml
+++ b/.github/workflows/nightly-browser-view.yml
@@ -11,6 +11,7 @@ defaults:
 
 env:
   TERM: xterm
+  MM_WIN_INSTALLERS: 1
 
 jobs:
   build-linux:

--- a/.github/workflows/nightly-rainforest.yml
+++ b/.github/workflows/nightly-rainforest.yml
@@ -13,6 +13,7 @@ env:
   TERM: xterm
   MM_DESKTOP_BUILD_DISABLEGPU: true
   MM_DESKTOP_BUILD_SKIPONBOARDINGSCREENS: true
+  MM_WIN_INSTALLERS: 1
 
 jobs:
   build-msi-installer:


### PR DESCRIPTION
#### Summary
We missed an environment variable for making sure we build and push the Windows installers as well.

```release-note
NONE
```
