### PR TITLE
Fix issue where logging will be stuck on `info` level

### DIFF
--- a/src/common/log.ts
+++ b/src/common/log.ts
@@ -15,6 +15,9 @@ export const setLoggingLevel = (level: string) => {
     log.transports.file.level = level as LevelOption;
 };
 
+// Start on info by default
+setLoggingLevel('info');
+
 export const getLevel = () => log.transports.file.level as string;
 
 export class Logger {
@@ -22,9 +25,6 @@ export class Logger {
 
     constructor(...prefixes: string[]) {
         this.prefixes = this.shortenPrefixes(...prefixes);
-
-        // Start on info by default
-        setLoggingLevel('info');
     }
 
     withPrefix = (...prefixes: string[]) => {


### PR DESCRIPTION
#### Summary
While fixing [this issue](https://github.com/mattermost/desktop/pull/2811) I neglected to take into account that the `Logger` class would be reinstantiated multiple times, thus keeping the app stuck on `info` level logging.

This PR moves the call to default to `info` right under the call to start logging so that it's only ever called once.

```release-note
Fix issue where logging will be stuck on `info` level
```
