### PR TITLE
Migrate downloads dropdown menus to singletons

### DIFF
--- a/src/main/views/downloadsDropdownMenuView.test.js
+++ b/src/main/views/downloadsDropdownMenuView.test.js
@@ -9,7 +9,7 @@ import {DOWNLOADS_DROPDOWN_FULL_WIDTH, DOWNLOADS_DROPDOWN_MENU_FULL_HEIGHT, DOWN
 
 import MainWindow from 'main/windows/mainWindow';
 
-import DownloadsDropdownMenuView from './downloadsDropdownMenuView';
+import {DownloadsDropdownMenuView} from './downloadsDropdownMenuView';
 
 jest.mock('main/utils', () => ({
     getLocalPreload: (file) => file,
@@ -76,12 +76,13 @@ describe('main/views/DownloadsDropdownMenuView', () => {
     describe('getBounds', () => {
         it('should be placed top-left inside the downloads dropdown if coordinates not used', () => {
             const downloadsDropdownMenuView = new DownloadsDropdownMenuView();
-            expect(downloadsDropdownMenuView.getBounds(DOWNLOADS_DROPDOWN_MENU_FULL_WIDTH, DOWNLOADS_DROPDOWN_MENU_FULL_HEIGHT)).toStrictEqual({x: 800 - DOWNLOADS_DROPDOWN_FULL_WIDTH - DOWNLOADS_DROPDOWN_MENU_FULL_WIDTH, y: TAB_BAR_HEIGHT, width: DOWNLOADS_DROPDOWN_MENU_FULL_WIDTH, height: DOWNLOADS_DROPDOWN_MENU_FULL_HEIGHT});
+            expect(downloadsDropdownMenuView.getBounds(800, DOWNLOADS_DROPDOWN_MENU_FULL_WIDTH, DOWNLOADS_DROPDOWN_MENU_FULL_HEIGHT)).toStrictEqual({x: 800 - DOWNLOADS_DROPDOWN_FULL_WIDTH - DOWNLOADS_DROPDOWN_MENU_FULL_WIDTH, y: TAB_BAR_HEIGHT, width: DOWNLOADS_DROPDOWN_MENU_FULL_WIDTH, height: DOWNLOADS_DROPDOWN_MENU_FULL_HEIGHT});
         });
     });
 
     it('should change the view bounds based on open/closed state', () => {
         const downloadsDropdownMenuView = new DownloadsDropdownMenuView();
+        downloadsDropdownMenuView.init();
         downloadsDropdownMenuView.bounds = {width: 400, height: 300};
         downloadsDropdownMenuView.handleOpen();
         expect(downloadsDropdownMenuView.view.setBounds).toBeCalledWith(downloadsDropdownMenuView.bounds);

--- a/src/main/views/downloadsDropdownView.test.js
+++ b/src/main/views/downloadsDropdownView.test.js
@@ -9,7 +9,7 @@ import {DOWNLOADS_DROPDOWN_FULL_WIDTH, DOWNLOADS_DROPDOWN_HEIGHT, TAB_BAR_HEIGHT
 
 import MainWindow from 'main/windows/mainWindow';
 
-import DownloadsDropdownView from './downloadsDropdownView';
+import {DownloadsDropdownView} from './downloadsDropdownView';
 
 jest.mock('main/utils', () => ({
     getLocalPreload: (file) => file,
@@ -81,20 +81,19 @@ describe('main/views/DownloadsDropdownView', () => {
     });
     describe('getBounds', () => {
         it('should be placed far right when window is large enough', () => {
-            MainWindow.getBounds.mockReturnValue({width: 800, height: 600, x: 0, y: 0});
             const downloadsDropdownView = new DownloadsDropdownView();
-            expect(downloadsDropdownView.getBounds(DOWNLOADS_DROPDOWN_FULL_WIDTH, DOWNLOADS_DROPDOWN_HEIGHT)).toStrictEqual({x: 800 - DOWNLOADS_DROPDOWN_FULL_WIDTH, y: TAB_BAR_HEIGHT, width: DOWNLOADS_DROPDOWN_FULL_WIDTH, height: DOWNLOADS_DROPDOWN_HEIGHT});
+            expect(downloadsDropdownView.getBounds(800, DOWNLOADS_DROPDOWN_FULL_WIDTH, DOWNLOADS_DROPDOWN_HEIGHT)).toStrictEqual({x: 800 - DOWNLOADS_DROPDOWN_FULL_WIDTH, y: TAB_BAR_HEIGHT, width: DOWNLOADS_DROPDOWN_FULL_WIDTH, height: DOWNLOADS_DROPDOWN_HEIGHT});
         });
         it('should be placed left if window is very small', () => {
-            MainWindow.getBounds.mockReturnValue({width: 500, height: 400, x: 0, y: 0});
             const downloadsDropdownView = new DownloadsDropdownView();
-            expect(downloadsDropdownView.getBounds(DOWNLOADS_DROPDOWN_FULL_WIDTH, DOWNLOADS_DROPDOWN_HEIGHT)).toStrictEqual({x: 0, y: TAB_BAR_HEIGHT, width: DOWNLOADS_DROPDOWN_FULL_WIDTH, height: DOWNLOADS_DROPDOWN_HEIGHT});
+            expect(downloadsDropdownView.getBounds(500, DOWNLOADS_DROPDOWN_FULL_WIDTH, DOWNLOADS_DROPDOWN_HEIGHT)).toStrictEqual({x: 0, y: TAB_BAR_HEIGHT, width: DOWNLOADS_DROPDOWN_FULL_WIDTH, height: DOWNLOADS_DROPDOWN_HEIGHT});
         });
     });
 
     it('should change the view bounds based on open/closed state', () => {
         MainWindow.getBounds.mockReturnValue({width: 800, height: 600, x: 0, y: 0});
         const downloadsDropdownView = new DownloadsDropdownView();
+        downloadsDropdownView.init();
         downloadsDropdownView.bounds = {width: 400, height: 300};
         downloadsDropdownView.handleOpen();
         expect(downloadsDropdownView.view.setBounds).toBeCalledWith(downloadsDropdownView.bounds);

--- a/src/main/windows/windowManager.test.js
+++ b/src/main/windows/windowManager.test.js
@@ -76,8 +76,12 @@ jest.mock('../views/loadingScreen', () => ({
 jest.mock('../views/teamDropdownView', () => ({
     updateWindowBounds: jest.fn(),
 }));
-jest.mock('../views/downloadsDropdownView', () => jest.fn());
-jest.mock('../views/downloadsDropdownMenuView', () => jest.fn());
+jest.mock('../views/downloadsDropdownView', () => ({
+    updateWindowBounds: jest.fn(),
+}));
+jest.mock('../views/downloadsDropdownMenuView', () => ({
+    updateWindowBounds: jest.fn(),
+}));
 jest.mock('./settingsWindow', () => ({
     show: jest.fn(),
     get: jest.fn(),

--- a/src/main/windows/windowManager.ts
+++ b/src/main/windows/windowManager.ts
@@ -44,9 +44,6 @@ import SettingsWindow from './settingsWindow';
 const log = new Logger('WindowManager');
 
 export class WindowManager {
-    private downloadsDropdown?: DownloadsDropdownView;
-    private downloadsDropdownMenu?: DownloadsDropdownMenuView;
-
     private isResizing: boolean;
 
     constructor() {
@@ -98,11 +95,10 @@ export class WindowManager {
         mainWindow.on('enter-full-screen', () => this.sendToRenderer('enter-full-screen'));
         mainWindow.on('leave-full-screen', () => this.sendToRenderer('leave-full-screen'));
 
-        this.downloadsDropdown = new DownloadsDropdownView();
-        this.downloadsDropdownMenu = new DownloadsDropdownMenuView();
-
         this.initializeViewManager();
         TeamDropdownView.init();
+        DownloadsDropdownView.init();
+        DownloadsDropdownMenuView.init();
     }
 
     // max retries allows the message to get to the renderer even if it is sent while the app is starting up.
@@ -240,14 +236,14 @@ export class WindowManager {
      *****************/
 
     private handleMaximizeMainWindow = () => {
-        this.downloadsDropdown?.updateWindowBounds();
-        this.downloadsDropdownMenu?.updateWindowBounds();
+        DownloadsDropdownView.updateWindowBounds();
+        DownloadsDropdownMenuView.updateWindowBounds();
         this.sendToRenderer(MAXIMIZE_CHANGE, true);
     }
 
     private handleUnmaximizeMainWindow = () => {
-        this.downloadsDropdown?.updateWindowBounds();
-        this.downloadsDropdownMenu?.updateWindowBounds();
+        DownloadsDropdownView.updateWindowBounds();
+        DownloadsDropdownMenuView.updateWindowBounds();
         this.sendToRenderer(MAXIMIZE_CHANGE, false);
     }
 
@@ -276,8 +272,8 @@ export class WindowManager {
         this.throttledWillResize(newBounds);
         LoadingScreen.setBounds();
         TeamDropdownView.updateWindowBounds();
-        this.downloadsDropdown?.updateWindowBounds();
-        this.downloadsDropdownMenu?.updateWindowBounds();
+        DownloadsDropdownView.updateWindowBounds();
+        DownloadsDropdownMenuView.updateWindowBounds();
         ipcMain.emit(RESIZE_MODAL, null, newBounds);
     }
 
@@ -288,8 +284,8 @@ export class WindowManager {
         this.throttledWillResize(bounds);
         ipcMain.emit(RESIZE_MODAL, null, bounds);
         TeamDropdownView.updateWindowBounds();
-        this.downloadsDropdown?.updateWindowBounds();
-        this.downloadsDropdownMenu?.updateWindowBounds();
+        DownloadsDropdownView.updateWindowBounds();
+        DownloadsDropdownMenuView.updateWindowBounds();
         this.isResizing = false;
     }
 
@@ -318,8 +314,8 @@ export class WindowManager {
 
         LoadingScreen.setBounds();
         TeamDropdownView.updateWindowBounds();
-        this.downloadsDropdown?.updateWindowBounds();
-        this.downloadsDropdownMenu?.updateWindowBounds();
+        DownloadsDropdownView.updateWindowBounds();
+        DownloadsDropdownMenuView.updateWindowBounds();
         ipcMain.emit(RESIZE_MODAL, null, bounds);
     };
 


### PR DESCRIPTION
#### Summary
This PR moves the last two objects (the downloads dropdown menus) out of the `WindowManager`  and into their own singletons.

```release-note
NONE
```
