### PR TITLE
Fixed Snap issue with resizing on Windows 11

### DIFF
--- a/src/main/preload/desktopAPI.js
+++ b/src/main/preload/desktopAPI.js
@@ -88,6 +88,7 @@ import {
     GET_ORDERED_SERVERS,
     GET_ORDERED_TABS_FOR_SERVER,
     SERVERS_UPDATE,
+    VIEW_FINISHED_RESIZING,
 } from 'common/communication';
 
 console.log('Preload initialized');
@@ -251,3 +252,7 @@ const createKeyDownListener = () => {
     });
 };
 createKeyDownListener();
+
+window.addEventListener('resize', () => {
+    ipcRenderer.send(VIEW_FINISHED_RESIZING);
+});

--- a/src/main/windows/mainWindow.test.js
+++ b/src/main/windows/mainWindow.test.js
@@ -462,6 +462,7 @@ describe('main/windows/mainWindow', () => {
             };
             BrowserWindow.mockImplementation(() => window);
             const mainWindow = new MainWindow();
+            mainWindow.getBounds = jest.fn();
             mainWindow.init();
             Object.defineProperty(process, 'platform', {
                 value: originalPlatform,

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -421,7 +421,7 @@ export class MainWindow extends EventEmitter {
      */
 
     private onWillResize = (event: Event, newBounds: Electron.Rectangle) => {
-        log.info('onWillResize', newBounds);
+        log.silly('onWillResize', newBounds);
 
         /**
          * Fixes an issue on win11 related to Snap where the first "will-resize" event would return the same bounds
@@ -445,7 +445,7 @@ export class MainWindow extends EventEmitter {
     }
 
     private onResize = () => {
-        log.info('onResize');
+        log.silly('onResize');
 
         if (this.isResizing) {
             return;
@@ -454,7 +454,7 @@ export class MainWindow extends EventEmitter {
     }
 
     private onResized = () => {
-        log.info('onResized');
+        log.debug('onResized');
 
         this.emit(MAIN_WINDOW_RESIZED, this.getBounds());
         this.isResizing = false;

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -133,6 +133,7 @@ export class MainWindow extends EventEmitter {
         this.win.on('leave-full-screen', () => this.win?.webContents.send('leave-full-screen'));
         this.win.on('will-resize', this.onWillResize);
         this.win.on('resized', this.onResized);
+        this.win.on('moved', this.onResized);
         if (process.platform !== 'darwin') {
             mainWindow.on('resize', this.onResize);
         }

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -287,6 +287,8 @@ export class MainWindow extends EventEmitter {
                 // do nothing because we want to supress the menu popping up
             });
         }
+
+        this.emit(MAIN_WINDOW_RESIZED, this.getBounds());
     }
 
     private onBlur = () => {
@@ -295,6 +297,8 @@ export class MainWindow extends EventEmitter {
         }
 
         globalShortcut.unregisterAll();
+
+        this.emit(MAIN_WINDOW_RESIZED, this.getBounds());
 
         // App should save bounds when a window is closed.
         // However, 'close' is not fired in some situations(shutdown, ctrl+c)
@@ -417,7 +421,7 @@ export class MainWindow extends EventEmitter {
      */
 
     private onWillResize = (event: Event, newBounds: Electron.Rectangle) => {
-        log.silly('onWillResize', newBounds);
+        log.info('onWillResize', newBounds);
 
         /**
          * Fixes an issue on win11 related to Snap where the first "will-resize" event would return the same bounds
@@ -441,7 +445,7 @@ export class MainWindow extends EventEmitter {
     }
 
     private onResize = () => {
-        log.silly('onResize');
+        log.info('onResize');
 
         if (this.isResizing) {
             return;
@@ -450,7 +454,7 @@ export class MainWindow extends EventEmitter {
     }
 
     private onResized = () => {
-        log.debug('onResized');
+        log.info('onResized');
 
         this.emit(MAIN_WINDOW_RESIZED, this.getBounds());
         this.isResizing = false;


### PR DESCRIPTION
#### Summary
Something I refactored caused the auto snap function in Windows 11 to stop resizing the window correctly.
This PR adds a check on another listener to make sure once the window is moved that the size of the elements are correct, which seems to have fixed the issue.

```release-note
NONE
```
