### PR TITLE
[MM-51406] Check for other server URLs when trying to navigate

### DIFF
--- a/src/main/views/webContentEvents.ts
+++ b/src/main/views/webContentEvents.ts
@@ -241,6 +241,12 @@ export class WebContentsEventManager {
                 return {action: 'deny'};
             }
 
+            const otherServerURL = WindowManager.viewManager?.getViewByURL(parsedURL);
+            if (otherServerURL && urlUtils.isTeamUrl(otherServerURL.server.url, parsedURL, true)) {
+                WindowManager.showMainWindow(parsedURL);
+                return {action: 'deny'};
+            }
+
             // If all else fails, just open externally
             shell.openExternal(details.url);
             return {action: 'deny'};


### PR DESCRIPTION
#### Summary
When I removed the use of `getView()` from the `webContentsEvents` module I neglected to check for the case where other servers would need to be switched to via permalinks.

This PR restores the use of the `getViewByUrl()` function as a last check before we try to open a URL in a browser window. This should still mean minimal performance hits since it won't need to be called very often.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51406

```release-note
NONE
```
