### PR TITLE
Fix weird macOS crash that occurs when closing the settings window

### DIFF
--- a/src/main/windows/settingsWindow.ts
+++ b/src/main/windows/settingsWindow.ts
@@ -73,8 +73,7 @@ export class SettingsWindow {
 
         this.win.on('closed', () => {
             delete this.win;
-
-            ViewManager.focusCurrentView();
+            setTimeout(() => MainWindow.get()?.focus(), 10);
         });
     }
 }

--- a/src/main/windows/settingsWindow.ts
+++ b/src/main/windows/settingsWindow.ts
@@ -73,6 +73,10 @@ export class SettingsWindow {
 
         this.win.on('closed', () => {
             delete this.win;
+
+            // For some reason, on macOS, the app will hard crash when the settings window is closed
+            // It seems to be related to calling view.focus() and there's no log output unfortunately
+            // Adding this arbitrary delay seems to get rid of it (it happens very frequently)
             setTimeout(() => MainWindow.get()?.focus(), 10);
         });
     }


### PR DESCRIPTION
#### Summary
For some reason, closing the Settings window is causing my app to crash on nightly on macOS.
The culprit seems to be calling `view.focus()` on a BrowserView too quickly after the window closes (not sure why).
To fix it, I just added an arbitrary delay on the focus call, which seems to have solved the issue for now.

```release-note
NONE
```
