### PR TITLE
[MM-53199] Update to use `notarytool`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "electron-is-dev": "2.0.0",
         "electron-log": "4.4.8",
         "electron-mocha": "11.0.2",
-        "electron-notarize": "1.2.1",
+        "electron-notarize": "1.2.2",
         "electron-rebuild": "3.2.9",
         "electron-updater": "5.2.1",
         "eslint": "7.29.0",
@@ -16267,9 +16267,10 @@
       }
     },
     "node_modules/electron-notarize": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-1.2.1.tgz",
-      "integrity": "sha512-u/ECWhIrhkSQpZM4cJzVZ5TsmkaqrRo5LDC/KMbGF0sPkm53Ng59+M0zp8QVaql0obfJy9vlVT+4iOkAi2UDlA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-1.2.2.tgz",
+      "integrity": "sha512-ZStVWYcWI7g87/PgjPJSIIhwQXOaw4/XeXU+pWqMMktSLHaGMLHdyPPN7Cmao7+Cr7fYufA16npdtMndYciHNw==",
+      "deprecated": "Please use @electron/notarize moving forward.  There is no API change, just a package name change",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
@@ -46038,9 +46039,9 @@
       }
     },
     "electron-notarize": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-1.2.1.tgz",
-      "integrity": "sha512-u/ECWhIrhkSQpZM4cJzVZ5TsmkaqrRo5LDC/KMbGF0sPkm53Ng59+M0zp8QVaql0obfJy9vlVT+4iOkAi2UDlA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-1.2.2.tgz",
+      "integrity": "sha512-ZStVWYcWI7g87/PgjPJSIIhwQXOaw4/XeXU+pWqMMktSLHaGMLHdyPPN7Cmao7+Cr7fYufA16npdtMndYciHNw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "electron-is-dev": "2.0.0",
     "electron-log": "4.4.8",
     "electron-mocha": "11.0.2",
-    "electron-notarize": "1.2.1",
+    "electron-notarize": "1.2.2",
     "electron-rebuild": "3.2.9",
     "electron-updater": "5.2.1",
     "eslint": "7.29.0",

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -26,5 +26,7 @@ exports.default = async function notarizing(context) {
         appPath: `${appOutDir}/${appName}.app`,
         appleId: process.env.APPLEID,
         appleIdPassword: process.env.APPLEIDPASS,
+        teamId: 'UQ8HT4Q2XM',
+        tool: 'notarytool',
     });
 };


### PR DESCRIPTION
#### Summary
We've been using a legacy method to notarize our app, and apparently a newer and much faster one exists called `notarytool`. I've updated the dependency, and enabled `notarytool`, so now macOS builds should be a LOT faster :)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53199

```release-note
NONE
```
