### PR TITLE
Fix window issues

### DIFF
--- a/src/main/windows/mainWindow.test.js
+++ b/src/main/windows/mainWindow.test.js
@@ -495,14 +495,35 @@ describe('main/windows/mainWindow', () => {
 
         afterEach(() => {
             mainWindow.ready = false;
+            mainWindow.win.visible = false;
             jest.resetAllMocks();
         });
 
-        it('should show main window and focus it if it is exists', () => {
+        it('should show main window if it is exists on macOS/Linux', () => {
+            const originalPlatform = process.platform;
+            Object.defineProperty(process, 'platform', {
+                value: 'darwin',
+            });
             mainWindow.ready = true;
             mainWindow.show();
             expect(mainWindow.win.show).toHaveBeenCalled();
+            Object.defineProperty(process, 'platform', {
+                value: originalPlatform,
+            });
+        });
+
+        it('should focus main window if it exists and is visible on Windows', () => {
+            const originalPlatform = process.platform;
+            Object.defineProperty(process, 'platform', {
+                value: 'win32',
+            });
+            mainWindow.ready = true;
+            mainWindow.win.visible = true;
+            mainWindow.show();
             expect(mainWindow.win.focus).toHaveBeenCalled();
+            Object.defineProperty(process, 'platform', {
+                value: originalPlatform,
+            });
         });
 
         it('should init if the main window does not exist', () => {

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -169,8 +169,19 @@ export class MainWindow extends EventEmitter {
 
     show = () => {
         if (this.win && this.isReady) {
-            this.win.show();
-            this.win.focus();
+            // There's a bug on Windows in Electron where if the window is snapped, it will unsnap when you call show()
+            // See here: https://github.com/electron/electron/issues/25359
+            // So to make sure we always show the window on macOS/Linux (need for workspace switching)
+            // We make an exception here
+            if (process.platform === 'win32') {
+                if (this.win.isVisible()) {
+                    this.win.focus();
+                } else {
+                    this.win.show();
+                }
+            } else {
+                this.win.show();
+            }
         } else {
             this.init();
         }


### PR DESCRIPTION
#### Summary
This PR fixes two issues with window sizing:
- On Windows 10/11, changing servers would cause the window to unsnap if snapped, due to [this bug](https://github.com/electron/electron/issues/25359). I've made an exception for Windows to fix this for our purposes.
- Restoring the saved window bounds for the `MainWindow` was failing due to calling the screen size before the app was ready, which wasn't working, so I've moved it over to the `init()` call.

```release-note
NONE
```
