### PR TITLE
[MM-54584] Fixed an issue where clicking on a link to an unregistered protocol on macOS would cause the app to crash

### DIFF
--- a/src/main/allowProtocolDialog.test.js
+++ b/src/main/allowProtocolDialog.test.js
@@ -160,6 +160,16 @@ describe('main/allowProtocolDialog', () => {
                 expect(allowProtocolDialog.allowedProtocols).not.toContain('mattermost:');
                 expect(fs.writeFile).not.toBeCalled();
             });
+
+            it('should not throw error when shell.openExternal fails', async () => {
+                const promise = Promise.resolve({response: 0});
+                dialog.showMessageBox.mockImplementation(() => promise);
+                shell.openExternal.mockReturnValue(Promise.reject(new Error('bad protocol')));
+                allowProtocolDialog.handleDialogEvent('bad-protocol:', 'bad-protocol://community.mattermost.com');
+                await promise;
+
+                expect(shell.openExternal).toBeCalledWith('bad-protocol://community.mattermost.com');
+            });
         });
     });
 });

--- a/src/main/allowProtocolDialog.ts
+++ b/src/main/allowProtocolDialog.ts
@@ -44,29 +44,31 @@ export class AllowProtocolDialog {
         }
     }
 
-    handleDialogEvent = (protocol: string, URL: string) => {
-        if (this.allowedProtocols.indexOf(protocol) !== -1) {
-            shell.openExternal(URL);
-            return;
-        }
-        const mainWindow = MainWindow.get();
-        if (!mainWindow) {
-            return;
-        }
-        dialog.showMessageBox(mainWindow, {
-            title: localizeMessage('main.allowProtocolDialog.title', 'Non http(s) protocol'),
-            message: localizeMessage('main.allowProtocolDialog.message', '{protocol} link requires an external application.', {protocol}),
-            detail: localizeMessage('main.allowProtocolDialog.detail', 'The requested link is {URL}. Do you want to continue?', {URL}),
-            defaultId: 2,
-            type: 'warning',
-            buttons: [
-                localizeMessage('label.yes', 'Yes'),
-                localizeMessage('main.allowProtocolDialog.button.saveProtocolAsAllowed', 'Yes (Save {protocol} as allowed)', {protocol}),
-                localizeMessage('label.no', 'No'),
-            ],
-            cancelId: 2,
-            noLink: true,
-        }).then(({response}) => {
+    handleDialogEvent = async (protocol: string, URL: string) => {
+        try {
+            if (this.allowedProtocols.indexOf(protocol) !== -1) {
+                await shell.openExternal(URL);
+                return;
+            }
+            const mainWindow = MainWindow.get();
+            if (!mainWindow) {
+                return;
+            }
+            const {response} = await dialog.showMessageBox(mainWindow, {
+                title: localizeMessage('main.allowProtocolDialog.title', 'Non http(s) protocol'),
+                message: localizeMessage('main.allowProtocolDialog.message', '{protocol} link requires an external application.', {protocol}),
+                detail: localizeMessage('main.allowProtocolDialog.detail', 'The requested link is {URL}. Do you want to continue?', {URL}),
+                defaultId: 2,
+                type: 'warning',
+                buttons: [
+                    localizeMessage('label.yes', 'Yes'),
+                    localizeMessage('main.allowProtocolDialog.button.saveProtocolAsAllowed', 'Yes (Save {protocol} as allowed)', {protocol}),
+                    localizeMessage('label.no', 'No'),
+                ],
+                cancelId: 2,
+                noLink: true,
+            });
+
             switch (response) {
             case 1: {
                 this.allowedProtocols.push(protocol);
@@ -76,16 +78,16 @@ export class AllowProtocolDialog {
                     }
                 }
                 fs.writeFile(allowedProtocolFile, JSON.stringify(this.allowedProtocols), handleError);
-                shell.openExternal(URL);
+                await shell.openExternal(URL);
                 break;
             }
             case 0:
-                shell.openExternal(URL);
-                break;
-            default:
+                await shell.openExternal(URL);
                 break;
             }
-        });
+        } catch (error) {
+            log.warn('Could not open external URL', error);
+        }
     }
 }
 


### PR DESCRIPTION
#### Summary
When calling `shell.openExternal` on macOS, it returns a `Promise`. If the protocol used in the URL provided is not registered, the Promise will reject.

We were not properly handling this rejection, and due to the changes in v5.4 that included unhandled promise rejections, the app was simply crashing even though it should just fail silently.

This PR adds the handler to catch the error, log in, and then fail silently like we would expect.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54584

```release-note
Fixed an issue where clicking on a link to an unregistered protocol on macOS would cause the app to crash.
```
