### PR TITLE
Add a checkbox asking users to reproduce on the latest version of the Desktop App

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,6 +16,8 @@ body:
         required: true
       - label: This issue doesn't reproduce on web browsers (such as in Chrome). If it does, [issue reports go to the Mattermost Server repository](https://github.com/mattermost/mattermost-server/issues).
         required: true
+      - label: This issue reproduces on the latest version of the Mattermost Desktop App. You can find the latest version [here](https://github.com/mattermost/desktop/releases/latest)
+        required: true
       - label: I have read the [contribution guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md).
         required: true
 - type: input

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,7 +16,7 @@ body:
         required: true
       - label: This issue doesn't reproduce on web browsers (such as in Chrome). If it does, [issue reports go to the Mattermost Server repository](https://github.com/mattermost/mattermost-server/issues).
         required: true
-      - label: This issue reproduces on the latest version of the Mattermost Desktop App. You can find the latest version [here](https://github.com/mattermost/desktop/releases/latest)
+      - label: This issue reproduces on the most recent [stable version](https://github.com/mattermost/desktop/releases/latest), or the most recent [prerelease version](https://github.com/mattermost/desktop/releases) of the Mattermost Desktop App.
         required: true
       - label: I have read the [contribution guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md).
         required: true


### PR DESCRIPTION
#### Summary
Adding a checkbox to make sure users are submitting issues for the latest version of the Desktop App, instead of older ones.

```release-note
NONE
```
