### PR TITLE
[MM-54742] Force secure keyboard entry off when window loses focus and when servers switch

### DIFF
--- a/src/app/serverViewState.ts
+++ b/src/app/serverViewState.ts
@@ -16,6 +16,7 @@ import {
     SHOW_NEW_SERVER_MODAL,
     SHOW_REMOVE_SERVER_MODAL,
     SWITCH_SERVER,
+    TOGGLE_SECURE_INPUT,
     UPDATE_SERVER_ORDER,
     UPDATE_SHORTCUT_MENU,
     UPDATE_TAB_ORDER,
@@ -87,6 +88,7 @@ export class ServerViewState {
             ServerManager.getServerLog(serverId, 'WindowManager').error('Cannot find server in config');
             return;
         }
+        ipcMain.emit(TOGGLE_SECURE_INPUT, null, false);
         this.currentServerId = serverId;
         const nextView = ServerManager.getLastActiveTabForServer(serverId);
         if (waitForViewToExist) {

--- a/src/main/preload/mattermost.js
+++ b/src/main/preload/mattermost.js
@@ -376,14 +376,21 @@ window.addEventListener('resize', () => {
 });
 
 let isPasswordBox = false;
-
-window.addEventListener('focusin', (event) => {
-    const targetIsPasswordBox = event.target.tagName === 'INPUT' && event.target.type === 'password';
-    if (targetIsPasswordBox && !isPasswordBox) {
+const shouldSecureInput = (element, force = false) => {
+    const targetIsPasswordBox = (element && element.tagName === 'INPUT' && element.type === 'password');
+    if (targetIsPasswordBox && (!isPasswordBox || force)) {
         ipcRenderer.send(TOGGLE_SECURE_INPUT, true);
-    } else if (!targetIsPasswordBox && isPasswordBox) {
+    } else if (!targetIsPasswordBox && (isPasswordBox || force)) {
         ipcRenderer.send(TOGGLE_SECURE_INPUT, false);
     }
 
     isPasswordBox = targetIsPasswordBox;
+};
+
+window.addEventListener('focusin', (event) => {
+    shouldSecureInput(event.target);
+});
+
+window.addEventListener('focus', () => {
+    shouldSecureInput(document.activeElement, true);
 });

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -27,6 +27,7 @@ import {
     MAIN_WINDOW_RESIZED,
     MAIN_WINDOW_FOCUSED,
     VIEW_FINISHED_RESIZING,
+    TOGGLE_SECURE_INPUT,
 } from 'common/communication';
 import Config from 'common/config';
 import {Logger} from 'common/log';
@@ -314,6 +315,7 @@ export class MainWindow extends EventEmitter {
         globalShortcut.unregisterAll();
 
         this.emit(MAIN_WINDOW_RESIZED, this.getBounds());
+        ipcMain.emit(TOGGLE_SECURE_INPUT, null, false);
 
         // App should save bounds when a window is closed.
         // However, 'close' is not fired in some situations(shutdown, ctrl+c)


### PR DESCRIPTION
#### Summary
We missed a couple cases in which it wouldn't make sense to have secure keyboard entry still enabled, so I've made sure to turn it off when the window is out of focus, and when servers switch. I've also added a check so that when the view is focused, if the password entry is still the active element, we turn the secure keyboard entry back on.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54742

```release-note
NONE
```
