### PR TITLE
MM-28933 Customize taskbar icon depends to session

### DIFF
--- a/src/main/badge.test.js
+++ b/src/main/badge.test.js
@@ -54,10 +54,10 @@ describe('main/badge', () => {
             jest.clearAllMocks();
         });
 
-        it('should show dot when session expired', async () => {
+        it('should show exclamation when session expired', async () => {
             Badge.showBadgeWindows(true, 0, false);
             await promise;
-            expect(window.setOverlayIcon).toBeCalledWith(expect.stringContaining('window.drawBadge(\'•\', false)'), expect.any(String));
+            expect(window.setOverlayIcon).toBeCalledWith(expect.stringContaining('window.drawBadge(\'!\', false)'), expect.any(String));
         });
 
         it('should show mention count when has mention count', async () => {
@@ -95,9 +95,9 @@ describe('main/badge', () => {
             jest.clearAllMocks();
         });
 
-        it('should show dot when session expired', () => {
+        it('should show exclamation when session expired', () => {
             Badge.showBadgeOSX(true, 0, false);
-            expect(app.dock.setBadge).toBeCalledWith('•');
+            expect(app.dock.setBadge).toBeCalledWith('!');
         });
 
         it('should show mention count when has mention count', () => {

--- a/src/main/badge.ts
+++ b/src/main/badge.ts
@@ -85,7 +85,7 @@ export function showBadgeWindows(sessionExpired: boolean, mentionCount: number, 
         text = '•';
         description = localizeMessage('main.badge.unreadChannels', 'You have unread channels');
     } else if (sessionExpired) {
-        text = '•';
+        text = '!';
         description = localizeMessage('main.badge.sessionExpired', 'Session Expired: Please sign in to continue receiving notifications.');
     }
     setOverlayIcon(text, description, mentionCount > 99);
@@ -98,7 +98,7 @@ export function showBadgeOSX(sessionExpired: boolean, mentionCount: number, show
     } else if (showUnreadBadge && showUnreadBadgeSetting) {
         badge = '•';
     } else if (sessionExpired) {
-        badge = '•';
+        badge = '!';
     }
     app.dock.setBadge(badge);
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost/issues/24618
Ticket: https://mattermost.atlassian.net/browse/MM-28933
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/desktop/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ x] Added or updated unit tests (required for all new features)
- [ x] Has UI changes
- [ x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [ x] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [ x] executed `npm run lint:js` for proper code formatting

#### Device Information
This PR was tested on: MacOS 14.0 & Windows 11 <!-- Device name(s), OS version(s) -->

#### Screenshots
<img width="301" alt="Ekran Resmi 2023-11-02 00 52 40" src="https://github.com/mattermost/desktop/assets/62356575/42579ec7-069a-4e75-aee4-2de3f946293a">

<!--
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
