### PR TITLE
Remove gconf dependencies for debian as no longer needed by Electron.

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -44,8 +44,6 @@
     "artifactName": "${version}/${name}_${version}-1_${arch}.${ext}",
     "synopsis": "Mattermost Desktop App",
     "depends": [
-      "gconf2",
-      "gconf-service",
       "libnotify4",
       "libxtst6",
       "libnss3"


### PR DESCRIPTION
#### Summary
As per https://github.com/electron/electron/issues/2727 and a slew of other issues, `gconf` has long been deprecated, and is no longer needed by Electron. This PR removes the dependency from the Debian package. 

#### Ticket Link
Closes #2853 

```release-note
Removed gconf dependency for Debian/Ubuntu
```
