### PR TITLE
[MM-52587] Clean up URL utils, use isInternalURL when possible

### DIFF
--- a/src/common/Validator.ts
+++ b/src/common/Validator.ts
@@ -13,7 +13,7 @@ import {PermissionType, TrustedOrigin} from 'types/trustedOrigin';
 
 import {Logger} from 'common/log';
 import {TAB_MESSAGING} from 'common/tabs/TabView';
-import urlUtils from 'common/utils/url';
+import {isValidURL} from 'common/utils/url';
 
 const log = new Logger('Validator');
 const defaultOptions = {
@@ -232,7 +232,7 @@ function cleanTeams<T extends {name: string; url: string}>(teams: T[], func: (te
         newTeams = newTeams.map((team) => func(team));
 
         // next filter out urls that are still invalid so all is not lost
-        newTeams = newTeams.filter(({url}) => urlUtils.isValidURL(url));
+        newTeams = newTeams.filter(({url}) => isValidURL(url));
     }
     return newTeams;
 }
@@ -245,7 +245,7 @@ export function validateV1ConfigData(data: ConfigV1) {
 
 export function validateV2ConfigData(data: ConfigV2) {
     data.teams = cleanTeams(data.teams, cleanTeam);
-    if (data.spellCheckerURL && !urlUtils.isValidURL(data.spellCheckerURL)) {
+    if (data.spellCheckerURL && !isValidURL(data.spellCheckerURL)) {
         log.error('Invalid download location for spellchecker dictionary, removing from config');
         delete data.spellCheckerURL;
     }
@@ -254,7 +254,7 @@ export function validateV2ConfigData(data: ConfigV2) {
 
 export function validateV3ConfigData(data: ConfigV3) {
     data.teams = cleanTeams(data.teams, cleanTeamWithTabs);
-    if (data.spellCheckerURL && !urlUtils.isValidURL(data.spellCheckerURL)) {
+    if (data.spellCheckerURL && !isValidURL(data.spellCheckerURL)) {
         log.error('Invalid download location for spellchecker dictionary, removing from config');
         delete data.spellCheckerURL;
     }

--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -102,7 +102,6 @@ export const GET_AVAILABLE_SPELL_CHECKER_LANGUAGES = 'get-available-spell-checke
 
 export const GET_VIEW_INFO_FOR_TEST = 'get-view-info-for-test';
 
-export const RESIZE_MODAL = 'resize-modal';
 export const GET_MODAL_UNCLOSEABLE = 'get-modal-uncloseable';
 
 export const UPDATE_PATHS = 'update-paths';

--- a/src/common/servers/MattermostServer.ts
+++ b/src/common/servers/MattermostServer.ts
@@ -5,7 +5,7 @@ import {v4 as uuid} from 'uuid';
 
 import {MattermostTeam, Team} from 'types/config';
 
-import urlUtils from 'common/utils/url';
+import {parseURL} from 'common/utils/url';
 
 export class MattermostServer {
     id: string;
@@ -23,7 +23,7 @@ export class MattermostServer {
     }
 
     updateURL = (url: string) => {
-        this.url = urlUtils.parseURL(url)!;
+        this.url = parseURL(url)!;
         if (!this.url) {
             throw new Error('Invalid url for creating a server');
         }

--- a/src/common/servers/serverManager.test.js
+++ b/src/common/servers/serverManager.test.js
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {TAB_MESSAGING, TAB_FOCALBOARD, TAB_PLAYBOOKS} from 'common/tabs/TabView';
-import urlUtils, {equalUrlsIgnoringSubpath} from 'common/utils/url';
+import {parseURL, isInternalURL} from 'common/utils/url';
 import Utils from 'common/utils/util';
 
 import {ServerManager} from './serverManager';
@@ -12,7 +12,7 @@ jest.mock('common/config', () => ({
 }));
 jest.mock('common/utils/url', () => ({
     parseURL: jest.fn(),
-    equalUrlsIgnoringSubpath: jest.fn(),
+    isInternalURL: jest.fn(),
 }));
 jest.mock('common/utils/util', () => ({
     isVersionGreaterThanOrEqualTo: jest.fn(),
@@ -125,8 +125,8 @@ describe('common/servers/serverManager', () => {
         };
 
         beforeEach(() => {
-            urlUtils.parseURL.mockImplementation((url) => new URL(url));
-            equalUrlsIgnoringSubpath.mockImplementation((url1, url2) => `${url1}`.startsWith(`${url2}`));
+            parseURL.mockImplementation((url) => new URL(url));
+            isInternalURL.mockImplementation((url1, url2) => `${url1}`.startsWith(`${url2}`));
         });
 
         afterEach(() => {

--- a/src/common/servers/serverManager.ts
+++ b/src/common/servers/serverManager.ts
@@ -17,7 +17,7 @@ import {TAB_FOCALBOARD, TAB_MESSAGING, TAB_PLAYBOOKS, TabView, getDefaultTabs} f
 import MessagingTabView from 'common/tabs/MessagingTabView';
 import FocalboardTabView from 'common/tabs/FocalboardTabView';
 import PlaybooksTabView from 'common/tabs/PlaybooksTabView';
-import urlUtils, {equalUrlsIgnoringSubpath} from 'common/utils/url';
+import {isInternalURL, parseURL} from 'common/utils/url';
 import Utils from 'common/utils/util';
 
 const log = new Logger('ServerManager');
@@ -133,12 +133,12 @@ export class ServerManager extends EventEmitter {
     lookupTabByURL = (inputURL: URL | string, ignoreScheme = false) => {
         log.silly('lookupTabByURL', `${inputURL}`, ignoreScheme);
 
-        const parsedURL = urlUtils.parseURL(inputURL);
+        const parsedURL = parseURL(inputURL);
         if (!parsedURL) {
             return undefined;
         }
         const server = this.getAllServers().find((server) => {
-            return equalUrlsIgnoringSubpath(parsedURL, server.url, ignoreScheme) && parsedURL.pathname.match(new RegExp(`^${server.url.pathname}(.+)?(/(.+))?$`));
+            return isInternalURL(parsedURL, server.url, ignoreScheme) && parsedURL.pathname.match(new RegExp(`^${server.url.pathname}(.+)?(/(.+))?$`));
         });
         if (!server) {
             return undefined;
@@ -204,7 +204,7 @@ export class ServerManager extends EventEmitter {
         }
 
         let urlModified;
-        if (existingServer.url.toString() !== urlUtils.parseURL(server.url)?.toString()) {
+        if (existingServer.url.toString() !== parseURL(server.url)?.toString()) {
             // Emit this event whenever we update a server URL to ensure remote info is fetched
             urlModified = () => this.emit(SERVERS_URL_MODIFIED, [serverId]);
         }

--- a/src/common/utils/url.test.js
+++ b/src/common/utils/url.test.js
@@ -2,7 +2,17 @@
 // See LICENSE.txt for license information.
 'use strict';
 
-import urlUtils, {getFormattedPathName, isUrlType, equalUrlsIgnoringSubpath, equalUrlsWithSubpath} from 'common/utils/url';
+import {
+    getFormattedPathName,
+    isUrlType,
+    isValidURL,
+    isValidURI,
+    parseURL,
+    isInternalURL,
+    isCustomLoginURL,
+    isCallsPopOutURL,
+    isTrustedURL,
+} from 'common/utils/url';
 
 jest.mock('common/tabs/TabView', () => ({
     getServerView: (srv, tab) => {
@@ -14,132 +24,6 @@ jest.mock('common/tabs/TabView', () => ({
 }));
 
 describe('common/utils/url', () => {
-    describe('isValidURL', () => {
-        it('should be true for a valid web url', () => {
-            const testURL = 'https://developers.mattermost.com/';
-            expect(urlUtils.isValidURL(testURL)).toBe(true);
-        });
-        it('should be true for a valid, non-https web url', () => {
-            const testURL = 'http://developers.mattermost.com/';
-            expect(urlUtils.isValidURL(testURL)).toBe(true);
-        });
-        it('should be true for an invalid, self-defined, top-level domain', () => {
-            const testURL = 'https://www.example.x';
-            expect(urlUtils.isValidURL(testURL)).toBe(true);
-        });
-        it('should be true for a file download url', () => {
-            const testURL = 'https://community.mattermost.com/api/v4/files/ka3xbfmb3ffnmgdmww8otkidfw?download=1';
-            expect(urlUtils.isValidURL(testURL)).toBe(true);
-        });
-        it('should be true for a permalink url', () => {
-            const testURL = 'https://community.mattermost.com/test-channel/pl/pdqowkij47rmbyk78m5hwc7r6r';
-            expect(urlUtils.isValidURL(testURL)).toBe(true);
-        });
-        it('should be true for a valid, internal domain', () => {
-            const testURL = 'https://mattermost.company-internal';
-            expect(urlUtils.isValidURL(testURL)).toBe(true);
-        });
-        it('should be true for a second, valid internal domain', () => {
-            const testURL = 'https://serverXY/mattermost';
-            expect(urlUtils.isValidURL(testURL)).toBe(true);
-        });
-        it('should be true for a valid, non-https internal domain', () => {
-            const testURL = 'http://mattermost.local';
-            expect(urlUtils.isValidURL(testURL)).toBe(true);
-        });
-        it('should be true for a valid, non-https, ip address with port number', () => {
-            const testURL = 'http://localhost:8065';
-            expect(urlUtils.isValidURL(testURL)).toBe(true);
-        });
-    });
-    describe('isValidURI', () => {
-        it('should be true for a deeplink url', () => {
-            const testURL = 'mattermost://community-release.mattermost.com/core/channels/developers';
-            expect(urlUtils.isValidURI(testURL)).toBe(true);
-        });
-        it('should be false for a malicious url', () => {
-            const testURL = String.raw`mattermost:///" --data-dir "\\deans-mbp\mattermost`;
-            expect(urlUtils.isValidURI(testURL)).toBe(false);
-        });
-    });
-
-    describe('getHost', () => {
-        it('should return the origin of a well formed url', () => {
-            const myurl = 'https://mattermost.com/download';
-            expect(urlUtils.getHost(myurl)).toBe('https://mattermost.com');
-        });
-
-        it('shoud raise an error on malformed urls', () => {
-            const myurl = 'http://example.com:-80/';
-            expect(() => {
-                urlUtils.getHost(myurl);
-            }).toThrow(SyntaxError);
-        });
-    });
-
-    describe('parseURL', () => {
-        it('should return the URL if it is already a URL', () => {
-            const url = new URL('http://mattermost.com');
-            expect(urlUtils.parseURL(url)).toBe(url);
-        });
-
-        it('should return undefined when a bad url is passed', () => {
-            const badURL = 'not-a-real-url-at-all';
-            expect(urlUtils.parseURL(badURL)).toBe(undefined);
-        });
-
-        it('should remove duplicate slashes in a URL when parsing', () => {
-            const urlWithExtraSlashes = 'https://mattermost.com//sub//path//example';
-            const parsedURL = urlUtils.parseURL(urlWithExtraSlashes);
-
-            expect(parsedURL.toString()).toBe('https://mattermost.com/sub/path/example');
-        });
-    });
-
-    describe('isInternalURL', () => {
-        it('should return false on different hosts', () => {
-            const baseURL = new URL('http://mattermost.com');
-            const externalURL = new URL('http://google.com');
-
-            expect(urlUtils.isInternalURL(externalURL, baseURL)).toBe(false);
-        });
-
-        it('should return false on different ports', () => {
-            const baseURL = new URL('http://mattermost.com:8080');
-            const externalURL = new URL('http://mattermost.com:9001');
-
-            expect(urlUtils.isInternalURL(externalURL, baseURL)).toBe(false);
-        });
-
-        it('should return false on different subpaths', () => {
-            const baseURL = new URL('http://mattermost.com/sub/path/');
-            const externalURL = new URL('http://mattermost.com/different/sub/path');
-
-            expect(urlUtils.isInternalURL(externalURL, baseURL)).toBe(false);
-        });
-
-        it('should return true if matching', () => {
-            const baseURL = new URL('http://mattermost.com/');
-            const externalURL = new URL('http://mattermost.com');
-
-            expect(urlUtils.isInternalURL(externalURL, baseURL)).toBe(true);
-        });
-
-        it('should return true if matching with subpath', () => {
-            const baseURL = new URL('http://mattermost.com/sub/path/');
-            const externalURL = new URL('http://mattermost.com/sub/path');
-
-            expect(urlUtils.isInternalURL(externalURL, baseURL)).toBe(true);
-        });
-
-        it('should return true if subpath of', () => {
-            const baseURL = new URL('http://mattermost.com/');
-            const externalURL = new URL('http://mattermost.com/sub/path');
-
-            expect(urlUtils.isInternalURL(externalURL, baseURL)).toBe(true);
-        });
-    });
-
     describe('getFormattedPathName', () => {
         it('should format all to lower case', () => {
             const unformattedPathName = '/aAbBbB/cC/DdeR/';
@@ -149,6 +33,159 @@ describe('common/utils/url', () => {
         it('should add trailing slash', () => {
             const unformattedPathName = '/aAbBbB/cC/DdeR';
             expect(getFormattedPathName(unformattedPathName)).toBe('/aabbbb/cc/dder/');
+        });
+    });
+    describe('parseURL', () => {
+        it('should return the URL if it is already a URL', () => {
+            const url = new URL('http://mattermost.com');
+            expect(parseURL(url)).toBe(url);
+        });
+
+        it('should return undefined when a bad url is passed', () => {
+            const badURL = 'not-a-real-url-at-all';
+            expect(parseURL(badURL)).toBe(undefined);
+        });
+
+        it('should remove duplicate slashes in a URL when parsing', () => {
+            const urlWithExtraSlashes = 'https://mattermost.com//sub//path//example';
+            const parsedURL = parseURL(urlWithExtraSlashes);
+
+            expect(parsedURL.toString()).toBe('https://mattermost.com/sub/path/example');
+        });
+    });
+
+    describe('isValidURL', () => {
+        it('should be true for a valid web url', () => {
+            const testURL = 'https://developers.mattermost.com/';
+            expect(isValidURL(testURL)).toBe(true);
+        });
+        it('should be true for a valid, non-https web url', () => {
+            const testURL = 'http://developers.mattermost.com/';
+            expect(isValidURL(testURL)).toBe(true);
+        });
+        it('should be true for an invalid, self-defined, top-level domain', () => {
+            const testURL = 'https://www.example.x';
+            expect(isValidURL(testURL)).toBe(true);
+        });
+        it('should be true for a file download url', () => {
+            const testURL = 'https://community.mattermost.com/api/v4/files/ka3xbfmb3ffnmgdmww8otkidfw?download=1';
+            expect(isValidURL(testURL)).toBe(true);
+        });
+        it('should be true for a permalink url', () => {
+            const testURL = 'https://community.mattermost.com/test-channel/pl/pdqowkij47rmbyk78m5hwc7r6r';
+            expect(isValidURL(testURL)).toBe(true);
+        });
+        it('should be true for a valid, internal domain', () => {
+            const testURL = 'https://mattermost.company-internal';
+            expect(isValidURL(testURL)).toBe(true);
+        });
+        it('should be true for a second, valid internal domain', () => {
+            const testURL = 'https://serverXY/mattermost';
+            expect(isValidURL(testURL)).toBe(true);
+        });
+        it('should be true for a valid, non-https internal domain', () => {
+            const testURL = 'http://mattermost.local';
+            expect(isValidURL(testURL)).toBe(true);
+        });
+        it('should be true for a valid, non-https, ip address with port number', () => {
+            const testURL = 'http://localhost:8065';
+            expect(isValidURL(testURL)).toBe(true);
+        });
+    });
+    describe('isValidURI', () => {
+        it('should be true for a deeplink url', () => {
+            const testURL = 'mattermost://community-release.mattermost.com/core/channels/developers';
+            expect(isValidURI(testURL)).toBe(true);
+        });
+        it('should be false for a malicious url', () => {
+            const testURL = String.raw`mattermost:///" --data-dir "\\deans-mbp\mattermost`;
+            expect(isValidURI(testURL)).toBe(false);
+        });
+    });
+    describe('isInternalURL', () => {
+        it('should return false on different hosts', () => {
+            const baseURL = new URL('http://mattermost.com');
+            const externalURL = new URL('http://google.com');
+
+            expect(isInternalURL(externalURL, baseURL)).toBe(false);
+        });
+
+        it('should return false on different ports', () => {
+            const baseURL = new URL('http://mattermost.com:8080');
+            const externalURL = new URL('http://mattermost.com:9001');
+
+            expect(isInternalURL(externalURL, baseURL)).toBe(false);
+        });
+
+        it('should return false on different subpaths', () => {
+            const baseURL = new URL('http://mattermost.com/sub/path/');
+            const externalURL = new URL('http://mattermost.com/different/sub/path');
+
+            expect(isInternalURL(externalURL, baseURL)).toBe(false);
+        });
+
+        it('should return true if matching', () => {
+            const baseURL = new URL('http://mattermost.com/');
+            const externalURL = new URL('http://mattermost.com');
+
+            expect(isInternalURL(externalURL, baseURL)).toBe(true);
+        });
+
+        it('should return true if matching with subpath', () => {
+            const baseURL = new URL('http://mattermost.com/sub/path/');
+            const externalURL = new URL('http://mattermost.com/sub/path');
+
+            expect(isInternalURL(externalURL, baseURL)).toBe(true);
+        });
+
+        it('should return true if subpath of', () => {
+            const baseURL = new URL('http://mattermost.com/');
+            const externalURL = new URL('http://mattermost.com/sub/path');
+
+            expect(isInternalURL(externalURL, baseURL)).toBe(true);
+        });
+
+        it('same host, different URL scheme, with ignore scheme', () => {
+            const url1 = new URL('http://server-1.com');
+            const url2 = new URL('mattermost://server-1.com');
+            expect(isInternalURL(url1, url2, true)).toBe(true);
+        });
+    });
+    describe('isTrustedURL', () => {
+        it('base urls', () => {
+            const url1 = new URL('http://server-1.com');
+            const url2 = new URL('http://server-1.com');
+            expect(isTrustedURL(url1, url2)).toBe(true);
+        });
+
+        it('different urls', () => {
+            const url1 = new URL('http://server-1.com');
+            const url2 = new URL('http://server-2.com');
+            expect(isTrustedURL(url1, url2)).toBe(false);
+        });
+
+        it('same host, different subpath', () => {
+            const url1 = new URL('http://server-1.com/subpath');
+            const url2 = new URL('http://server-1.com');
+            expect(isTrustedURL(url1, url2)).toBe(true);
+        });
+
+        it('same host and subpath', () => {
+            const url1 = new URL('http://server-1.com/subpath');
+            const url2 = new URL('http://server-1.com/subpath');
+            expect(isTrustedURL(url1, url2)).toBe(true);
+        });
+
+        it('same host, different URL scheme', () => {
+            const url1 = new URL('http://server-1.com');
+            const url2 = new URL('mattermost://server-1.com');
+            expect(isTrustedURL(url1, url2)).toBe(false);
+        });
+
+        it('same host, different ports', () => {
+            const url1 = new URL('http://server-1.com:8080');
+            const url2 = new URL('http://server-1.com');
+            expect(isTrustedURL(url1, url2)).toBe(false);
         });
     });
 
@@ -172,175 +209,100 @@ describe('common/utils/url', () => {
         });
     });
 
-    describe('equalUrls', () => {
-        it('base urls', () => {
-            const url1 = new URL('http://server-1.com');
-            const url2 = new URL('http://server-1.com');
-            expect(equalUrlsIgnoringSubpath(url1, url2)).toBe(true);
-            expect(equalUrlsWithSubpath(url1, url2)).toBe(true);
-        });
-
-        it('different urls', () => {
-            const url1 = new URL('http://server-1.com');
-            const url2 = new URL('http://server-2.com');
-            expect(equalUrlsIgnoringSubpath(url1, url2)).toBe(false);
-            expect(equalUrlsWithSubpath(url1, url2)).toBe(false);
-        });
-
-        it('same host, different subpath', () => {
-            const url1 = new URL('http://server-1.com/subpath');
-            const url2 = new URL('http://server-1.com');
-            expect(equalUrlsIgnoringSubpath(url1, url2)).toBe(true);
-            expect(equalUrlsWithSubpath(url1, url2)).toBe(false);
-        });
-
-        it('same host and subpath', () => {
-            const url1 = new URL('http://server-1.com/subpath');
-            const url2 = new URL('http://server-1.com/subpath');
-            expect(equalUrlsIgnoringSubpath(url1, url2)).toBe(true);
-            expect(equalUrlsWithSubpath(url1, url2)).toBe(true);
-        });
-
-        it('same host, different URL scheme', () => {
-            const url1 = new URL('http://server-1.com');
-            const url2 = new URL('mattermost://server-1.com');
-            expect(equalUrlsIgnoringSubpath(url1, url2)).toBe(false);
-            expect(equalUrlsWithSubpath(url1, url2)).toBe(false);
-        });
-
-        it('same host, different URL scheme, with ignore scheme', () => {
-            const url1 = new URL('http://server-1.com');
-            const url2 = new URL('mattermost://server-1.com');
-            expect(equalUrlsIgnoringSubpath(url1, url2, true)).toBe(true);
-            expect(equalUrlsWithSubpath(url1, url2, true)).toBe(true);
-        });
-
-        it('same host, different ports', () => {
-            const url1 = new URL('http://server-1.com:8080');
-            const url2 = new URL('http://server-1.com');
-            expect(equalUrlsIgnoringSubpath(url1, url2, true)).toBe(false);
-            expect(equalUrlsWithSubpath(url1, url2, true)).toBe(false);
-        });
-    });
-
-    describe('cleanPathName', () => {
-        it('should not clean path name if it occurs other than the beginning', () => {
-            expect(urlUtils.cleanPathName('/mattermost', '/home/channels/mattermost/test')).toBe('/home/channels/mattermost/test');
-        });
-
-        it('should clean path name if it occurs at the beginning', () => {
-            expect(urlUtils.cleanPathName('/mattermost', '/mattermost/channels/home/test')).toBe('/channels/home/test');
-        });
-
-        it('should do nothing if it doesnt occur', () => {
-            expect(urlUtils.cleanPathName('/mattermost', '/channels/home/test')).toBe('/channels/home/test');
-        });
-    });
-
     describe('isCustomLoginURL', () => {
         it('should match correct URL', () => {
-            expect(urlUtils.isCustomLoginURL(
-                'http://server.com/oauth/authorize',
-                'http://server.com',
+            expect(isCustomLoginURL(
+                new URL('http://server.com/oauth/authorize'),
+                new URL('http://server.com'),
             )).toBe(true);
         });
         it('should not match incorrect URL', () => {
-            expect(urlUtils.isCustomLoginURL(
-                'http://server.com/oauth/notauthorize',
-                'http://server.com',
+            expect(isCustomLoginURL(
+                new URL('http://server.com/oauth/notauthorize'),
+                new URL('http://server.com'),
             )).toBe(false);
         });
         it('should not match base URL', () => {
-            expect(urlUtils.isCustomLoginURL(
-                'http://server.com/',
-                'http://server.com',
+            expect(isCustomLoginURL(
+                new URL('http://server.com/'),
+                new URL('http://server.com'),
             )).toBe(false);
         });
         it('should match with subpath', () => {
-            expect(urlUtils.isCustomLoginURL(
-                'http://server.com/subpath/oauth/authorize',
-                'http://server.com/subpath',
+            expect(isCustomLoginURL(
+                new URL('http://server.com/subpath/oauth/authorize'),
+                new URL('http://server.com/subpath'),
             )).toBe(true);
         });
         it('should not match with different subpath', () => {
-            expect(urlUtils.isCustomLoginURL(
-                'http://server.com/subpath/oauth/authorize',
-                'http://server.com/different/subpath',
+            expect(isCustomLoginURL(
+                new URL('http://server.com/subpath/oauth/authorize'),
+                new URL('http://server.com/different/subpath'),
             )).toBe(false);
         });
         it('should not match with oauth subpath', () => {
-            expect(urlUtils.isCustomLoginURL(
-                'http://server.com/oauth/authorize',
-                'http://server.com/oauth/authorize',
+            expect(isCustomLoginURL(
+                new URL('http://server.com/oauth/authorize'),
+                new URL('http://server.com/oauth/authorize'),
             )).toBe(false);
         });
     });
 
     describe('isCallsPopOutURL', () => {
         it('should match correct URL', () => {
-            expect(urlUtils.isCallsPopOutURL(
-                'http://example.org',
-                'http://example.org/team/com.mattermost.calls/expanded/callid',
+            expect(isCallsPopOutURL(
+                new URL('http://example.org'),
+                new URL('http://example.org/team/com.mattermost.calls/expanded/callid'),
                 'callid',
             )).toBe(true);
         });
 
         it('should match with subpath', () => {
-            expect(urlUtils.isCallsPopOutURL(
-                'http://example.org/subpath',
-                'http://example.org/subpath/team/com.mattermost.calls/expanded/callid',
+            expect(isCallsPopOutURL(
+                new URL('http://example.org/subpath'),
+                new URL('http://example.org/subpath/team/com.mattermost.calls/expanded/callid'),
                 'callid',
             )).toBe(true);
         });
 
         it('should match with teamname with dash', () => {
-            expect(urlUtils.isCallsPopOutURL(
-                'http://example.org',
-                'http://example.org/team-name/com.mattermost.calls/expanded/callid',
+            expect(isCallsPopOutURL(
+                new URL('http://example.org'),
+                new URL('http://example.org/team-name/com.mattermost.calls/expanded/callid'),
                 'callid',
             )).toBe(true);
         });
 
         it('should not match with invalid team name', () => {
-            expect(urlUtils.isCallsPopOutURL(
-                'http://example.org',
-                'http://example.org/invalid$team/com.mattermost.calls/expanded/othercallid',
+            expect(isCallsPopOutURL(
+                new URL('http://example.org'),
+                new URL('http://example.org/invalid$team/com.mattermost.calls/expanded/othercallid'),
                 'callid',
             )).toBe(false);
         });
 
         it('should not match with incorrect callid', () => {
-            expect(urlUtils.isCallsPopOutURL(
-                'http://example.org',
-                'http://example.org/team/com.mattermost.calls/expanded/othercallid',
+            expect(isCallsPopOutURL(
+                new URL('http://example.org'),
+                new URL('http://example.org/team/com.mattermost.calls/expanded/othercallid'),
                 'callid',
             )).toBe(false);
         });
 
         it('should not match with incorrect origin', () => {
-            expect(urlUtils.isCallsPopOutURL(
-                'http://example.com',
-                'http://example.org/team/com.mattermost.calls/expanded/callid',
+            expect(isCallsPopOutURL(
+                new URL('http://example.com'),
+                new URL('http://example.org/team/com.mattermost.calls/expanded/callid'),
                 'callid',
             )).toBe(false);
         });
 
-        it('should not match with missing arguments', () => {
-            expect(urlUtils.isCallsPopOutURL()).toBe(false);
-        });
-    });
-
-    describe('escapeRegExp', () => {
-        it('simple', () => {
-            expect(urlUtils.escapeRegExp('simple')).toBe('simple');
-        });
-
-        it('path', () => {
-            expect(urlUtils.escapeRegExp('/path/')).toBe('/path/');
-        });
-
-        it('regexp', () => {
-            expect(urlUtils.escapeRegExp('/path(a+)+')).toBe('/path\\(a\\+\\)\\+');
+        it('should match with regex path embedded', () => {
+            expect(isCallsPopOutURL(
+                new URL('http://example.com/path(a+)+'),
+                new URL('http://example.org//path\\(a\\+\\)\\+/team/com.mattermost.calls/expanded/callid'),
+                'callid',
+            )).toBe(false);
         });
     });
 });

--- a/src/common/utils/url.ts
+++ b/src/common/utils/url.ts
@@ -6,137 +6,40 @@ import {isHttpsUri, isHttpUri, isUri} from 'valid-url';
 import buildConfig from 'common/config/buildConfig';
 import {customLoginRegexPaths, nonTeamUrlPaths, CALLS_PLUGIN_ID} from 'common/utils/constants';
 
-function isValidURL(testURL: string) {
-    return Boolean(isHttpUri(testURL) || isHttpsUri(testURL)) && Boolean(parseURL(testURL));
-}
-
-function isValidURI(testURL: string) {
-    return Boolean(isUri(testURL));
-}
-
-function startsWithProtocol(testURL: string) {
-    return Boolean((/^https?:\/\/.*/).test(testURL.trim()));
-}
-
-function parseURL(inputURL: URL | string) {
+export const getFormattedPathName = (pn: string) => (pn.endsWith('/') ? pn.toLowerCase() : `${pn.toLowerCase()}/`);
+export const parseURL = (inputURL: string | URL) => {
     if (inputURL instanceof URL) {
         return inputURL;
     }
     try {
-        return new URL(inputURL.replace(/([^:]\/)\/+/g, '$1'));
+        return new URL(inputURL.replace(/([^:]\/)\/+/g, '$1')); // Regex here to remove extra slashes
     } catch (e) {
         return undefined;
     }
-}
+};
 
-function getHost(inputURL: URL | string) {
-    const parsedURL = parseURL(inputURL);
-    if (parsedURL) {
-        return parsedURL.origin;
-    }
-    throw new SyntaxError(`Couldn't parse url: ${inputURL}`);
-}
+/**
+ * URL form checks
+ */
+
+export const isValidURL = (testURL: string) => Boolean(isHttpUri(testURL) || isHttpsUri(testURL)) && Boolean(parseURL(testURL));
+export const isValidURI = (testURL: string) => Boolean(isUri(testURL));
 
 // isInternalURL determines if the target url is internal to the application.
 // - currentURL is the current url inside the webview
-function isInternalURL(targetURL: URL | undefined, currentURL: URL) {
-    if (!targetURL) {
-        return false;
-    }
-
+export const isInternalURL = (targetURL: URL, currentURL: URL, ignoreScheme?: boolean) => {
     if (targetURL.host !== currentURL.host) {
         return false;
     }
 
-    if (!equalUrlsWithSubpath(targetURL, currentURL) && !(targetURL.pathname || '/').startsWith(currentURL.pathname)) {
+    if (!equalUrlsWithSubpath(targetURL, currentURL, ignoreScheme) && !(targetURL.pathname || '/').startsWith(currentURL.pathname)) {
         return false;
     }
 
     return true;
-}
+};
 
-function getServerInfo(serverUrl: URL | string) {
-    const parsedServer = parseURL(serverUrl);
-    if (!parsedServer) {
-        return undefined;
-    }
-
-    // does the server have a subpath?
-    const pn = parsedServer.pathname.toLowerCase();
-    const subpath = getFormattedPathName(pn);
-    return {subpath, url: parsedServer};
-}
-
-export function getFormattedPathName(pn: string) {
-    return pn.endsWith('/') ? pn.toLowerCase() : `${pn.toLowerCase()}/`;
-}
-
-function getManagedResources() {
-    if (!buildConfig) {
-        return [];
-    }
-
-    return buildConfig.managedResources || [];
-}
-
-export function isUrlType(urlType: string, serverUrl: URL | string, inputURL: URL | string) {
-    if (!serverUrl || !inputURL) {
-        return false;
-    }
-
-    const parsedURL = parseURL(inputURL);
-    const server = getServerInfo(serverUrl);
-    if (!parsedURL || !server || (!equalUrlsIgnoringSubpath(server.url, parsedURL))) {
-        return false;
-    }
-    return (getFormattedPathName(parsedURL.pathname).startsWith(`${server.subpath}${urlType}/`) ||
-    getFormattedPathName(parsedURL.pathname).startsWith(`/${urlType}/`));
-}
-
-function isAdminUrl(serverUrl: URL | string, inputURL: URL | string) {
-    return isUrlType('admin_console', serverUrl, inputURL);
-}
-
-function isTeamUrl(serverUrl: URL | string, inputURL: URL | string, withApi?: boolean) {
-    const parsedURL = parseURL(inputURL);
-    const server = getServerInfo(serverUrl);
-    if (!parsedURL || !server || (!equalUrlsIgnoringSubpath(server.url, parsedURL))) {
-        return false;
-    }
-
-    const paths = [...getManagedResources(), ...nonTeamUrlPaths];
-
-    if (withApi) {
-        paths.push('api');
-    }
-    return !(paths.some((testPath) => isUrlType(testPath, serverUrl, inputURL)));
-}
-
-function isPluginUrl(serverUrl: URL | string, inputURL: URL | string) {
-    return isUrlType('plugins', serverUrl, inputURL);
-}
-
-function isManagedResource(serverUrl: URL | string, inputURL: URL | string) {
-    const paths = [...getManagedResources()];
-    return paths.some((testPath) => isUrlType(testPath, serverUrl, inputURL));
-}
-
-// next two functions are defined to clarify intent
-export function equalUrlsWithSubpath(url1: URL, url2: URL, ignoreScheme?: boolean) {
-    if (ignoreScheme) {
-        return url1.host === url2.host && getFormattedPathName(url2.pathname).startsWith(getFormattedPathName(url1.pathname));
-    }
-    return url1.origin === url2.origin && getFormattedPathName(url2.pathname).startsWith(getFormattedPathName(url1.pathname));
-}
-
-export function equalUrlsIgnoringSubpath(url1: URL, url2: URL, ignoreScheme?: boolean) {
-    if (ignoreScheme) {
-        return url1.host.toLowerCase() === url2.host.toLowerCase();
-    }
-    return url1.origin.toLowerCase() === url2.origin.toLowerCase();
-}
-
-function isTrustedURL(url: URL | string, rootURL: URL | string) {
+export const isTrustedURL = (url: URL, rootURL: URL) => {
     const parsedURL = parseURL(url);
     const rootParsedURL = parseURL(rootURL);
     if (!parsedURL || !rootParsedURL) {
@@ -144,19 +47,41 @@ function isTrustedURL(url: URL | string, rootURL: URL | string) {
     }
     return (getFormattedPathName(rootParsedURL.pathname) !== '/' && equalUrlsWithSubpath(rootParsedURL, parsedURL)) ||
         (getFormattedPathName(rootParsedURL.pathname) === '/' && equalUrlsIgnoringSubpath(rootParsedURL, parsedURL));
-}
+};
 
-function isCustomLoginURL(url: URL | string, serverURL: URL | string): boolean {
-    const parsedServerURL = parseURL(serverURL);
-    const parsedURL = parseURL(url);
-    if (!parsedURL || !parsedServerURL) {
+export const isUrlType = (urlType: string, serverURL: URL, inputURL: URL) => {
+    if (!isInternalURL(inputURL, serverURL)) {
         return false;
     }
-    if (!isTrustedURL(parsedURL, parsedServerURL)) {
+    return (getFormattedPathName(inputURL.pathname).startsWith(`${getFormattedPathName(serverURL.pathname)}${urlType}/`) ||
+    getFormattedPathName(inputURL.pathname).startsWith(`/${urlType}/`));
+};
+
+export const isHelpUrl = (serverURL: URL, inputURL: URL) => isUrlType('help', serverURL, inputURL);
+export const isImageProxyUrl = (serverURL: URL, inputURL: URL) => isUrlType('api/v4/image', serverURL, inputURL);
+export const isPublicFilesUrl = (serverURL: URL, inputURL: URL) => isUrlType('files', serverURL, inputURL);
+export const isAdminUrl = (serverURL: URL, inputURL: URL) => isUrlType('admin_console', serverURL, inputURL);
+export const isPluginUrl = (serverURL: URL, inputURL: URL) => isUrlType('plugins', serverURL, inputURL);
+export const isChannelExportUrl = (serverURL: URL, inputURL: URL) => isUrlType('plugins/com.mattermost.plugin-channel-export/api/v1/export', serverURL, inputURL);
+export const isManagedResource = (serverURL: URL, inputURL: URL) => [...buildConfig.managedResources].some((testPath) => isUrlType(testPath, serverURL, inputURL));
+export const isTeamUrl = (serverURL: URL, inputURL: URL, withApi?: boolean) => {
+    if (!isInternalURL(inputURL, serverURL)) {
         return false;
     }
-    const subpath = parsedServerURL.pathname;
-    const urlPath = parsedURL.pathname;
+
+    const paths = [...buildConfig.managedResources, ...nonTeamUrlPaths];
+
+    if (withApi) {
+        paths.push('api');
+    }
+    return !(paths.some((testPath) => isUrlType(testPath, serverURL, inputURL)));
+};
+export const isCustomLoginURL = (inputURL: URL, serverURL: URL) => {
+    if (!isTrustedURL(inputURL, serverURL)) {
+        return false;
+    }
+    const subpath = serverURL.pathname;
+    const urlPath = inputURL.pathname;
     const replacement = subpath.endsWith('/') ? '/' : '';
     const replacedPath = urlPath.replace(subpath, replacement);
     for (const regexPath of customLoginRegexPaths) {
@@ -166,42 +91,10 @@ function isCustomLoginURL(url: URL | string, serverURL: URL | string): boolean {
     }
 
     return false;
-}
+};
 
-function isChannelExportUrl(serverUrl: URL | string, inputUrl: URL | string): boolean {
-    return isUrlType('plugins/com.mattermost.plugin-channel-export/api/v1/export', serverUrl, inputUrl);
-}
-
-function cleanPathName(basePathName: string, pathName: string) {
-    if (basePathName === '/') {
-        return pathName;
-    }
-
-    if (pathName.startsWith(basePathName)) {
-        return pathName.replace(basePathName, '');
-    }
-
-    return pathName;
-}
-
-// RegExp string escaping function, as recommended by
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
-function escapeRegExp(s: string) {
-    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
-}
-
-function isCallsPopOutURL(serverURL: URL | string, inputURL: URL | string, callID: string) {
-    if (!serverURL || !inputURL || !callID) {
-        return false;
-    }
-
-    const parsedURL = parseURL(inputURL);
-    const server = getServerInfo(serverURL);
-    if (!server || !parsedURL) {
-        return false;
-    }
-
-    const matches = parsedURL.pathname.match(new RegExp(`^${escapeRegExp(server.subpath)}([A-Za-z0-9-_]+)/`, 'i'));
+export const isCallsPopOutURL = (serverURL: URL, inputURL: URL, callID: string) => {
+    const matches = inputURL.pathname.match(new RegExp(`^${escapeRegExp(getFormattedPathName(serverURL.pathname))}([A-Za-z0-9-_]+)/`, 'i'));
     if (matches?.length !== 2) {
         return false;
     }
@@ -210,25 +103,28 @@ function isCallsPopOutURL(serverURL: URL | string, inputURL: URL | string, callI
     const subPath = `${teamName}/${CALLS_PLUGIN_ID}/expanded/${callID}`;
 
     return isUrlType(subPath, serverURL, inputURL);
-}
+};
 
-export default {
-    isValidURL,
-    isValidURI,
-    isInternalURL,
-    parseURL,
-    getServerInfo,
-    isAdminUrl,
-    isTeamUrl,
-    isPluginUrl,
-    isManagedResource,
-    getHost,
-    isTrustedURL,
-    isCustomLoginURL,
-    isChannelExportUrl,
-    isUrlType,
-    cleanPathName,
-    startsWithProtocol,
-    isCallsPopOutURL,
-    escapeRegExp,
+/**
+ * Helper functions
+ */
+
+// next two functions are defined to clarify intent
+const equalUrlsWithSubpath = (url1: URL, url2: URL, ignoreScheme?: boolean) => {
+    if (ignoreScheme) {
+        return url1.host === url2.host && getFormattedPathName(url2.pathname).startsWith(getFormattedPathName(url1.pathname));
+    }
+    return url1.origin === url2.origin && getFormattedPathName(url2.pathname).startsWith(getFormattedPathName(url1.pathname));
+};
+const equalUrlsIgnoringSubpath = (url1: URL, url2: URL, ignoreScheme?: boolean) => {
+    if (ignoreScheme) {
+        return url1.host.toLowerCase() === url2.host.toLowerCase();
+    }
+    return url1.origin.toLowerCase() === url2.origin.toLowerCase();
+};
+
+// RegExp string escaping function, as recommended by
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
+const escapeRegExp = (s: string) => {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 };

--- a/src/main/app/app.test.js
+++ b/src/main/app/app.test.js
@@ -159,7 +159,7 @@ describe('main/app/app', () => {
             await handleAppCertificateError(event, webContents, testURL, 'error-1', certificate, callback);
             expect(callback).toHaveBeenCalledWith(true);
             expect(certificateErrorCallbacks.has('http://server-1.com:error-1')).toBe(false);
-            expect(CertificateStore.add).toHaveBeenCalledWith('http://server-1.com', certificate);
+            expect(CertificateStore.add).toHaveBeenCalledWith(new URL('http://server-1.com'), certificate);
             expect(CertificateStore.save).toHaveBeenCalled();
         });
 
@@ -175,7 +175,7 @@ describe('main/app/app', () => {
             await handleAppCertificateError(event, webContents, testURL, 'error-1', certificate, callback);
             expect(callback).toHaveBeenCalledWith(false);
             expect(certificateErrorCallbacks.has('http://server-1.com:error-1')).toBe(false);
-            expect(CertificateStore.add).toHaveBeenCalledWith('http://server-1.com', certificate, true);
+            expect(CertificateStore.add).toHaveBeenCalledWith(new URL('http://server-1.com'), certificate, true);
             expect(CertificateStore.save).toHaveBeenCalled();
         });
     });

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -44,8 +44,8 @@ import {
     DOUBLE_CLICK_ON_WINDOW,
 } from 'common/communication';
 import Config from 'common/config';
+import {isTrustedURL, parseURL} from 'common/utils/url';
 import {Logger} from 'common/log';
-import urlUtils from 'common/utils/url';
 
 import AllowProtocolDialog from 'main/allowProtocolDialog';
 import AppVersionManager from 'main/AppVersionManager';
@@ -463,8 +463,14 @@ async function initializeAfterAppReady() {
             return;
         }
 
+        const parsedURL = parseURL(requestingURL);
+        if (!parsedURL) {
+            callback(false);
+            return;
+        }
+
         // is the requesting url trusted?
-        callback(urlUtils.isTrustedURL(requestingURL, serverURL));
+        callback(isTrustedURL(parsedURL, serverURL));
     });
 
     if (wasUpdated(AppVersionManager.lastAppVersion)) {

--- a/src/main/app/utils.ts
+++ b/src/main/app/utils.ts
@@ -16,8 +16,8 @@ import {Logger} from 'common/log';
 import JsonFileManager from 'common/JsonFileManager';
 import ServerManager from 'common/servers/serverManager';
 import {MattermostServer} from 'common/servers/MattermostServer';
-import urlUtils from 'common/utils/url';
 import {APP_MENU_WILL_CLOSE} from 'common/communication';
+import {isValidURI} from 'common/utils/url';
 
 import updateManager from 'main/autoUpdater';
 import {migrationInfoPath, updatePaths} from 'main/constants';
@@ -72,7 +72,7 @@ export function getDeeplinkingURL(args: string[]) {
     if (Array.isArray(args) && args.length) {
     // deeplink urls should always be the last argument, but may not be the first (i.e. Windows with the app already running)
         const url = args[args.length - 1];
-        if (url && mainProtocol && url.startsWith(mainProtocol) && urlUtils.isValidURI(url)) {
+        if (url && mainProtocol && url.startsWith(mainProtocol) && isValidURI(url)) {
             return url;
         }
     }

--- a/src/main/authManager.test.js
+++ b/src/main/authManager.test.js
@@ -58,7 +58,7 @@ jest.mock('common/config', () => ({
 jest.mock('common/utils/url', () => {
     const actualUrl = jest.requireActual('common/utils/url');
     return {
-        ...actualUrl.default,
+        ...actualUrl,
         isTrustedURL: (url) => {
             return url.toString() === 'http://trustedurl.com/';
         },

--- a/src/main/certificateStore.test.js
+++ b/src/main/certificateStore.test.js
@@ -65,26 +65,26 @@ describe('main/certificateStore', () => {
         it('should return true for stored matching certificate', () => {
             certificateStore = new CertificateStore('someFilename');
 
-            expect(certificateStore.isTrusted('https://server-1.com', {
+            expect(certificateStore.isTrusted(new URL('https://server-1.com'), {
                 data: 'someRandomData',
                 issuerName: 'someIssuer',
             })).toBe(true);
         });
 
         it('should return false for missing url', () => {
-            expect(certificateStore.isTrusted('https://server-3.com', {
+            expect(certificateStore.isTrusted(new URL('https://server-3.com'), {
                 data: 'someRandomData',
                 issuerName: 'someIssuer',
             })).toBe(false);
         });
 
         it('should return false for unmatched cert', () => {
-            expect(certificateStore.isTrusted('https://server-1.com', {
+            expect(certificateStore.isTrusted(new URL('https://server-1.com'), {
                 data: 'someOtherRandomData',
                 issuerName: 'someIssuer',
             })).toBe(false);
 
-            expect(certificateStore.isTrusted('https://server-1.com', {
+            expect(certificateStore.isTrusted(new URL('https://server-1.com'), {
                 data: 'someRandomData',
                 issuerName: 'someOtherIssuer',
             })).toBe(false);
@@ -99,8 +99,8 @@ describe('main/certificateStore', () => {
             };
 
             certificateStore = new CertificateStore('someFilename');
-            certificateStore.add(certOrigin, certData);
-            expect(certificateStore.isTrusted(wssCertOrigin, certData)).toBe(true);
+            certificateStore.add(new URL(certOrigin), certData);
+            expect(certificateStore.isTrusted(new URL(wssCertOrigin), certData)).toBe(true);
         });
     });
 
@@ -113,14 +113,14 @@ describe('main/certificateStore', () => {
         });
 
         it('should return true for explicitly untrusted cert', () => {
-            expect(certificateStore.isExplicitlyUntrusted('https://server-2.com', {
+            expect(certificateStore.isExplicitlyUntrusted(new URL('https://server-2.com'), {
                 data: 'someRandomData',
                 issuerName: 'someIssuer',
             })).toBe(true);
         });
 
         it('should return false for trusted cert', () => {
-            expect(certificateStore.isExplicitlyUntrusted('https://server-1.com', {
+            expect(certificateStore.isExplicitlyUntrusted(new URL('https://server-1.com'), {
                 data: 'someRandomData',
                 issuerName: 'someIssuer',
             })).toBe(false);

--- a/src/main/certificateStore.ts
+++ b/src/main/certificateStore.ts
@@ -11,7 +11,6 @@ import {ComparableCertificate} from 'types/certificate';
 
 import {UPDATE_PATHS} from 'common/communication';
 import {Logger} from 'common/log';
-import urlUtils from 'common/utils/url';
 import * as Validator from 'common/Validator';
 
 import {certificateStorePath} from './constants';
@@ -57,35 +56,32 @@ export class CertificateStore {
         fs.writeFileSync(this.storeFile, JSON.stringify(this.data, null, '  '));
     };
 
-    add = (targetURL: string, certificate: Certificate, dontTrust = false) => {
-        const host = urlUtils.getHost(targetURL);
+    add = (targetURL: URL, certificate: Certificate, dontTrust = false) => {
         const comparableCert = comparableCertificate(certificate, dontTrust);
-        this.data[host] = comparableCert;
+        this.data[targetURL.origin] = comparableCert;
 
         // Trust certificate for websocket connections on the same origin.
-        if (host.startsWith('https://')) {
-            const wssHost = host.replace('https', 'wss');
+        if (targetURL.origin.startsWith('https://')) {
+            const wssHost = targetURL.origin.replace('https', 'wss');
             this.data[wssHost] = comparableCert;
         }
     };
 
-    isExisting = (targetURL: string) => {
-        return Object.prototype.hasOwnProperty.call(this.data, urlUtils.getHost(targetURL));
+    isExisting = (targetURL: URL) => {
+        return Object.prototype.hasOwnProperty.call(this.data, targetURL.origin);
     };
 
-    isTrusted = (targetURL: string, certificate: Certificate) => {
-        const host = urlUtils.getHost(targetURL);
+    isTrusted = (targetURL: URL, certificate: Certificate) => {
         if (!this.isExisting(targetURL)) {
             return false;
         }
-        return areEqual(this.data[host], comparableCertificate(certificate));
+        return areEqual(this.data[targetURL.origin], comparableCertificate(certificate));
     };
 
-    isExplicitlyUntrusted = (targetURL: string) => {
+    isExplicitlyUntrusted = (targetURL: URL) => {
         // Whether or not the certificate was explicitly marked as untrusted by
         // clicking "Don't ask again" checkbox before cancelling the connection.
-        const host = urlUtils.getHost(targetURL);
-        const dontTrust = this.data[host]?.dontTrust;
+        const dontTrust = this.data[targetURL.origin]?.dontTrust;
         return dontTrust === undefined ? false : dontTrust;
     }
 }

--- a/src/main/contextMenu.ts
+++ b/src/main/contextMenu.ts
@@ -5,14 +5,14 @@
 import {BrowserView, BrowserWindow, ContextMenuParams, Event} from 'electron';
 import electronContextMenu, {Options} from 'electron-context-menu';
 
-import urlUtils from 'common/utils/url';
+import {parseURL} from 'common/utils/url';
 
 const defaultMenuOptions = {
     shouldShowMenu: (e: Event, p: ContextMenuParams) => {
         const isInternalLink = p.linkURL.endsWith('#') && p.linkURL.slice(0, -1) === p.pageURL;
         let isInternalSrc;
         try {
-            const srcurl = urlUtils.parseURL(p.srcURL);
+            const srcurl = parseURL(p.srcURL);
             isInternalSrc = srcurl?.protocol === 'file:';
         } catch (err) {
             isInternalSrc = false;

--- a/src/main/trustedOrigins.test.js
+++ b/src/main/trustedOrigins.test.js
@@ -80,16 +80,16 @@ describe('Trusted Origins', () => {
             expect(tos.data.size).toBe(2);
         });
         it('should say ok if the permission is set', () => {
-            expect(tos.checkPermission('https://mattermost.com', BASIC_AUTH_PERMISSION)).toBe(true);
+            expect(tos.checkPermission(new URL('https://mattermost.com'), BASIC_AUTH_PERMISSION)).toBe(true);
         });
         it('should say ko if the permission is set to false', () => {
-            expect(tos.checkPermission('https://notmattermost.com', BASIC_AUTH_PERMISSION)).toBe(false);
+            expect(tos.checkPermission(new URL('https://notmattermost.com'), BASIC_AUTH_PERMISSION)).toBe(false);
         });
         it('should say ko if the uri is not set', () => {
-            expect(tos.checkPermission('https://undefined.com', BASIC_AUTH_PERMISSION)).toBe(undefined);
+            expect(tos.checkPermission(new URL('https://undefined.com'), BASIC_AUTH_PERMISSION)).toBe(undefined);
         });
         it('should say null if the permission is unknown', () => {
-            expect(tos.checkPermission('https://mattermost.com')).toBe(null);
+            expect(tos.checkPermission(new URL('https://mattermost.com'))).toBe(null);
         });
     });
 
@@ -105,9 +105,9 @@ describe('Trusted Origins', () => {
         const tos = mockTOS('permission_test', JSON.stringify(value));
         tos.load();
         it('deleting revokes access', () => {
-            expect(tos.checkPermission('https://mattermost.com', BASIC_AUTH_PERMISSION)).toBe(true);
-            tos.delete('https://mattermost.com');
-            expect(tos.checkPermission('https://mattermost.com', BASIC_AUTH_PERMISSION)).toBe(undefined);
+            expect(tos.checkPermission(new URL('https://mattermost.com'), BASIC_AUTH_PERMISSION)).toBe(true);
+            tos.delete(new URL('https://mattermost.com'));
+            expect(tos.checkPermission(new URL('https://mattermost.com'), BASIC_AUTH_PERMISSION)).toBe(undefined);
         });
     });
 });

--- a/src/main/utils.test.js
+++ b/src/main/utils.test.js
@@ -107,11 +107,11 @@ describe('main/utils', () => {
 
     describe('shouldHaveBackBar', () => {
         it('should have back bar for custom logins', () => {
-            expect(Utils.shouldHaveBackBar('https://server-1.com', 'https://server-1.com/login/sso/saml')).toBe(true);
+            expect(Utils.shouldHaveBackBar(new URL('https://server-1.com'), new URL('https://server-1.com/login/sso/saml'))).toBe(true);
         });
 
         it('should not have back bar for regular login', () => {
-            expect(Utils.shouldHaveBackBar('https://server-1.com', 'https://server-1.com/login')).toBe(false);
+            expect(Utils.shouldHaveBackBar(new URL('https://server-1.com'), new URL('https://server-1.com/login'))).toBe(false);
         });
     });
 

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -15,8 +15,8 @@ import {app, BrowserWindow} from 'electron';
 import {Args} from 'types/args';
 
 import {BACK_BAR_HEIGHT, customLoginRegexPaths, PRODUCTION, TAB_BAR_HEIGHT} from 'common/utils/constants';
-import UrlUtils from 'common/utils/url';
 import Utils from 'common/utils/util';
+import {isAdminUrl, isPluginUrl, isTeamUrl, isUrlType, parseURL} from 'common/utils/url';
 
 export function isInsideRectangle(container: Electron.Rectangle, rect: Electron.Rectangle) {
     return container.x <= rect.x && container.y <= rect.y && container.width >= rect.width && container.height >= rect.height;
@@ -48,11 +48,11 @@ export function getAdjustedWindowBoundaries(width: number, height: number, hasBa
     };
 }
 
-export function shouldHaveBackBar(serverUrl: URL | string, inputURL: URL | string) {
-    if (UrlUtils.isUrlType('login', serverUrl, inputURL)) {
-        const serverURL = UrlUtils.parseURL(serverUrl);
+export function shouldHaveBackBar(serverUrl: URL, inputURL: URL) {
+    if (isUrlType('login', serverUrl, inputURL)) {
+        const serverURL = parseURL(serverUrl);
         const subpath = serverURL ? serverURL.pathname : '';
-        const parsedURL = UrlUtils.parseURL(inputURL);
+        const parsedURL = parseURL(inputURL);
         if (!parsedURL) {
             return false;
         }
@@ -67,7 +67,7 @@ export function shouldHaveBackBar(serverUrl: URL | string, inputURL: URL | strin
 
         return false;
     }
-    return !UrlUtils.isTeamUrl(serverUrl, inputURL) && !UrlUtils.isAdminUrl(serverUrl, inputURL) && !UrlUtils.isPluginUrl(serverUrl, inputURL);
+    return !isTeamUrl(serverUrl, inputURL) && !isAdminUrl(serverUrl, inputURL) && !isPluginUrl(serverUrl, inputURL);
 }
 
 export function getLocalURLString(urlPath: string, query?: Map<string, string>, isMain?: boolean) {

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -21,7 +21,7 @@ import {getLocalPreload, openScreensharePermissionsSettingsMacOS, resetScreensha
 import {Logger} from 'common/log';
 import {CALLS_PLUGIN_ID, MINIMUM_CALLS_WIDGET_HEIGHT, MINIMUM_CALLS_WIDGET_WIDTH} from 'common/utils/constants';
 import Utils from 'common/utils/util';
-import urlUtils, {getFormattedPathName} from 'common/utils/url';
+import {getFormattedPathName, isCallsPopOutURL, parseURL} from 'common/utils/url';
 import {
     BROWSER_HISTORY_PUSH,
     CALLS_ERROR,
@@ -90,7 +90,7 @@ export class CallsWidgetWindow {
      */
 
     getURL = () => {
-        return this.win && urlUtils.parseURL(this.win?.webContents.getURL());
+        return this.win && parseURL(this.win?.webContents.getURL());
     }
 
     isCallsWidget = (webContentsId: number) => {
@@ -101,7 +101,7 @@ export class CallsWidgetWindow {
         if (!this.mainView) {
             return undefined;
         }
-        const u = urlUtils.parseURL(this.mainView.tab.server.url.toString()) as URL;
+        const u = parseURL(this.mainView.tab.server.url.toString()) as URL;
 
         u.pathname = getFormattedPathName(u.pathname);
         u.pathname += `plugins/${CALLS_PLUGIN_ID}/standalone/widget.html`;
@@ -266,7 +266,11 @@ export class CallsWidgetWindow {
             return {action: 'deny' as const};
         }
 
-        if (urlUtils.isCallsPopOutURL(this.mainView?.tab.server.url, url, this.options?.callID)) {
+        const parsedURL = parseURL(url);
+        if (!parsedURL) {
+            return {action: 'deny' as const};
+        }
+        if (isCallsPopOutURL(this.mainView?.tab.server.url, parsedURL, this.options?.callID)) {
             return {
                 action: 'allow' as const,
                 overrideBrowserWindowOptions: {

--- a/src/renderer/components/ConfigureServer.tsx
+++ b/src/renderer/components/ConfigureServer.tsx
@@ -7,15 +7,15 @@ import classNames from 'classnames';
 
 import {MattermostTeam} from 'types/config';
 
+import {isValidURL, parseURL} from 'common/utils/url';
+import {MODAL_TRANSITION_TIMEOUT} from 'common/utils/constants';
+
 import womanLaptop from 'renderer/assets/svg/womanLaptop.svg';
 
 import Header from 'renderer/components/Header';
 import Input, {STATUS, SIZE} from 'renderer/components/Input';
 import LoadingBackground from 'renderer/components/LoadingScreen/LoadingBackground';
 import SaveButton from 'renderer/components/SaveButton/SaveButton';
-
-import {MODAL_TRANSITION_TIMEOUT} from 'common/utils/constants';
-import urlUtils from 'common/utils/url';
 
 import 'renderer/css/components/Button.scss';
 import 'renderer/css/components/ConfigureServer.scss';
@@ -72,7 +72,7 @@ function ConfigureServer({
     }, []);
 
     const checkProtocolInURL = (checkURL: string): Promise<string> => {
-        if (urlUtils.startsWithProtocol(checkURL)) {
+        if (isValidURL(checkURL)) {
             return Promise.resolve(checkURL);
         }
         return window.desktop.modals.pingDomain(checkURL).
@@ -115,21 +115,21 @@ function ConfigureServer({
             });
         }
 
-        if (!urlUtils.startsWithProtocol(fullURL)) {
-            return formatMessage({
-                id: 'renderer.components.newTeamModal.error.urlNeedsHttp',
-                defaultMessage: 'URL should start with http:// or https://.',
-            });
-        }
-
-        if (!urlUtils.isValidURL(fullURL)) {
+        if (!parseURL(fullURL)) {
             return formatMessage({
                 id: 'renderer.components.newTeamModal.error.urlIncorrectFormatting',
                 defaultMessage: 'URL is not formatted correctly.',
             });
         }
 
-        if (currentTeams.find(({url: existingURL}) => existingURL === fullURL)) {
+        if (!isValidURL(fullURL)) {
+            return formatMessage({
+                id: 'renderer.components.newTeamModal.error.urlNeedsHttp',
+                defaultMessage: 'URL should start with http:// or https://.',
+            });
+        }
+
+        if (currentTeams.find(({url: existingURL}) => parseURL(existingURL)?.toString === parseURL(fullURL)?.toString())) {
             return formatMessage({
                 id: 'renderer.components.newTeamModal.error.serverUrlExists',
                 defaultMessage: 'A server with the same URL already exists.',

--- a/src/renderer/components/NewTeamModal.tsx
+++ b/src/renderer/components/NewTeamModal.tsx
@@ -8,7 +8,7 @@ import {FormattedMessage, injectIntl, IntlShape} from 'react-intl';
 
 import {MattermostTeam} from 'types/config';
 
-import urlUtils from 'common/utils/url';
+import {isValidURL} from 'common/utils/url';
 
 type Props = {
     onClose?: () => void;
@@ -124,7 +124,7 @@ class NewTeamModal extends React.PureComponent<Props, State> {
                 />
             );
         }
-        if (!urlUtils.isValidURL(this.state.teamUrl.trim())) {
+        if (!isValidURL(this.state.teamUrl.trim())) {
             return (
                 <FormattedMessage
                     id='renderer.components.newTeamModal.error.urlIncorrectFormatting'

--- a/src/renderer/modals/login/loginModal.tsx
+++ b/src/renderer/modals/login/loginModal.tsx
@@ -10,7 +10,7 @@ import {AuthenticationResponseDetails, AuthInfo} from 'electron/renderer';
 
 import {LoginModalInfo} from 'types/modals';
 
-import urlUtils from 'common/utils/url';
+import {parseURL} from 'common/utils/url';
 
 type Props = {
     onCancel: (request: AuthenticationResponseDetails) => void;
@@ -86,7 +86,7 @@ class LoginModal extends React.PureComponent<Props, State> {
                 />
             );
         }
-        const tmpURL = urlUtils.parseURL(this.state.request.url);
+        const tmpURL = parseURL(this.state.request.url);
         return (
             <FormattedMessage
                 id='renderer.modals.login.loginModal.message.server'

--- a/src/renderer/modals/permission/permissionModal.tsx
+++ b/src/renderer/modals/permission/permissionModal.tsx
@@ -7,9 +7,9 @@ import {FormattedMessage, injectIntl, IntlShape} from 'react-intl';
 
 import {PermissionModalInfo} from 'types/modals';
 
-import urlUtil from 'common/utils/url';
 import {t} from 'common/utils/util';
 import {PERMISSION_DESCRIPTION} from 'common/permissions';
+import {parseURL} from 'common/utils/url';
 
 type Props = {
     handleDeny: React.MouseEventHandler<HTMLButtonElement>;
@@ -51,14 +51,14 @@ class PermissionModal extends React.PureComponent<Props, State> {
         }
 
         const {url, permission} = this.state;
-        const originDisplay = url ? urlUtil.getHost(url) : this.props.intl.formatMessage({id: 'renderer.modals.permission.permissionModal.unknownOrigin', defaultMessage: 'unknown origin'});
-        const originLink = url ? originDisplay : '';
+        const originDisplay = url ? parseURL(url)?.origin : this.props.intl.formatMessage({id: 'renderer.modals.permission.permissionModal.unknownOrigin', defaultMessage: 'unknown origin'});
+        const originLink = originDisplay ?? '';
 
         const click = (e: React.MouseEvent<HTMLAnchorElement>) => {
             e.preventDefault();
             let parseUrl;
             try {
-                parseUrl = urlUtil.parseURL(originLink);
+                parseUrl = parseURL(originLink);
                 this.props.openExternalLink(parseUrl!.protocol, originLink);
             } catch (err) {
                 console.error(`invalid url ${originLink} supplied to externallink: ${err}`);


### PR DESCRIPTION
#### Summary
A community member reported that subpaths were causing issues when clicking links and attempting to navigate incorrectly. This led me to do some refactoring of the URL utils while fixing the bug.

Here are the highlights:
- Removed the default import and a few redundant functions
- Converted over everything checking for internal URLs to use `isInternalURL` (this fixed the bug)
- Reworked the tests a bit

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52587
Closes https://github.com/mattermost/desktop/issues/2692

```release-note
Fixed an issue where servers on subpaths would not navigate to external URLs on the same domain properly
```
