### PR TITLE
[MM-54509] Upgrade to Electron v26.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "mattermost-desktop",
-      "version": "5.5.0-rc.1",
+      "version": "5.6.0-develop.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -50,7 +50,7 @@
         "copy-webpack-plugin": "10.2.4",
         "cross-env": "7.0.3",
         "css-loader": "6.7.1",
-        "electron": "26.1.0",
+        "electron": "26.2.1",
         "electron-builder": "23.3.3",
         "electron-connect": "0.6.3",
         "electron-context-menu": "3.6.1",
@@ -15930,9 +15930,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-26.1.0.tgz",
-      "integrity": "sha512-qEh19H09Pysn3ibms5nZ0haIh5pFoOd7/5Ww7gzmAwDQOulRi8Sa2naeueOyIb1GKpf+6L4ix3iceYRAuA5r5Q==",
+      "version": "26.2.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-26.2.1.tgz",
+      "integrity": "sha512-SNT24Cf/wRvfcFZQoERXjzswUlg5ouqhIuA2t9x2L7VdTn+2Jbs0QXRtOfzcnOV/raVMz3e8ICyaU2GGeciKLg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -46146,9 +46146,9 @@
       }
     },
     "electron": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-26.1.0.tgz",
-      "integrity": "sha512-qEh19H09Pysn3ibms5nZ0haIh5pFoOd7/5Ww7gzmAwDQOulRi8Sa2naeueOyIb1GKpf+6L4ix3iceYRAuA5r5Q==",
+      "version": "26.2.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-26.2.1.tgz",
+      "integrity": "sha512-SNT24Cf/wRvfcFZQoERXjzswUlg5ouqhIuA2t9x2L7VdTn+2Jbs0QXRtOfzcnOV/raVMz3e8ICyaU2GGeciKLg==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/mattermost/desktop.git"
   },
   "config": {
-    "target": "26.1.0",
+    "target": "26.2.1",
     "arch": "x64",
     "target_arch": "x64",
     "disturl": "https://electronjs.org/headers",
@@ -168,7 +168,7 @@
     "copy-webpack-plugin": "10.2.4",
     "cross-env": "7.0.3",
     "css-loader": "6.7.1",
-    "electron": "26.1.0",
+    "electron": "26.2.1",
     "electron-builder": "23.3.3",
     "electron-connect": "0.6.3",
     "electron-context-menu": "3.6.1",


### PR DESCRIPTION
#### Summary
Upgrade to Electron v26.2.1 for the latest security and bug fixes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54509
Closes #2833

```release-note
Upgrade to Electron v26.2.1
```
