### PR TITLE
Disable creation of blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
#### Summary
Some users have erroneously been creating issues in the Desktop App repository that should belong to webapp, or might be a feature request. We have issue templates that handle pointing users towards the places they need to go to do that, but some choose to use a blank issue which doesn't allow us to control how issues are created.

This PR will disable blank issue creation in the Desktop App repo, as users should be using one of the created templates.

```release-note
NONE
```
