### PR TITLE
[MM-53841] Remove upgrade notification if auto updates were switched off

### DIFF
--- a/src/main/downloadsManager.test.js
+++ b/src/main/downloadsManager.test.js
@@ -7,6 +7,9 @@ import {shell} from 'electron';
 
 import {getDoNotDisturb as getDarwinDoNotDisturb} from 'macos-notification-state';
 
+import Config from 'common/config';
+import {APP_UPDATE_KEY} from 'common/constants';
+
 import {DownloadsManager} from 'main/downloadsManager';
 
 const downloadLocationMock = '/path/to/downloads';
@@ -85,6 +88,7 @@ jest.mock('common/config', () => {
     const original = jest.requireActual('common/config');
     return {
         ...original,
+        canUpgrade: true,
         downloadLocation: downloadLocationMock,
     };
 });
@@ -223,6 +227,27 @@ describe('main/downloadsManager', () => {
         expect(Object.keys(dl.downloads).includes('invalid_file4.txt')).toBe(false);
         expect(Object.keys(dl.downloads).includes('invalid_file5.txt')).toBe(false);
         expect(Object.keys(dl.downloads).includes('invalid_file6.txt')).toBe(false);
+    });
+
+    it('should remove updates if they are disabled', () => {
+        const file = JSON.stringify({
+            ...downloadsJson,
+            [APP_UPDATE_KEY]: {
+                type: 'update',
+                progress: 0,
+                location: '',
+                addedAt: 0,
+                receivedBytes: 0,
+                totalBytes: 0,
+                state: 'available',
+                filename: '1.2.3',
+            },
+        });
+        const dl = new DownloadsManager(file);
+        expect(dl.hasUpdate()).toBe(true);
+        Config.canUpgrade = false;
+        dl.init();
+        expect(dl.hasUpdate()).toBe(false);
     });
 });
 

--- a/src/main/downloadsManager.ts
+++ b/src/main/downloadsManager.ts
@@ -201,9 +201,9 @@ export class DownloadsManager extends JsonFileManager<DownloadedItems> {
                     continue;
                 }
 
-                // Remove update if app was updated and restarted
+                // Remove update if app was updated and restarted OR if we disabled auto updates
                 if (fileId === APP_UPDATE_KEY) {
-                    if (appVersionManager.lastAppVersion === file.filename) {
+                    if (appVersionManager.lastAppVersion === file.filename || !Config.canUpgrade) {
                         delete downloads[APP_UPDATE_KEY];
                         modified = true;
                         continue;


### PR DESCRIPTION
#### Summary
Disabling automatic updates will not automatically dismiss the notification if it's already been saved to the Downloads dropdown. This PR makes sure to clear that out on startup if auto-updates were disabled to avoid any confusion.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53841

```release-note
Fixed an issue where auto updating wouldn't be properly disabled
```
