### PR TITLE
[MM-53490] Reduce min window width to 600px

### DIFF
--- a/e2e/specs/menu_bar/full_screen.test.js
+++ b/e2e/specs/menu_bar/full_screen.test.js
@@ -19,7 +19,7 @@ describe('menu/view', function desc() {
         env.createTestUserDataDir();
         env.cleanTestConfig();
         fs.writeFileSync(env.configFilePath, JSON.stringify(config));
-        fs.writeFileSync(env.boundsInfoPath, JSON.stringify({x: 0, y: 0, width: 700, height: 240, maximized: false, fullscreen: false}));
+        fs.writeFileSync(env.boundsInfoPath, JSON.stringify({x: 0, y: 0, width: 600, height: 240, maximized: false, fullscreen: false}));
         await asyncSleep(1000);
         this.app = await env.getApp();
         this.serverMap = await env.getServerMap(this.app);

--- a/src/common/utils/constants.ts
+++ b/src/common/utils/constants.ts
@@ -22,7 +22,7 @@ export const MENU_SHADOW_WIDTH = 24;
 
 export const DEFAULT_WINDOW_WIDTH = 1280;
 export const DEFAULT_WINDOW_HEIGHT = 800;
-export const MINIMUM_WINDOW_WIDTH = 700;
+export const MINIMUM_WINDOW_WIDTH = 600;
 export const MINIMUM_WINDOW_HEIGHT = 240;
 
 // Calls


### PR DESCRIPTION
#### Summary
Dropping the minimum width of the Desktop App down to 600px to accommodate for users wanting to have the app in a smaller window.

#### Ticket Link
Closes https://github.com/mattermost/desktop/issues/2786
https://mattermost.atlassian.net/browse/MM-53490

```release-note
Set minimum window width to 600px
```
