### PR TITLE
[GH 2874] Fix category for deb and clairfy directory information in README for linux

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -48,7 +48,6 @@
       "libxtst6",
       "libnss3"
     ],
-    "category": "contrib/net",
     "priority": "optional"
   },
   "asarUnpack": [

--- a/src/assets/linux/README.md
+++ b/src/assets/linux/README.md
@@ -12,14 +12,14 @@
 
 If you installed the application via a package manager, it's ready to use in your system. Please follow the [User Guide](#user-guide) for further information.
 
-Otherwise, first locate the extracted directory in your desired directory (e.g. `/opt/mattermost-desktop-<VERSION>`) and follow the steps below.
+Otherwise, first locate the extracted directory in your desired directory (e.g. `/opt/mattermost-desktop`) and follow the steps below. (This directory also contains this README here.)
 
 ### Desktop launcher
 
 Execute the script file to create a `Mattermost.desktop` file.
 
 ```
-/opt/mattermost-desktop-<VERSION>/create_desktop_file.sh
+/opt/mattermost-desktop/create_desktop_file.sh
 ```
 
 Then move it to the appropriate directory of your desktop environment. For example, on Ubuntu Unity it's `~/.local/share/applications/` for the current user.
@@ -33,14 +33,14 @@ mv Mattermost.desktop ~/.local/share/applications/
 Set a `PATH` environment variable to enable launching from the terminal. For example, you can append the following line into `~/.bashrc`.
 
 ```sh
-# assuming that /opt/mattermost-desktop-<VERSION>/mattermost-desktop is the executable file.
-export PATH=$PATH:/opt/mattermost-desktop-<VERSION>
+# assuming that /opt/mattermost-desktop/mattermost-desktop is the executable file.
+export PATH=$PATH:/opt/mattermost-desktop
 ```
 
 Alternatively, you can also create a symbolic link for the application.
 
 ```sh
-sudo ln -s /opt/mattermost-desktop-<VERSION>/mattermost-desktop /usr/local/bin/
+sudo ln -s /opt/mattermost-desktop/mattermost-desktop /usr/local/bin/
 ```
 
 You're now all set! See the [User Guide](#user-guide) below for instructions.


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Fix the `category` for deb installation. The abnormal `category` for deb was been added with f4e2d91 by @Willyfrog. The changes in the commit seems to be not related with the `category` so it was probably a mistake to set the `category` for deb at this point.

And some changes to clarify where the directory of the application can be found.

I did not "execute" or test my changes in any way. I have no glue how to build such a electron application. I hope someone can check it before it will be merged.

And about the Unittest topic: Is it even possible to check such things in a Unittest

#### Ticket Link
 issue #2874

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [ ] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [ ] executed `npm run lint:js` for proper code formatting

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Release Note
```release-note
Set the category for the main menu correctly for installation with deb package.
```
