### PR TITLE
[MM-54979] Stop auto opening Boards/Playbooks tabs, close existing open tabs once for users that might have them open

### DIFF
--- a/src/common/config/migrationPreferences.test.js
+++ b/src/common/config/migrationPreferences.test.js
@@ -29,7 +29,7 @@ describe('common/config/migrationPreferences', () => {
                 getValue: () => false,
                 setValue: jest.fn(),
             }));
-            expect(migrateConfigItems({})).toBe(true);
+            expect(migrateConfigItems({teams: []})).toBe(true);
             Object.defineProperty(process, 'platform', {
                 value: originalPlatform,
             });

--- a/src/common/config/migrationPreferences.ts
+++ b/src/common/config/migrationPreferences.ts
@@ -4,6 +4,7 @@
 import {Config, MigrationInfo} from 'types/config';
 
 import JsonFileManager from 'common/JsonFileManager';
+import {TAB_MESSAGING} from 'common/views/View';
 
 import {migrationInfoPath} from 'main/constants';
 
@@ -14,6 +15,16 @@ export default function migrateConfigItems(config: Config) {
     if (!migrationPrefs.getValue('updateTrayIconWin32') && process.platform === 'win32') {
         config.trayIconTheme = 'use_system';
         migrationPrefs.setValue('updateTrayIconWin32', true);
+        didMigrate = true;
+    }
+
+    if (!migrationPrefs.getValue('closeExtraTabs')) {
+        config.teams.forEach((team) => {
+            team.tabs.filter((tab) => tab.name !== TAB_MESSAGING).forEach((tab) => {
+                tab.isOpen = false;
+            });
+        });
+        migrationPrefs.setValue('closeExtraTabs', true);
         didMigrate = true;
     }
 

--- a/src/common/servers/serverManager.test.js
+++ b/src/common/servers/serverManager.test.js
@@ -53,42 +53,6 @@ describe('common/servers/serverManager', () => {
             expect(serverManager.persistServers).not.toHaveBeenCalled();
         });
 
-        it('should open all views', async () => {
-            serverManager.updateRemoteInfos(new Map([['server-1', {
-                siteURL: 'http://server-1.com',
-                serverVersion: '6.0.0',
-                hasPlaybooks: true,
-                hasFocalboard: true,
-            }]]));
-
-            expect(serverManager.views.get('view-2').isOpen).toBe(true);
-            expect(serverManager.views.get('view-3').isOpen).toBe(true);
-        });
-
-        it('should open only playbooks', async () => {
-            serverManager.updateRemoteInfos(new Map([['server-1', {
-                siteURL: 'http://server-1.com',
-                serverVersion: '6.0.0',
-                hasPlaybooks: true,
-                hasFocalboard: false,
-            }]]));
-
-            expect(serverManager.views.get('view-2').isOpen).toBe(true);
-            expect(serverManager.views.get('view-3').isOpen).toBeUndefined();
-        });
-
-        it('should open none when server version is too old', async () => {
-            serverManager.updateRemoteInfos(new Map([['server-1', {
-                siteURL: 'http://server-1.com',
-                serverVersion: '5.0.0',
-                hasPlaybooks: true,
-                hasFocalboard: true,
-            }]]));
-
-            expect(serverManager.views.get('view-2').isOpen).toBeUndefined();
-            expect(serverManager.views.get('view-3').isOpen).toBeUndefined();
-        });
-
         it('should update server URL using site URL', async () => {
             serverManager.updateRemoteInfos(new Map([['server-1', {
                 siteURL: 'http://server-2.com',

--- a/src/common/servers/serverManager.ts
+++ b/src/common/servers/serverManager.ts
@@ -18,7 +18,6 @@ import MessagingView from 'common/views/MessagingView';
 import FocalboardView from 'common/views/FocalboardView';
 import PlaybooksView from 'common/views/PlaybooksView';
 import {getFormattedPathName, isInternalURL, parseURL} from 'common/utils/url';
-import Utils from 'common/utils/util';
 
 const log = new Logger('ServerManager');
 
@@ -108,7 +107,6 @@ export class ServerManager extends EventEmitter {
         remoteInfos.forEach((remoteInfo, serverId) => {
             this.remoteInfo.set(serverId, remoteInfo);
             hasUpdates = this.updateServerURL(serverId) || hasUpdates;
-            hasUpdates = this.openExtraViews(serverId) || hasUpdates;
         });
 
         if (hasUpdates) {
@@ -377,42 +375,6 @@ export class ServerManager extends EventEmitter {
             return true;
         }
         return false;
-    }
-
-    private openExtraViews = (serverId: string) => {
-        const server = this.servers.get(serverId);
-        const remoteInfo = this.remoteInfo.get(serverId);
-
-        if (!(server && remoteInfo)) {
-            return false;
-        }
-
-        if (!(remoteInfo.serverVersion && Utils.isVersionGreaterThanOrEqualTo(remoteInfo.serverVersion, '6.0.0'))) {
-            return false;
-        }
-
-        let hasUpdates = false;
-        const viewOrder = this.viewOrder.get(serverId);
-        if (viewOrder) {
-            viewOrder.forEach((viewId) => {
-                const view = this.views.get(viewId);
-                if (view) {
-                    if (view.type === TAB_PLAYBOOKS && remoteInfo.hasPlaybooks && typeof view.isOpen === 'undefined') {
-                        log.withPrefix(view.id).verbose('opening Playbooks');
-                        view.isOpen = true;
-                        this.views.set(viewId, view);
-                        hasUpdates = true;
-                    }
-                    if (view.type === TAB_FOCALBOARD && remoteInfo.hasFocalboard && typeof view.isOpen === 'undefined') {
-                        log.withPrefix(view.id).verbose('opening Boards');
-                        view.isOpen = true;
-                        this.views.set(viewId, view);
-                        hasUpdates = true;
-                    }
-                }
-            });
-        }
-        return hasUpdates;
     }
 
     private includeId = (id: string, ...prefixes: string[]) => {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -131,4 +131,5 @@ export type LocalConfiguration = Config & {
 export type MigrationInfo = {
     updateTrayIconWin32: boolean;
     masConfigs: boolean;
+    closeExtraTabs: boolean;
 }


### PR DESCRIPTION
#### Summary
To improve overall memory usage, we are electing to stop opening the Boards and Playbooks tabs automatically when a new server is added. These tabs are often left running unnecessarily and take up memory.

Additionally, I've added a migration to close the tabs for everyone who currently has them open. This would be a good memory improvement for those who aren't using the tabs, but will be a bit jarring for those who do. They can re-open them afterwards and shouldn't see any further effects. cc @abhijit-singh on what you think of this approach/if you have any better ideas.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54979

```release-note
Stop auto opening Boards/Playbooks tabs
```
