### PR TITLE
Upgrade to Electron v24.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "copy-webpack-plugin": "10.2.4",
         "cross-env": "7.0.3",
         "css-loader": "6.7.1",
-        "electron": "23.3.0",
+        "electron": "24.3.1",
         "electron-builder": "23.3.3",
         "electron-connect": "0.6.3",
         "electron-context-menu": "3.6.1",
@@ -15808,14 +15808,14 @@
       }
     },
     "node_modules/electron": {
-      "version": "23.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-23.3.0.tgz",
-      "integrity": "sha512-DVAtptpOSxM7ycgriphSxzlkb3R92d28sFKG1hMtmPkAwHl/e87reaHXhGwyj8Xu4GY69e6yUoAJqma20w0Vgw==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-24.3.1.tgz",
+      "integrity": "sha512-lKfC0umie1k5LW48troHzpPKJrqPEW+5j14/CPTC41K9+dJA98oUPt/05G7QAe8OGD4fHjQQuulfRdZ9MjjXeQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^16.11.26",
+        "@types/node": "^18.11.18",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -16807,9 +16807,9 @@
       }
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "16.11.26",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
-      "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==",
+      "version": "18.16.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.14.tgz",
+      "integrity": "sha512-+ImzUB3mw2c5ISJUq0punjDilUQ5GnUim0ZRvchHIWJmOC0G+p0kzhXBqj6cDjK0QdPFwzrHWgrJp3RPvCG5qg==",
       "dev": true
     },
     "node_modules/element-resize-detector": {
@@ -45692,20 +45692,20 @@
       }
     },
     "electron": {
-      "version": "23.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-23.3.0.tgz",
-      "integrity": "sha512-DVAtptpOSxM7ycgriphSxzlkb3R92d28sFKG1hMtmPkAwHl/e87reaHXhGwyj8Xu4GY69e6yUoAJqma20w0Vgw==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-24.3.1.tgz",
+      "integrity": "sha512-lKfC0umie1k5LW48troHzpPKJrqPEW+5j14/CPTC41K9+dJA98oUPt/05G7QAe8OGD4fHjQQuulfRdZ9MjjXeQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^16.11.26",
+        "@types/node": "^18.11.18",
         "extract-zip": "^2.0.1"
       },
       "dependencies": {
         "@types/node": {
-          "version": "16.11.26",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
-          "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==",
+          "version": "18.16.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.14.tgz",
+          "integrity": "sha512-+ImzUB3mw2c5ISJUq0punjDilUQ5GnUim0ZRvchHIWJmOC0G+p0kzhXBqj6cDjK0QdPFwzrHWgrJp3RPvCG5qg==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/mattermost/desktop.git"
   },
   "config": {
-    "target": "23.3.0",
+    "target": "24.3.1",
     "arch": "x64",
     "target_arch": "x64",
     "disturl": "https://electronjs.org/headers",
@@ -168,7 +168,7 @@
     "copy-webpack-plugin": "10.2.4",
     "cross-env": "7.0.3",
     "css-loader": "6.7.1",
-    "electron": "23.3.0",
+    "electron": "24.3.1",
     "electron-builder": "23.3.3",
     "electron-connect": "0.6.3",
     "electron-context-menu": "3.6.1",


### PR DESCRIPTION
#### Summary
This PR upgrades the Desktop App to Electron v24, which includes the latest Chromium and Node fixes.

```release-note
Upgrade to Electron v24.3.1
```
