### PR TITLE
MM-51850 - Calls: Fix for crash after closing popout

### DIFF
--- a/src/main/windows/callsWidgetWindow.test.js
+++ b/src/main/windows/callsWidgetWindow.test.js
@@ -531,6 +531,23 @@ describe('main/windows/callsWidgetWindow', () => {
             expect(popOut.webContents.on).toHaveBeenCalledWith('will-redirect', widgetWindow.onWillRedirect);
         });
 
+        it('onPopOutClosed', () => {
+            const widgetWindow = new CallsWidgetWindow(mainWindow, mainView, widgetConfig);
+            expect(widgetWindow.popOut).toBeNull();
+
+            const popOut = new EventEmitter();
+            popOut.webContents = {
+                on: jest.fn(),
+                id: 'webContentsId',
+            };
+
+            widgetWindow.onPopOutCreate(popOut);
+            expect(widgetWindow.popOut).toBe(popOut);
+
+            popOut.emit('closed');
+            expect(widgetWindow.popOut).toBeNull();
+        });
+
         it('getWebContentsId', () => {
             baseWindow.webContents = {
                 ...baseWindow.webContents,

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -243,12 +243,19 @@ export default class CallsWidgetWindow extends EventEmitter {
 
     private onPopOutCreate = (win: BrowserWindow) => {
         this.popOut = win;
+        this.popOut.on('closed', this.onPopOutClosed);
 
         // Let the webContentsEventManager handle links that try to open a new window.
         webContentsEventManager.addWebContentsEventListeners(this.popOut.webContents);
 
         // Need to capture and handle redirects for security.
         this.popOut.webContents.on('will-redirect', this.onWillRedirect);
+    }
+
+    private onPopOutClosed = () => {
+        log.debug('CallsWidgetWindow.onPopOutClosed');
+        this.popOut?.removeAllListeners('closed');
+        this.popOut = null;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -273,7 +280,7 @@ export default class CallsWidgetWindow extends EventEmitter {
     }
 
     public getPopOutWebContentsId() {
-        return this.popOut?.webContents.id;
+        return this.popOut?.webContents?.id;
     }
 
     public getURL() {


### PR DESCRIPTION
#### Summary
- If the user opens the calls popout and then closes it (without leaving the call), any click on the webapp will cause a crash. We need to manually set the popout to null so that the null/undefined guards will work. (Otherwise, the var will be pointing to a non-empty object after the popout is closed.)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-51850

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [ ] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [ ] executed `npm run lint:js` for proper code formatting


#### Release Note
```release-note
Calls: fixed a bug where, after opening the calls popout then closing it (without leaving the call), subsequent clicks will cause a crash.
```

