### PR TITLE
[MM-52380] Fix unhandled rejection when clearing app cache

### DIFF
--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -345,11 +345,6 @@ async function initializeAfterAppReady() {
         updateSpellCheckerLocales();
     }
 
-    if (wasUpdated(AppVersionManager.lastAppVersion)) {
-        clearAppCache();
-    }
-    AppVersionManager.lastAppVersion = app.getVersion();
-
     if (typeof Config.canUpgrade === 'undefined') {
         // windows might not be ready, so we have to wait until it is
         Config.once('update', () => {
@@ -471,6 +466,11 @@ async function initializeAfterAppReady() {
         // is the requesting url trusted?
         callback(urlUtils.isTrustedURL(requestingURL, serverURL));
     });
+
+    if (wasUpdated(AppVersionManager.lastAppVersion)) {
+        clearAppCache();
+    }
+    AppVersionManager.lastAppVersion = app.getVersion();
 
     handleMainWindowIsShown();
 }

--- a/src/main/app/utils.ts
+++ b/src/main/app/utils.ts
@@ -92,7 +92,7 @@ export function clearAppCache() {
     const mainWindow = MainWindow.get();
     if (mainWindow) {
         mainWindow.webContents.session.clearCache().
-            then(mainWindow.reload).
+            then(mainWindow.webContents.reload).
             catch((err) => {
                 log.error('clearAppCache', err);
             });

--- a/src/main/app/utils.ts
+++ b/src/main/app/utils.ts
@@ -91,7 +91,11 @@ export function clearAppCache() {
     // TODO: clear cache on browserviews, not in the renderer.
     const mainWindow = MainWindow.get();
     if (mainWindow) {
-        mainWindow.webContents.session.clearCache().then(mainWindow.reload);
+        mainWindow.webContents.session.clearCache().
+            then(mainWindow.reload).
+            catch((err) => {
+                log.error('clearAppCache', err);
+            });
     } else {
     //Wait for mainWindow
         setTimeout(clearAppCache, 100);


### PR DESCRIPTION
#### Summary
There's a case for some reason when we update to a new version that the application will crash when trying to ensure we update the browser cache for the main window. We force a reload on the main window, which fails saying that the object is destroyed. It's possible that this is just a check to make sure the page is reloaded afterwards, but it might be doing it itself.

I've done 2 things to mitigate any issues:
- Move the app cache call down a bit to hopefully make sure the window exists
- Add a catch to ensure the crash doesn't happen (we just need to log it if the object is already reloading)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52380

```release-note
NONE
```
