### PR TITLE
[MM-51527] Escape regexp input in isCallsPopOutURL

### DIFF
--- a/src/common/utils/url.test.js
+++ b/src/common/utils/url.test.js
@@ -329,4 +329,18 @@ describe('common/utils/url', () => {
             expect(urlUtils.isCallsPopOutURL()).toBe(false);
         });
     });
+
+    describe('escapeRegExp', () => {
+        it('simple', () => {
+            expect(urlUtils.escapeRegExp('simple')).toBe('simple');
+        });
+
+        it('path', () => {
+            expect(urlUtils.escapeRegExp('/path/')).toBe('/path/');
+        });
+
+        it('regexp', () => {
+            expect(urlUtils.escapeRegExp('/path(a+)+')).toBe('/path\\(a\\+\\)\\+');
+        });
+    });
 });

--- a/src/common/utils/url.ts
+++ b/src/common/utils/url.ts
@@ -184,6 +184,12 @@ function cleanPathName(basePathName: string, pathName: string) {
     return pathName;
 }
 
+// RegExp string escaping function, as recommended by
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
+function escapeRegExp(s: string) {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}
+
 function isCallsPopOutURL(serverURL: URL | string, inputURL: URL | string, callID: string) {
     if (!serverURL || !inputURL || !callID) {
         return false;
@@ -195,7 +201,7 @@ function isCallsPopOutURL(serverURL: URL | string, inputURL: URL | string, callI
         return false;
     }
 
-    const matches = parsedURL.pathname.match(new RegExp(`^${server.subpath}([A-Za-z0-9-_]+)/`, 'i'));
+    const matches = parsedURL.pathname.match(new RegExp(`^${escapeRegExp(server.subpath)}([A-Za-z0-9-_]+)/`, 'i'));
     if (matches?.length !== 2) {
         return false;
     }
@@ -224,4 +230,5 @@ export default {
     cleanPathName,
     startsWithProtocol,
     isCallsPopOutURL,
+    escapeRegExp,
 };


### PR DESCRIPTION
#### Summary

Looks like regular expressions  in a URL are considered valid so the parsing would not complain and we could potentially execute something undesired. Adding a regexp escaping function, as recommended in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping should fix this.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51527

#### Release Notes

```release-note
NONE
```

