### PR TITLE
[MM-55132] Upgrade to Electron v27.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "copy-webpack-plugin": "10.2.4",
         "cross-env": "7.0.3",
         "css-loader": "6.7.1",
-        "electron": "26.2.1",
+        "electron": "27.0.2",
         "electron-builder": "23.3.3",
         "electron-connect": "0.6.3",
         "electron-context-menu": "3.6.1",
@@ -80,7 +80,7 @@
         "mocha-circleci-reporter": "0.0.3",
         "mochawesome": "7.1.3",
         "nan": "2.17.0",
-        "node-abi": "3.47.0",
+        "node-abi": "3.51.0",
         "node-jq": "2.3.4",
         "node-loader": "2.0.0",
         "npm-run-all": "4.1.5",
@@ -15930,9 +15930,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "26.2.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-26.2.1.tgz",
-      "integrity": "sha512-SNT24Cf/wRvfcFZQoERXjzswUlg5ouqhIuA2t9x2L7VdTn+2Jbs0QXRtOfzcnOV/raVMz3e8ICyaU2GGeciKLg==",
+      "version": "27.0.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-27.0.2.tgz",
+      "integrity": "sha512-4fbcHQ40ZDlqhr5Pamm+M5BF7ry2lGqjFTWTJ/mrBwuiPWu6xhV/RWgUhKBaLqKNfAaNl3eMxV3Jc82gv6JauQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -25946,9 +25946,9 @@
       "dev": true
     },
     "node_modules/node-abi": {
-      "version": "3.47.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.47.0.tgz",
-      "integrity": "sha512-2s6B2CWZM//kPgwnuI0KrYwNjfdByE25zvAaEpq9IH4zcNsarH8Ihu/UuX6XMPEogDAxkuUFeZn60pXNHAqn3A==",
+      "version": "3.51.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.51.0.tgz",
+      "integrity": "sha512-SQkEP4hmNWjlniS5zdnfIXTk1x7Ome85RDzHlTbBtzE97Gfwz/Ipw4v/Ryk20DWIy3yCNVLVlGKApCnmvYoJbA==",
       "dev": true,
       "dependencies": {
         "semver": "^7.3.5"
@@ -46146,9 +46146,9 @@
       }
     },
     "electron": {
-      "version": "26.2.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-26.2.1.tgz",
-      "integrity": "sha512-SNT24Cf/wRvfcFZQoERXjzswUlg5ouqhIuA2t9x2L7VdTn+2Jbs0QXRtOfzcnOV/raVMz3e8ICyaU2GGeciKLg==",
+      "version": "27.0.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-27.0.2.tgz",
+      "integrity": "sha512-4fbcHQ40ZDlqhr5Pamm+M5BF7ry2lGqjFTWTJ/mrBwuiPWu6xhV/RWgUhKBaLqKNfAaNl3eMxV3Jc82gv6JauQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",
@@ -53846,9 +53846,9 @@
       }
     },
     "node-abi": {
-      "version": "3.47.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.47.0.tgz",
-      "integrity": "sha512-2s6B2CWZM//kPgwnuI0KrYwNjfdByE25zvAaEpq9IH4zcNsarH8Ihu/UuX6XMPEogDAxkuUFeZn60pXNHAqn3A==",
+      "version": "3.51.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.51.0.tgz",
+      "integrity": "sha512-SQkEP4hmNWjlniS5zdnfIXTk1x7Ome85RDzHlTbBtzE97Gfwz/Ipw4v/Ryk20DWIy3yCNVLVlGKApCnmvYoJbA==",
       "dev": true,
       "requires": {
         "semver": "^7.3.5"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/mattermost/desktop.git"
   },
   "config": {
-    "target": "26.2.1",
+    "target": "27.0.2",
     "arch": "x64",
     "target_arch": "x64",
     "disturl": "https://electronjs.org/headers",
@@ -169,7 +169,7 @@
     "copy-webpack-plugin": "10.2.4",
     "cross-env": "7.0.3",
     "css-loader": "6.7.1",
-    "electron": "26.2.1",
+    "electron": "27.0.2",
     "electron-builder": "23.3.3",
     "electron-connect": "0.6.3",
     "electron-context-menu": "3.6.1",
@@ -199,7 +199,7 @@
     "mocha-circleci-reporter": "0.0.3",
     "mochawesome": "7.1.3",
     "nan": "2.17.0",
-    "node-abi": "3.47.0",
+    "node-abi": "3.51.0",
     "node-jq": "2.3.4",
     "node-loader": "2.0.0",
     "npm-run-all": "4.1.5",


### PR DESCRIPTION
#### Summary
This PR upgrades our app to Electron v27.0.2, which includes a fix in Chromium that was causing a memory leak in cases of lazy loading images.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-55132

```release-note
Upgrade to Electron v27.0.2
```
