### PR TITLE
Fixed a few resizing issues

### DIFF
--- a/src/main/preload/desktopAPI.js
+++ b/src/main/preload/desktopAPI.js
@@ -88,7 +88,6 @@ import {
     GET_ORDERED_SERVERS,
     GET_ORDERED_TABS_FOR_SERVER,
     SERVERS_UPDATE,
-    VIEW_FINISHED_RESIZING,
 } from 'common/communication';
 
 console.log('Preload initialized');
@@ -253,6 +252,3 @@ const createKeyDownListener = () => {
 };
 createKeyDownListener();
 
-window.addEventListener('resize', () => {
-    ipcRenderer.send(VIEW_FINISHED_RESIZING);
-});

--- a/src/main/preload/desktopAPI.js
+++ b/src/main/preload/desktopAPI.js
@@ -252,7 +252,3 @@ const createKeyDownListener = () => {
     });
 };
 createKeyDownListener();
-
-window.addEventListener('resize', () => {
-    ipcRenderer.send(VIEW_FINISHED_RESIZING);
-});

--- a/src/main/preload/desktopAPI.js
+++ b/src/main/preload/desktopAPI.js
@@ -252,3 +252,7 @@ const createKeyDownListener = () => {
     });
 };
 createKeyDownListener();
+
+window.addEventListener('resize', () => {
+    ipcRenderer.send(VIEW_FINISHED_RESIZING);
+});

--- a/src/main/windows/mainWindow.test.js
+++ b/src/main/windows/mainWindow.test.js
@@ -85,6 +85,7 @@ describe('main/windows/mainWindow', () => {
     describe('init', () => {
         const baseWindow = {
             setMenuBarVisibility: jest.fn(),
+            setAutoHideMenuBar: jest.fn(),
             loadURL: jest.fn(),
             once: jest.fn(),
             on: jest.fn(),

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -134,8 +134,8 @@ export class MainWindow extends EventEmitter {
         this.win.on('will-resize', this.onWillResize);
         this.win.on('resized', this.onResized);
         this.win.on('moved', this.onResized);
-        if (process.platform !== 'darwin') {
-            mainWindow.on('resize', this.onResize);
+        if (process.platform === 'linux') {
+            this.win.on('resize', this.onResize);
         }
 
         this.win.webContents.on('before-input-event', this.onBeforeInputEvent);

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -458,7 +458,7 @@ export class MainWindow extends EventEmitter {
             return;
         }
 
-        if (this.isResizing) {
+        if (process.platform === 'darwin' && this.isResizing) {
             log.debug('prevented resize');
             event.preventDefault();
             return;
@@ -471,7 +471,7 @@ export class MainWindow extends EventEmitter {
     private onResize = () => {
         log.silly('onResize');
 
-        if (this.isResizing) {
+        if (process.platform === 'darwin' && this.isResizing) {
             return;
         }
         this.emit(MAIN_WINDOW_RESIZED, this.getBounds());

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -458,6 +458,7 @@ export class MainWindow extends EventEmitter {
             return;
         }
 
+        // Workaround for macOS to stop the window from sending too many resize calls to the BrowserViews
         if (process.platform === 'darwin' && this.isResizing) {
             log.debug('prevented resize');
             event.preventDefault();
@@ -471,6 +472,7 @@ export class MainWindow extends EventEmitter {
     private onResize = () => {
         log.silly('onResize');
 
+        // Workaround for macOS to stop the window from sending too many resize calls to the BrowserViews
         if (process.platform === 'darwin' && this.isResizing) {
             return;
         }


### PR DESCRIPTION
#### Summary
A few of the weird resizing cases showed up again after the refactor, I've made fixes for them:
- macOS; Fixed the issue where rapidly resizing cues up a bunch of changes to the BrowserViews and keeps it bouncing back and forth
- Linux: Fixed the issue where maximizing/full-screening doesn't resize the window properly
- Windows: Ensured that users with 'Show window contents while dragging" is off will still be able to resize.

```release-note
NONE
```
