### PR TITLE
Fix two server manager issues

### DIFF
--- a/src/common/servers/serverManager.ts
+++ b/src/common/servers/serverManager.ts
@@ -238,6 +238,10 @@ export class ServerManager extends EventEmitter {
             this.currentServerId = this.serverOrder[0];
         }
 
+        if (!this.hasServers()) {
+            delete this.currentServerId;
+        }
+
         this.persistServers();
     }
 

--- a/src/main/app/intercom.ts
+++ b/src/main/app/intercom.ts
@@ -38,6 +38,10 @@ function handleShowOnboardingScreens(showWelcomeScreen: boolean, showNewServerMo
     log.debug('handleShowOnboardingScreens', {showWelcomeScreen, showNewServerModal, mainWindowIsVisible});
 
     if (showWelcomeScreen) {
+        if (ModalManager.isModalDisplayed()) {
+            return;
+        }
+
         handleWelcomeScreenModal();
 
         if (process.env.NODE_ENV === 'test') {


### PR DESCRIPTION
#### Summary
This PR fixes two server manager issues:
- If the last server is deleted, re-adding a server causes the app to crash. This was caused by not resetting the `currentServerId` when no servers were left.
- When adding the first server on launch, the app would add it twice. This was caused by us calling the Welcome Screen twice.

```release-note
NONE
```
