### PR TITLE
Fix multiple permission dialogs displaying for the same permission check

### DIFF
--- a/src/main/permissionsManager.test.js
+++ b/src/main/permissionsManager.test.js
@@ -175,4 +175,17 @@ describe('main/PermissionsManager', () => {
         expect(permissionsManager.writeToFile).toHaveBeenCalled();
         expect(cb).toHaveBeenCalledWith(false);
     });
+
+    it('should only pop dialog once upon multiple permission checks', async () => {
+        const permissionsManager = new PermissionsManager('anyfile.json');
+        permissionsManager.writeToFile = jest.fn();
+        const cb = jest.fn();
+        dialog.showMessageBox.mockReturnValue(Promise.resolve({response: 0}));
+        await Promise.all([
+            permissionsManager.handlePermissionRequest({id: 2}, 'notifications', cb, {securityOrigin: 'http://anyurl.com'}),
+            permissionsManager.handlePermissionRequest({id: 2}, 'notifications', cb, {securityOrigin: 'http://anyurl.com'}),
+            permissionsManager.handlePermissionRequest({id: 2}, 'notifications', cb, {securityOrigin: 'http://anyurl.com'}),
+        ]);
+        expect(dialog.showMessageBox).toHaveBeenCalledTimes(1);
+    });
 });


### PR DESCRIPTION
#### Summary
Fixed an issue I found in the permissions manager where if you received multiple permissions checks before the dialog finished, you would see all the additional dialogs even if you explicitly allowed.

```release-note
NONE
```

