### PR TITLE
[GH-2694] Upgrade to Electron v24.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "copy-webpack-plugin": "10.2.4",
         "cross-env": "7.0.3",
         "css-loader": "6.7.1",
-        "electron": "24.3.1",
+        "electron": "24.6.3",
         "electron-builder": "23.3.3",
         "electron-connect": "0.6.3",
         "electron-context-menu": "3.6.1",
@@ -15930,9 +15930,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-24.3.1.tgz",
-      "integrity": "sha512-lKfC0umie1k5LW48troHzpPKJrqPEW+5j14/CPTC41K9+dJA98oUPt/05G7QAe8OGD4fHjQQuulfRdZ9MjjXeQ==",
+      "version": "24.6.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-24.6.3.tgz",
+      "integrity": "sha512-hWy2ot0987DRzhOxIyv9tgybd0yrAcc9MRFYZ+znjXgdmbvcSveXdcGKGdtpgw1EW/TKUonJMH3VfDNeAmdPUg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -46146,9 +46146,9 @@
       }
     },
     "electron": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-24.3.1.tgz",
-      "integrity": "sha512-lKfC0umie1k5LW48troHzpPKJrqPEW+5j14/CPTC41K9+dJA98oUPt/05G7QAe8OGD4fHjQQuulfRdZ9MjjXeQ==",
+      "version": "24.6.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-24.6.3.tgz",
+      "integrity": "sha512-hWy2ot0987DRzhOxIyv9tgybd0yrAcc9MRFYZ+znjXgdmbvcSveXdcGKGdtpgw1EW/TKUonJMH3VfDNeAmdPUg==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/mattermost/desktop.git"
   },
   "config": {
-    "target": "24.3.1",
+    "target": "24.6.3",
     "arch": "x64",
     "target_arch": "x64",
     "disturl": "https://electronjs.org/headers",
@@ -168,7 +168,7 @@
     "copy-webpack-plugin": "10.2.4",
     "cross-env": "7.0.3",
     "css-loader": "6.7.1",
-    "electron": "24.3.1",
+    "electron": "24.6.3",
     "electron-builder": "23.3.3",
     "electron-connect": "0.6.3",
     "electron-context-menu": "3.6.1",


### PR DESCRIPTION
#### Summary
Upgrading to the latest release of Electron v24 to fix an issue with screen sharing in Calls on Linux.

#### Ticket Link
Closes https://github.com/mattermost/desktop/issues/2694

```release-note
Upgrade to Electron v24.6.3
```
