### PR TITLE
[MM-50536] Add workaround for Dev Tools not opening correctly on Mac

### DIFF
--- a/src/main/views/MattermostBrowserView.ts
+++ b/src/main/views/MattermostBrowserView.ts
@@ -293,6 +293,21 @@ export class MattermostBrowserView extends EventEmitter {
     }
 
     openDevTools = () => {
+        // Workaround for a bug with our Dev Tools on Mac
+        // For some reason if you open two Dev Tools windows and close the first one, it won't register the closing
+        // So what we do here is check to see if it's opened correctly and if not we reset it
+        if (process.platform === 'darwin') {
+            const timeout = setTimeout(() => {
+                if (this.browserView.webContents.isDevToolsOpened()) {
+                    this.browserView.webContents.closeDevTools();
+                    this.browserView.webContents.openDevTools({mode: 'detach'});
+                }
+            }, 500);
+            this.browserView.webContents.on('devtools-opened', () => {
+                clearTimeout(timeout);
+            });
+        }
+
         this.browserView.webContents.openDevTools({mode: 'detach'});
     }
 


### PR DESCRIPTION
#### Summary
Some reports were happening of developers having trouble opening the Dev Tools on macOS, requiring them to restart the Desktop App to make it work. After some investigating, I noticed that the `devtools-closed` event wasn't firing and the `isDevToolsOpened()` call was returning true. This was happening everytime I would open a Dev Tools window for one server, then open a second window for a different, close the original one and then try to re-open the original one.

I unfortunately wasn't able to find the root cause of this, since nothing had been reported to Electron and I wasn't able to reproduce on a Fiddle, so what I've done is create a workaround in which we check if the Dev Tools was successfully opened after the call was made, and if not we manually call `closeDevTools()` and then re-open, which seems to solve the issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50536

```release-note
NONE
```
