### PR TITLE
fix: use XDG_DOWNLOAD_DIR as default download dir

### DIFF
--- a/src/common/config/defaultPreferences.ts
+++ b/src/common/config/defaultPreferences.ts
@@ -19,6 +19,11 @@ export const getDefaultDownloadLocation = (): string | undefined => {
     if (__IS_MAC_APP_STORE__) {
         return undefined;
     }
+
+    if (process.platform === 'linux' && process.env.XDG_DOWNLOAD_DIR) {
+        return process.env.XDG_DOWNLOAD_DIR;
+    }
+
     return path.join(os.homedir(), 'Downloads');
 };
 


### PR DESCRIPTION
On Linux machines that are using a desktop env which conforms to the FreeDesktop spec, users should have the XDG_DOWNLOAD_DIR variable set to specify their default download directory.

This patch ensures that this directory is used if the variable is present.

Hoping this will fix the following issue in the Mattermost snap: https://github.com/snapcrafters/mattermost-desktop/issues/65

It's not super clear to me where best to add a test for this, but I'm happy to do so if someone can give a quick pointer on where might be most appropriate.

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [x] executed `npm run lint:js` for proper code formatting

#### Device Information
This PR was tested on: my desktop machine, Linux/ubuntu

#### Release Note

```release-note
Ensure that default download location respects `XDG_DOWNLOAD_DIR` where it is set.
```

