### PR TITLE
[MM-51532] Allow starting a call from existing thread

### DIFF
--- a/src/main/windows/callsWidgetWindow.test.js
+++ b/src/main/windows/callsWidgetWindow.test.js
@@ -384,6 +384,16 @@ describe('main/windows/callsWidgetWindow', () => {
             expect(widgetWindow.getWidgetURL()).toBe(expected);
         });
 
+        it('getWidgetURL - with rootID', () => {
+            const config = {
+                ...widgetConfig,
+                rootID: 'call_thread_id',
+            };
+            const widgetWindow = new CallsWidgetWindow(mainWindow, mainView, config);
+            const expected = `${mainView.serverInfo.server.url}plugins/${CALLS_PLUGIN_ID}/standalone/widget.html?call_id=${config.callID}&root_id=call_thread_id`;
+            expect(widgetWindow.getWidgetURL()).toBe(expected);
+        });
+
         it('onShareScreen', () => {
             baseWindow.webContents = {
                 ...baseWindow.webContents,

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -146,6 +146,9 @@ export default class CallsWidgetWindow extends EventEmitter {
         if (this.config.title) {
             u.searchParams.append('title', this.config.title);
         }
+        if (this.config.rootID) {
+            u.searchParams.append('root_id', this.config.rootID);
+        }
 
         return u.toString();
     }

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -148,6 +148,7 @@ export class WindowManager {
         this.callsWidgetWindow = new CallsWidgetWindow(this.mainWindow!, currentView, {
             callID: msg.callID,
             title: msg.title,
+            rootID: msg.rootID,
             channelURL: msg.channelURL,
         });
 

--- a/src/types/calls.ts
+++ b/src/types/calls.ts
@@ -3,14 +3,11 @@
 export type CallsWidgetWindowConfig = {
     callID: string;
     title: string;
+    rootID: string;
     channelURL: string;
 }
 
-export type CallsJoinCallMessage = {
-    callID: string;
-    title: string;
-    channelURL: string;
-}
+export type CallsJoinCallMessage = CallsWidgetWindowConfig;
 
 export type CallsWidgetResizeMessage = {
     element: string;


### PR DESCRIPTION
#### Summary

This functionality was originally implemented in https://github.com/mattermost/mattermost-plugin-calls/pull/318 but I forgot to update the desktop side which needed a small addition to make things work with the global widget.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51532

#### Related PR

https://github.com/mattermost/mattermost-plugin-calls/pull/375

#### Release Note

```release-note
Added support for starting a call from an existing thread through the `/call start` slash command.
```


