### PR TITLE
Remove unneeded entitlements for MAS

### DIFF
--- a/entitlements.mas.plist
+++ b/entitlements.mas.plist
@@ -20,14 +20,6 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
-	<key>com.apple.security.files.downloads.read-write</key>
-	<true/>
-	<key>com.apple.security.assets.pictures.read-write</key>
-	<true/>
-	<key>com.apple.security.assets.music.read-write</key>
-	<true/>
-	<key>com.apple.security.assets.movies.read-write</key>
-	<true/>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.security.application-groups</key>


### PR DESCRIPTION
#### Summary
We had a rejection from Apple in which they told us a bunch of entitlements were unnecessary, so I've removed them.

#### Ticket Link
NONE

```release-note
NONE
```
