### PR TITLE
[MM-52879] Fixed calls popout URL checking

### DIFF
--- a/src/main/views/webContentEvents.ts
+++ b/src/main/views/webContentEvents.ts
@@ -78,7 +78,7 @@ export class WebContentsEventManager {
         }
 
         if (CallsWidgetWindow.isCallsWidget(webContentsId)) {
-            return CallsWidgetWindow.getURL();
+            return CallsWidgetWindow.getViewURL();
         }
 
         return ViewManager.getViewByWebContentsId(webContentsId)?.view.server.url;

--- a/src/main/windows/callsWidgetWindow.test.js
+++ b/src/main/windows/callsWidgetWindow.test.js
@@ -438,15 +438,16 @@ describe('main/windows/callsWidgetWindow', () => {
         expect(callsWidgetWindow.popOut).not.toBeDefined();
     });
 
-    it('getURL', () => {
+    it('getViewURL', () => {
         const callsWidgetWindow = new CallsWidgetWindow();
-        callsWidgetWindow.win = {
-            webContents: {
-                getURL: () => 'http://localhost:8065/',
+        callsWidgetWindow.mainView = {
+            view: {
+                server: {
+                    url: new URL('http://localhost:8065/'),
+                },
             },
         };
-        urlUtils.parseURL.mockImplementation((url) => new URL(url));
-        expect(callsWidgetWindow.getURL().toString()).toBe('http://localhost:8065/');
+        expect(callsWidgetWindow.getViewURL().toString()).toBe('http://localhost:8065/');
     });
 
     describe('isAllowedEvent', () => {

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -94,8 +94,8 @@ export class CallsWidgetWindow {
      * Helper functions
      */
 
-    getURL = () => {
-        return this.win && parseURL(this.win?.webContents.getURL());
+    getViewURL = () => {
+        return this.mainView?.view.server.url;
     }
 
     isCallsWidget = (webContentsId: number) => {

--- a/src/main/windows/settingsWindow.ts
+++ b/src/main/windows/settingsWindow.ts
@@ -7,8 +7,6 @@ import {SHOW_SETTINGS_WINDOW} from 'common/communication';
 import Config from 'common/config';
 import {Logger} from 'common/log';
 
-import ViewManager from 'main/views/viewManager';
-
 import ContextMenu from '../contextMenu';
 import {getLocalPreload, getLocalURLString} from '../utils';
 


### PR DESCRIPTION
#### Summary
Some navigation code changes, as well as https://github.com/mattermost/desktop/pull/2713 revealed an issue with how we check for the calls widget/popout. We should be getting the root server URL to check against instead of the calls widget URL, whatever that may be, so I've fixed that.

This was causing a white screen for users of nightly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52879

```release-note
NONE
```
