### PR TITLE
MM-51535 - Calls: Fix unrestricted redirect from calls widget

### DIFF
--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -2,25 +2,21 @@
 // See LICENSE.txt for license information.
 
 import {EventEmitter} from 'events';
-import {BrowserWindow, Rectangle, ipcMain, IpcMainEvent} from 'electron';
+import {BrowserWindow, ipcMain, IpcMainEvent, Rectangle} from 'electron';
 import log from 'electron-log';
 
 import {
-    CallsWidgetWindowConfig,
+    CallsJoinedCallMessage,
     CallsWidgetResizeMessage,
     CallsWidgetShareScreenMessage,
-    CallsJoinedCallMessage,
+    CallsWidgetWindowConfig,
 } from 'types/calls';
 
 import {MattermostView} from 'main/views/MattermostView';
 
 import {getLocalPreload} from 'main/utils';
 
-import {
-    MINIMUM_CALLS_WIDGET_WIDTH,
-    MINIMUM_CALLS_WIDGET_HEIGHT,
-    CALLS_PLUGIN_ID,
-} from 'common/utils/constants';
+import {CALLS_PLUGIN_ID, MINIMUM_CALLS_WIDGET_HEIGHT, MINIMUM_CALLS_WIDGET_WIDTH} from 'common/utils/constants';
 import Utils from 'common/utils/util';
 import urlUtils, {getFormattedPathName} from 'common/utils/url';
 import {
@@ -231,7 +227,7 @@ export default class CallsWidgetWindow extends EventEmitter {
         this.setBounds(initialBounds);
     }
 
-    private onPopOutOpen = ({url}: {url: string}) => {
+    private onPopOutOpen = ({url}: { url: string }) => {
         if (urlUtils.isCallsPopOutURL(this.mainView.serverInfo.server.url, url, this.config.callID)) {
             return {
                 action: 'allow' as const,

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -250,6 +250,19 @@ export default class CallsWidgetWindow extends EventEmitter {
 
         // Let the webContentsEventManager handle links that try to open a new window
         webContentsEventManager.addWebContentsEventListeners(this.popOut.webContents);
+
+        this.popOut.webContents.on('will-redirect', (event, url) => {
+            const parsedURL = urlUtils.parseURL(url);
+            if (!parsedURL) {
+                event.preventDefault();
+                return;
+            }
+
+            const serverURL = this.mainView.serverInfo.server.url;
+            if (urlUtils.isInternalURL(serverURL, parsedURL) && !urlUtils.isPluginUrl(serverURL, parsedURL) && !urlUtils.isManagedResource(serverURL, parsedURL)) {
+                event.preventDefault();
+            }
+        });
     }
 
     private onPopOutFocus = () => {


### PR DESCRIPTION
#### Summary
- A malicious server could send a redirect like so: `window.open("https://community.mattermost.com/core/com.mattermost.calls/expanded/<CALLS_ID>/..%2f..%2f..%2f..%2flogin/sso/saml?redirect_to=https://google.com")` to the call widget's window, causing it to open a new window which would then redirect to an arbitrary url.
- Similar to #2580 , adding a will-redirect handler on the popout window to prevent this.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-51535

#### Release Note
```release-note
Calls: Fixed an issue where a certain URL form would allow the call's widget to open a popup window that could navigate to an arbitrary URL
```
