### PR TITLE
[MM-54465] Remove lowercase call when checking path names

### DIFF
--- a/src/common/Validator.ts
+++ b/src/common/Validator.ts
@@ -201,7 +201,7 @@ export function validateV0ConfigData(data: ConfigV0) {
 function cleanURL(url: string): string {
     let updatedURL = url;
     if (updatedURL.includes('\\')) {
-        updatedURL = updatedURL.toLowerCase().replace(/\\/gi, '/');
+        updatedURL = updatedURL.replace(/\\/gi, '/');
     }
     return updatedURL;
 }

--- a/src/common/utils/url.test.js
+++ b/src/common/utils/url.test.js
@@ -25,14 +25,9 @@ jest.mock('common/views/View', () => ({
 
 describe('common/utils/url', () => {
     describe('getFormattedPathName', () => {
-        it('should format all to lower case', () => {
-            const unformattedPathName = '/aAbBbB/cC/DdeR/';
-            expect(getFormattedPathName(unformattedPathName)).toBe('/aabbbb/cc/dder/');
-        });
-
         it('should add trailing slash', () => {
             const unformattedPathName = '/aAbBbB/cC/DdeR';
-            expect(getFormattedPathName(unformattedPathName)).toBe('/aabbbb/cc/dder/');
+            expect(getFormattedPathName(unformattedPathName)).toBe('/aAbBbB/cC/DdeR/');
         });
     });
     describe('parseURL', () => {

--- a/src/common/utils/url.ts
+++ b/src/common/utils/url.ts
@@ -6,7 +6,7 @@ import {isHttpsUri, isHttpUri, isUri} from 'valid-url';
 import buildConfig from 'common/config/buildConfig';
 import {customLoginRegexPaths, nonTeamUrlPaths, CALLS_PLUGIN_ID} from 'common/utils/constants';
 
-export const getFormattedPathName = (pn: string) => (pn.endsWith('/') ? pn.toLowerCase() : `${pn.toLowerCase()}/`);
+export const getFormattedPathName = (pn: string) => (pn.endsWith('/') ? pn : `${pn}/`);
 export const parseURL = (inputURL: string | URL) => {
     if (inputURL instanceof URL) {
         return inputURL;

--- a/src/main/windows/callsWidgetWindow.test.js
+++ b/src/main/windows/callsWidgetWindow.test.js
@@ -241,7 +241,7 @@ describe('main/windows/callsWidgetWindow', () => {
         beforeEach(() => {
             urlUtils.parseURL.mockImplementation((url) => new URL(url));
             urlUtils.getFormattedPathName.mockImplementation((pn) => {
-                return pn.endsWith('/') ? pn.toLowerCase() : `${pn.toLowerCase()}/`;
+                return pn.endsWith('/') ? pn : `${pn}/`;
             });
             callsWidgetWindow.options = {
                 callID: 'test-call-id',


### PR DESCRIPTION
#### Summary
When we were checking if two URLs were equal, we were assuming that like the URL's origin, the pathname was also not case-sensitive. This is not the case so it was possible that two URLs with different URLs could be considered equal.

This PR removed the call to `toLowerCase()` to make sure we respect case sensitivity for path names.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54465

```release-note
Fixed an issue where two different URLs could be considered the same.
```
