### PR TITLE
[MM-53295] Fix crash in diagnostics when server is unreachable

### DIFF
--- a/src/main/diagnostics/steps/internal/utils.ts
+++ b/src/main/diagnostics/steps/internal/utils.ts
@@ -72,11 +72,11 @@ export async function isOnline(logger: ElectronLog = log, url = IS_ONLINE_ENDPOI
             resp.on('end', () => {
                 logger.debug('resp.on.end', {data, url});
                 if (data.length) {
-                const respBody = JSON.parse(data);
-                if (respBody.status === 'OK') {
-                    resolve(true);
-                    return;
-                }
+                    const respBody = JSON.parse(data);
+                    if (respBody.status === 'OK') {
+                        resolve(true);
+                        return;
+                    }
                 }
                 resolve(false);
             });

--- a/src/main/diagnostics/steps/internal/utils.ts
+++ b/src/main/diagnostics/steps/internal/utils.ts
@@ -70,11 +70,13 @@ export async function isOnline(logger: ElectronLog = log, url = IS_ONLINE_ENDPOI
 
             // The whole response has been received. Print out the result.
             resp.on('end', () => {
-                logger.debug('resp.on.end', {data});
+                logger.debug('resp.on.end', {data, url});
+                if (data.length) {
                 const respBody = JSON.parse(data);
                 if (respBody.status === 'OK') {
                     resolve(true);
                     return;
+                }
                 }
                 resolve(false);
             });

--- a/src/main/diagnostics/steps/step3.serverConnectivity.ts
+++ b/src/main/diagnostics/steps/step3.serverConnectivity.ts
@@ -24,7 +24,7 @@ const run = async (logger: ElectronLog): Promise<DiagnosticStepResponse> => {
                 throw new Error(`Invalid server configuration. Server Url: ${server.url}, server name: ${server.name}`);
             }
 
-            const serverOnline = await isOnline(logger, `${server.url}/api/v4/system/ping`);
+            const serverOnline = await isOnline(logger, `${server.url}api/v4/system/ping`);
 
             if (!serverOnline) {
                 throw new Error(`Server appears to be offline. Server url: ${server.url}`);

--- a/src/main/diagnostics/steps/step3.serverConnectivity.ts
+++ b/src/main/diagnostics/steps/step3.serverConnectivity.ts
@@ -5,6 +5,7 @@ import {ElectronLog} from 'electron-log';
 import {DiagnosticStepResponse} from 'types/diagnostics';
 
 import ServerManager from 'common/servers/serverManager';
+import {parseURL} from 'common/utils/url';
 
 import DiagnosticsStep from '../DiagnosticStep';
 
@@ -24,7 +25,7 @@ const run = async (logger: ElectronLog): Promise<DiagnosticStepResponse> => {
                 throw new Error(`Invalid server configuration. Server Url: ${server.url}, server name: ${server.name}`);
             }
 
-            const serverOnline = await isOnline(logger, `${server.url}api/v4/system/ping`);
+            const serverOnline = await isOnline(logger, parseURL(`${server.url}/api/v4/system/ping`)?.toString());
 
             if (!serverOnline) {
                 throw new Error(`Server appears to be offline. Server url: ${server.url}`);

--- a/src/main/server/serverInfo.ts
+++ b/src/main/server/serverInfo.ts
@@ -4,6 +4,7 @@
 import {ClientConfig, RemoteInfo} from 'types/server';
 
 import {MattermostServer} from 'common/servers/MattermostServer';
+import {parseURL} from 'common/utils/url';
 
 import {getServerAPI} from './serverAPI';
 
@@ -18,21 +19,24 @@ export class ServerInfo {
 
     fetchRemoteInfo = async () => {
         await this.getRemoteInfo<ClientConfig>(
-            new URL(`${this.server.url.toString()}/api/v4/config/client?format=old`),
             this.onGetConfig,
+            parseURL(`${this.server.url}/api/v4/config/client?format=old`),
         );
         await this.getRemoteInfo<Array<{id: string; version: string}>>(
-            new URL(`${this.server.url.toString()}/api/v4/plugins/webapp`),
             this.onGetPlugins,
+            parseURL(`${this.server.url}/api/v4/plugins/webapp`),
         );
 
         return this.remoteInfo;
     }
 
     private getRemoteInfo = <T>(
-        url: URL,
         callback: (data: T) => void,
+        url?: URL,
     ) => {
+        if (!url) {
+            return Promise.reject(new Error('Malformed URL'));
+        }
         return new Promise<void>((resolve, reject) => {
             getServerAPI<T>(
                 url,


### PR DESCRIPTION
#### Summary
When running diagnostics, we check the current configured servers to ensure reachability. Unfortunately, there was a bug introduced when refactoring for the `ServerManager` in which the wrong URL was provided and would always crash. This revealed a further bug where if the server was unreachable, diagnostics would always crash.

This PR fixes the issue with the wrong URL, as well as catches the potential crash that could happen.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53295
Closes https://github.com/mattermost/desktop/issues/2769

```release-note
Fix crash in diagnostics when server is unreachable
```
