### PR TITLE
Fixed bad mention counts in the dropdown menu

### DIFF
--- a/src/main/views/teamDropdownView.ts
+++ b/src/main/views/teamDropdownView.ts
@@ -172,6 +172,7 @@ export class TeamDropdownView {
     }
 
     private reduceNotifications = <T>(inputMap: Map<string, T>, items: Map<string, T>, modifier: (base?: T, value?: T) => T) => {
+        inputMap.clear();
         return [...items.keys()].reduce((map, key) => {
             const view = ServerManager.getTab(key);
             if (!view) {


### PR DESCRIPTION
#### Summary
One of the changes I made to the team dropdown causes the mentions to accumulate and never reset.
This PR makes sure the maps are cleared before trying to re-fill them.

```release-note
NONE
```
