### PR TITLE
Fix the issue where we sometimes need to wait for GPO teams properly

### DIFF
--- a/src/common/config/index.ts
+++ b/src/common/config/index.ts
@@ -106,9 +106,17 @@ export class Config extends EventEmitter {
         if (process.platform === 'darwin' || process.platform === 'win32') {
             nativeTheme.on('updated', this.handleUpdateTheme);
         }
-        this.registryConfig = new RegistryConfig();
-        this.registryConfig.once(REGISTRY_READ_EVENT, this.loadRegistry);
-        this.registryConfig.init();
+    }
+
+    initRegistry = () => {
+        return new Promise<void>((resolve) => {
+            this.registryConfig = new RegistryConfig();
+            this.registryConfig.once(REGISTRY_READ_EVENT, (data) => {
+                this.loadRegistry(data);
+                resolve();
+            });
+            this.registryConfig.init();
+        });
     }
 
     /**

--- a/src/main/app/config.ts
+++ b/src/main/app/config.ts
@@ -17,8 +17,6 @@ import WindowManager from 'main/windows/windowManager';
 import {handleMainWindowIsShown} from './intercom';
 import {handleUpdateMenuEvent, setLoggingLevel, updateServerInfos, updateSpellCheckerLocales} from './utils';
 
-let didCheckForAddServerModal = false;
-
 //
 // config event handlers
 //
@@ -63,12 +61,9 @@ export function handleConfigUpdate(newConfig: CombinedConfig) {
         });
     }
 
-    if (process.platform === 'win32' && !didCheckForAddServerModal && typeof Config.registryConfigData !== 'undefined') {
-        didCheckForAddServerModal = true;
-        updateServerInfos(newConfig.teams);
-        WindowManager.initializeCurrentServerName();
-        handleMainWindowIsShown();
-    }
+    updateServerInfos(newConfig.teams);
+    WindowManager.initializeCurrentServerName();
+    handleMainWindowIsShown();
 
     handleUpdateMenuEvent();
     if (newConfig.trayIconTheme) {

--- a/src/main/app/initialize.test.js
+++ b/src/main/app/initialize.test.js
@@ -97,6 +97,7 @@ jest.mock('common/config', () => ({
     once: jest.fn(),
     on: jest.fn(),
     init: jest.fn(),
+    initRegistry: jest.fn(),
 }));
 
 jest.mock('common/utils/url', () => ({

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -117,6 +117,7 @@ export async function initialize() {
     // wait for registry config data to load and app ready event
     await Promise.all([
         app.whenReady(),
+        Config.initRegistry(),
     ]);
 
     // no need to continue initializing if app is quitting
@@ -425,10 +426,7 @@ function initializeAfterAppReady() {
         callback(urlUtils.isTrustedURL(requestingURL, serverURL));
     });
 
-    // only check for non-Windows, as with Windows we have to wait for GPO teams
-    if (process.platform !== 'win32' || typeof Config.registryConfigData !== 'undefined') {
-        handleMainWindowIsShown();
-    }
+    handleMainWindowIsShown();
 }
 
 function handleStartDownload() {

--- a/src/main/app/intercom.ts
+++ b/src/main/app/intercom.ts
@@ -4,11 +4,10 @@
 import {app, dialog, IpcMainEvent, IpcMainInvokeEvent, Menu} from 'electron';
 import log from 'electron-log';
 
-import {Team, TeamWithIndex, RegistryConfig as RegistryConfigType} from 'types/config';
+import {Team, TeamWithIndex} from 'types/config';
 import {MentionData} from 'types/notification';
 
 import Config from 'common/config';
-import {REGISTRY_READ_EVENT} from 'common/config/RegistryConfig';
 import {getDefaultTeamWithTabsFromTeam} from 'common/tabs/TabView';
 import {ping} from 'common/utils/requests';
 
@@ -89,36 +88,24 @@ export function handleOpenTab(event: IpcMainEvent, serverName: string, tabName: 
 export function handleShowOnboardingScreens(showWelcomeScreen: boolean, showNewServerModal: boolean, mainWindowIsVisible: boolean) {
     log.debug('Intercom.handleShowOnboardingScreens', {showWelcomeScreen, showNewServerModal, mainWindowIsVisible});
 
-    const showWelcomeScreenFunc = () => {
-        if (showWelcomeScreen) {
-            handleWelcomeScreenModal();
+    if (showWelcomeScreen) {
+        handleWelcomeScreenModal();
 
-            if (process.env.NODE_ENV === 'test') {
-                const welcomeScreen = ModalManager.modalQueue.find((modal) => modal.key === 'welcomeScreen');
-                if (welcomeScreen?.view.webContents.isLoading()) {
-                    welcomeScreen?.view.webContents.once('did-finish-load', () => {
-                        app.emit('e2e-app-loaded');
-                    });
-                } else {
+        if (process.env.NODE_ENV === 'test') {
+            const welcomeScreen = ModalManager.modalQueue.find((modal) => modal.key === 'welcomeScreen');
+            if (welcomeScreen?.view.webContents.isLoading()) {
+                welcomeScreen?.view.webContents.once('did-finish-load', () => {
                     app.emit('e2e-app-loaded');
-                }
+                });
+            } else {
+                app.emit('e2e-app-loaded');
             }
-
-            return;
         }
-        if (showNewServerModal) {
-            handleNewServerModal();
-        }
-    };
 
-    if (process.platform === 'win32' && !Config.registryConfigData) {
-        Config.registryConfig.once(REGISTRY_READ_EVENT, (data: Partial<RegistryConfigType>) => {
-            if (data.teams?.length === 0) {
-                showWelcomeScreenFunc();
-            }
-        });
-    } else {
-        showWelcomeScreenFunc();
+        return;
+    }
+    if (showNewServerModal) {
+        handleNewServerModal();
     }
 }
 


### PR DESCRIPTION
#### Summary
A while back, there was an issue in which the new server modal or the Welcome modal would show up when the user had GPO teams configured. At the time, it was fixed by checking for the teams to be added later on and not popping the modal until then. What was neglected was that we could just await the call before the rest of the app even loaded, which seems to be the right call and was removed at some point during v4.7.

This PR goes back to doing it the correct way and should be cleaner in general.

```release-note
Fix the issue where we sometimes need to wait for GPO teams properly.
```

