### PR TITLE
[MM-51406] Update node-abi, fix some server modal bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "mocha-circleci-reporter": "0.0.3",
         "mochawesome": "7.1.3",
         "nan": "2.17.0",
-        "node-abi": "3.26.0",
+        "node-abi": "3.33.0",
         "node-jq": "2.3.4",
         "node-loader": "2.0.0",
         "npm-run-all": "4.1.5",
@@ -25609,9 +25609,9 @@
       "dev": true
     },
     "node_modules/node-abi": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.26.0.tgz",
-      "integrity": "sha512-jRVtMFTChbi2i/jqo/i2iP9634KMe+7K1v35mIdj3Mn59i5q27ZYhn+sW6npISM/PQg7HrP2kwtRBMmh5Uvzdg==",
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.33.0.tgz",
+      "integrity": "sha512-7GGVawqyHF4pfd0YFybhv/eM9JwTtPqx0mAanQ146O3FlSh3pA24zf9IRQTOsfTSqXTNzPSP5iagAJ94jjuVog==",
       "dev": true,
       "dependencies": {
         "semver": "^7.3.5"
@@ -53136,9 +53136,9 @@
       }
     },
     "node-abi": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.26.0.tgz",
-      "integrity": "sha512-jRVtMFTChbi2i/jqo/i2iP9634KMe+7K1v35mIdj3Mn59i5q27ZYhn+sW6npISM/PQg7HrP2kwtRBMmh5Uvzdg==",
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.33.0.tgz",
+      "integrity": "sha512-7GGVawqyHF4pfd0YFybhv/eM9JwTtPqx0mAanQ146O3FlSh3pA24zf9IRQTOsfTSqXTNzPSP5iagAJ94jjuVog==",
       "dev": true,
       "requires": {
         "semver": "^7.3.5"

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "mocha-circleci-reporter": "0.0.3",
     "mochawesome": "7.1.3",
     "nan": "2.17.0",
-    "node-abi": "3.26.0",
+    "node-abi": "3.33.0",
     "node-jq": "2.3.4",
     "node-loader": "2.0.0",
     "npm-run-all": "4.1.5",

--- a/src/renderer/components/ConfigureServer.tsx
+++ b/src/renderer/components/ConfigureServer.tsx
@@ -76,16 +76,16 @@ function ConfigureServer({
         if (urlUtils.startsWithProtocol(checkURL)) {
             return Promise.resolve(checkURL);
         }
-        return window.desktop.modals.pingDomain(checkURL).then((result: string | Error) => {
-            let newURL = checkURL;
-            if (result instanceof Error) {
-                console.error(`Could not ping url: ${checkURL}`);
-            } else {
-                newURL = `${result}://${checkURL}`;
+        return window.desktop.modals.pingDomain(checkURL).
+            then((result: string) => {
+                const newURL = `${result}://${checkURL}`;
                 setUrl(newURL);
-            }
-            return newURL;
-        });
+                return newURL;
+            }).
+            catch(() => {
+                console.error(`Could not ping url: ${checkURL}`);
+                return checkURL;
+            });
     };
 
     const validateName = () => {

--- a/src/renderer/components/NewTeamModal.tsx
+++ b/src/renderer/components/NewTeamModal.tsx
@@ -156,13 +156,13 @@ class NewTeamModal extends React.PureComponent<Props, State> {
             return Promise.resolve(undefined);
         }
 
-        return window.desktop.modals.pingDomain(teamUrl).then((result: string | Error) => {
-            if (result instanceof Error) {
-                console.error(`Could not ping url: ${teamUrl}`);
-            } else {
+        return window.desktop.modals.pingDomain(teamUrl).
+            then((result: string) => {
                 this.setState({teamUrl: `${result}://${this.state.teamUrl}`});
-            }
-        });
+            }).
+            catch(() => {
+                console.error(`Could not ping url: ${teamUrl}`);
+            });
     }
 
     getError() {


### PR DESCRIPTION
#### Summary
When I upgraded Electron, I missed checking the E2E tests (and my automated job had apparently stalled out and not updated) so they weren't running on the latest code. In order to run, we needed to update to the latest `node-abi` so that we could build modules on the latest Electron.

Once the tests were run, some modal bugs were uncovered, caused by the migration away from `window.postMessage`. Some error handling was not properly coded in, so I've fixed that too. All tests should be passing now :)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51406

```release-note
NONE
```
