### PR TITLE
Fix issue where Linux menubar pops up when it's not supposed to

### DIFF
--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -97,7 +97,6 @@ export class MainWindow extends EventEmitter {
             throw new Error('unable to create main window');
         }
 
-        this.win.setAutoHideMenuBar(true);
         this.win.setMenuBarVisibility(false);
 
         this.win.once('ready-to-show', () => {
@@ -416,6 +415,9 @@ export class MainWindow extends EventEmitter {
                 return;
             }
 
+            // For some reason on Linux I've seen the menu bar popup again
+            this.win?.setMenuBarVisibility(false);
+
             this.emit(MAIN_WINDOW_RESIZED, newBounds);
             this.lastEmittedBounds = newBounds;
         }, 10);
@@ -434,9 +436,6 @@ export class MainWindow extends EventEmitter {
     private onEnterFullScreen = () => {
         this.win?.webContents.send('enter-full-screen');
         this.emitBounds();
-
-        // For some reason on Linux I've seen the menu bar popup again
-        this.win?.setMenuBarVisibility(false);
     }
 
     private onLeaveFullScreen = () => {


### PR DESCRIPTION
#### Summary
My addition of `setAutoHideMenuBar` actually caused a different issue on Linux when you press Alt. This fix should now make sure the menu bar never shows up as it should be forced hidden everytime we emit bounds.

```release-note
NONE
```
