### PR TITLE
Change default devServer port to 9065

### DIFF
--- a/webpack.config.renderer.js
+++ b/webpack.config.renderer.js
@@ -14,7 +14,7 @@ const {merge} = require('webpack-merge');
 
 const base = require('./webpack.config.base');
 
-const WEBSERVER_PORT = process.env.WEBSERVER_PORT ?? 9001;
+const WEBSERVER_PORT = process.env.WEBSERVER_PORT ?? 9065;
 
 module.exports = merge(base, {
     entry: {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
Change default devServer port to 9065, as 9001 is already used by the server to run inbucket. 

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
