### PR TITLE
Add MAS approval step to the release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -104,6 +104,32 @@ case "${1}" in
 
         fi
     ;;
+    "pre-final")
+        if [[ "${branch_name}" =~ "release-" ]]; then
+            print_info "Releasing v${current_version} for MAS approval"
+            new_pkg_version="${current_version}"
+            write_package_version "${new_pkg_version}"
+            if [[ "${new_pkg_version}" =~ "-mas." ]]; then
+                mas="${new_pkg_version#*-mas.}"
+            else
+                mas=0
+            fi
+            case "${mas}" in
+                ''|*[!0-9]*)
+                    mas=0
+                ;;
+                *)
+                    mas=$(( mas + 1 ))
+                ;;
+            esac
+            tag "${new_pkg_version}-mas.${mas}" "MAS approval ${mas}"
+            print_info "Locally created an MAS approval version. In order to build you'll have to:"
+            print_info "$ git push --follow-tags ${git_origin} ${branch_name}:${branch_name}"
+        else
+            print_error "Can't release on a non release-X.Y branch"
+            exit 2
+        fi
+    ;;
     "final")
         if [[ "${branch_name}" =~ "release-" ]]; then
             print_info "Releasing v${current_version}"


### PR DESCRIPTION
#### Summary
I'm adding an extra step to the release script in which we will generate a "final" release that goes to MAS for approval. If approved, it already has the version number without the `rc` or `develop` post-fix and can be directly releases to MAS. If not, it is tagged as `vx.x.x-mas.x` instead of `vx.x.x` and we can submit fixes and generate new tags until it is approved. Once approved, we can tag it appropriately.

```release-note
NONE
```
