### PR TITLE
Prevent calls widget window from showing native shadow

### DIFF
--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -62,6 +62,7 @@ export default class CallsWidgetWindow extends EventEmitter {
             transparent: true,
             show: false,
             alwaysOnTop: true,
+            hasShadow: false,
             backgroundColor: '#00ffffff',
             webPreferences: {
                 preload: getLocalPreload('callsWidget.js'),


### PR DESCRIPTION
#### Summary

PR sets the `hasShadow` option to `false` for the calls widget window. The native macOS shadow is not playing nicely and causing some weird artifacts and inconsistencies in sizing as we already have some shadow in place at the CSS level.

The only concern with this change is that it makes it a little more difficult to figure out whether the widget window is focused but not sure how important that is. @tanmay-des Maybe we could work on improving that at the widget level through some clever styling

#### Screenshots

Before:

<img width="379" alt="Screenshot 2023-04-27 at 14 26 12" src="https://user-images.githubusercontent.com/1832946/234983178-4aeb0875-1362-4ecb-9556-3db0a325b780.png">

After:

<img width="367" alt="Screenshot 2023-04-27 at 14 27 10" src="https://user-images.githubusercontent.com/1832946/234983182-c160603a-570b-4450-a34c-2cfc0ab64ca0.png">

#### Release Note

```release-note
NONE
```

