### PR TITLE
MM-51956 - Fix for: Calls popout generating duplicate notifications

### DIFF
--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -16,7 +16,12 @@ import {
 
 import {MattermostView} from 'main/views/MattermostView';
 
-import {getLocalPreload, openScreensharePermissionsSettingsMacOS, resetScreensharePermissionsMacOS} from 'main/utils';
+import {
+    composeUserAgent,
+    getLocalPreload,
+    openScreensharePermissionsSettingsMacOS,
+    resetScreensharePermissionsMacOS,
+} from 'main/utils';
 
 import {Logger} from 'common/log';
 import {CALLS_PLUGIN_ID, MINIMUM_CALLS_WIDGET_HEIGHT, MINIMUM_CALLS_WIDGET_WIDTH} from 'common/utils/constants';
@@ -261,7 +266,7 @@ export class CallsWidgetWindow {
         this.setBounds(initialBounds);
     }
 
-    private onPopOutOpen = ({url}: {url: string}) => {
+    private onPopOutOpen = ({url}: { url: string }) => {
         if (!(this.mainView && this.options)) {
             return {action: 'deny' as const};
         }
@@ -294,6 +299,23 @@ export class CallsWidgetWindow {
 
         this.popOut.on('closed', () => {
             delete this.popOut;
+        });
+
+        // Set the userAgent so that the widget's popout is considered a desktop window in the webapp code.
+        // 'did-frame-finish-load' is the earliest moment that allows us to call loadURL without throwing an error.
+        this.popOut.webContents.once('did-frame-finish-load', async () => {
+            const url = this.popOut?.webContents.getURL() || '';
+            if (!url) {
+                return;
+            }
+
+            try {
+                await this.popOut?.loadURL(url, {
+                    userAgent: composeUserAgent(),
+                });
+            } catch (e) {
+                log.error('did-frame-finish-load, failed to reload with correct userAgent', e);
+            }
         });
     }
 

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -158,7 +158,9 @@ export class CallsWidgetWindow {
         if (!widgetURL) {
             return;
         }
-        this.win?.loadURL(widgetURL).catch((reason) => {
+        this.win?.loadURL(widgetURL, {
+            userAgent: composeUserAgent(),
+        }).catch((reason) => {
             log.error(`failed to load: ${reason}`);
         });
     }

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -305,6 +305,7 @@ export class CallsWidgetWindow {
 
         // Set the userAgent so that the widget's popout is considered a desktop window in the webapp code.
         // 'did-frame-finish-load' is the earliest moment that allows us to call loadURL without throwing an error.
+        // https://mattermost.atlassian.net/browse/MM-52756 is the proper fix for this.
         this.popOut.webContents.once('did-frame-finish-load', async () => {
             const url = this.popOut?.webContents.getURL() || '';
             if (!url) {


### PR DESCRIPTION
#### Summary
- The popout didn't have the `Mattermost/version` userAgent. The only way to set this (that works) is through the `browserWindow.loadURL` fn, but we don't use that for the popout, we use the `window.open` from the calls side. It's not possible to set the userAgent directly with `window.open` or in the `windowOpenHandler` return options. The best way I could come up with is to just reload the calls popout using the `loadURL`. Through trial and error I found a place to do that, which doesn't cause the screen to flicker or load and reload, luckily. We can do it even earlier in the process (e.g., the `dom-ready` event) but that returns an error (but, oddly, everything works and the userAgent does get correctly set). The `did-frame-finish-load` event is the earliest that doesn't return an error.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-51956

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [ ] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [ ] executed `npm run lint:js` for proper code formatting

#### Release Note
```release-note
Calls: Fix duplicate desktop notifications when calls popout is open
```
