### PR TITLE
promoting Simplified Chinese from Alpha to Beta across the platform

### DIFF
--- a/i18n/i18n.ts
+++ b/i18n/i18n.ts
@@ -149,7 +149,7 @@ export const languages: Record<string, Language> = {
     },
     'zh-CN': {
         value: 'zh-CN',
-        name: '中文 (简体)',
+        name: '中文 (简体) (Beta)',
         order: 19,
         url: zhCN,
     },


### PR DESCRIPTION
#### Summary
 Simplified Chinese was in  Alpha back is been actively maintained again and is promoted to Beta across the platform

#### Ticket Link

#### Checklist
/CONTRIBUTING.md)
- [X ] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)

#### Release Note
```release-note
Promoted Simplified Chinese language to Beta.
```