### PR TITLE
Upgrade to Electron v26.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "copy-webpack-plugin": "10.2.4",
         "cross-env": "7.0.3",
         "css-loader": "6.7.1",
-        "electron": "24.6.3",
+        "electron": "26.1.0",
         "electron-builder": "23.3.3",
         "electron-connect": "0.6.3",
         "electron-context-menu": "3.6.1",
@@ -15930,9 +15930,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "24.6.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-24.6.3.tgz",
-      "integrity": "sha512-hWy2ot0987DRzhOxIyv9tgybd0yrAcc9MRFYZ+znjXgdmbvcSveXdcGKGdtpgw1EW/TKUonJMH3VfDNeAmdPUg==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-26.1.0.tgz",
+      "integrity": "sha512-qEh19H09Pysn3ibms5nZ0haIh5pFoOd7/5Ww7gzmAwDQOulRi8Sa2naeueOyIb1GKpf+6L4ix3iceYRAuA5r5Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -46146,9 +46146,9 @@
       }
     },
     "electron": {
-      "version": "24.6.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-24.6.3.tgz",
-      "integrity": "sha512-hWy2ot0987DRzhOxIyv9tgybd0yrAcc9MRFYZ+znjXgdmbvcSveXdcGKGdtpgw1EW/TKUonJMH3VfDNeAmdPUg==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-26.1.0.tgz",
+      "integrity": "sha512-qEh19H09Pysn3ibms5nZ0haIh5pFoOd7/5Ww7gzmAwDQOulRi8Sa2naeueOyIb1GKpf+6L4ix3iceYRAuA5r5Q==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/mattermost/desktop.git"
   },
   "config": {
-    "target": "24.6.3",
+    "target": "26.1.0",
     "arch": "x64",
     "target_arch": "x64",
     "disturl": "https://electronjs.org/headers",
@@ -168,7 +168,7 @@
     "copy-webpack-plugin": "10.2.4",
     "cross-env": "7.0.3",
     "css-loader": "6.7.1",
-    "electron": "24.6.3",
+    "electron": "26.1.0",
     "electron-builder": "23.3.3",
     "electron-connect": "0.6.3",
     "electron-context-menu": "3.6.1",

--- a/src/main/authManager.ts
+++ b/src/main/authManager.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import {AuthenticationResponseDetails, AuthInfo, WebContents} from 'electron';
+import {AuthenticationResponseDetails, AuthInfo, WebContents, Event} from 'electron';
 
 import {PermissionType} from 'types/trustedOrigin';
 import {LoginModalData} from 'types/auth';

--- a/src/main/certificateManager.ts
+++ b/src/main/certificateManager.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {Certificate, WebContents} from 'electron';
+import {Certificate, WebContents, Event} from 'electron';
 
 import {CertificateModalData} from 'types/certificate';
 

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {BrowserView, dialog, ipcMain, IpcMainEvent, IpcMainInvokeEvent} from 'electron';
+import {BrowserView, dialog, ipcMain, IpcMainEvent, IpcMainInvokeEvent, Event} from 'electron';
 
 import ServerViewState from 'app/serverViewState';
 

--- a/src/main/views/webContentEvents.ts
+++ b/src/main/views/webContentEvents.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {BrowserWindow, session, shell, WebContents} from 'electron';
+import {BrowserWindow, session, shell, WebContents, Event} from 'electron';
 
 import Config from 'common/config';
 import {Logger} from 'common/log';

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {BrowserWindow, desktopCapturer, ipcMain, IpcMainEvent, Rectangle, systemPreferences} from 'electron';
+import {BrowserWindow, desktopCapturer, ipcMain, IpcMainEvent, Rectangle, systemPreferences, Event} from 'electron';
 
 import {
     CallsErrorMessage,


### PR DESCRIPTION
### Summary

This PR upgrades the Desktop App to Electron v26, which includes the latest Chromium and Node fixes.

### Ticket Link
Closes https://github.com/mattermost/desktop/issues/2694


```release-note
Upgrade to Electron v26.1.0
```