### PR TITLE
Force end notification to pull all commits

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -210,6 +210,8 @@ jobs:
     steps:
       - name: release/checkout-repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          fetch-depth: 0
       - name: release/notify-channel
         run: |
           git fetch --all


### PR DESCRIPTION
#### Summary
The release script wasn't pulling all commits when finishing the notification, missing commits.

```release-note
NONE
```
