### PR TITLE
Adding extra dependencies to the release flow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,7 +85,13 @@ jobs:
         run: ./scripts/Makefile.ps1 optimize
       - name: release/install-deps
         shell: powershell
-        run: ./scripts/Makefile.ps1 install-deps
+        run: |
+          ./scripts/Makefile.ps1 install-deps
+          choco install yq --version 4.15.1 -y
+          npm i -g node-gyp
+          node-gyp install
+          node-gyp install --devdir="C:\Users\runneradmin\.electron-gyp" --target=$(jq -r .devDependencies.electron package.json) --dist-url="https://electronjs.org/headers"
+          npm ci --openssl_fips=''
       - name: release/test
         uses: ./.github/actions/test
       - name: release/build


### PR DESCRIPTION
#### Summary
The release workflow was missing the extra dependencies we didn't add the first time for the Windows install, this PR adds those.

```release-note
NONE
```
