### PR TITLE
[MM-53201] Fix piping concurrency issues with release post generation script

### DIFF
--- a/scripts/generate_release_post.sh
+++ b/scripts/generate_release_post.sh
@@ -2,12 +2,18 @@
 set -eu
 
 VERSION="$1" # such as 5.3.0-rc.1, 5.0.0
-LAST_VERSION="$(git for-each-ref --sort=creatordate --format '%(refname)' refs/tags | grep "v[0-9]\.[0-9]\.[0-9]" | grep -v mas | grep -v "v$VERSION" | tail -1 | sed "s/refs\/tags\/v//")"
+
+TEMP_VERSION_FILE="$(mktemp -t temp_version_file.XXXX)"
+git for-each-ref --sort=creatordate --format '%(refname)' refs/tags | grep "v[0-9]\.[0-9]\.[0-9]" | grep -v mas | grep -v "v$VERSION" | sed "s/refs\/tags\/v//" > $TEMP_VERSION_FILE
+LAST_VERSION="$(cat $TEMP_VERSION_FILE | tail -1)"
+
+TEMP_CHANGES_FILE="$(mktemp -t temp_changes_file.XXXX)"
+git cherry -v v$LAST_VERSION v$VERSION | grep ^+ | grep "(#[0-9]\+)" > $TEMP_CHANGES_FILE
 
 cat <<-MD
 ### [v$VERSION](https://github.com/mattermost/desktop/releases/tag/v$VERSION) :tada:
 Changes:
-$(git cherry -v v$LAST_VERSION v$VERSION | grep ^+ | grep "(#[0-9]\+)" | sed "s/^+\s[a-zA-Z0-9]\+\s/- /" | sed "s/\s(#\([0-9]\+\))$/ [(#\1)](https:\/\/github.com\/mattermost\/desktop\/pull\/\1)/" | sed "s/\[\?MM-\([0-9]\+\)\]\?/[[MM-\1]](https:\/\/mattermost.atlassian.net\/browse\/MM-\1)/")
+$(cat $TEMP_CHANGES_FILE | sed "s/^+\s[a-zA-Z0-9]\+\s/- /" | sed "s/\s(#\([0-9]\+\))$/ [(#\1)](https:\/\/github.com\/mattermost\/desktop\/pull\/\1)/" | sed "s/\[\?MM-\([0-9]\+\)\]\?/[[MM-\1]](https:\/\/mattermost.atlassian.net\/browse\/MM-\1)/")
 
 The release will be available on GitHub shortly.
 MD


### PR DESCRIPTION
#### Summary
Fixing an issue with the release post generation script in which some of the pipe calls don't run in order, so we need to separate them out.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53201

```release-note
NONE
```
