### PR TITLE
[MM-53056] Force a pathname when checking for deep links

### DIFF
--- a/src/common/servers/serverManager.test.js
+++ b/src/common/servers/serverManager.test.js
@@ -13,6 +13,7 @@ jest.mock('common/config', () => ({
 jest.mock('common/utils/url', () => ({
     parseURL: jest.fn(),
     isInternalURL: jest.fn(),
+    getFormattedPathName: (pathname) => (pathname.length ? pathname : '/'),
 }));
 jest.mock('common/utils/util', () => ({
     isVersionGreaterThanOrEqualTo: jest.fn(),

--- a/src/common/servers/serverManager.ts
+++ b/src/common/servers/serverManager.ts
@@ -17,7 +17,7 @@ import {TAB_FOCALBOARD, TAB_MESSAGING, TAB_PLAYBOOKS, MattermostView, getDefault
 import MessagingView from 'common/views/MessagingView';
 import FocalboardView from 'common/views/FocalboardView';
 import PlaybooksView from 'common/views/PlaybooksView';
-import {isInternalURL, parseURL} from 'common/utils/url';
+import {getFormattedPathName, isInternalURL, parseURL} from 'common/utils/url';
 import Utils from 'common/utils/util';
 
 const log = new Logger('ServerManager');
@@ -138,7 +138,7 @@ export class ServerManager extends EventEmitter {
             return undefined;
         }
         const server = this.getAllServers().find((server) => {
-            return isInternalURL(parsedURL, server.url, ignoreScheme) && parsedURL.pathname.match(new RegExp(`^${server.url.pathname}(.+)?(/(.+))?$`));
+            return isInternalURL(parsedURL, server.url, ignoreScheme) && getFormattedPathName(parsedURL.pathname).match(new RegExp(`^${server.url.pathname}(.+)?(/(.+))?$`));
         });
         if (!server) {
             return undefined;
@@ -149,7 +149,7 @@ export class ServerManager extends EventEmitter {
         views.
             filter((view) => view && view.type !== TAB_MESSAGING).
             forEach((view) => {
-                if (parsedURL.pathname.match(new RegExp(`^${view.url.pathname}(/(.+))?`))) {
+                if (getFormattedPathName(parsedURL.pathname).match(new RegExp(`^${view.url.pathname}(/(.+))?`))) {
                     selectedView = view;
                 }
             });

--- a/src/main/views/viewManager.test.js
+++ b/src/main/views/viewManager.test.js
@@ -50,6 +50,7 @@ jest.mock('common/utils/url', () => ({
             return null;
         }
     },
+    getFormattedPathName: (pathname) => (pathname.length ? pathname : '/'),
     equalUrlsIgnoringSubpath: jest.fn(),
 }));
 

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -34,7 +34,7 @@ import Utils from 'common/utils/util';
 import {MattermostServer} from 'common/servers/MattermostServer';
 import ServerManager from 'common/servers/serverManager';
 import {MattermostView, TAB_MESSAGING} from 'common/views/View';
-import {parseURL} from 'common/utils/url';
+import {getFormattedPathName, parseURL} from 'common/utils/url';
 
 import {localizeMessage} from 'main/i18nManager';
 import MainWindow from 'main/windows/mainWindow';
@@ -177,7 +177,7 @@ export class ViewManager {
             const parsedURL = parseURL(url)!;
             const view = ServerManager.lookupViewByURL(parsedURL, true);
             if (view) {
-                const urlWithSchema = `${view.url.origin}${parsedURL.pathname}${parsedURL.search}`;
+                const urlWithSchema = `${view.url.origin}${getFormattedPathName(parsedURL.pathname)}${parsedURL.search}`;
                 if (this.closedViews.has(view.id)) {
                     this.openClosedView(view.id, urlWithSchema);
                 } else {


### PR DESCRIPTION
#### Summary
When clicking on a deep link, for links that don't include a pathname (eg. [mattermost://community.mattermost.com](mattermost://community.mattermost.com)), the app would fail to open them with an error message.

This PR forces a pathname so that matching works correctly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53056

```release-note
NONE
```
