### PR TITLE
Fixed issue where launching the app a second time wouldn't show the main window if it was hidden

### DIFF
--- a/src/main/app/app.ts
+++ b/src/main/app/app.ts
@@ -29,6 +29,7 @@ export function handleAppSecondInstance(event: Event, argv: string[]) {
 
     // Protocol handler for win32
     // argv: An array of the second instance’s (command line / deep linked) arguments
+    MainWindow.show();
     const deeplinkingURL = getDeeplinkingURL(argv);
     if (deeplinkingURL) {
         openDeepLink(deeplinkingURL);


### PR DESCRIPTION
#### Summary
I missed adding a call to `MainWindow.show()` when updating the deep linking/second instance call, so I've re-added that.

```release-note
NONE
```
