### PR TITLE
Fix session expired issue

### DIFF
--- a/src/common/appState.ts
+++ b/src/common/appState.ts
@@ -25,7 +25,7 @@ export class AppState extends EventEmitter {
     updateExpired = (viewId: string, expired: boolean) => {
         ServerManager.getViewLog(viewId, 'AppState').silly('updateExpired', expired);
 
-        this.unreads.set(viewId, expired);
+        this.expired.set(viewId, expired);
         this.emitStatusForView(viewId);
     }
 


### PR DESCRIPTION
The session expired badge would not show up due to updating the wrong map in `appState`.

```release-note
Fixed an issue where the session expired badge wouldn't show.
```
