### PR TITLE
[MM-55317] Force deep linking to use formatted path names when rewriting the URL

### DIFF
--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -196,7 +196,8 @@ export class ViewManager {
                     }
 
                     if (browserView.isReady() && ServerManager.getRemoteInfo(browserView.view.server.id)?.serverVersion && Utils.isVersionGreaterThanOrEqualTo(ServerManager.getRemoteInfo(browserView.view.server.id)?.serverVersion ?? '', '6.0.0')) {
-                        const pathName = `/${urlWithSchema.replace(`${browserView.view.server.url.origin}${getFormattedPathName(browserView.view.server.url.pathname)}`, '')}`;
+                        const formattedServerURL = `${browserView.view.server.url.origin}${getFormattedPathName(browserView.view.server.url.pathname)}`;
+                        const pathName = `/${urlWithSchema.replace(formattedServerURL, '')}`;
                         browserView.sendToRenderer(BROWSER_HISTORY_PUSH, pathName);
                         this.deeplinkSuccess(browserView.id);
                     } else {

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -196,7 +196,7 @@ export class ViewManager {
                     }
 
                     if (browserView.isReady() && ServerManager.getRemoteInfo(browserView.view.server.id)?.serverVersion && Utils.isVersionGreaterThanOrEqualTo(ServerManager.getRemoteInfo(browserView.view.server.id)?.serverVersion ?? '', '6.0.0')) {
-                        const pathName = `/${urlWithSchema.replace(browserView.view.server.url.toString(), '')}`;
+                        const pathName = `/${urlWithSchema.replace(`${browserView.view.server.url.origin}${getFormattedPathName(browserView.view.server.url.pathname)}`, '')}`;
                         browserView.sendToRenderer(BROWSER_HISTORY_PUSH, pathName);
                         this.deeplinkSuccess(browserView.id);
                     } else {


### PR DESCRIPTION
#### Summary
When deep linking, we were re-writing the path incorrect by not removing the trailing slash for servers with subpaths. This was causing issues with the Desktop App's auth flow.

This PR fixes the deep linking flow to make sure to clean the subpath properly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-55317
Closes #2906

```release-note
Fixed a deep linking issue for servers with subpaths
```
