### PR TITLE
[MM-54170] Automatically set the logging level to info if not specified

### DIFF
--- a/src/common/config/defaultPreferences.ts
+++ b/src/common/config/defaultPreferences.ts
@@ -48,6 +48,7 @@ const defaultPreferences: ConfigV3 = {
     lastActiveTeam: 0,
     downloadLocation: getDefaultDownloadLocation(),
     startInFullscreen: false,
+    logLevel: 'info',
 };
 
 export default defaultPreferences;

--- a/src/common/log.test.js
+++ b/src/common/log.test.js
@@ -10,6 +10,14 @@ jest.unmock('common/log');
 
 jest.mock('electron-log', () => ({
     log: jest.fn(),
+    transports: {
+        file: {
+            level: 'info',
+        },
+        console: {
+            level: 'info',
+        },
+    },
 }));
 
 jest.mock('common/utils/util', () => ({

--- a/src/common/log.ts
+++ b/src/common/log.ts
@@ -22,6 +22,9 @@ export class Logger {
 
     constructor(...prefixes: string[]) {
         this.prefixes = this.shortenPrefixes(...prefixes);
+
+        // Start on info by default
+        setLoggingLevel('info');
     }
 
     withPrefix = (...prefixes: string[]) => {


### PR DESCRIPTION
#### Summary
New installations did not have a default logging level set, so `electron-log` was defaulting to `silly` which was logging all keystrokes and a lot of other noise, which could fill up a user's hard drive.

This PR makes sure to set the default config item to `info` and to set the log level to `info` when the app starts by default in case the user (or some other source) removes the config item.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54170

```release-note
Fixed an issue where the default logging level was `silly` for all new installs
```
