### PR TITLE
[MM-55261] Allow embedded video links to go fullscreen after a permission check

### DIFF
--- a/src/main/permissionsManager.ts
+++ b/src/main/permissionsManager.ts
@@ -105,13 +105,17 @@ export class PermissionsManager extends JsonFileManager<Permissions> {
             return false;
         }
 
+        // Exception for embedded videos such as YouTube
+        // We still want to ask permission to do this though
+        const isExternalFullscreen = permission === 'fullscreen' && parsedURL.origin !== serverURL.origin;
+
         // is the requesting url trusted?
-        if (!(isTrustedURL(parsedURL, serverURL) || (permission === 'media' && parsedURL.origin === serverURL.origin))) {
+        if (!(isTrustedURL(parsedURL, serverURL) || (permission === 'media' && parsedURL.origin === serverURL.origin) || isExternalFullscreen)) {
             return false;
         }
 
         // For certain permission types, we need to confirm with the user
-        if (authorizablePermissionTypes.includes(permission)) {
+        if (authorizablePermissionTypes.includes(permission) || isExternalFullscreen) {
             const currentPermission = this.json[parsedURL.origin]?.[permission];
 
             // If previously allowed, just allow


### PR DESCRIPTION
#### Summary
When adding per-server permissions, I neglected to test for YouTube and other embedded videos that will want to fullscreen the app. Those requests always come from the video's source and would get auto-denied otherwise.

This PR adds an exception for the `fullscreen` permission to allow the user to decide whether to allow/deny the full screen permission, which allows these embedded videos to work again.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-55261

```release-note
Fix an issue where user's could not fullscreen embedded videos.
```
