### PR TITLE
Add argument passing to the desktop file script

### DIFF
--- a/src/assets/linux/create_desktop_file.sh
+++ b/src/assets/linux/create_desktop_file.sh
@@ -9,7 +9,7 @@ cat <<EOS > Mattermost.desktop
 [Desktop Entry]
 Name=Mattermost
 Comment=Mattermost Desktop application for Linux
-Exec="${FULL_PATH}/mattermost-desktop"
+Exec="${FULL_PATH}/mattermost-desktop" %U
 Terminal=false
 Type=Application
 Icon=${FULL_PATH}/app_icon.png


### PR DESCRIPTION
#### Summary
Apparently as shown [here](https://github.com/mattermost/desktop/issues/2895#issuecomment-1779381109) our desktop file creation script was missing the argument passing bit, which was throwing off some users, especially with the new authentication changes.

This PR fixes the script so that it does include the `%U` placeholder.

```release-note
NONE
```
