### PR TITLE
[MM-55054] Consider a matching origin for a media request as a trusted URL when checking permissions

### DIFF
--- a/src/main/permissionsManager.test.js
+++ b/src/main/permissionsManager.test.js
@@ -65,7 +65,7 @@ describe('main/PermissionsManager', () => {
                 return null;
             }
         });
-        isTrustedURL.mockImplementation((url, baseURL) => baseURL.toString().startsWith(url.toString()));
+        isTrustedURL.mockImplementation((url, baseURL) => url.toString().startsWith(baseURL.toString()));
     });
 
     afterEach(() => {
@@ -187,5 +187,21 @@ describe('main/PermissionsManager', () => {
             permissionsManager.handlePermissionRequest({id: 2}, 'notifications', cb, {securityOrigin: 'http://anyurl.com'}),
         ]);
         expect(dialog.showMessageBox).toHaveBeenCalledTimes(1);
+    });
+
+    it('should still pop dialog for media requests from the servers origin', async () => {
+        ViewManager.getViewByWebContentsId.mockImplementation((id) => {
+            if (id === 2) {
+                return {view: {server: {url: new URL('http://anyurl.com/subpath')}}};
+            }
+
+            return null;
+        });
+        const permissionsManager = new PermissionsManager('anyfile.json');
+        permissionsManager.writeToFile = jest.fn();
+        const cb = jest.fn();
+        dialog.showMessageBox.mockReturnValue(Promise.resolve({response: 0}));
+        await permissionsManager.handlePermissionRequest({id: 2}, 'media', cb, {securityOrigin: 'http://anyurl.com'});
+        expect(dialog.showMessageBox).toHaveBeenCalled();
     });
 });

--- a/src/main/permissionsManager.ts
+++ b/src/main/permissionsManager.ts
@@ -106,7 +106,7 @@ export class PermissionsManager extends JsonFileManager<Permissions> {
         }
 
         // is the requesting url trusted?
-        if (!isTrustedURL(parsedURL, serverURL)) {
+        if (!(isTrustedURL(parsedURL, serverURL) || (permission === 'media' && parsedURL.origin === serverURL.origin))) {
             return false;
         }
 


### PR DESCRIPTION
#### Summary
With the new permission changes, we were stopping servers with subpaths from being able to grant the `media` permission, due to being too strict about which URLs we were considering trusted.

The `media` permission generally populates the `securityOrigin` field when doing a permission check, so when checking for that permission if the URL can be trusted, we just need to match the two origins.

This PR makes that exception in the permissions handler.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-55054
Closes https://github.com/mattermost/desktop/issues/2881

```release-note
Fixed an issue where servers on a subpath could not grant the `media` permission
```

