### PR TITLE
[MM-52139] Force user to reset default downloads directory when the app is not allowed to access it

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -43,6 +43,8 @@
   "main.CriticalErrorHandler.uncaughtException.button.showDetails": "Show Details",
   "main.CriticalErrorHandler.uncaughtException.dialog.message": "The {appName} app quit unexpectedly. Click \"{showDetails}\" to learn more or \"{reopen}\" to open the application again.\n\nInternal error: {err}",
   "main.CriticalErrorHandler.unresponsive.dialog.message": "The window is no longer responsive.\nDo you want to wait until the window becomes responsive again?",
+  "main.downloadsManager.resetDownloadsFolder": "Please reset the folder where files will download",
+  "main.downloadsManager.specifyDownloadsFolder": "Specify the folder where files will download",
   "main.menus.app.edit": "&Edit",
   "main.menus.app.edit.copy": "Copy",
   "main.menus.app.edit.cut": "Cut",

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -13,7 +13,6 @@ import {
     QUIT,
     SHOW_NEW_SERVER_MODAL,
     NOTIFY_MENTION,
-    GET_DOWNLOAD_LOCATION,
     SWITCH_TAB,
     CLOSE_TAB,
     OPEN_TAB,
@@ -92,7 +91,6 @@ import {
     handleMentionNotification,
     handleOpenAppMenu,
     handleQuit,
-    handleSelectDownload,
     handlePingDomain,
 } from './intercom';
 import {
@@ -290,7 +288,6 @@ function initializeInterCommunicationEventListeners() {
     ipcMain.on(SHOW_EDIT_SERVER_MODAL, handleEditServerModal);
     ipcMain.on(SHOW_REMOVE_SERVER_MODAL, handleRemoveServerModal);
     ipcMain.handle(GET_AVAILABLE_SPELL_CHECKER_LANGUAGES, () => session.defaultSession.availableSpellCheckerLanguages);
-    ipcMain.handle(GET_DOWNLOAD_LOCATION, handleSelectDownload);
     ipcMain.on(START_UPDATE_DOWNLOAD, handleStartDownload);
     ipcMain.on(START_UPGRADE, handleStartUpgrade);
     ipcMain.handle(PING_DOMAIN, handlePingDomain);

--- a/src/main/app/intercom.ts
+++ b/src/main/app/intercom.ts
@@ -1,18 +1,17 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {app, dialog, IpcMainEvent, IpcMainInvokeEvent, Menu} from 'electron';
+import {app, IpcMainEvent, IpcMainInvokeEvent, Menu} from 'electron';
 
 import {MattermostTeam} from 'types/config';
 import {MentionData} from 'types/notification';
 
-import Config from 'common/config';
 import {Logger} from 'common/log';
+import ServerManager from 'common/servers/serverManager';
 import {ping} from 'common/utils/requests';
 
 import {displayMention} from 'main/notifications';
 import {getLocalPreload, getLocalURLString} from 'main/utils';
-import ServerManager from 'common/servers/serverManager';
 import ModalManager from 'main/views/modalManager';
 import MainWindow from 'main/windows/mainWindow';
 
@@ -128,17 +127,6 @@ export function handleOpenAppMenu() {
         x: 18,
         y: 18,
     });
-}
-
-export async function handleSelectDownload(event: IpcMainInvokeEvent, startFrom: string) {
-    log.debug('handleSelectDownload', startFrom);
-
-    const message = 'Specify the folder where files will download';
-    const result = await dialog.showOpenDialog({defaultPath: startFrom || Config.downloadLocation,
-        message,
-        properties:
-     ['openDirectory', 'createDirectory', 'dontAddToRecent', 'promptToCreate']});
-    return result.filePaths[0];
 }
 
 export function handlePingDomain(event: IpcMainInvokeEvent, url: string): Promise<string> {


### PR DESCRIPTION
#### Summary
When the application is upgraded, it loses access to the folders it was previously granted entitlements to, including whatever the configured default downloads directory is. Since we still keep the configuration between upgrades however, it confuses the app when it doesn't have access.

This PR will force the user to reset the default downloads directory when the folder becomes inaccessible, allowing the app to download normally to whatever folder was chosen.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52139

```release-note
Fixed an issue for the MAS build where the default downloads directory would be invalid after upgrade.
```
