### PR TITLE
Fixed a crash when the view loads for the first time

### DIFF
--- a/src/main/views/MattermostBrowserView.ts
+++ b/src/main/views/MattermostBrowserView.ts
@@ -192,7 +192,6 @@ export class MattermostBrowserView extends EventEmitter {
         } else {
             loadURL = this.view.url.toString();
         }
-        AppState.updateExpired(this.id, false);
         this.log.verbose(`Loading ${loadURL}`);
         const loading = this.browserView.webContents.loadURL(loadURL, {userAgent: composeUserAgent()});
         loading.then(this.loadSuccess(loadURL)).catch((err) => {
@@ -240,6 +239,7 @@ export class MattermostBrowserView extends EventEmitter {
 
     reload = () => {
         this.resetLoadingStatus();
+        AppState.updateExpired(this.id, false);
         this.load();
     }
 


### PR DESCRIPTION
#### Summary
When creating a view, we were calling `AppState.updateExpired` on `load` to reset the expired flag. But this only needs to be called on `reload` in case that flag is no longer valid. The original implementation was causing a crash when the first server was added, moving the call to `reload` ensures that won't happen.

```release-note
NONE
```
