### PR TITLE
Fixed the maximize/full screen for Windows

### DIFF
--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -408,13 +408,8 @@ export class MainWindow extends EventEmitter {
     }
 
     private emitBoundsForMaximize = () => {
-        // Workaround for Linux since the window bounds aren't updated immediately when the window is maximized for some reason
-        if (process.platform !== 'linux') {
-            return;
-        }
-        setTimeout(() => {
-            this.emit(MAIN_WINDOW_RESIZED, this.getBounds());
-        }, 10);
+        // Workaround since the window bounds aren't updated immediately when the window is maximized for some reason
+        setTimeout(() => this.emit(MAIN_WINDOW_RESIZED, this.getBounds()), 10);
     }
 
     private onMaximize = () => {


### PR DESCRIPTION
#### Summary
The same delayed bounds update was observed on Windows as well, so I've changed the timeout to happen on all OSes (shouldn't affect macOS at all)

```release-note
NONE
```
