### PR TITLE
cherry-pick: MM-51850 - Calls: Fix for crash after closing popout (#2647)

### DIFF
--- a/src/main/windows/callsWidgetWindow.test.js
+++ b/src/main/windows/callsWidgetWindow.test.js
@@ -531,6 +531,23 @@ describe('main/windows/callsWidgetWindow', () => {
             expect(popOut.webContents.on).toHaveBeenCalledWith('will-redirect', widgetWindow.onWillRedirect);
         });
 
+        it('onPopOutClosed', () => {
+            const widgetWindow = new CallsWidgetWindow(mainWindow, mainView, widgetConfig);
+            expect(widgetWindow.popOut).toBeNull();
+
+            const popOut = new EventEmitter();
+            popOut.webContents = {
+                on: jest.fn(),
+                id: 'webContentsId',
+            };
+
+            widgetWindow.onPopOutCreate(popOut);
+            expect(widgetWindow.popOut).toBe(popOut);
+
+            popOut.emit('closed');
+            expect(widgetWindow.popOut).toBeNull();
+        });
+
         it('getWebContentsId', () => {
             baseWindow.webContents = {
                 ...baseWindow.webContents,

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -243,12 +243,19 @@ export default class CallsWidgetWindow extends EventEmitter {
 
     private onPopOutCreate = (win: BrowserWindow) => {
         this.popOut = win;
+        this.popOut.on('closed', this.onPopOutClosed);
 
         // Let the webContentsEventManager handle links that try to open a new window.
         webContentsEventManager.addWebContentsEventListeners(this.popOut.webContents);
 
         // Need to capture and handle redirects for security.
         this.popOut.webContents.on('will-redirect', this.onWillRedirect);
+    }
+
+    private onPopOutClosed = () => {
+        log.debug('CallsWidgetWindow.onPopOutClosed');
+        this.popOut?.removeAllListeners('closed');
+        this.popOut = null;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -273,7 +280,7 @@ export default class CallsWidgetWindow extends EventEmitter {
     }
 
     public getPopOutWebContentsId() {
-        return this.popOut?.webContents.id;
+        return this.popOut?.webContents?.id;
     }
 
     public getURL() {


### PR DESCRIPTION
#### Summary
(cherry picked from commit 4fe66b298deae51a4c83113579f0834feec5924f)
- #2647 

#### Release Note
```release-note
Calls: fixed a bug where, after opening the calls popout then closing it (without leaving the call), subsequent clicks will cause a crash.
```