### PR TITLE
Fix release post script

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -210,6 +210,7 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: release/notify-channel
         run: |
+          git fetch --all
           jq --null-input \
           --arg icon_url "https://mattermost.com/wp-content/uploads/2022/02/icon.png" \
           --arg username "MattermostRelease" \

--- a/scripts/generate_release_post.sh
+++ b/scripts/generate_release_post.sh
@@ -2,12 +2,12 @@
 set -eu
 
 VERSION="$1" # such as 5.3.0-rc.1, 5.0.0
-LAST_VERSION="$(git for-each-ref --sort=creatordate --format '%(refname)' refs/tags | grep "v[0-9]\.[0-9]\.[0-9]" | grep -v mas | tail -2 | head -1 | sed "s/refs\/tags\/v//")"
+LAST_VERSION="$(git for-each-ref --sort=creatordate --format '%(refname)' refs/tags | grep "v[0-9]\.[0-9]\.[0-9]" | grep -v mas | grep -v "v$VERSION" | tail -1 | sed "s/refs\/tags\/v//")"
 
 cat <<-MD
 ### [v$VERSION](https://github.com/mattermost/desktop/releases/tag/v$VERSION) :tada:
 Changes:
-$(git cherry -v v$LAST_VERSION | grep ^+ | grep "(#[0-9]\+)" | sed "s/^+\s[a-zA-Z0-9]\+\s/- /" | sed "s/\s(#\([0-9]\+\))$/ [(#\1)](https:\/\/github.com\/mattermost\/desktop\/pull\/\1)/" | sed "s/\[\?MM-\([0-9]\+\)\]\?/[[MM-\1]](https:\/\/mattermost.atlassian.net\/browse\/MM-\1)/")
+$(git cherry -v v$LAST_VERSION v$VERSION | grep ^+ | grep "(#[0-9]\+)" | sed "s/^+\s[a-zA-Z0-9]\+\s/- /" | sed "s/\s(#\([0-9]\+\))$/ [(#\1)](https:\/\/github.com\/mattermost\/desktop\/pull\/\1)/" | sed "s/\[\?MM-\([0-9]\+\)\]\?/[[MM-\1]](https:\/\/mattermost.atlassian.net\/browse\/MM-\1)/")
 
 The release will be available on GitHub shortly.
 MD


### PR DESCRIPTION
#### Summary
For some reason, the script running in GitHub Actions grabbed the same tag that we just made. So I fixed up the script to explicitly exclude it.

```release-note
NONE
```
