### PR TITLE
Include more obvious prompt to reproduce issues in the Web App first

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,18 +3,25 @@ description: Create a report about an issue you found in the Mattermost Desktop 
 title: "[Bug]: "
 labels: "Type/Bug"
 body:
+- type: markdown
+  attributes:
+    value: |
+      ## STOP! Before you file a bug report
+      Check that the issue is truly a Desktop App issue and not an issue with our Web App. The Desktop App makes use of the Mattermost Web App to render Mattermost. This repository is for issues with the Desktop App wrapper.
+      You can do this by going to your web browser (preferably Chrome) and attempting to reproduce the issue there.
+      If it does, the issue should be reported to the [main Mattermost repository](https://github.com/mattermost/mattermost/issues).
 - type: checkboxes
   attributes:
     label: Before you file a bug report
     description: Please ensure you can confirm the following
     options:
+      - label: This issue doesn't reproduce on web browsers (such as in Chrome). If it does, [issue reports go to the Mattermost Server repository](https://github.com/mattermost/mattermost-server/issues).
+        required: true
       - label: I have checked the [issue tracker](https://github.com/mattermost/desktop/issues) and have not found an issue that matches the one I'm filing.
         required: true
       - label: "This issue is not a troubleshooting question. Troubleshooting questions go here: https://forum.mattermost.com/c/trouble-shoot/16."
         required: true
       - label: "This issue is not a feature request. You can request features and make product suggestions here: https://mattermost.com/suggestions/."
-        required: true
-      - label: This issue doesn't reproduce on web browsers (such as in Chrome). If it does, [issue reports go to the Mattermost Server repository](https://github.com/mattermost/mattermost-server/issues).
         required: true
       - label: This issue reproduces on the most recent [stable version](https://github.com/mattermost/desktop/releases/latest), or the most recent [prerelease version](https://github.com/mattermost/desktop/releases) of the Mattermost Desktop App.
         required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
       If it does, the issue should be reported to the [main Mattermost repository](https://github.com/mattermost/mattermost/issues).
 - type: checkboxes
   attributes:
-    label: Before you file a bug report
+    label: Checks before filing an issue
     description: Please ensure you can confirm the following
     options:
       - label: This issue doesn't reproduce on web browsers (such as in Chrome). If it does, [issue reports go to the Mattermost Server repository](https://github.com/mattermost/mattermost-server/issues).


### PR DESCRIPTION
#### Summary
We've received a very large volume of issues to the Desktop App repository that are actually Web App issues. It would appear that users are missing/misinterpreting the prompt to try and reproduce in the Web App first.

This PR adds a much large prompt in the issue template to hopefully ensure reporter will know where the issues should go.

```release-note
NONE
```
