### PR TITLE
[MM-51875] Migrate viewManager to singleton

### DIFF
--- a/src/main/app/app.test.js
+++ b/src/main/app/app.test.js
@@ -5,6 +5,7 @@ import {app, dialog} from 'electron';
 
 import CertificateStore from 'main/certificateStore';
 import WindowManager from 'main/windows/windowManager';
+import ViewManager from 'main/views/viewManager';
 
 import {handleAppWillFinishLaunching, handleAppCertificateError, certificateErrorCallbacks} from 'main/app/app';
 import {getDeeplinkingURL, openDeepLink} from 'main/app/utils';
@@ -18,13 +19,6 @@ jest.mock('electron', () => ({
     dialog: {
         showMessageBox: jest.fn(),
     },
-}));
-
-jest.mock('common/config', () => ({
-    teams: [{
-        name: 'test-team',
-        url: 'http://server-1.com',
-    }],
 }));
 
 jest.mock('main/app/utils', () => ({
@@ -46,11 +40,13 @@ jest.mock('main/i18nManager', () => ({
 jest.mock('main/tray/tray', () => ({}));
 jest.mock('main/windows/windowManager', () => ({
     getMainWindow: jest.fn(),
-    getViewNameByWebContentsId: jest.fn(),
-    getServerNameByWebContentsId: jest.fn(),
-    viewManager: {
-        views: new Map(),
-    },
+}));
+jest.mock('main/windows/mainWindow', () => ({
+    get: jest.fn(),
+}));
+jest.mock('main/views/viewManager', () => ({
+    getView: jest.fn(),
+    getViewByWebContentsId: jest.fn(),
 }));
 
 describe('main/app/app', () => {
@@ -68,7 +64,6 @@ describe('main/app/app', () => {
         });
 
         afterEach(() => {
-            WindowManager.viewManager.views.clear();
             jest.resetAllMocks();
         });
 
@@ -101,10 +96,19 @@ describe('main/app/app', () => {
         const mainWindow = {};
         const promise = Promise.resolve({});
         const certificate = {};
+        const view = {
+            tab: {
+                server: {
+                    name: 'test-team',
+                    url: new URL(testURL),
+                },
+            },
+            load: jest.fn(),
+        };
 
         beforeEach(() => {
             WindowManager.getMainWindow.mockReturnValue(mainWindow);
-            WindowManager.getServerNameByWebContentsId.mockReturnValue('test-team');
+            ViewManager.getViewByWebContentsId.mockReturnValue(view);
         });
 
         afterEach(() => {
@@ -163,12 +167,9 @@ describe('main/app/app', () => {
 
         it('should load URL using MattermostView when trusting certificate', async () => {
             dialog.showMessageBox.mockResolvedValue({response: 0});
-            const load = jest.fn();
-            WindowManager.viewManager.views.set('view-name', {load});
-            WindowManager.getViewNameByWebContentsId.mockReturnValue('view-name');
             await handleAppCertificateError(event, webContents, testURL, 'error-1', certificate, callback);
             expect(callback).toHaveBeenCalledWith(true);
-            expect(load).toHaveBeenCalledWith(testURL);
+            expect(view.load).toHaveBeenCalledWith(testURL);
         });
 
         it('should explicitly untrust if user selects More Details and then cancel with the checkbox checked', async () => {

--- a/src/main/app/config.test.js
+++ b/src/main/app/config.test.js
@@ -44,6 +44,9 @@ jest.mock('main/badge', () => ({
 jest.mock('main/tray/tray', () => ({
     refreshTrayImages: jest.fn(),
 }));
+jest.mock('main/views/viewManager', () => ({
+    reloadConfiguration: jest.fn(),
+}));
 jest.mock('main/windows/windowManager', () => ({
     handleUpdateConfig: jest.fn(),
     sendToRenderer: jest.fn(),

--- a/src/main/app/config.ts
+++ b/src/main/app/config.ts
@@ -12,6 +12,7 @@ import Config from 'common/config';
 import AutoLauncher from 'main/AutoLauncher';
 import {setUnreadBadgeSetting} from 'main/badge';
 import {refreshTrayImages} from 'main/tray/tray';
+import ViewManager from 'main/views/viewManager';
 import WindowManager from 'main/windows/windowManager';
 
 import {handleMainWindowIsShown} from './intercom';
@@ -36,8 +37,8 @@ export function handleConfigUpdate(newConfig: CombinedConfig) {
         return;
     }
 
-    WindowManager.handleUpdateConfig();
     if (app.isReady()) {
+        ViewManager.reloadConfiguration();
         WindowManager.sendToRenderer(RELOAD_CONFIGURATION);
     }
 
@@ -78,7 +79,7 @@ export function handleDarkModeChange(darkMode: boolean) {
 
     refreshTrayImages(Config.trayIconTheme);
     WindowManager.sendToRenderer(DARK_MODE_CHANGE, darkMode);
-    WindowManager.updateLoadingScreenDarkMode(darkMode);
+    ViewManager.updateLoadingScreenDarkMode(darkMode);
 
     ipcMain.emit(EMIT_CONFIGURATION, true, Config.data);
 }

--- a/src/main/app/initialize.test.js
+++ b/src/main/app/initialize.test.js
@@ -164,6 +164,10 @@ jest.mock('main/windows/windowManager', () => ({
     getServerNameByWebContentsId: jest.fn(),
     getServerURLFromWebContentsId: jest.fn(),
 }));
+jest.mock('main/views/viewManager', () => ({
+    get: jest.fn(),
+    sendToAllViews: jest.fn(),
+}));
 const originalProcess = process;
 describe('main/app/initialize', () => {
     beforeAll(() => {

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -55,6 +55,7 @@ import parseArgs from 'main/ParseArgs';
 import TrustedOriginsStore from 'main/trustedOrigins';
 import {refreshTrayImages, setupTray} from 'main/tray/tray';
 import UserActivityMonitor from 'main/UserActivityMonitor';
+import ViewManager from 'main/views/viewManager';
 import WindowManager from 'main/windows/windowManager';
 
 import {protocols} from '../../../electron-builder.json';
@@ -234,7 +235,7 @@ function initializeInterCommunicationEventListeners() {
     ipcMain.on(NOTIFY_MENTION, handleMentionNotification);
     ipcMain.handle('get-app-version', handleAppVersion);
     ipcMain.on(UPDATE_SHORTCUT_MENU, handleUpdateMenuEvent);
-    ipcMain.on(FOCUS_BROWSERVIEW, WindowManager.focusBrowserView);
+    ipcMain.on(FOCUS_BROWSERVIEW, ViewManager.focusCurrentView);
     ipcMain.on(UPDATE_LAST_ACTIVE, handleUpdateLastActive);
 
     if (process.platform !== 'darwin') {
@@ -349,7 +350,7 @@ function initializeAfterAppReady() {
     // listen for status updates and pass on to renderer
     UserActivityMonitor.on('status', (status) => {
         log.debug('Initialize.UserActivityMonitor.on(status)', status);
-        WindowManager.sendToMattermostViews(USER_ACTIVITY_UPDATE, status);
+        ViewManager.sendToAllViews(USER_ACTIVITY_UPDATE, status);
     });
 
     // start monitoring user activity (needs to be started after the app is ready)

--- a/src/main/app/intercom.test.js
+++ b/src/main/app/intercom.test.js
@@ -29,6 +29,7 @@ jest.mock('main/utils', () => ({
     getLocalPreload: jest.fn(),
     getLocalURLString: jest.fn(),
 }));
+jest.mock('main/views/viewManager', () => ({}));
 jest.mock('main/views/modalManager', () => ({
     addModal: jest.fn(),
 }));

--- a/src/main/app/intercom.ts
+++ b/src/main/app/intercom.ts
@@ -14,6 +14,7 @@ import {ping} from 'common/utils/requests';
 import {displayMention} from 'main/notifications';
 import {getLocalPreload, getLocalURLString} from 'main/utils';
 import ModalManager from 'main/views/modalManager';
+import ViewManager from 'main/views/viewManager';
 import WindowManager from 'main/windows/windowManager';
 
 import {handleAppBeforeQuit} from './app';
@@ -23,7 +24,7 @@ export function handleReloadConfig() {
     log.debug('Intercom.handleReloadConfig');
 
     Config.reload();
-    WindowManager.handleUpdateConfig();
+    ViewManager.reloadConfiguration();
 }
 
 export function handleAppVersion() {

--- a/src/main/app/utils.test.js
+++ b/src/main/app/utils.test.js
@@ -60,6 +60,8 @@ jest.mock('main/server/serverInfo', () => ({
     ServerInfo: jest.fn(),
 }));
 jest.mock('main/tray/tray', () => ({}));
+jest.mock('main/views/viewManager', () => ({}));
+jest.mock('main/windows/mainWindow', () => ({}));
 jest.mock('main/windows/windowManager', () => ({}));
 
 jest.mock('./initialize', () => ({

--- a/src/main/app/utils.ts
+++ b/src/main/app/utils.ts
@@ -27,6 +27,7 @@ import {createMenu as createAppMenu} from 'main/menus/app';
 import {createMenu as createTrayMenu} from 'main/menus/tray';
 import {ServerInfo} from 'main/server/serverInfo';
 import {setTrayMenu} from 'main/tray/tray';
+import ViewManager from 'main/views/viewManager';
 import WindowManager from 'main/windows/windowManager';
 
 import {mainProtocol} from './initialize';
@@ -108,7 +109,7 @@ export function handleUpdateMenuEvent() {
     const aMenu = createAppMenu(Config, updateManager);
     Menu.setApplicationMenu(aMenu);
     aMenu.addListener('menu-will-close', () => {
-        WindowManager.focusBrowserView();
+        ViewManager.focusCurrentView();
         WindowManager.sendToRenderer(APP_MENU_WILL_CLOSE);
     });
 

--- a/src/main/downloadsManager.test.js
+++ b/src/main/downloadsManager.test.js
@@ -79,6 +79,7 @@ jest.mock('macos-notification-state', () => ({
 jest.mock('main/windows/windowManager', () => ({
     sendToRenderer: jest.fn(),
 }));
+jest.mock('main/views/viewManager', () => ({}));
 jest.mock('common/config', () => {
     const original = jest.requireActual('common/config');
     return {

--- a/src/main/downloadsManager.ts
+++ b/src/main/downloadsManager.ts
@@ -30,6 +30,7 @@ import {APP_UPDATE_KEY, UPDATE_DOWNLOAD_ITEM} from 'common/constants';
 import {DOWNLOADS_DROPDOWN_AUTOCLOSE_TIMEOUT, DOWNLOADS_DROPDOWN_MAX_ITEMS} from 'common/utils/constants';
 import {localizeMessage} from 'main/i18nManager';
 import {displayDownloadCompleted} from 'main/notifications';
+import ViewManager from 'main/views/viewManager';
 import WindowManager from 'main/windows/windowManager';
 import {doubleSecToMs, getPercentage, isStringWithLength, readFilenameFromContentDispositionHeader, shouldIncrementFilename} from 'main/utils';
 
@@ -507,7 +508,7 @@ export class DownloadsManager extends JsonFileManager<DownloadedItems> {
         log.debug('DownloadsManager.doneEventController', {state});
 
         if (state === 'completed' && !this.open) {
-            displayDownloadCompleted(path.basename(item.savePath), item.savePath, WindowManager.getServerNameByWebContentsId(webContents.id) || '');
+            displayDownloadCompleted(path.basename(item.savePath), item.savePath, ViewManager.getViewByWebContentsId(webContents.id)?.tab.server.name ?? '');
         }
 
         const bookmark = this.bookmarks.get(this.getFileId(item));

--- a/src/main/menus/app.test.js
+++ b/src/main/menus/app.test.js
@@ -49,6 +49,11 @@ jest.mock('macos-notification-state', () => ({
 jest.mock('main/i18nManager', () => ({
     localizeMessage: jest.fn(),
 }));
+jest.mock('main/diagnostics', () => ({}));
+jest.mock('main/downloadsManager', () => ({
+    hasDownloads: jest.fn(),
+}));
+jest.mock('main/views/viewManager', () => ({}));
 jest.mock('main/windows/windowManager', () => ({
     getCurrentTeamName: jest.fn(),
     sendToRenderer: jest.fn(),

--- a/src/main/menus/app.ts
+++ b/src/main/menus/app.ts
@@ -6,7 +6,7 @@
 import {app, ipcMain, Menu, MenuItemConstructorOptions, MenuItem, session, shell, WebContents, clipboard} from 'electron';
 import log from 'electron-log';
 
-import {BROWSER_HISTORY_BUTTON, OPEN_TEAMS_DROPDOWN, SHOW_NEW_SERVER_MODAL} from 'common/communication';
+import {OPEN_TEAMS_DROPDOWN, SHOW_NEW_SERVER_MODAL} from 'common/communication';
 import {t} from 'common/utils/util';
 import {getTabDisplayName, TabType} from 'common/tabs/TabView';
 import {Config} from 'common/config';
@@ -16,6 +16,7 @@ import WindowManager from 'main/windows/windowManager';
 import {UpdateManager} from 'main/autoUpdater';
 import downloadsManager from 'main/downloadsManager';
 import Diagnostics from 'main/diagnostics';
+import ViewManager from 'main/views/viewManager';
 
 export function createTemplate(config: Config, updateManager: UpdateManager) {
     const separatorItem: MenuItemConstructorOptions = {
@@ -125,20 +126,20 @@ export function createTemplate(config: Config, updateManager: UpdateManager) {
         label: localizeMessage('main.menus.app.view.find', 'Find..'),
         accelerator: 'CmdOrCtrl+F',
         click() {
-            WindowManager.sendToFind();
+            ViewManager.sendToFind();
         },
     }, {
         label: localizeMessage('main.menus.app.view.reload', 'Reload'),
         accelerator: 'CmdOrCtrl+R',
         click() {
-            WindowManager.reload();
+            ViewManager.reload();
         },
     }, {
         label: localizeMessage('main.menus.app.view.clearCacheAndReload', 'Clear Cache and Reload'),
         accelerator: 'Shift+CmdOrCtrl+R',
         click() {
             session.defaultSession.clearCache();
-            WindowManager.reload();
+            ViewManager.reload();
         },
     }, {
         role: 'togglefullscreen',
@@ -192,7 +193,7 @@ export function createTemplate(config: Config, updateManager: UpdateManager) {
     }, {
         label: localizeMessage('main.menus.app.view.devToolsCurrentServer', 'Developer Tools for Current Server'),
         click() {
-            WindowManager.openBrowserViewDevTools();
+            ViewManager.getCurrentView()?.openDevTools();
         },
     }];
 
@@ -218,21 +219,13 @@ export function createTemplate(config: Config, updateManager: UpdateManager) {
             label: localizeMessage('main.menus.app.history.back', 'Back'),
             accelerator: process.platform === 'darwin' ? 'Cmd+[' : 'Alt+Left',
             click: () => {
-                const view = WindowManager.viewManager?.getCurrentView();
-                if (view && view.view.webContents.canGoBack() && !view.isAtRoot) {
-                    view.view.webContents.goBack();
-                    ipcMain.emit(BROWSER_HISTORY_BUTTON, null, view.name);
-                }
+                ViewManager.getCurrentView()?.goToOffset(-1);
             },
         }, {
             label: localizeMessage('main.menus.app.history.forward', 'Forward'),
             accelerator: process.platform === 'darwin' ? 'Cmd+]' : 'Alt+Right',
             click: () => {
-                const view = WindowManager.viewManager?.getCurrentView();
-                if (view && view.view.webContents.canGoForward()) {
-                    view.view.webContents.goForward();
-                    ipcMain.emit(BROWSER_HISTORY_BUTTON, null, view.name);
-                }
+                ViewManager.getCurrentView()?.goToOffset(1);
             },
         }],
     });

--- a/src/main/notifications/index.test.js
+++ b/src/main/notifications/index.test.js
@@ -70,9 +70,17 @@ jest.mock('windows-focus-assist', () => ({
 jest.mock('macos-notification-state', () => ({
     getDoNotDisturb: jest.fn(),
 }));
-
+jest.mock('../views/viewManager', () => ({
+    getViewByWebContentsId: () => ({
+        id: 'server_id',
+        tab: {
+            server: {
+                name: 'server_name',
+            },
+        },
+    }),
+}));
 jest.mock('../windows/windowManager', () => ({
-    getServerNameByWebContentsId: () => 'server_name',
     sendToRenderer: jest.fn(),
     flashFrame: jest.fn(),
     switchTab: jest.fn(),

--- a/src/main/notifications/index.ts
+++ b/src/main/notifications/index.ts
@@ -11,6 +11,7 @@ import {MentionData} from 'types/notification';
 import {PLAY_SOUND} from 'common/communication';
 import {TAB_MESSAGING} from 'common/tabs/TabView';
 
+import ViewManager from '../views/viewManager';
 import WindowManager from '../windows/windowManager';
 
 import {Mention} from './Mention';
@@ -33,7 +34,11 @@ export function displayMention(title: string, body: string, channel: {id: string
         return;
     }
 
-    const serverName = WindowManager.getServerNameByWebContentsId(webcontents.id);
+    const view = ViewManager.getViewByWebContentsId(webcontents.id);
+    if (!view) {
+        return;
+    }
+    const serverName = view.tab.server.name;
 
     const options = {
         title: `${serverName}: ${title}`,

--- a/src/main/views/downloadsDropdownMenuView.test.js
+++ b/src/main/views/downloadsDropdownMenuView.test.js
@@ -50,6 +50,7 @@ jest.mock('electron', () => {
 jest.mock('macos-notification-state', () => ({
     getDoNotDisturb: jest.fn(),
 }));
+jest.mock('main/downloadsManager', () => ({}));
 jest.mock('main/windows/windowManager', () => ({
     sendToRenderer: jest.fn(),
 }));

--- a/src/main/views/downloadsDropdownView.test.js
+++ b/src/main/views/downloadsDropdownView.test.js
@@ -59,6 +59,10 @@ jest.mock('electron', () => {
         Notification: NotificationMock,
     };
 });
+jest.mock('main/downloadsManager', () => ({
+    onOpen: jest.fn(),
+    onClose: jest.fn(),
+}));
 jest.mock('main/windows/windowManager', () => ({
     sendToRenderer: jest.fn(),
 }));

--- a/src/main/views/modalManager.test.js
+++ b/src/main/views/modalManager.test.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-import * as WindowManager from '../windows/windowManager';
+import ViewManager from 'main/views/viewManager';
 
 import {ModalManager} from './modalManager';
 
@@ -26,9 +26,11 @@ jest.mock('main/views/webContentEvents', () => ({
 jest.mock('./modalView', () => ({
     ModalView: jest.fn(),
 }));
-jest.mock('../windows/windowManager', () => ({
+jest.mock('main/views/viewManager', () => ({
+    focusCurrentView: jest.fn(),
+}));
+jest.mock('main/windows/windowManager', () => ({
     sendToRenderer: jest.fn(),
-    focusBrowserView: jest.fn(),
 }));
 jest.mock('process', () => ({
     env: {},
@@ -161,7 +163,7 @@ describe('main/views/modalManager', () => {
             modalManager.modalQueue.pop();
             modalManager.modalPromises.delete('test2');
             modalManager.handleModalFinished('resolve', {sender: {id: 1}}, 'something');
-            expect(WindowManager.focusBrowserView).toBeCalled();
+            expect(ViewManager.focusCurrentView).toBeCalled();
         });
     });
 });

--- a/src/main/views/modalManager.ts
+++ b/src/main/views/modalManager.ts
@@ -23,6 +23,7 @@ import Config from 'common/config';
 
 import {getAdjustedWindowBoundaries} from 'main/utils';
 import WebContentsEventManager from 'main/views/webContentEvents';
+import ViewManager from 'main/views/viewManager';
 import WindowManager from 'main/windows/windowManager';
 
 import {ModalView} from './modalView';
@@ -114,7 +115,7 @@ export class ModalManager {
             this.showModal();
         } else {
             WindowManager.sendToRenderer(MODAL_CLOSE);
-            WindowManager.focusBrowserView();
+            ViewManager.focusCurrentView();
         }
     }
 

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+import {BrowserView, BrowserWindow, dialog, ipcMain, IpcMainEvent, IpcMainInvokeEvent} from 'electron';
 import log from 'electron-log';
-import {BrowserView, BrowserWindow, dialog, ipcMain, IpcMainEvent} from 'electron';
 import {BrowserViewConstructorOptions} from 'electron/main';
 import {Tuple as tuple} from '@bloomberg/record-tuple-polyfill';
 
@@ -21,6 +21,13 @@ import {
     UPDATE_URL_VIEW_WIDTH,
     MAIN_WINDOW_SHOWN,
     DARK_MODE_CHANGE,
+    RELOAD_CURRENT_VIEW,
+    REACT_APP_INITIALIZED,
+    APP_LOGGED_IN,
+    BROWSER_HISTORY_BUTTON,
+    APP_LOGGED_OUT,
+    UNREAD_RESULT,
+    GET_VIEW_NAME,
 } from 'common/communication';
 import Config from 'common/config';
 import urlUtils, {equalUrlsIgnoringSubpath} from 'common/utils/url';
@@ -34,6 +41,7 @@ import PlaybooksTabView from 'common/tabs/PlaybooksTabView';
 import {localizeMessage} from 'main/i18nManager';
 import {ServerInfo} from 'main/server/serverInfo';
 
+import * as appState from '../appState';
 import {getLocalURLString, getLocalPreload, getWindowBoundaries} from '../utils';
 
 import {MattermostView} from './MattermostView';
@@ -50,62 +58,200 @@ export enum LoadingScreenState {
 }
 
 export class ViewManager {
-    lastActiveServer?: number;
-    viewOptions: BrowserViewConstructorOptions;
-    closedViews: Map<string, {srv: MattermostServer; tab: Tab}>;
-    views: Map<string, MattermostView>;
-    currentView?: string;
-    urlView?: BrowserView;
-    urlViewCancel?: () => void;
-    mainWindow: BrowserWindow;
-    loadingScreen?: BrowserView;
-    loadingScreenState: LoadingScreenState;
+    private closedViews: Map<string, {srv: MattermostServer; tab: Tab}>;
+    private views: Map<string, MattermostView>;
+    private currentView?: string;
+    private mainWindow?: BrowserWindow;
 
-    constructor(mainWindow: BrowserWindow) {
+    private loadingScreen?: BrowserView;
+    private loadingScreenState: LoadingScreenState;
+
+    private urlViewCancel?: () => void;
+
+    private lastActiveServer?: number;
+    private viewOptions: BrowserViewConstructorOptions;
+
+    constructor() {
         this.lastActiveServer = Config.lastActiveTeam;
         this.viewOptions = {webPreferences: {spellcheck: Config.useSpellChecker}};
         this.views = new Map(); // keep in mind that this doesn't need to hold server order, only tabs on the renderer need that.
-        this.mainWindow = mainWindow;
         this.closedViews = new Map();
         this.loadingScreenState = LoadingScreenState.HIDDEN;
+
+        ipcMain.on(REACT_APP_INITIALIZED, this.handleReactAppInitialized);
+        ipcMain.on(BROWSER_HISTORY_PUSH, this.handleBrowserHistoryPush);
+        ipcMain.on(BROWSER_HISTORY_BUTTON, this.handleBrowserHistoryButton);
+        ipcMain.on(APP_LOGGED_IN, this.handleAppLoggedIn);
+        ipcMain.on(APP_LOGGED_OUT, this.handleAppLoggedOut);
+        ipcMain.on(RELOAD_CURRENT_VIEW, this.handleReloadCurrentView);
+        ipcMain.on(UNREAD_RESULT, this.handleFaviconIsUnread);
+        ipcMain.handle(GET_VIEW_NAME, this.handleGetViewName);
     }
 
     updateMainWindow = (mainWindow: BrowserWindow) => {
         this.mainWindow = mainWindow;
     }
 
-    getServers = () => {
-        return Config.teams.concat();
+    init = () => {
+        this.getServers().forEach((server) => this.loadServer(server));
+        this.showInitial();
     }
 
-    loadServer = (server: TeamWithTabs) => {
+    getView = (viewName: string) => {
+        return this.views.get(viewName);
+    }
+
+    getCurrentView = () => {
+        if (this.currentView) {
+            return this.views.get(this.currentView);
+        }
+
+        return undefined;
+    }
+
+    getViewByWebContentsId = (webContentsId: number) => {
+        return [...this.views.values()].find((view) => view.view.webContents.id === webContentsId);
+    }
+
+    showByName = (name: string) => {
+        log.debug('viewManager.showByName', name);
+
+        const newView = this.views.get(name);
+        if (newView) {
+            if (newView.isVisible) {
+                return;
+            }
+            if (this.currentView && this.currentView !== name) {
+                const previous = this.getCurrentView();
+                if (previous) {
+                    previous.hide();
+                }
+            }
+
+            this.currentView = name;
+            if (!newView.isErrored()) {
+                newView.show();
+                if (newView.needsLoadingScreen()) {
+                    this.showLoadingScreen();
+                }
+            }
+            newView.window.webContents.send(SET_ACTIVE_VIEW, newView.tab.server.name, newView.tab.type);
+            ipcMain.emit(SET_ACTIVE_VIEW, true, newView.tab.server.name, newView.tab.type);
+            if (newView.isReady()) {
+                ipcMain.emit(UPDATE_LAST_ACTIVE, true, newView.tab.server.name, newView.tab.type);
+            } else {
+                log.warn(`couldn't show ${name}, not ready`);
+            }
+        } else {
+            log.warn(`Couldn't find a view with name: ${name}`);
+        }
+        modalManager.showModal();
+    }
+
+    focusCurrentView = () => {
+        if (modalManager.isModalDisplayed()) {
+            modalManager.focusCurrentModal();
+            return;
+        }
+
+        const view = this.getCurrentView();
+        if (view) {
+            view.focus();
+        }
+    }
+
+    reload = () => {
+        const currentView = this.getCurrentView();
+        if (currentView) {
+            this.showLoadingScreen();
+            currentView.reload();
+        }
+    }
+
+    sendToAllViews = (channel: string, ...args: unknown[]) => {
+        this.views.forEach((view) => {
+            if (!view.view.webContents.isDestroyed()) {
+                view.view.webContents.send(channel, ...args);
+            }
+        });
+    }
+
+    sendToFind = () => {
+        this.getCurrentView()?.openFind();
+    }
+
+    /**
+     * Deep linking
+     */
+
+    handleDeepLink = (url: string | URL) => {
+        // TODO: fix for new tabs
+        if (url) {
+            const parsedURL = urlUtils.parseURL(url)!;
+            const tabView = this.getViewByURL(parsedURL, true);
+            if (tabView) {
+                const urlWithSchema = `${urlUtils.parseURL(tabView.url)?.origin}${parsedURL.pathname}${parsedURL.search}`;
+                if (this.closedViews.has(tabView.name)) {
+                    this.openClosedTab(tabView.name, urlWithSchema);
+                } else {
+                    const view = this.views.get(tabView.name);
+                    if (!view) {
+                        log.error(`Couldn't find a view matching the name ${tabView.name}`);
+                        return;
+                    }
+
+                    if (view.isInitialized() && view.serverInfo.remoteInfo.serverVersion && Utils.isVersionGreaterThanOrEqualTo(view.serverInfo.remoteInfo.serverVersion, '6.0.0')) {
+                        const pathName = `/${urlWithSchema.replace(view.tab.server.url.toString(), '')}`;
+                        view.view.webContents.send(BROWSER_HISTORY_PUSH, pathName);
+                        this.deeplinkSuccess(view.name);
+                    } else {
+                        // attempting to change parsedURL protocol results in it not being modified.
+                        view.resetLoadingStatus();
+                        view.load(urlWithSchema);
+                        view.once(LOAD_SUCCESS, this.deeplinkSuccess);
+                        view.once(LOAD_FAILED, this.deeplinkFailed);
+                    }
+                }
+            } else {
+                dialog.showErrorBox(
+                    localizeMessage('main.views.viewManager.handleDeepLink.error.title', 'No matching server'),
+                    localizeMessage('main.views.viewManager.handleDeepLink.error.body', 'There is no configured server in the app that matches the requested url: {url}', {url: parsedURL.toString()}),
+                );
+            }
+        }
+    };
+
+    private deeplinkSuccess = (viewName: string) => {
+        log.debug('deeplinkSuccess', viewName);
+
+        const view = this.views.get(viewName);
+        if (!view) {
+            return;
+        }
+        this.showByName(viewName);
+        view.removeListener(LOAD_FAILED, this.deeplinkFailed);
+    };
+
+    private deeplinkFailed = (viewName: string, err: string, url: string) => {
+        log.error(`[${viewName}] failed to load deeplink ${url}: ${err}`);
+        const view = this.views.get(viewName);
+        if (!view) {
+            return;
+        }
+        view.removeListener(LOAD_SUCCESS, this.deeplinkSuccess);
+    }
+
+    /**
+     * View loading helpers
+     */
+
+    private loadServer = (server: TeamWithTabs) => {
         const srv = new MattermostServer(server.name, server.url);
         const serverInfo = new ServerInfo(srv);
         server.tabs.forEach((tab) => this.loadView(srv, serverInfo, tab));
     }
 
-    makeView = (srv: MattermostServer, serverInfo: ServerInfo, tab: Tab, url?: string): MattermostView => {
-        const tabView = this.getServerView(srv, tab.name);
-        const view = new MattermostView(tabView, serverInfo, this.mainWindow, this.viewOptions);
-        view.once(LOAD_SUCCESS, this.activateView);
-        view.load(url);
-        view.on(UPDATE_TARGET_URL, this.showURLView);
-        view.on(LOADSCREEN_END, this.finishLoading);
-        view.on(LOAD_FAILED, this.failLoading);
-        return view;
-    }
-
-    addView = (view: MattermostView): void => {
-        this.views.set(view.name, view);
-        if (this.closedViews.has(view.name)) {
-            this.closedViews.delete(view.name);
-        }
-        if (!this.loadingScreen) {
-            this.createLoadingScreen();
-        }
-    }
-
-    loadView = (srv: MattermostServer, serverInfo: ServerInfo, tab: Tab, url?: string) => {
+    private loadView = (srv: MattermostServer, serverInfo: ServerInfo, tab: Tab, url?: string) => {
         if (!tab.isOpen) {
             this.closedViews.set(getTabViewName(srv.name, tab.name), {srv, tab});
             return;
@@ -114,23 +260,168 @@ export class ViewManager {
         this.addView(view);
     }
 
-    reloadViewIfNeeded = (viewName: string) => {
-        const view = this.views.get(viewName);
-        if (view && view.view.webContents.getURL() !== view.tab.url.toString() && !view.view.webContents.getURL().startsWith(view.tab.url.toString())) {
-            view.load(view.tab.url);
+    private makeView = (srv: MattermostServer, serverInfo: ServerInfo, tab: Tab, url?: string): MattermostView => {
+        const tabView = this.getServerView(srv, tab.name);
+        const view = new MattermostView(tabView, serverInfo, this.mainWindow!, this.viewOptions);
+        view.once(LOAD_SUCCESS, this.activateView);
+        view.load(url);
+        view.on(UPDATE_TARGET_URL, this.showURLView);
+        view.on(LOADSCREEN_END, this.finishLoading);
+        view.on(LOAD_FAILED, this.failLoading);
+        return view;
+    }
+
+    private addView = (view: MattermostView): void => {
+        this.views.set(view.name, view);
+        if (this.closedViews.has(view.name)) {
+            this.closedViews.delete(view.name);
         }
     }
 
-    load = () => {
-        this.getServers().forEach((server) => this.loadServer(server));
+    private showInitial = () => {
+        log.verbose('showInitial');
+
+        const servers = this.getServers();
+        if (servers.length) {
+            const element = servers.find((e) => e.order === this.lastActiveServer) || servers.find((e) => e.order === 0);
+            if (element && element.tabs.length) {
+                let tab = element.tabs.find((tab) => tab.order === element.lastActiveTab) || element.tabs.find((tab) => tab.order === 0);
+                if (!tab?.isOpen) {
+                    const openTabs = element.tabs.filter((tab) => tab.isOpen);
+                    tab = openTabs.find((e) => e.order === 0) || openTabs.concat().sort((a, b) => a.order - b.order)[0];
+                }
+                if (tab) {
+                    const tabView = getTabViewName(element.name, tab.name);
+                    this.showByName(tabView);
+                }
+            }
+        } else {
+            this.mainWindow?.webContents.send(SET_ACTIVE_VIEW, null, null);
+            ipcMain.emit(MAIN_WINDOW_SHOWN);
+        }
     }
+
+    /**
+     * Mattermost view event handlers
+     */
+
+    private activateView = (viewName: string) => {
+        log.debug('activateView', viewName);
+
+        if (this.currentView === viewName) {
+            this.showByName(this.currentView);
+        }
+        const view = this.views.get(viewName);
+        if (!view) {
+            log.error(`Couldn't find a view with the name ${viewName}`);
+            return;
+        }
+        WebContentsEventManager.addMattermostViewEventListeners(view);
+    }
+
+    private finishLoading = (server: string) => {
+        log.debug('finishLoading', server);
+
+        const view = this.views.get(server);
+        if (view && this.getCurrentView() === view) {
+            this.showByName(this.currentView!);
+            this.fadeLoadingScreen();
+        }
+    }
+
+    private failLoading = (tabName: string) => {
+        log.debug('failLoading', tabName);
+
+        this.fadeLoadingScreen();
+        if (this.currentView === tabName) {
+            this.getCurrentView()?.hide();
+        }
+    }
+
+    private showURLView = (url: URL | string) => {
+        log.silly('showURLView', url);
+
+        if (!this.mainWindow) {
+            return;
+        }
+
+        if (this.urlViewCancel) {
+            this.urlViewCancel();
+        }
+        if (url && url !== '') {
+            const urlString = typeof url === 'string' ? url : url.toString();
+            const preload = getLocalPreload('desktopAPI.js');
+            const urlView = new BrowserView({
+                webPreferences: {
+                    preload,
+
+                    // Workaround for this issue: https://github.com/electron/electron/issues/30993
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-ignore
+                    transparent: true,
+                }});
+            const query = new Map([['url', urlString]]);
+            const localURL = getLocalURLString('urlView.html', query);
+            urlView.webContents.loadURL(localURL);
+            this.mainWindow.addBrowserView(urlView);
+            const boundaries = this.views.get(this.currentView || '')?.view.getBounds() ?? this.mainWindow.getBounds();
+
+            const hideView = () => {
+                delete this.urlViewCancel;
+                try {
+                    this.mainWindow?.removeBrowserView(urlView);
+                } catch (e) {
+                    log.error('Failed to remove URL view', e);
+                }
+
+                // workaround to eliminate zombie processes
+                // https://github.com/mattermost/desktop/pull/1519
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                urlView.webContents.destroy();
+            };
+
+            const adjustWidth = (event: IpcMainEvent, width: number) => {
+                log.silly('showURLView.adjustWidth', width);
+
+                const bounds = {
+                    x: 0,
+                    y: (boundaries.height + TAB_BAR_HEIGHT) - URL_VIEW_HEIGHT,
+                    width: width + 5, // add some padding to ensure that we don't cut off the border
+                    height: URL_VIEW_HEIGHT,
+                };
+
+                log.silly('showURLView setBounds', boundaries, bounds);
+                urlView.setBounds(bounds);
+            };
+
+            ipcMain.on(UPDATE_URL_VIEW_WIDTH, adjustWidth);
+
+            const timeout = setTimeout(hideView,
+                URL_VIEW_DURATION);
+
+            this.urlViewCancel = () => {
+                clearTimeout(timeout);
+                ipcMain.removeListener(UPDATE_URL_VIEW_WIDTH, adjustWidth);
+                hideView();
+            };
+        }
+    }
+
+    /**
+     * Event Handlers
+     */
 
     /** Called when a new configuration is received
      * Servers or tabs have been added or edited. We need to
      * close, open, or reload tabs, taking care to reuse tabs and
      * preserve focus on the currently selected tab. */
-    reloadConfiguration = (configServers: TeamWithTabs[]) => {
-        log.debug('viewManager.reloadConfiguration');
+    reloadConfiguration = () => {
+        log.debug('reloadConfiguration');
+
+        if (!this.mainWindow) {
+            return;
+        }
 
         const focusedTuple: TabTuple | undefined = this.views.get(this.currentView as string)?.urlTypeTuple;
 
@@ -142,7 +433,7 @@ export class ViewManager {
         const views: Map<TabTuple, MattermostView> = new Map();
         const closed: Map<TabTuple, {srv: MattermostServer; tab: Tab; name: string}> = new Map();
 
-        const sortedTabs = configServers.flatMap((x) => [...x.tabs].
+        const sortedTabs = this.getServers().flatMap((x) => [...x.tabs].
             sort((a, b) => a.order - b.order).
             map((t): [TeamWithTabs, Tab] => [x, t]));
 
@@ -182,11 +473,11 @@ export class ViewManager {
         }
 
         if ((focusedTuple && closed.has(focusedTuple)) || (this.currentView && this.closedViews.has(this.currentView))) {
-            if (configServers.length) {
+            if (this.getServers().length) {
                 this.currentView = undefined;
                 this.showInitial();
             } else {
-                this.mainWindow.webContents.send(SET_ACTIVE_VIEW);
+                this.mainWindow?.webContents.send(SET_ACTIVE_VIEW);
             }
         }
 
@@ -196,108 +487,104 @@ export class ViewManager {
             if (view) {
                 this.currentView = view.name;
                 this.showByName(view.name);
-                this.mainWindow.webContents.send(SET_ACTIVE_VIEW, view.tab.server.name, view.tab.type);
+                this.mainWindow?.webContents.send(SET_ACTIVE_VIEW, view.tab.server.name, view.tab.type);
             }
         } else {
             this.showInitial();
         }
     }
 
-    showInitial = () => {
-        log.verbose('viewManager.showInitial');
+    private handleAppLoggedIn = (event: IpcMainEvent, viewName: string) => {
+        log.debug('handleAppLoggedIn', viewName);
 
-        const servers = this.getServers();
-        if (servers.length) {
-            const element = servers.find((e) => e.order === this.lastActiveServer) || servers.find((e) => e.order === 0);
-            if (element && element.tabs.length) {
-                let tab = element.tabs.find((tab) => tab.order === element.lastActiveTab) || element.tabs.find((tab) => tab.order === 0);
-                if (!tab?.isOpen) {
-                    const openTabs = element.tabs.filter((tab) => tab.isOpen);
-                    tab = openTabs.find((e) => e.order === 0) || openTabs.concat().sort((a, b) => a.order - b.order)[0];
-                }
-                if (tab) {
-                    const tabView = getTabViewName(element.name, tab.name);
-                    this.showByName(tabView);
-                }
+        const view = this.views.get(viewName);
+        if (view && !view.isLoggedIn) {
+            view.isLoggedIn = true;
+            if (view.view.webContents.getURL() !== view.tab.url.toString() && !view.view.webContents.getURL().startsWith(view.tab.url.toString())) {
+                view.load(view.tab.url);
             }
-        } else {
-            this.mainWindow.webContents.send(SET_ACTIVE_VIEW, null, null);
-            ipcMain.emit(MAIN_WINDOW_SHOWN);
         }
     }
 
-    showByName = (name: string) => {
-        log.debug('viewManager.showByName', name);
+    private handleAppLoggedOut = (event: IpcMainEvent, viewName: string) => {
+        log.debug('handleAppLoggedOut', viewName);
 
-        const newView = this.views.get(name);
-        if (newView) {
-            if (newView.isVisible) {
-                return;
-            }
-            if (this.currentView && this.currentView !== name) {
-                const previous = this.getCurrentView();
-                if (previous) {
-                    previous.hide();
-                }
-            }
-
-            this.currentView = name;
-            if (!newView.isErrored()) {
-                newView.show();
-                if (newView.needsLoadingScreen()) {
-                    this.showLoadingScreen();
-                }
-            }
-            newView.window.webContents.send(SET_ACTIVE_VIEW, newView.tab.server.name, newView.tab.type);
-            ipcMain.emit(SET_ACTIVE_VIEW, true, newView.tab.server.name, newView.tab.type);
-            if (newView.isReady()) {
-                ipcMain.emit(UPDATE_LAST_ACTIVE, true, newView.tab.server.name, newView.tab.type);
-            } else {
-                log.warn(`couldn't show ${name}, not ready`);
-            }
-        } else {
-            log.warn(`Couldn't find a view with name: ${name}`);
+        const view = this.views.get(viewName);
+        if (view && view.isLoggedIn) {
+            view.isLoggedIn = false;
         }
-        modalManager.showModal();
     }
 
-    focus = () => {
-        if (modalManager.isModalDisplayed()) {
-            modalManager.focusCurrentModal();
+    private handleBrowserHistoryPush = (e: IpcMainEvent, viewName: string, pathName: string) => {
+        log.debug('handleBrowserHistoryPush', {viewName, pathName});
+
+        const currentView = this.views.get(viewName);
+        const cleanedPathName = urlUtils.cleanPathName(currentView?.tab.server.url.pathname || '', pathName);
+        const redirectedViewName = this.getViewByURL(`${currentView?.tab.server.url.toString().replace(/\/$/, '')}${cleanedPathName}`)?.name || viewName;
+        if (this.closedViews.has(redirectedViewName)) {
+            // If it's a closed view, just open it and stop
+            this.openClosedTab(redirectedViewName, `${currentView?.tab.server.url}${cleanedPathName}`);
             return;
         }
+        let redirectedView = this.views.get(redirectedViewName) || currentView;
+        if (redirectedView !== currentView && redirectedView?.tab.name === this.currentView && redirectedView?.isLoggedIn) {
+            log.info('redirecting to a new view', redirectedView?.name || viewName);
+            this.showByName(redirectedView?.name || viewName);
+        } else {
+            redirectedView = currentView;
+        }
+
+        // Special case check for Channels to not force a redirect to "/", causing a refresh
+        if (!(redirectedView !== currentView && redirectedView?.tab.type === TAB_MESSAGING && cleanedPathName === '/')) {
+            redirectedView?.view.webContents.send(BROWSER_HISTORY_PUSH, cleanedPathName);
+            if (redirectedView) {
+                this.handleBrowserHistoryButton(e, redirectedView.name);
+            }
+        }
+    }
+
+    private handleBrowserHistoryButton = (e: IpcMainEvent, viewName: string) => {
+        log.debug('handleBrowserHistoryButton', viewName);
+
+        this.getView(viewName)?.updateHistoryButton();
+    }
+
+    private handleReactAppInitialized = (e: IpcMainEvent, viewName: string) => {
+        log.debug('handleReactAppInitialized', viewName);
+
+        const view = this.views.get(viewName);
+        if (view) {
+            view.setInitialized();
+            if (this.getCurrentView() === view) {
+                this.fadeLoadingScreen();
+            }
+        }
+    }
+
+    private handleReloadCurrentView = () => {
+        log.debug('handleReloadCurrentView');
 
         const view = this.getCurrentView();
-        if (view) {
-            view.focus();
-        }
-    }
-
-    activateView = (viewName: string) => {
-        log.debug('viewManager.activateView', viewName);
-
-        if (this.currentView === viewName) {
-            this.showByName(this.currentView);
-        }
-        const view = this.views.get(viewName);
         if (!view) {
-            log.error(`Couldn't find a view with the name ${viewName}`);
             return;
         }
-        WebContentsEventManager.addMattermostViewEventListeners(view);
+        view?.reload();
+        this.showByName(view?.name);
     }
 
-    finishLoading = (server: string) => {
-        log.debug('viewManager.finishLoading', server);
+    // if favicon is null, it means it is the initial load,
+    // so don't memoize as we don't have the favicons and there is no rush to find out.
+    private handleFaviconIsUnread = (e: Event, favicon: string, viewName: string, result: boolean) => {
+        log.silly('handleFaviconIsUnread', {favicon, viewName, result});
 
-        const view = this.views.get(server);
-        if (view && this.getCurrentView() === view) {
-            this.showByName(this.currentView!);
-            this.fadeLoadingScreen();
-        }
+        appState.updateUnreads(viewName, result);
     }
 
-    openClosedTab = (name: string, url?: string) => {
+    /**
+     * Helper functions
+     */
+
+    private openClosedTab = (name: string, url?: string) => {
         if (!this.closedViews.has(name)) {
             return;
         }
@@ -314,114 +601,60 @@ export class ViewManager {
         ipcMain.emit(OPEN_TAB, null, srv.name, tab.name);
     }
 
-    failLoading = (tabName: string) => {
-        log.debug('viewManager.failLoading', tabName);
+    getViewByURL = (inputURL: URL | string, ignoreScheme = false) => {
+        log.silly('ViewManager.getViewByURL', `${inputURL}`, ignoreScheme);
 
-        this.fadeLoadingScreen();
-        if (this.currentView === tabName) {
-            this.getCurrentView()?.hide();
+        const parsedURL = urlUtils.parseURL(inputURL);
+        if (!parsedURL) {
+            return undefined;
         }
-    }
-
-    getCurrentView() {
-        if (this.currentView) {
-            return this.views.get(this.currentView);
+        const server = this.getServers().find((team) => {
+            const parsedServerUrl = urlUtils.parseURL(team.url)!;
+            return equalUrlsIgnoringSubpath(parsedURL, parsedServerUrl, ignoreScheme) && parsedURL.pathname.match(new RegExp(`^${parsedServerUrl.pathname}(.+)?(/(.+))?$`));
+        });
+        if (!server) {
+            return undefined;
         }
-
-        return undefined;
-    }
-
-    openViewDevTools = () => {
-        const view = this.getCurrentView();
-        if (view) {
-            view.openDevTools();
-        } else {
-            log.error(`couldn't find ${this.currentView}`);
-        }
-    }
-
-    findViewByWebContent(webContentId: number) {
-        let found = null;
-        let view;
-        const entries = this.views.values();
-
-        for (view of entries) {
-            const wc = view.getWebContents();
-            if (wc && wc.id === webContentId) {
-                found = view;
-            }
-        }
-        return found;
-    }
-
-    showURLView = (url: URL | string) => {
-        log.silly('viewManager.showURLView', url);
-
-        if (this.urlViewCancel) {
-            this.urlViewCancel();
-        }
-        if (url && url !== '') {
-            const urlString = typeof url === 'string' ? url : url.toString();
-            const preload = getLocalPreload('desktopAPI.js');
-            const urlView = new BrowserView({
-                webPreferences: {
-                    preload,
-
-                    // Workaround for this issue: https://github.com/electron/electron/issues/30993
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-ignore
-                    transparent: true,
-                }});
-            const query = new Map([['url', urlString]]);
-            const localURL = getLocalURLString('urlView.html', query);
-            urlView.webContents.loadURL(localURL);
-            this.mainWindow.addBrowserView(urlView);
-            const boundaries = this.views.get(this.currentView || '')?.view.getBounds() ?? this.mainWindow.getBounds();
-
-            const hideView = () => {
-                delete this.urlViewCancel;
-                try {
-                    this.mainWindow.removeBrowserView(urlView);
-                } catch (e) {
-                    log.error('Failed to remove URL view', e);
+        const mmServer = new MattermostServer(server.name, server.url);
+        let selectedTab = this.getServerView(mmServer, TAB_MESSAGING);
+        server.tabs.
+            filter((tab) => tab.name !== TAB_MESSAGING).
+            forEach((tab) => {
+                const tabCandidate = this.getServerView(mmServer, tab.name);
+                if (parsedURL.pathname.match(new RegExp(`^${tabCandidate.url.pathname}(/(.+))?`))) {
+                    selectedTab = tabCandidate;
                 }
+            });
+        return selectedTab;
+    }
 
-                // workaround to eliminate zombie processes
-                // https://github.com/mattermost/desktop/pull/1519
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                urlView.webContents.destroy();
-            };
-
-            const adjustWidth = (event: IpcMainEvent, width: number) => {
-                log.silly('showURLView.adjustWidth', width);
-
-                const bounds = {
-                    x: 0,
-                    y: (boundaries.height + TAB_BAR_HEIGHT) - URL_VIEW_HEIGHT,
-                    width: width + 5, // add some padding to ensure that we don't cut off the border
-                    height: URL_VIEW_HEIGHT,
-                };
-
-                log.silly('showURLView setBounds', boundaries, bounds);
-                urlView.setBounds(bounds);
-            };
-
-            ipcMain.on(UPDATE_URL_VIEW_WIDTH, adjustWidth);
-
-            const timeout = setTimeout(hideView,
-                URL_VIEW_DURATION);
-
-            this.urlViewCancel = () => {
-                clearTimeout(timeout);
-                ipcMain.removeListener(UPDATE_URL_VIEW_WIDTH, adjustWidth);
-                hideView();
-            };
+    private getServerView = (srv: MattermostServer, tabName: string) => {
+        switch (tabName) {
+        case TAB_MESSAGING:
+            return new MessagingTabView(srv);
+        case TAB_FOCALBOARD:
+            return new FocalboardTabView(srv);
+        case TAB_PLAYBOOKS:
+            return new PlaybooksTabView(srv);
+        default:
+            throw new Error('Not implemeneted');
         }
     }
+
+    private getServers = () => {
+        return Config.teams.concat();
+    }
+
+    handleGetViewName = (event: IpcMainInvokeEvent) => {
+        return this.getViewByWebContentsId(event.sender.id);
+    }
+
+    /**
+     * Loading screen
+     */
 
     setLoadingScreenBounds = () => {
-        if (this.loadingScreen) {
+        if (this.loadingScreen && this.mainWindow) {
             this.loadingScreen.setBounds(getWindowBoundaries(this.mainWindow));
         }
     }
@@ -455,10 +688,10 @@ export class ViewManager {
             this.loadingScreen!.webContents.send(TOGGLE_LOADING_SCREEN_VISIBILITY, true);
         }
 
-        if (this.mainWindow.getBrowserViews().includes(this.loadingScreen!)) {
+        if (this.mainWindow?.getBrowserViews().includes(this.loadingScreen!)) {
             this.mainWindow.setTopBrowserView(this.loadingScreen!);
         } else {
-            this.mainWindow.addBrowserView(this.loadingScreen!);
+            this.mainWindow?.addBrowserView(this.loadingScreen!);
         }
 
         this.setLoadingScreenBounds();
@@ -474,17 +707,7 @@ export class ViewManager {
     hideLoadingScreen = () => {
         if (this.loadingScreen && this.loadingScreenState !== LoadingScreenState.HIDDEN) {
             this.loadingScreenState = LoadingScreenState.HIDDEN;
-            this.mainWindow.removeBrowserView(this.loadingScreen);
-        }
-    }
-
-    setServerInitialized = (server: string) => {
-        const view = this.views.get(server);
-        if (view) {
-            view.setInitialized();
-            if (this.getCurrentView() === view) {
-                this.fadeLoadingScreen();
-            }
+            this.mainWindow?.removeBrowserView(this.loadingScreen);
         }
     }
 
@@ -494,108 +717,10 @@ export class ViewManager {
         }
     }
 
-    deeplinkSuccess = (viewName: string) => {
-        log.debug('viewManager.deeplinkSuccess', viewName);
-
-        const view = this.views.get(viewName);
-        if (!view) {
-            return;
-        }
-        this.showByName(viewName);
-        view.removeListener(LOAD_FAILED, this.deeplinkFailed);
-    };
-
-    deeplinkFailed = (viewName: string, err: string, url: string) => {
-        log.error(`[${viewName}] failed to load deeplink ${url}: ${err}`);
-        const view = this.views.get(viewName);
-        if (!view) {
-            return;
-        }
-        view.removeListener(LOAD_SUCCESS, this.deeplinkSuccess);
-    }
-
-    getViewByURL = (inputURL: URL | string, ignoreScheme = false) => {
-        log.silly('ViewManager.getViewByURL', `${inputURL}`, ignoreScheme);
-
-        const parsedURL = urlUtils.parseURL(inputURL);
-        if (!parsedURL) {
-            return undefined;
-        }
-        const server = this.getServers().find((team) => {
-            const parsedServerUrl = urlUtils.parseURL(team.url)!;
-            return equalUrlsIgnoringSubpath(parsedURL, parsedServerUrl, ignoreScheme) && parsedURL.pathname.match(new RegExp(`^${parsedServerUrl.pathname}(.+)?(/(.+))?$`));
-        });
-        if (!server) {
-            return undefined;
-        }
-        const mmServer = new MattermostServer(server.name, server.url);
-        let selectedTab = this.getServerView(mmServer, TAB_MESSAGING);
-        server.tabs.
-            filter((tab) => tab.name !== TAB_MESSAGING).
-            forEach((tab) => {
-                const tabCandidate = this.getServerView(mmServer, tab.name);
-                if (parsedURL.pathname.match(new RegExp(`^${tabCandidate.url.pathname}(/(.+))?`))) {
-                    selectedTab = tabCandidate;
-                }
-            });
-        return selectedTab;
-    }
-
-    handleDeepLink = (url: string | URL) => {
-        // TODO: fix for new tabs
-        if (url) {
-            const parsedURL = urlUtils.parseURL(url)!;
-            const tabView = this.getViewByURL(parsedURL, true);
-            if (tabView) {
-                const urlWithSchema = `${urlUtils.parseURL(tabView.url)?.origin}${parsedURL.pathname}${parsedURL.search}`;
-                if (this.closedViews.has(tabView.name)) {
-                    this.openClosedTab(tabView.name, urlWithSchema);
-                } else {
-                    const view = this.views.get(tabView.name);
-                    if (!view) {
-                        log.error(`Couldn't find a view matching the name ${tabView.name}`);
-                        return;
-                    }
-
-                    if (view.isInitialized() && view.serverInfo.remoteInfo.serverVersion && Utils.isVersionGreaterThanOrEqualTo(view.serverInfo.remoteInfo.serverVersion, '6.0.0')) {
-                        const pathName = `/${urlWithSchema.replace(view.tab.server.url.toString(), '')}`;
-                        view.view.webContents.send(BROWSER_HISTORY_PUSH, pathName);
-                        this.deeplinkSuccess(view.name);
-                    } else {
-                        // attempting to change parsedURL protocol results in it not being modified.
-                        view.resetLoadingStatus();
-                        view.load(urlWithSchema);
-                        view.once(LOAD_SUCCESS, this.deeplinkSuccess);
-                        view.once(LOAD_FAILED, this.deeplinkFailed);
-                    }
-                }
-            } else {
-                dialog.showErrorBox(
-                    localizeMessage('main.views.viewManager.handleDeepLink.error.title', 'No matching server'),
-                    localizeMessage('main.views.viewManager.handleDeepLink.error.body', 'There is no configured server in the app that matches the requested url: {url}', {url: parsedURL.toString()}),
-                );
-            }
-        }
-    };
-
-    sendToAllViews = (channel: string, ...args: unknown[]) => {
-        this.views.forEach((view) => {
-            if (!view.view.webContents.isDestroyed()) {
-                view.view.webContents.send(channel, ...args);
-            }
-        });
-    }
-
-    private getServerView = (srv: MattermostServer, tabName: string) => {
-        switch (tabName) {
-        case TAB_MESSAGING:
-            return new MessagingTabView(srv);
-        case TAB_FOCALBOARD:
-            return new FocalboardTabView(srv);
-        case TAB_PLAYBOOKS:
-            return new PlaybooksTabView(srv);
-        default:
-            throw new Error('Not implemeneted');
-        }
+    isLoadingScreenHidden = () => {
+        return this.loadingScreenState === LoadingScreenState.HIDDEN;
     }
 }
+
+const viewManager = new ViewManager();
+export default viewManager;

--- a/src/main/views/webContentEvents.test.js
+++ b/src/main/views/webContentEvents.test.js
@@ -25,6 +25,10 @@ jest.mock('electron', () => ({
 jest.mock('main/contextMenu', () => jest.fn());
 
 jest.mock('../allowProtocolDialog', () => ({}));
+jest.mock('main/views/viewManager', () => ({
+    getViewByWebContentsId: jest.fn(),
+    getViewByURL: jest.fn(),
+}));
 jest.mock('../windows/windowManager', () => ({
     getServerURLFromWebContentsId: jest.fn(),
     showMainWindow: jest.fn(),

--- a/src/main/views/webContentEvents.ts
+++ b/src/main/views/webContentEvents.ts
@@ -18,6 +18,7 @@ import allowProtocolDialog from '../allowProtocolDialog';
 import {composeUserAgent} from '../utils';
 
 import {MattermostView} from './MattermostView';
+import ViewManager from './viewManager';
 
 type CustomLogin = {
     inProgress: boolean;
@@ -241,7 +242,7 @@ export class WebContentsEventManager {
                 return {action: 'deny'};
             }
 
-            const otherServerURL = WindowManager.viewManager?.getViewByURL(parsedURL);
+            const otherServerURL = ViewManager.getViewByURL(parsedURL);
             if (otherServerURL && urlUtils.isTeamUrl(otherServerURL.server.url, parsedURL, true)) {
                 WindowManager.showMainWindow(parsedURL);
                 return {action: 'deny'};

--- a/src/main/windows/windowManager.test.js
+++ b/src/main/windows/windowManager.test.js
@@ -7,8 +7,7 @@
 import {app, systemPreferences, desktopCapturer} from 'electron';
 
 import Config from 'common/config';
-import {getTabViewName, TAB_MESSAGING} from 'common/tabs/TabView';
-import urlUtils from 'common/utils/url';
+import {getTabViewName} from 'common/tabs/TabView';
 
 import {
     getAdjustedWindowBoundaries,
@@ -16,10 +15,11 @@ import {
     openScreensharePermissionsSettingsMacOS,
 } from 'main/utils';
 
+import ViewManager from 'main/views/viewManager';
+
 import {WindowManager} from './windowManager';
 import createMainWindow from './mainWindow';
 import {createSettingsWindow} from './settingsWindow';
-
 import CallsWidgetWindow from './callsWidgetWindow';
 
 jest.mock('path', () => ({
@@ -52,11 +52,6 @@ jest.mock('electron', () => ({
 
 jest.mock('common/config', () => ({}));
 
-jest.mock('common/utils/url', () => ({
-    isTeamUrl: jest.fn(),
-    isAdminUrl: jest.fn(),
-    cleanPathName: jest.fn(),
-}));
 jest.mock('common/tabs/TabView', () => ({
     getTabViewName: jest.fn(),
     TAB_MESSAGING: 'tab-messaging',
@@ -68,10 +63,16 @@ jest.mock('../utils', () => ({
     resetScreensharePermissionsMacOS: jest.fn(),
 }));
 jest.mock('../views/viewManager', () => ({
-    ViewManager: jest.fn(),
-    LoadingScreenState: {
-        HIDDEN: 3,
-    },
+    isLoadingScreenHidden: jest.fn(),
+    getView: jest.fn(),
+    getViewByWebContentsId: jest.fn(),
+    getCurrentView: jest.fn(),
+    isViewClosed: jest.fn(),
+    openClosedTab: jest.fn(),
+    handleDeepLink: jest.fn(),
+    setLoadingScreenBounds: jest.fn(),
+    showByName: jest.fn(),
+    updateMainWindow: jest.fn(),
 }));
 jest.mock('../CriticalErrorHandler', () => jest.fn());
 jest.mock('../views/teamDropdownView', () => jest.fn());
@@ -89,21 +90,6 @@ jest.mock('./callsWidgetWindow');
 jest.mock('main/views/webContentEvents', () => ({}));
 
 describe('main/windows/windowManager', () => {
-    describe('handleUpdateConfig', () => {
-        const windowManager = new WindowManager();
-
-        beforeEach(() => {
-            windowManager.viewManager = {
-                reloadConfiguration: jest.fn(),
-            };
-        });
-
-        it('should reload config', () => {
-            windowManager.handleUpdateConfig();
-            expect(windowManager.viewManager.reloadConfiguration).toHaveBeenCalled();
-        });
-    });
-
     describe('showSettingsWindow', () => {
         const windowManager = new WindowManager();
         windowManager.showMainWindow = jest.fn();
@@ -140,10 +126,6 @@ describe('main/windows/windowManager', () => {
 
     describe('showMainWindow', () => {
         const windowManager = new WindowManager();
-        windowManager.viewManager = {
-            handleDeepLink: jest.fn(),
-            updateMainWindow: jest.fn(),
-        };
         windowManager.initializeViewManager = jest.fn();
 
         afterEach(() => {
@@ -197,7 +179,7 @@ describe('main/windows/windowManager', () => {
             };
             createMainWindow.mockReturnValue(window);
             windowManager.showMainWindow('mattermost://server-1.com/subpath');
-            expect(windowManager.viewManager.handleDeepLink).toHaveBeenCalledWith('mattermost://server-1.com/subpath');
+            expect(ViewManager.handleDeepLink).toHaveBeenCalledWith('mattermost://server-1.com/subpath');
         });
     });
 
@@ -214,10 +196,6 @@ describe('main/windows/windowManager', () => {
                 },
             },
         };
-        windowManager.viewManager = {
-            getCurrentView: () => view,
-            setLoadingScreenBounds: jest.fn(),
-        };
         windowManager.mainWindow = {
             getContentBounds: () => ({width: 800, height: 600}),
             getSize: () => [1000, 900],
@@ -228,6 +206,7 @@ describe('main/windows/windowManager', () => {
 
         beforeEach(() => {
             jest.useFakeTimers();
+            ViewManager.getCurrentView.mockReturnValue(view);
             getAdjustedWindowBoundaries.mockImplementation((width, height) => ({width, height}));
         });
 
@@ -241,7 +220,7 @@ describe('main/windows/windowManager', () => {
 
         it('should update loading screen and team dropdown bounds', () => {
             windowManager.handleResizeMainWindow();
-            expect(windowManager.viewManager.setLoadingScreenBounds).toHaveBeenCalled();
+            expect(ViewManager.setLoadingScreenBounds).toHaveBeenCalled();
             expect(windowManager.teamDropdown.updateWindowBounds).toHaveBeenCalled();
         });
 
@@ -276,11 +255,6 @@ describe('main/windows/windowManager', () => {
                 },
             },
         };
-        windowManager.viewManager = {
-            getCurrentView: () => view,
-            setLoadingScreenBounds: jest.fn(),
-            loadingScreenState: 3,
-        };
         windowManager.mainWindow = {
             getContentBounds: () => ({width: 1000, height: 900}),
             getSize: () => [1000, 900],
@@ -290,18 +264,20 @@ describe('main/windows/windowManager', () => {
         };
 
         beforeEach(() => {
+            ViewManager.getCurrentView.mockReturnValue(view);
+            ViewManager.isLoadingScreenHidden.mockReturnValue(true);
             getAdjustedWindowBoundaries.mockImplementation((width, height) => ({width, height}));
         });
 
         afterEach(() => {
             windowManager.isResizing = false;
-            jest.resetAllMocks();
+            jest.clearAllMocks();
         });
 
         it('should update loading screen and team dropdown bounds', () => {
             const event = {preventDefault: jest.fn()};
             windowManager.handleWillResizeMainWindow(event, {width: 800, height: 600});
-            expect(windowManager.viewManager.setLoadingScreenBounds).toHaveBeenCalled();
+            expect(ViewManager.setLoadingScreenBounds).toHaveBeenCalled();
             expect(windowManager.teamDropdown.updateWindowBounds).toHaveBeenCalled();
         });
 
@@ -309,6 +285,7 @@ describe('main/windows/windowManager', () => {
             windowManager.isResizing = true;
             const event = {preventDefault: jest.fn()};
             windowManager.handleWillResizeMainWindow(event, {width: 800, height: 600});
+            expect(event.preventDefault).toHaveBeenCalled();
             expect(view.setBounds).not.toHaveBeenCalled();
         });
 
@@ -339,6 +316,7 @@ describe('main/windows/windowManager', () => {
         };
 
         beforeEach(() => {
+            ViewManager.getCurrentView.mockReturnValue(view);
             getAdjustedWindowBoundaries.mockImplementation((width, height) => ({width, height}));
         });
 
@@ -347,17 +325,7 @@ describe('main/windows/windowManager', () => {
             jest.resetAllMocks();
         });
 
-        it('should not handle bounds if no window available', () => {
-            windowManager.handleResizedMainWindow();
-            expect(windowManager.isResizing).toBe(false);
-            expect(view.setBounds).not.toHaveBeenCalled();
-        });
-
         it('should use getContentBounds when the platform is different to linux', () => {
-            windowManager.viewManager = {
-                getCurrentView: () => view,
-            };
-
             const originalPlatform = process.platform;
             Object.defineProperty(process, 'platform', {
                 value: 'windows',
@@ -606,66 +574,63 @@ describe('main/windows/windowManager', () => {
 
     describe('switchServer', () => {
         const windowManager = new WindowManager();
-        windowManager.viewManager = {
-            showByName: jest.fn(),
-        };
+        const servers = [
+            {
+                name: 'server-1',
+                order: 1,
+                tabs: [
+                    {
+                        name: 'tab-1',
+                        order: 0,
+                        isOpen: false,
+                    },
+                    {
+                        name: 'tab-2',
+                        order: 2,
+                        isOpen: true,
+                    },
+                    {
+                        name: 'tab-3',
+                        order: 1,
+                        isOpen: true,
+                    },
+                ],
+            }, {
+                name: 'server-2',
+                order: 0,
+                tabs: [
+                    {
+                        name: 'tab-1',
+                        order: 0,
+                        isOpen: false,
+                    },
+                    {
+                        name: 'tab-2',
+                        order: 2,
+                        isOpen: true,
+                    },
+                    {
+                        name: 'tab-3',
+                        order: 1,
+                        isOpen: true,
+                    },
+                ],
+                lastActiveTab: 2,
+            },
+        ];
+        const map = servers.reduce((arr, item) => {
+            item.tabs.forEach((tab) => {
+                arr.push([`${item.name}_${tab.name}`, {}]);
+            });
+            return arr;
+        }, []);
+        const views = new Map(map);
 
         beforeEach(() => {
             jest.useFakeTimers();
             getTabViewName.mockImplementation((server, tab) => `${server}_${tab}`);
-
-            Config.teams = [
-                {
-                    name: 'server-1',
-                    order: 1,
-                    tabs: [
-                        {
-                            name: 'tab-1',
-                            order: 0,
-                            isOpen: false,
-                        },
-                        {
-                            name: 'tab-2',
-                            order: 2,
-                            isOpen: true,
-                        },
-                        {
-                            name: 'tab-3',
-                            order: 1,
-                            isOpen: true,
-                        },
-                    ],
-                }, {
-                    name: 'server-2',
-                    order: 0,
-                    tabs: [
-                        {
-                            name: 'tab-1',
-                            order: 0,
-                            isOpen: false,
-                        },
-                        {
-                            name: 'tab-2',
-                            order: 2,
-                            isOpen: true,
-                        },
-                        {
-                            name: 'tab-3',
-                            order: 1,
-                            isOpen: true,
-                        },
-                    ],
-                    lastActiveTab: 2,
-                },
-            ];
-
-            const map = Config.teams.reduce((arr, item) => {
-                item.tabs.forEach((tab) => {
-                    arr.push([`${item.name}_${tab.name}`, {}]);
-                });
-                return arr;
-            }, []);
-            windowManager.viewManager.views = new Map(map);
+            Config.teams = servers.concat();
+            ViewManager.getView.mockImplementation((name) => views.get(name));
         });
 
         afterEach(() => {
@@ -682,38 +647,35 @@ describe('main/windows/windowManager', () => {
         it('should do nothing if cannot find the server', () => {
             windowManager.switchServer('server-3');
             expect(getTabViewName).not.toBeCalled();
-            expect(windowManager.viewManager.showByName).not.toBeCalled();
+            expect(ViewManager.showByName).not.toBeCalled();
         });
 
         it('should show first open tab in order when last active not defined', () => {
             windowManager.switchServer('server-1');
-            expect(windowManager.viewManager.showByName).toHaveBeenCalledWith('server-1_tab-3');
+            expect(ViewManager.showByName).toHaveBeenCalledWith('server-1_tab-3');
         });
 
         it('should show last active tab of chosen server', () => {
             windowManager.switchServer('server-2');
-            expect(windowManager.viewManager.showByName).toHaveBeenCalledWith('server-2_tab-2');
+            expect(ViewManager.showByName).toHaveBeenCalledWith('server-2_tab-2');
         });
 
         it('should wait for view to exist if specified', () => {
-            windowManager.viewManager.views.delete('server-1_tab-3');
+            views.delete('server-1_tab-3');
             windowManager.switchServer('server-1', true);
-            expect(windowManager.viewManager.showByName).not.toBeCalled();
+            expect(ViewManager.showByName).not.toBeCalled();
 
             jest.advanceTimersByTime(200);
-            expect(windowManager.viewManager.showByName).not.toBeCalled();
+            expect(ViewManager.showByName).not.toBeCalled();
 
-            windowManager.viewManager.views.set('server-1_tab-3', {});
+            views.set('server-1_tab-3', {});
             jest.advanceTimersByTime(200);
-            expect(windowManager.viewManager.showByName).toBeCalledWith('server-1_tab-3');
+            expect(ViewManager.showByName).toBeCalledWith('server-1_tab-3');
         });
     });
 
     describe('handleHistory', () => {
         const windowManager = new WindowManager();
-        windowManager.viewManager = {
-            getCurrentView: jest.fn(),
-        };
 
         it('should only go to offset if it can', () => {
             const view = {
@@ -724,12 +686,12 @@ describe('main/windows/windowManager', () => {
                     },
                 },
             };
-            windowManager.viewManager.getCurrentView.mockReturnValue(view);
+            ViewManager.getCurrentView.mockReturnValue(view);
 
             windowManager.handleHistory(null, 1);
             expect(view.view.webContents.goToOffset).not.toBeCalled();
 
-            windowManager.viewManager.getCurrentView.mockReturnValue({
+            ViewManager.getCurrentView.mockReturnValue({
                 ...view,
                 view: {
                     ...view.view,
@@ -760,7 +722,7 @@ describe('main/windows/windowManager', () => {
             view.view.webContents.goToOffset.mockImplementation(() => {
                 throw new Error('hi');
             });
-            windowManager.viewManager.getCurrentView.mockReturnValue(view);
+            ViewManager.getCurrentView.mockReturnValue(view);
 
             windowManager.handleHistory(null, 1);
             expect(view.load).toBeCalledWith('http://server-1.com');
@@ -769,9 +731,6 @@ describe('main/windows/windowManager', () => {
 
     describe('selectTab', () => {
         const windowManager = new WindowManager();
-        windowManager.viewManager = {
-            getCurrentView: jest.fn(),
-        };
         windowManager.switchTab = jest.fn();
 
         beforeEach(() => {
@@ -806,7 +765,7 @@ describe('main/windows/windowManager', () => {
         });
 
         it('should select next server when open', () => {
-            windowManager.viewManager.getCurrentView.mockReturnValue({
+            ViewManager.getCurrentView.mockReturnValue({
                 tab: {
                     server: {
                         name: 'server-1',
@@ -820,7 +779,7 @@ describe('main/windows/windowManager', () => {
         });
 
         it('should select previous server when open', () => {
-            windowManager.viewManager.getCurrentView.mockReturnValue({
+            ViewManager.getCurrentView.mockReturnValue({
                 tab: {
                     server: {
                         name: 'server-1',
@@ -834,7 +793,7 @@ describe('main/windows/windowManager', () => {
         });
 
         it('should skip over closed tab', () => {
-            windowManager.viewManager.getCurrentView.mockReturnValue({
+            ViewManager.getCurrentView.mockReturnValue({
                 tab: {
                     server: {
                         name: 'server-1',
@@ -847,183 +806,8 @@ describe('main/windows/windowManager', () => {
         });
     });
 
-    describe('handleBrowserHistoryPush', () => {
-        const windowManager = new WindowManager();
-        const view1 = {
-            name: 'server-1_tab-messaging',
-            isLoggedIn: true,
-            tab: {
-                type: TAB_MESSAGING,
-                server: {
-                    url: 'http://server-1.com',
-                },
-            },
-            view: {
-                webContents: {
-                    send: jest.fn(),
-                },
-            },
-        };
-        const view2 = {
-            ...view1,
-            name: 'server-1_other_type_1',
-            tab: {
-                ...view1.tab,
-                type: 'other_type_1',
-            },
-            view: {
-                webContents: {
-                    send: jest.fn(),
-                },
-            },
-        };
-        const view3 = {
-            ...view1,
-            name: 'server-1_other_type_2',
-            tab: {
-                ...view1.tab,
-                type: 'other_type_2',
-            },
-            view: {
-                webContents: {
-                    send: jest.fn(),
-                },
-            },
-        };
-        windowManager.viewManager = {
-            views: new Map([
-                ['server-1_tab-messaging', view1],
-                ['server-1_other_type_1', view2],
-            ]),
-            closedViews: new Map([
-                ['server-1_other_type_2', view3],
-            ]),
-            openClosedTab: jest.fn(),
-            showByName: jest.fn(),
-            getViewByURL: jest.fn(),
-        };
-        windowManager.handleBrowserHistoryButton = jest.fn();
-
-        beforeEach(() => {
-            Config.teams = [
-                {
-                    name: 'server-1',
-                    url: 'http://server-1.com',
-                    order: 0,
-                    tabs: [
-                        {
-                            name: 'tab-messaging',
-                            order: 0,
-                            isOpen: true,
-                        },
-                        {
-                            name: 'other_type_1',
-                            order: 2,
-                            isOpen: true,
-                        },
-                        {
-                            name: 'other_type_2',
-                            order: 1,
-                            isOpen: false,
-                        },
-                    ],
-                },
-            ];
-            urlUtils.cleanPathName.mockImplementation((base, path) => path);
-        });
-
-        afterEach(() => {
-            jest.resetAllMocks();
-            Config.teams = [];
-        });
-
-        it('should open closed view if pushing to it', () => {
-            windowManager.viewManager.getViewByURL.mockReturnValue({name: 'server-1_other_type_2'});
-            windowManager.viewManager.openClosedTab.mockImplementation((name) => {
-                const view = windowManager.viewManager.closedViews.get(name);
-                windowManager.viewManager.closedViews.delete(name);
-                windowManager.viewManager.views.set(name, view);
-            });
-
-            windowManager.handleBrowserHistoryPush(null, 'server-1_tab-messaging', '/other_type_2/subpath');
-            expect(windowManager.viewManager.openClosedTab).toBeCalledWith('server-1_other_type_2', 'http://server-1.com/other_type_2/subpath');
-        });
-
-        it('should open redirect view if different from current view', () => {
-            windowManager.viewManager.getViewByURL.mockReturnValue({name: 'server-1_other_type_1'});
-            windowManager.handleBrowserHistoryPush(null, 'server-1_tab-messaging', '/other_type_1/subpath');
-            expect(windowManager.viewManager.showByName).toBeCalledWith('server-1_other_type_1');
-        });
-
-        it('should ignore redirects to "/" to Messages from other tabs', () => {
-            windowManager.viewManager.getViewByURL.mockReturnValue({name: 'server-1_tab-messaging'});
-            windowManager.handleBrowserHistoryPush(null, 'server-1_other_type_1', '/');
-            expect(view1.view.webContents.send).not.toBeCalled();
-        });
-    });
-
-    describe('handleBrowserHistoryButton', () => {
-        const windowManager = new WindowManager();
-        const view1 = {
-            name: 'server-1_tab-messaging',
-            isLoggedIn: true,
-            isAtRoot: true,
-            tab: {
-                type: TAB_MESSAGING,
-                server: {
-                    url: 'http://server-1.com',
-                },
-                url: new URL('http://server-1.com'),
-            },
-            view: {
-                webContents: {
-                    canGoBack: jest.fn(),
-                    canGoForward: jest.fn(),
-                    clearHistory: jest.fn(),
-                    send: jest.fn(),
-                    getURL: jest.fn(),
-                },
-            },
-        };
-        windowManager.viewManager = {
-            views: new Map([
-                ['server-1_tab-messaging', view1],
-            ]),
-        };
-
-        beforeEach(() => {
-            Config.teams = [
-                {
-                    name: 'server-1',
-                    url: 'http://server-1.com',
-                    order: 0,
-                    tabs: [
-                        {
-                            name: 'tab-messaging',
-                            order: 0,
-                            isOpen: true,
-                        },
-                    ],
-                },
-            ];
-        });
-
-        afterEach(() => {
-            jest.resetAllMocks();
-            Config.teams = [];
-            view1.isAtRoot = true;
-        });
-
-        it('should erase history and set isAtRoot when navigating to root URL', () => {
-            view1.isAtRoot = false;
-            view1.view.webContents.getURL.mockReturnValue(view1.tab.url.toString());
-            windowManager.handleBrowserHistoryButton(null, 'server-1_tab-messaging');
-            expect(view1.view.webContents.clearHistory).toHaveBeenCalled();
-            expect(view1.isAtRoot).toBe(true);
-        });
-    });
-
     describe('createCallsWidgetWindow', () => {
+        const windowManager = new WindowManager();
         const view = {
             name: 'server-1_tab-messaging',
             serverInfo: {
@@ -1043,18 +827,12 @@ describe('main/windows/windowManager', () => {
                     close: jest.fn(),
                 };
             });
+            ViewManager.getView.mockReturnValue(view);
         });
 
         afterEach(() => {
             jest.resetAllMocks();
         });
-
-        const windowManager = new WindowManager();
-        windowManager.viewManager = {
-            views: new Map([
-                ['server-1_tab-messaging', view],
-            ]),
-        };
 
         it('should create calls widget window', async () => {
             expect(windowManager.callsWidgetWindow).toBeUndefined();
@@ -1081,10 +859,6 @@ describe('main/windows/windowManager', () => {
 
     describe('handleGetDesktopSources', () => {
         const windowManager = new WindowManager();
-        windowManager.viewManager = {
-            showByName: jest.fn(),
-            getCurrentView: jest.fn(),
-        };
 
         beforeEach(() => {
             CallsWidgetWindow.mockImplementation(() => {
@@ -1147,7 +921,8 @@ describe('main/windows/windowManager', () => {
                 });
                 return arr;
             }, []);
-            windowManager.viewManager.views = new Map(map);
+            const views = new Map(map);
+            ViewManager.getView.mockImplementation((name) => views.get(name));
         });
 
         afterEach(() => {
@@ -1174,7 +949,7 @@ describe('main/windows/windowManager', () => {
 
             await windowManager.handleGetDesktopSources('server-1_tab-1', null);
 
-            expect(windowManager.viewManager.views.get('server-1_tab-1').view.webContents.send).toHaveBeenCalledWith('desktop-sources-result', [
+            expect(ViewManager.getView('server-1_tab-1').view.webContents.send).toHaveBeenCalledWith('desktop-sources-result', [
                 {
                     id: 'screen0',
                 },
@@ -1190,7 +965,7 @@ describe('main/windows/windowManager', () => {
             expect(windowManager.callsWidgetWindow.win.webContents.send).toHaveBeenCalledWith('calls-error', {
                 err: 'screen-permissions',
             });
-            expect(windowManager.viewManager.views.get('server-2_tab-1').view.webContents.send).toHaveBeenCalledWith('calls-error', {
+            expect(ViewManager.getView('server-2_tab-1').view.webContents.send).toHaveBeenCalledWith('calls-error', {
                 err: 'screen-permissions',
             });
             expect(windowManager.callsWidgetWindow.win.webContents.send).toHaveBeenCalledTimes(1);
@@ -1213,10 +988,10 @@ describe('main/windows/windowManager', () => {
             expect(windowManager.callsWidgetWindow.win.webContents.send).toHaveBeenCalledWith('calls-error', {
                 err: 'screen-permissions',
             });
-            expect(windowManager.viewManager.views.get('server-1_tab-1').view.webContents.send).toHaveBeenCalledWith('calls-error', {
+            expect(ViewManager.getView('server-1_tab-1').view.webContents.send).toHaveBeenCalledWith('calls-error', {
                 err: 'screen-permissions',
             });
-            expect(windowManager.viewManager.views.get('server-1_tab-1').view.webContents.send).toHaveBeenCalledTimes(1);
+            expect(ViewManager.getView('server-1_tab-1').view.webContents.send).toHaveBeenCalledTimes(1);
             expect(windowManager.callsWidgetWindow.win.webContents.send).toHaveBeenCalledTimes(1);
         });
 
@@ -1244,7 +1019,7 @@ describe('main/windows/windowManager', () => {
             expect(windowManager.callsWidgetWindow.win.webContents.send).toHaveBeenCalledWith('calls-error', {
                 err: 'screen-permissions',
             });
-            expect(windowManager.viewManager.views.get('server-1_tab-1').view.webContents.send).toHaveBeenCalledWith('calls-error', {
+            expect(ViewManager.getView('server-1_tab-1').view.webContents.send).toHaveBeenCalledWith('calls-error', {
                 err: 'screen-permissions',
             });
 
@@ -1262,10 +1037,6 @@ describe('main/windows/windowManager', () => {
     describe('handleDesktopSourcesModalRequest', () => {
         const windowManager = new WindowManager();
         windowManager.switchServer = jest.fn();
-        windowManager.viewManager = {
-            showByName: jest.fn(),
-            getCurrentView: jest.fn(),
-        };
 
         beforeEach(() => {
             CallsWidgetWindow.mockImplementation(() => {
@@ -1322,7 +1093,8 @@ describe('main/windows/windowManager', () => {
                 });
                 return arr;
             }, []);
-            windowManager.viewManager.views = new Map(map);
+            const views = new Map(map);
+            ViewManager.getView.mockImplementation((name) => views.get(name));
         });
 
         afterEach(() => {
@@ -1340,10 +1112,6 @@ describe('main/windows/windowManager', () => {
     describe('handleCallsWidgetChannelLinkClick', () => {
         const windowManager = new WindowManager();
         windowManager.switchServer = jest.fn();
-        windowManager.viewManager = {
-            showByName: jest.fn(),
-            getCurrentView: jest.fn(),
-        };
 
         beforeEach(() => {
             CallsWidgetWindow.mockImplementation(() => {
@@ -1401,7 +1169,8 @@ describe('main/windows/windowManager', () => {
                 });
                 return arr;
             }, []);
-            windowManager.viewManager.views = new Map(map);
+            const views = new Map(map);
+            ViewManager.getView.mockImplementation((name) => views.get(name));
         });
 
         afterEach(() => {
@@ -1462,11 +1231,6 @@ describe('main/windows/windowManager', () => {
                 },
             },
         };
-        windowManager.viewManager = {
-            views: new Map([
-                ['server-1_tab-messaging', view1],
-            ]),
-        };
 
         beforeEach(() => {
             CallsWidgetWindow.mockImplementation(() => {
@@ -1475,6 +1239,7 @@ describe('main/windows/windowManager', () => {
                     getMainView: jest.fn().mockReturnValue(view1),
                 };
             });
+            ViewManager.getView.mockReturnValue(view1);
         });
 
         afterEach(() => {
@@ -1491,23 +1256,10 @@ describe('main/windows/windowManager', () => {
     });
 
     describe('getServerURLFromWebContentsId', () => {
-        const view = {
-            name: 'server-1_tab-messaging',
-            serverInfo: {
-                server: {
-                    url: new URL('http://server-1.com'),
-                },
-            },
-        };
         const windowManager = new WindowManager();
-        windowManager.viewManager = {
-            views: new Map([
-                ['server-1_tab-messaging', view],
-            ]),
-            findViewByWebContent: jest.fn(),
-        };
 
         it('should return calls widget URL', () => {
+            ViewManager.getView.mockReturnValue({name: 'server-1_tab-messaging'});
             CallsWidgetWindow.mockImplementation(() => {
                 return {
                     on: jest.fn(),

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -17,21 +17,14 @@ import {
 import {
     MAXIMIZE_CHANGE,
     HISTORY,
-    REACT_APP_INITIALIZED,
-    LOADING_SCREEN_ANIMATION_FINISHED,
     FOCUS_THREE_DOT_MENU,
     GET_DARK_MODE,
     UPDATE_SHORTCUT_MENU,
     BROWSER_HISTORY_PUSH,
-    APP_LOGGED_IN,
-    GET_VIEW_NAME,
     GET_VIEW_WEBCONTENTS_ID,
     RESIZE_MODAL,
-    APP_LOGGED_OUT,
-    BROWSER_HISTORY_BUTTON,
     DISPATCH_GET_DESKTOP_SOURCES,
     DESKTOP_SOURCES_RESULT,
-    RELOAD_CURRENT_VIEW,
     VIEW_FINISHED_RESIZING,
     CALLS_JOIN_CALL,
     CALLS_LEAVE_CALL,
@@ -40,11 +33,11 @@ import {
     CALLS_ERROR,
     CALLS_LINK_CLICK,
 } from 'common/communication';
-import urlUtils from 'common/utils/url';
 import {SECOND} from 'common/utils/constants';
 import Config from 'common/config';
-import {getTabViewName, TAB_MESSAGING} from 'common/tabs/TabView';
+import {getTabViewName} from 'common/tabs/TabView';
 
+import downloadsManager from 'main/downloadsManager';
 import {MattermostView} from 'main/views/MattermostView';
 
 import {
@@ -54,14 +47,11 @@ import {
     openScreensharePermissionsSettingsMacOS,
 } from '../utils';
 
-import {ViewManager, LoadingScreenState} from '../views/viewManager';
 import CriticalErrorHandler from '../CriticalErrorHandler';
-
+import ViewManager from '../views/viewManager';
 import TeamDropdownView from '../views/teamDropdownView';
 import DownloadsDropdownView from '../views/downloadsDropdownView';
 import DownloadsDropdownMenuView from '../views/downloadsDropdownMenuView';
-
-import downloadsManager from 'main/downloadsManager';
 
 import {createSettingsWindow} from './settingsWindow';
 import createMainWindow from './mainWindow';
@@ -77,7 +67,6 @@ export class WindowManager {
     mainWindowReady: boolean;
     settingsWindow?: BrowserWindow;
     callsWidgetWindow?: CallsWidgetWindow;
-    viewManager?: ViewManager;
     teamDropdown?: TeamDropdownView;
     downloadsDropdown?: DownloadsDropdownView;
     downloadsDropdownMenu?: DownloadsDropdownMenuView;
@@ -90,15 +79,7 @@ export class WindowManager {
 
         ipcMain.on(HISTORY, this.handleHistory);
         ipcMain.handle(GET_DARK_MODE, this.handleGetDarkMode);
-        ipcMain.on(REACT_APP_INITIALIZED, this.handleReactAppInitialized);
-        ipcMain.on(LOADING_SCREEN_ANIMATION_FINISHED, this.handleLoadingScreenAnimationFinished);
-        ipcMain.on(BROWSER_HISTORY_PUSH, this.handleBrowserHistoryPush);
-        ipcMain.on(BROWSER_HISTORY_BUTTON, this.handleBrowserHistoryButton);
-        ipcMain.on(APP_LOGGED_IN, this.handleAppLoggedIn);
-        ipcMain.on(APP_LOGGED_OUT, this.handleAppLoggedOut);
-        ipcMain.handle(GET_VIEW_NAME, this.handleGetViewName);
         ipcMain.handle(GET_VIEW_WEBCONTENTS_ID, this.handleGetWebContentsId);
-        ipcMain.on(RELOAD_CURRENT_VIEW, this.handleReloadCurrentView);
         ipcMain.on(VIEW_FINISHED_RESIZING, this.handleViewFinishedResizing);
 
         // Calls handlers
@@ -109,12 +90,6 @@ export class WindowManager {
         ipcMain.on(CALLS_WIDGET_CHANNEL_LINK_CLICK, this.genCallsEventHandler(this.handleCallsWidgetChannelLinkClick));
         ipcMain.on(CALLS_ERROR, this.genCallsEventHandler(this.handleCallsError));
         ipcMain.on(CALLS_LINK_CLICK, this.genCallsEventHandler(this.handleCallsLinkClick));
-    }
-
-    handleUpdateConfig = () => {
-        if (this.viewManager) {
-            this.viewManager.reloadConfiguration(Config.teams || []);
-        }
     }
 
     genCallsEventHandler = (handler: CallsEventHandler) => {
@@ -139,7 +114,7 @@ export class WindowManager {
             // window to be fully closed.
             await this.callsWidgetWindow.close();
         }
-        const currentView = this.viewManager?.views.get(viewName);
+        const currentView = ViewManager.getView(viewName);
         if (!currentView) {
             log.error('unable to create calls widget window: currentView is missing');
             return;
@@ -261,7 +236,7 @@ export class WindowManager {
             }
             this.mainWindow.on('will-resize', this.handleWillResizeMainWindow);
             this.mainWindow.on('resized', this.handleResizedMainWindow);
-            this.mainWindow.on('focus', this.focusBrowserView);
+            this.mainWindow.on('focus', ViewManager.focusCurrentView);
             this.mainWindow.on('enter-full-screen', () => this.sendToRenderer('enter-full-screen'));
             this.mainWindow.on('leave-full-screen', () => this.sendToRenderer('leave-full-screen'));
 
@@ -272,18 +247,15 @@ export class WindowManager {
                 this.mainWindow.webContents.openDevTools({mode: 'detach'});
             }
 
-            if (this.viewManager) {
-                this.viewManager.updateMainWindow(this.mainWindow);
-            }
+            this.initializeViewManager();
 
             this.teamDropdown = new TeamDropdownView(this.mainWindow, Config.teams, Config.darkMode, Config.enableServerManagement);
             this.downloadsDropdown = new DownloadsDropdownView(this.mainWindow, downloadsManager.getDownloads(), Config.darkMode);
             this.downloadsDropdownMenu = new DownloadsDropdownMenuView(this.mainWindow, Config.darkMode);
         }
-        this.initializeViewManager();
 
         if (deeplinkingURL) {
-            this.viewManager!.handleDeepLink(deeplinkingURL);
+            ViewManager.handleDeepLink(deeplinkingURL);
         }
     }
 
@@ -313,7 +285,7 @@ export class WindowManager {
     handleWillResizeMainWindow = (event: Event, newBounds: Electron.Rectangle) => {
         log.silly('WindowManager.handleWillResizeMainWindow');
 
-        if (!(this.viewManager && this.mainWindow)) {
+        if (!this.mainWindow) {
             return;
         }
 
@@ -326,14 +298,14 @@ export class WindowManager {
             return;
         }
 
-        if (this.isResizing && this.viewManager.loadingScreenState === LoadingScreenState.HIDDEN && this.viewManager.getCurrentView()) {
+        if (this.isResizing && ViewManager.isLoadingScreenHidden() && ViewManager.getCurrentView()) {
             log.debug('prevented resize');
             event.preventDefault();
             return;
         }
 
         this.throttledWillResize(newBounds);
-        this.viewManager?.setLoadingScreenBounds();
+        ViewManager.setLoadingScreenBounds();
         this.teamDropdown?.updateWindowBounds();
         this.downloadsDropdown?.updateWindowBounds();
         this.downloadsDropdownMenu?.updateWindowBounds();
@@ -368,7 +340,7 @@ export class WindowManager {
     handleResizeMainWindow = () => {
         log.silly('WindowManager.handleResizeMainWindow');
 
-        if (!(this.viewManager && this.mainWindow)) {
+        if (!this.mainWindow) {
             return;
         }
         if (this.isResizing) {
@@ -380,7 +352,7 @@ export class WindowManager {
         // Another workaround since the window doesn't update properly under Linux for some reason
         // See above comment
         setTimeout(this.setCurrentViewBounds, 10, bounds);
-        this.viewManager.setLoadingScreenBounds();
+        ViewManager.setLoadingScreenBounds();
         this.teamDropdown?.updateWindowBounds();
         this.downloadsDropdown?.updateWindowBounds();
         this.downloadsDropdownMenu?.updateWindowBounds();
@@ -390,7 +362,7 @@ export class WindowManager {
     setCurrentViewBounds = (bounds: {width: number; height: number}) => {
         log.debug('WindowManager.setCurrentViewBounds', {bounds});
 
-        const currentView = this.viewManager?.getCurrentView();
+        const currentView = ViewManager.getCurrentView();
         if (currentView) {
             const adjustedBounds = getAdjustedWindowBoundaries(bounds.width, bounds.height, shouldHaveBackBar(currentView.tab.url, currentView.view.webContents.getURL()));
             this.setBoundsFunction(currentView, adjustedBounds);
@@ -454,12 +426,6 @@ export class WindowManager {
         }
 
         // TODO: should we include popups?
-    }
-
-    sendToMattermostViews = (channel: string, ...args: unknown[]) => {
-        if (this.viewManager) {
-            this.viewManager.sendToAllViews(channel, ...args);
-        }
     }
 
     restoreMain = () => {
@@ -592,12 +558,11 @@ export class WindowManager {
     }
 
     initializeViewManager = () => {
-        if (!this.viewManager && Config && this.mainWindow) {
-            this.viewManager = new ViewManager(this.mainWindow);
-            this.viewManager.load();
-            this.viewManager.showInitial();
-            this.initializeCurrentServerName();
+        if (this.mainWindow) {
+            ViewManager.updateMainWindow(this.mainWindow);
         }
+        ViewManager.init();
+        this.initializeCurrentServerName();
     }
 
     initializeCurrentServerName = () => {
@@ -623,13 +588,13 @@ export class WindowManager {
         const tabViewName = getTabViewName(serverName, nextTab.name);
         if (waitForViewToExist) {
             const timeout = setInterval(() => {
-                if (this.viewManager?.views.has(tabViewName)) {
-                    this.viewManager?.showByName(tabViewName);
+                if (ViewManager.getView(tabViewName)) {
+                    ViewManager.showByName(tabViewName);
                     clearTimeout(timeout);
                 }
             }, 100);
         } else {
-            this.viewManager?.showByName(tabViewName);
+            ViewManager.showByName(tabViewName);
         }
         ipcMain.emit(UPDATE_SHORTCUT_MENU);
     }
@@ -638,23 +603,7 @@ export class WindowManager {
         log.debug('windowManager.switchTab');
         this.showMainWindow();
         const tabViewName = getTabViewName(serverName, tabName);
-        this.viewManager?.showByName(tabViewName);
-    }
-
-    focusBrowserView = () => {
-        log.debug('WindowManager.focusBrowserView');
-
-        if (this.viewManager) {
-            this.viewManager.focus();
-        } else {
-            log.error('Trying to call focus when the viewManager has not yet been initialized');
-        }
-    }
-
-    openBrowserViewDevTools = () => {
-        if (this.viewManager) {
-            this.viewManager.openViewDevTools();
-        }
+        ViewManager.showByName(tabViewName);
     }
 
     focusThreeDotMenu = () => {
@@ -668,42 +617,6 @@ export class WindowManager {
         return {
             darkMode: Config.darkMode || false,
         };
-    }
-
-    handleReactAppInitialized = (e: IpcMainEvent, view: string) => {
-        log.debug('WindowManager.handleReactAppInitialized', view);
-
-        if (this.viewManager) {
-            this.viewManager.setServerInitialized(view);
-        }
-    }
-
-    handleLoadingScreenAnimationFinished = () => {
-        log.debug('WindowManager.handleLoadingScreenAnimationFinished');
-
-        if (this.viewManager) {
-            this.viewManager.hideLoadingScreen();
-        }
-
-        if (process.env.NODE_ENV === 'test') {
-            app.emit('e2e-app-loaded');
-        }
-    }
-
-    updateLoadingScreenDarkMode = (darkMode: boolean) => {
-        if (this.viewManager) {
-            this.viewManager.updateLoadingScreenDarkMode(darkMode);
-        }
-    }
-
-    getViewNameByWebContentsId = (webContentsId: number) => {
-        const view = this.viewManager?.findViewByWebContent(webContentsId);
-        return view?.name;
-    }
-
-    getServerNameByWebContentsId = (webContentsId: number) => {
-        const view = this.viewManager?.findViewByWebContent(webContentsId);
-        return view?.tab.server.name;
     }
 
     close = () => {
@@ -733,15 +646,15 @@ export class WindowManager {
     }
 
     reload = () => {
-        const currentView = this.viewManager?.getCurrentView();
+        const currentView = ViewManager.getCurrentView();
         if (currentView) {
-            this.viewManager?.showLoadingScreen();
+            ViewManager.showLoadingScreen();
             currentView.reload();
         }
     }
 
     sendToFind = () => {
-        const currentView = this.viewManager?.getCurrentView();
+        const currentView = ViewManager.getCurrentView();
         if (currentView) {
             currentView.view.webContents.sendInputEvent({type: 'keyDown', keyCode: 'F', modifiers: [process.platform === 'darwin' ? 'cmd' : 'ctrl', 'shift']});
         }
@@ -750,15 +663,13 @@ export class WindowManager {
     handleHistory = (event: IpcMainEvent, offset: number) => {
         log.debug('WindowManager.handleHistory', offset);
 
-        if (this.viewManager) {
-            const activeView = this.viewManager.getCurrentView();
-            if (activeView && activeView.view.webContents.canGoToOffset(offset)) {
-                try {
-                    activeView.view.webContents.goToOffset(offset);
-                } catch (error) {
-                    log.error(error);
-                    activeView.load(activeView.tab.url);
-                }
+        const activeView = ViewManager.getCurrentView();
+        if (activeView && activeView.view.webContents.canGoToOffset(offset)) {
+            try {
+                activeView.view.webContents.goToOffset(offset);
+            } catch (error) {
+                log.error(error);
+                activeView.load(activeView.tab.url);
             }
         }
     }
@@ -772,7 +683,7 @@ export class WindowManager {
     }
 
     selectTab = (fn: (order: number, length: number) => number) => {
-        const currentView = this.viewManager?.getCurrentView();
+        const currentView = ViewManager.getCurrentView();
         if (!currentView) {
             return;
         }
@@ -800,74 +711,8 @@ export class WindowManager {
         return Config.darkMode;
     }
 
-    handleBrowserHistoryPush = (e: IpcMainEvent, viewName: string, pathName: string) => {
-        log.debug('WindowManager.handleBrowserHistoryPush', {viewName, pathName});
-
-        const currentView = this.viewManager?.views.get(viewName);
-        const cleanedPathName = urlUtils.cleanPathName(currentView?.tab.server.url.pathname || '', pathName);
-        const redirectedViewName = this.viewManager?.getViewByURL(`${currentView?.tab.server.url.toString().replace(/\/$/, '')}${cleanedPathName}`)?.name || viewName;
-        if (this.viewManager?.closedViews.has(redirectedViewName)) {
-            // If it's a closed view, just open it and stop
-            this.viewManager.openClosedTab(redirectedViewName, `${currentView?.tab.server.url}${cleanedPathName}`);
-            return;
-        }
-        let redirectedView = this.viewManager?.views.get(redirectedViewName) || currentView;
-        if (redirectedView !== currentView && redirectedView?.tab.server.name === this.currentServerName && redirectedView?.isLoggedIn) {
-            log.info('redirecting to a new view', redirectedView?.name || viewName);
-            this.viewManager?.showByName(redirectedView?.name || viewName);
-        } else {
-            redirectedView = currentView;
-        }
-
-        // Special case check for Channels to not force a redirect to "/", causing a refresh
-        if (!(redirectedView !== currentView && redirectedView?.tab.type === TAB_MESSAGING && cleanedPathName === '/')) {
-            redirectedView?.view.webContents.send(BROWSER_HISTORY_PUSH, cleanedPathName);
-            if (redirectedView) {
-                this.handleBrowserHistoryButton(e, redirectedView.name);
-            }
-        }
-    }
-
-    handleBrowserHistoryButton = (e: IpcMainEvent, viewName: string) => {
-        log.debug('WindowManager.handleBrowserHistoryButton', viewName);
-
-        const currentView = this.viewManager?.views.get(viewName);
-        if (currentView) {
-            if (currentView.view.webContents.getURL() === currentView.tab.url.toString()) {
-                currentView.view.webContents.clearHistory();
-                currentView.isAtRoot = true;
-            } else {
-                currentView.isAtRoot = false;
-            }
-            currentView?.view.webContents.send(BROWSER_HISTORY_BUTTON, currentView.view.webContents.canGoBack(), currentView.view.webContents.canGoForward());
-        }
-    }
-
     getCurrentTeamName = () => {
         return this.currentServerName;
-    }
-
-    handleAppLoggedIn = (event: IpcMainEvent, viewName: string) => {
-        log.debug('WindowManager.handleAppLoggedIn', viewName);
-
-        const view = this.viewManager?.views.get(viewName);
-        if (view && !view.isLoggedIn) {
-            view.isLoggedIn = true;
-            this.viewManager?.reloadViewIfNeeded(viewName);
-        }
-    }
-
-    handleAppLoggedOut = (event: IpcMainEvent, viewName: string) => {
-        log.debug('WindowManager.handleAppLoggedOut', viewName);
-
-        const view = this.viewManager?.views.get(viewName);
-        if (view && view.isLoggedIn) {
-            view.isLoggedIn = false;
-        }
-    }
-
-    handleGetViewName = (event: IpcMainInvokeEvent) => {
-        return this.getViewNameByWebContentsId(event.sender.id);
     }
 
     handleGetWebContentsId = (event: IpcMainInvokeEvent) => {
@@ -877,7 +722,7 @@ export class WindowManager {
     handleGetDesktopSources = async (viewName: string, opts: Electron.SourcesOptions) => {
         log.debug('WindowManager.handleGetDesktopSources', {viewName, opts});
 
-        const view = this.viewManager?.views.get(viewName);
+        const view = ViewManager.getView(viewName);
         if (!view) {
             log.error('WindowManager.handleGetDesktopSources: view not found');
             return Promise.resolve();
@@ -939,27 +784,12 @@ export class WindowManager {
         });
     }
 
-    handleReloadCurrentView = () => {
-        log.debug('WindowManager.handleReloadCurrentView');
-
-        const view = this.viewManager?.getCurrentView();
-        if (!view) {
-            return;
-        }
-        view?.reload();
-        this.viewManager?.showByName(view?.name);
-    }
-
     getServerURLFromWebContentsId = (id: number) => {
         if (this.callsWidgetWindow && (id === this.callsWidgetWindow.getWebContentsId() || id === this.callsWidgetWindow.getPopOutWebContentsId())) {
             return this.callsWidgetWindow.getURL();
         }
 
-        const viewName = this.getViewNameByWebContentsId(id);
-        if (!viewName) {
-            return undefined;
-        }
-        return this.viewManager?.views.get(viewName)?.tab.server.url;
+        return ViewManager.getViewByWebContentsId(id)?.tab.server.url;
     }
 }
 


### PR DESCRIPTION
#### Summary
This PR contains the changes to migrate the `viewManager` module out of the `windowManager` into a singleton class, meaning that many associated objects can now directly access the remote views without needing to import the `windowManager`. It should encapsulate that logic better and require less helper functions and such.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51875

```release-note
NONE
```
