### PR TITLE
[MM-54463] Enforce secure keyboard entry on macOS when a password box is focused

### DIFF
--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -175,3 +175,5 @@ export const MAIN_WINDOW_FOCUSED = 'main-window-focused';
 export const VALIDATE_SERVER_URL = 'validate-server-url';
 
 export const GET_IS_DEV_MODE = 'get-is-dev-mode';
+
+export const TOGGLE_SECURE_INPUT = 'toggle-secure-input';

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -29,6 +29,7 @@ import {
     WINDOW_MINIMIZE,
     WINDOW_RESTORE,
     DOUBLE_CLICK_ON_WINDOW,
+    TOGGLE_SECURE_INPUT,
 } from 'common/communication';
 import Config from 'common/config';
 import {isTrustedURL, parseURL} from 'common/utils/url';
@@ -80,6 +81,7 @@ import {
     handleOpenAppMenu,
     handleQuit,
     handlePingDomain,
+    handleToggleSecureInput,
 } from './intercom';
 import {
     clearAppCache,
@@ -272,6 +274,8 @@ function initializeInterCommunicationEventListeners() {
     ipcMain.on(WINDOW_MINIMIZE, handleMinimize);
     ipcMain.on(WINDOW_RESTORE, handleRestore);
     ipcMain.on(DOUBLE_CLICK_ON_WINDOW, handleDoubleClick);
+
+    ipcMain.on(TOGGLE_SECURE_INPUT, handleToggleSecureInput);
 }
 
 async function initializeAfterAppReady() {

--- a/src/main/app/intercom.ts
+++ b/src/main/app/intercom.ts
@@ -147,3 +147,9 @@ export function handlePingDomain(event: IpcMainInvokeEvent, url: string): Promis
         throw new Error('Could not find server ' + url);
     });
 }
+
+export function handleToggleSecureInput(event: IpcMainEvent, secureInput: boolean) {
+    // Enforce macOS to restrict processes from reading the keyboard input when in a password field
+    log.debug('handleToggleSecureInput', secureInput);
+    app.setSecureKeyboardEntryEnabled(secureInput);
+}

--- a/src/main/preload/mattermost.js
+++ b/src/main/preload/mattermost.js
@@ -378,21 +378,12 @@ window.addEventListener('resize', () => {
 let isPasswordBox = false;
 
 window.addEventListener('focusin', (event) => {
-    if (isPasswordBox) {
-        return;
-    }
-
-    if (event.target.tagName === 'INPUT' && event.target.type === 'password') {
+    const targetIsPasswordBox = event.target.tagName === 'INPUT' && event.target.type === 'password';
+    if (targetIsPasswordBox && !isPasswordBox) {
         ipcRenderer.send(TOGGLE_SECURE_INPUT, true);
-        isPasswordBox = true;
-    }
-});
-
-window.addEventListener('focusout', () => {
-    if (!isPasswordBox) {
-        return;
+    } else if (!targetIsPasswordBox && isPasswordBox) {
+        ipcRenderer.send(TOGGLE_SECURE_INPUT, false);
     }
 
-    isPasswordBox = false;
-    ipcRenderer.send(TOGGLE_SECURE_INPUT, false);
+    isPasswordBox = targetIsPasswordBox;
 });

--- a/src/main/preload/mattermost.js
+++ b/src/main/preload/mattermost.js
@@ -38,6 +38,7 @@ import {
     CALLS_ERROR,
     CALLS_JOIN_REQUEST,
     GET_IS_DEV_MODE,
+    TOGGLE_SECURE_INPUT,
 } from 'common/communication';
 
 const UNREAD_COUNT_INTERVAL = 1000;
@@ -372,4 +373,26 @@ ipcRenderer.on(CALLS_JOIN_REQUEST, (event, message) => {
 
 window.addEventListener('resize', () => {
     ipcRenderer.send(VIEW_FINISHED_RESIZING);
+});
+
+let isPasswordBox = false;
+
+window.addEventListener('focusin', (event) => {
+    if (isPasswordBox) {
+        return;
+    }
+
+    if (event.target.tagName === 'INPUT' && event.target.type === 'password') {
+        ipcRenderer.send(TOGGLE_SECURE_INPUT, true);
+        isPasswordBox = true;
+    }
+});
+
+window.addEventListener('focusout', () => {
+    if (!isPasswordBox) {
+        return;
+    }
+
+    isPasswordBox = false;
+    ipcRenderer.send(TOGGLE_SECURE_INPUT, false);
 });


### PR DESCRIPTION
#### Summary
When a user types a password, there is a risk that another process on the user's computer could read the keyboard input and retrieve sensitive information from the user. On macOS, there is an API designed to prevent this.

This PR adds a call to that API that fires whenever the user has a password box focused.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54463

```release-note
NONE
```
