### PR TITLE
Remove elevate.exe from the NSIS installer

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -166,7 +166,8 @@
     "publisherName": "CN=\"Mattermost, Inc.\", O=\"Mattermost, Inc.\", L=Palo Alto, S=California, C=US"
   },
   "nsis": {
-    "artifactName": "${version}/${name}-setup-${version}-win.${ext}"
+    "artifactName": "${version}/${name}-setup-${version}-win.${ext}",
+    "packElevateHelper": false
   },
   "rpm": {
     "fpm": ["--rpm-rpmbuild-define", "_build_id_links none"]


### PR DESCRIPTION
#### Summary
This PR removes the inclusion of `elevate.exe`, an application used for scripting elevated permissions when installing our app in a per-machine fashion instead of per-user. Since we don't explicitly support per-machine for the EXE installer, this is no longer necessary.

```release-note
NONE
```
