### PR TITLE
[MM-54617] Remove regex matching for URL lookups

### DIFF
--- a/src/common/servers/serverManager.ts
+++ b/src/common/servers/serverManager.ts
@@ -124,7 +124,8 @@ export class ServerManager extends EventEmitter {
             return undefined;
         }
         const server = this.getAllServers().find((server) => {
-            return isInternalURL(parsedURL, server.url, ignoreScheme) && getFormattedPathName(parsedURL.pathname).match(new RegExp(`^${server.url.pathname}(.+)?(/(.+))?$`));
+            return isInternalURL(parsedURL, server.url, ignoreScheme) &&
+                getFormattedPathName(parsedURL.pathname).startsWith(server.url.pathname);
         });
         if (!server) {
             return undefined;
@@ -135,7 +136,7 @@ export class ServerManager extends EventEmitter {
         views.
             filter((view) => view && view.type !== TAB_MESSAGING).
             forEach((view) => {
-                if (getFormattedPathName(parsedURL.pathname).match(new RegExp(`^${view.url.pathname}(/(.+))?`))) {
+                if (getFormattedPathName(parsedURL.pathname).startsWith(view.url.pathname)) {
                     selectedView = view;
                 }
             });


### PR DESCRIPTION
#### Summary
Our URL lookup check was using regular expressions to check if URLs were part of a certain server, instead of just using `startsWith`, which is much simpler. This PR switches us to just using `startsWith`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54517

```release-note
NONE
```
