### PR TITLE
[MM-52285] Upgrade to Electron v23.3.0, electron-context-menu to v3.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,10 +50,10 @@
         "copy-webpack-plugin": "10.2.4",
         "cross-env": "7.0.3",
         "css-loader": "6.7.1",
-        "electron": "23.1.2",
+        "electron": "23.3.0",
         "electron-builder": "23.3.3",
         "electron-connect": "0.6.3",
-        "electron-context-menu": "3.5.0",
+        "electron-context-menu": "3.6.1",
         "electron-devtools-installer": "3.2.0",
         "electron-is-dev": "2.0.0",
         "electron-log": "4.4.8",
@@ -15808,9 +15808,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "23.1.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-23.1.2.tgz",
-      "integrity": "sha512-ajE6xzIwH7swf8TlTU5WklDqpI3mPj4Am6690YrpCXzcp+E+dmMBXIajUUNt4joDrFhJC/lC6ZqDS2Q1BApKgQ==",
+      "version": "23.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-23.3.0.tgz",
+      "integrity": "sha512-DVAtptpOSxM7ycgriphSxzlkb3R92d28sFKG1hMtmPkAwHl/e87reaHXhGwyj8Xu4GY69e6yUoAJqma20w0Vgw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -15920,9 +15920,9 @@
       }
     },
     "node_modules/electron-context-menu": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/electron-context-menu/-/electron-context-menu-3.5.0.tgz",
-      "integrity": "sha512-z4agpok6YnXlGFs66zU9EBFft4llUFJ41NYFEMMS0fnprMKBztJUCHBA6LMAqJgjabfqsYC7kxlvjvepxodOqg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/electron-context-menu/-/electron-context-menu-3.6.1.tgz",
+      "integrity": "sha512-lcpO6tzzKUROeirhzBjdBWNqayEThmdW+2I2s6H6QMrwqTVyT3EK47jW3Nxm60KTxl5/bWfEoIruoUNn57/QkQ==",
       "dev": true,
       "dependencies": {
         "cli-truncate": "^2.1.0",
@@ -45692,9 +45692,9 @@
       }
     },
     "electron": {
-      "version": "23.1.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-23.1.2.tgz",
-      "integrity": "sha512-ajE6xzIwH7swf8TlTU5WklDqpI3mPj4Am6690YrpCXzcp+E+dmMBXIajUUNt4joDrFhJC/lC6ZqDS2Q1BApKgQ==",
+      "version": "23.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-23.3.0.tgz",
+      "integrity": "sha512-DVAtptpOSxM7ycgriphSxzlkb3R92d28sFKG1hMtmPkAwHl/e87reaHXhGwyj8Xu4GY69e6yUoAJqma20w0Vgw==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",
@@ -45785,9 +45785,9 @@
       }
     },
     "electron-context-menu": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/electron-context-menu/-/electron-context-menu-3.5.0.tgz",
-      "integrity": "sha512-z4agpok6YnXlGFs66zU9EBFft4llUFJ41NYFEMMS0fnprMKBztJUCHBA6LMAqJgjabfqsYC7kxlvjvepxodOqg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/electron-context-menu/-/electron-context-menu-3.6.1.tgz",
+      "integrity": "sha512-lcpO6tzzKUROeirhzBjdBWNqayEThmdW+2I2s6H6QMrwqTVyT3EK47jW3Nxm60KTxl5/bWfEoIruoUNn57/QkQ==",
       "dev": true,
       "requires": {
         "cli-truncate": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/mattermost/desktop.git"
   },
   "config": {
-    "target": "23.1.2",
+    "target": "23.3.0",
     "arch": "x64",
     "target_arch": "x64",
     "disturl": "https://electronjs.org/headers",
@@ -168,10 +168,10 @@
     "copy-webpack-plugin": "10.2.4",
     "cross-env": "7.0.3",
     "css-loader": "6.7.1",
-    "electron": "23.1.2",
+    "electron": "23.3.0",
     "electron-builder": "23.3.3",
     "electron-connect": "0.6.3",
-    "electron-context-menu": "3.5.0",
+    "electron-context-menu": "3.6.1",
     "electron-devtools-installer": "3.2.0",
     "electron-is-dev": "2.0.0",
     "electron-log": "4.4.8",


### PR DESCRIPTION
#### Summary
There was a weird, inconsistent bug where sometimes spellchecker highlighting would persist even after text was deleted. This is likely related to an Electron thing, so I've upgraded us to v23.0.0, and also made sure the context-menu wasn't the culprit either.

This may not be the exact fix, but it's the most likely one. We'll see if it comes back again.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52285

```release-note
Fixed an issue where spellcheck highlighting might persist after text is deleted.
```
