### PR TITLE
[MM-54276] Stop URL from being populated on validation regardless of change/timeout

### DIFF
--- a/src/renderer/components/ConfigureServer.tsx
+++ b/src/renderer/components/ConfigureServer.tsx
@@ -127,9 +127,6 @@ function ConfigureServer({
     const validateURL = async (url: string) => {
         let message;
         const validationResult = await window.desktop.validateServerURL(url);
-        if (validationResult.validatedURL) {
-            setUrl(validationResult.validatedURL);
-        }
 
         if (validationResult?.status === URLValidationStatus.Missing) {
             message = {


### PR DESCRIPTION
#### Summary
On the Welcome Screen while we are validating a URL, we would always populate the returned validated URL from the main process after it was returned, regardless of whether the URL was changed in the meantime.

This PR removes the extra call that was doing that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54276
Closes https://github.com/mattermost/desktop/issues/2809

```release-note
NONE
```
