### PR TITLE
[MM-52984] Fix minimized window not showing when clicking the notification

### DIFF
--- a/src/main/notifications/index.test.js
+++ b/src/main/notifications/index.test.js
@@ -86,6 +86,7 @@ jest.mock('../views/viewManager', () => ({
 }));
 jest.mock('../windows/mainWindow', () => ({
     get: jest.fn(),
+    show: jest.fn(),
     sendToRenderer: jest.fn(),
 }));
 
@@ -244,6 +245,7 @@ describe('main/notifications', () => {
             );
             const mention = mentions.find((m) => m.body === 'mention_click_body');
             mention.value.click();
+            expect(MainWindow.show).toHaveBeenCalled();
             expect(ViewManager.showById).toHaveBeenCalledWith('server_id');
         });
 

--- a/src/main/notifications/index.ts
+++ b/src/main/notifications/index.ts
@@ -73,6 +73,7 @@ export function displayMention(title: string, body: string, channel: {id: string
 
     mention.on('click', () => {
         log.debug('notification click', serverName, mention);
+        MainWindow.show();
         if (serverName) {
             ViewManager.showById(view.id);
             webcontents.send('notification-clicked', {channel, teamId, url});


### PR DESCRIPTION
#### Summary
When clicking on a notification, we weren't calling `MainWindow.show()` in the handler to make sure the window showed itself. This PR changes so that we make sure to do that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52984

```release-note
NONE
```
