### PR TITLE
Re-add React Developer Tools to nightly builds

### DIFF
--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -19,7 +19,7 @@ const isRelease = process.env.CIRCLE_BRANCH && process.env.CIRCLE_BRANCH.startsW
 const codeDefinitions = {
     __HASH_VERSION__: !isRelease && JSON.stringify(VERSION),
     __CAN_UPGRADE__: isTest || JSON.stringify(process.env.CAN_UPGRADE === 'true'),
-    __IS_NIGHTLY_BUILD__: JSON.stringify(process.env.CIRCLE_BRANCH === 'nightly'),
+    __IS_NIGHTLY_BUILD__: JSON.stringify(process.env.GITHUB_WORKFLOW === 'nightly-main'),
     __IS_MAC_APP_STORE__: JSON.stringify(process.env.IS_MAC_APP_STORE === 'true'),
     __SKIP_ONBOARDING_SCREENS__: JSON.stringify(process.env.MM_DESKTOP_BUILD_SKIPONBOARDINGSCREENS === 'true'),
     __DISABLE_GPU__: JSON.stringify(process.env.MM_DESKTOP_BUILD_DISABLEGPU === 'true'),


### PR DESCRIPTION
#### Summary
When we migrated to GitHub Actions, I neglected to fix the flag for the nightly build to turn on the React Developer Tools. This PR fixes that by checking for the right workflow.

```release-note
NONE
```
