### PR TITLE
[MM-54279] Fix issues around working with saved downloads

### DIFF
--- a/src/main/downloadsManager.ts
+++ b/src/main/downloadsManager.ts
@@ -174,14 +174,19 @@ export class DownloadsManager extends JsonFileManager<DownloadedItems> {
         }
 
         for (const file of Object.values(this.downloads)) {
-            if (file.bookmark) {
-                this.bookmarks.set(this.getDownloadedFileId(file), {originalPath: file.location, bookmark: file.bookmark});
+            try {
+                if (file.bookmark) {
+                    this.bookmarks.set(this.getDownloadedFileId(file), {originalPath: file.location, bookmark: file.bookmark});
 
-                if (file.mimeType?.toLowerCase().startsWith('image/')) {
-                    const func = app.startAccessingSecurityScopedResource(file.bookmark);
-                    fs.copyFileSync(file.location, path.resolve(app.getPath('temp'), path.basename(file.location)));
-                    func();
+                    if (file.mimeType?.toLowerCase().startsWith('image/')) {
+                        const func = app.startAccessingSecurityScopedResource(file.bookmark);
+                        fs.copyFileSync(file.location, path.resolve(app.getPath('temp'), path.basename(file.location)));
+                        func();
+                    }
                 }
+            } catch (e) {
+                log.warn('could not load bookmark', file.filename, e);
+                this.clearFile(file);
             }
         }
     }


### PR DESCRIPTION
#### Summary
There was a report of users having the app crash when restarting due to missing files that were downloaded, deleted from the file system, but not cleared from the Downloads dropdown.

I wasn't able to reproduce the exact issue, but I found and fixed 2 issues that were likely contributing:
- The initial crash report was due to an `ENOENT` error (file not found) which I've wrapped in a `try/catch` to make sure that the app won't crash in the same way again.
- The reason that this was hard to reproduce was being caused by the saved downloads list not saving correctly (it was being corrupted by multiple async saves), so I've added a queue of promises that need to happen subsequently in order to save correctly.

Between these two fixes this should help alleviate the linked ticket. I also noticed that in my case I had an issue where the window wouldn't load at all, which should now be fixed (might also fix some of the other reports of this kind)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54279

```release-note
NONE
```
