### PR TITLE
[MM-51092] Automate release post for RCs and finals, include changelog

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -213,6 +213,6 @@ jobs:
           jq --null-input \
           --arg icon_url "https://mattermost.com/wp-content/uploads/2022/02/icon.png" \
           --arg username "MattermostRelease" \
-          --arg text "[$(jq -r .version package.json)] Release process for the desktop app ended, the new release can be found on [GitHub](https://github.com/mattermost/desktop/releases)." \
+          --arg text "$(bash -x scripts/generate_release_post.sh $(jq -r .version package.json))" \
           '{"username":$username,"icon_url": $icon_url, "text": $text }' > /tmp/webhook-data.json
           curl -i -H "Content-Type: application/json" -X POST -d @/tmp/webhook-data.json ${{ secrets.MM_DESKTOP_RELEASE_WEBHOOK_URL }} || echo "NOFICATION FAILED! check logs as this will succeed intentionally"

--- a/scripts/generate_release_post.sh
+++ b/scripts/generate_release_post.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -eu
+
+VERSION="$1" # such as 5.3.0-rc.1, 5.0.0
+LAST_VERSION="$(git for-each-ref --sort=creatordate --format '%(refname)' refs/tags | grep "v[0-9]\.[0-9]\.[0-9]" | grep -v mas | tail -2 | head -1 | sed "s/refs\/tags\/v//")"
+
+cat <<-MD
+### [v$VERSION](https://github.com/mattermost/desktop/releases/tag/v$VERSION) :tada:
+Changes:
+$(git cherry -v v$LAST_VERSION | grep ^+ | grep "(#[0-9]\+)" | sed "s/^+\s[a-zA-Z0-9]\+\s/- /" | sed "s/\s(#\([0-9]\+\))$/ [(#\1)](https:\/\/github.com\/mattermost\/desktop\/pull\/\1)/" | sed "s/\[\?MM-\([0-9]\+\)\]\?/[[MM-\1]](https:\/\/mattermost.atlassian.net\/browse\/MM-\1)/")
+
+The release will be available on GitHub shortly.
+MD


### PR DESCRIPTION
#### Summary
This PR adds an automation to assist in posting to the "Release: Desktop Apps" channel when new RCs or releases are available. It will scrape the cherry-pick log and determine which PRs were added in the most recent version, and adds links wrt. JIRA tickets and GitHub PRs.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51092

```release-note
NONE
```
