### PR TITLE
Fixed a typo in MAS workflow

### DIFF
--- a/.github/workflows/release-mas-only.yaml
+++ b/.github/workflows/release-mas-only.yaml
@@ -67,7 +67,7 @@ jobs:
   end-notification:
     runs-on: ubuntu-22.04
     needs:
-      - github-release
+      - mac-app-store-preflight
     steps:
       - name: release/checkout-repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0


### PR DESCRIPTION
```release-note
NONE
```
