### PR TITLE
[MM-52581] Add USB entitlement for MAS build

### DIFF
--- a/entitlements.mas.plist
+++ b/entitlements.mas.plist
@@ -8,6 +8,8 @@
 	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
+	<key>com.apple.security.device.usb</key>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>


### PR DESCRIPTION
#### Summary
App Sandbox requires an entitlement for USB devices, which was blocking YubiKeys from being used to authenticate.
This PR adds the USB entitlement.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52581

```release-note
Fix YubiKeys not working on the MAS build
```
