### PR TITLE
[MM-53294] Fix bad user feedback on server URL validation when plugins are disabled

### DIFF
--- a/src/app/serverViewState.test.js
+++ b/src/app/serverViewState.test.js
@@ -336,7 +336,7 @@ describe('app/serverViewState', () => {
         beforeEach(() => {
             MattermostServer.mockImplementation(({url}) => ({url}));
             ServerInfo.mockImplementation(({url}) => ({
-                fetchRemoteInfo: jest.fn().mockImplementation(() => ({
+                fetchConfigData: jest.fn().mockImplementation(() => ({
                     serverVersion: '7.8.0',
                     siteName: 'Mattermost',
                     siteURL: url,
@@ -400,7 +400,7 @@ describe('app/serverViewState', () => {
 
         it('should attempt HTTP when HTTPS fails, and generate a warning', async () => {
             ServerInfo.mockImplementation(({url}) => ({
-                fetchRemoteInfo: jest.fn().mockImplementation(() => {
+                fetchConfigData: jest.fn().mockImplementation(() => {
                     if (url.startsWith('https:')) {
                         return undefined;
                     }
@@ -420,7 +420,7 @@ describe('app/serverViewState', () => {
 
         it('should show a warning when the ping request times out', async () => {
             ServerInfo.mockImplementation(() => ({
-                fetchRemoteInfo: jest.fn().mockImplementation(() => {
+                fetchConfigData: jest.fn().mockImplementation(() => {
                     throw new Error();
                 }),
             }));
@@ -432,7 +432,7 @@ describe('app/serverViewState', () => {
 
         it('should update the users URL when the Site URL is different', async () => {
             ServerInfo.mockImplementation(() => ({
-                fetchRemoteInfo: jest.fn().mockImplementation(() => {
+                fetchConfigData: jest.fn().mockImplementation(() => {
                     return {
                         serverVersion: '7.8.0',
                         siteName: 'Mattermost',
@@ -448,7 +448,7 @@ describe('app/serverViewState', () => {
 
         it('should warn the user when the Site URL is different but unreachable', async () => {
             ServerInfo.mockImplementation(({url}) => ({
-                fetchRemoteInfo: jest.fn().mockImplementation(() => {
+                fetchConfigData: jest.fn().mockImplementation(() => {
                     if (url === 'https://mainserver.com/') {
                         return undefined;
                     }
@@ -468,7 +468,7 @@ describe('app/serverViewState', () => {
         it('should warn the user when the Site URL already exists as another server', async () => {
             ServerManager.lookupViewByURL.mockReturnValue({server: {name: 'Server 1', id: 'server-1', url: new URL('https://mainserver.com')}});
             ServerInfo.mockImplementation(() => ({
-                fetchRemoteInfo: jest.fn().mockImplementation(() => {
+                fetchConfigData: jest.fn().mockImplementation(() => {
                     return {
                         serverVersion: '7.8.0',
                         siteName: 'Mattermost',

--- a/src/app/serverViewState.ts
+++ b/src/app/serverViewState.ts
@@ -343,7 +343,7 @@ export class ServerViewState {
         const server = new MattermostServer({name: 'temp', url: parsedURL.toString()}, false);
         const serverInfo = new ServerInfo(server);
         try {
-            const remoteInfo = await serverInfo.fetchRemoteInfo();
+            const remoteInfo = await serverInfo.fetchConfigData();
             return remoteInfo;
         } catch (error) {
             return undefined;

--- a/src/main/server/serverInfo.ts
+++ b/src/main/server/serverInfo.ts
@@ -16,11 +16,17 @@ export class ServerInfo {
         this.remoteInfo = {};
     }
 
-    fetchRemoteInfo = async () => {
+    fetchConfigData = async () => {
         await this.getRemoteInfo<ClientConfig>(
             new URL(`${this.server.url.toString()}/api/v4/config/client?format=old`),
             this.onGetConfig,
         );
+
+        return this.remoteInfo;
+    }
+
+    fetchRemoteInfo = async () => {
+        await this.fetchConfigData();
         await this.getRemoteInfo<Array<{id: string; version: string}>>(
             new URL(`${this.server.url.toString()}/api/v4/plugins/webapp`),
             this.onGetPlugins,


### PR DESCRIPTION
#### Summary
When a user tries to enter a server URL that has plugins disabled, the app will tell the user that their server isn't valid, even though it is.

This PR changes the logic to not require the user of the plugins API to get the server status.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53294
Closes https://github.com/mattermost/desktop/issues/2766

```release-note
Fix bad user feedback on server URL validation when plugins are disabled
```
