### PR TITLE
[GH-2857] Allow only macOS to call setSecureKeyboardEntryEnabled

### DIFF
--- a/src/main/app/intercom.ts
+++ b/src/main/app/intercom.ts
@@ -149,6 +149,10 @@ export function handlePingDomain(event: IpcMainInvokeEvent, url: string): Promis
 }
 
 export function handleToggleSecureInput(event: IpcMainEvent, secureInput: boolean) {
+    if (process.platform !== 'darwin') {
+        return;
+    }
+
     // Enforce macOS to restrict processes from reading the keyboard input when in a password field
     log.debug('handleToggleSecureInput', secureInput);
     app.setSecureKeyboardEntryEnabled(secureInput);


### PR DESCRIPTION
#### Summary
It would appear that the `app.setSecureKeyboardEntryEnabled` function is undefined for Windows and Linux, instead of escaped for those OSes since it doesn't affect them.

This PR ensures that we only call this function for macOS.

#### Ticket Link
Closes #2857

```release-note
NONE
```
