### PR TITLE
Improves German translation

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -266,7 +266,7 @@
     "renderer.downloadsDropdown.Update.RestartAndUpdate": "Erneut starten und aktualisieren",
     "renderer.downloadsDropdown.Update.NewDesktopVersionAvailable": "Neue Desktop Version verfügbar",
     "renderer.downloadsDropdown.Update.MattermostVersionX": "{appName}-Version {version}",
-    "renderer.downloadsDropdown.Update.DownloadUpdate": "Aktualisierung runterladen",
+    "renderer.downloadsDropdown.Update.DownloadUpdate": "Aktualisierung herunterladen",
     "renderer.downloadsDropdown.Update.ANewVersionIsAvailableToInstall": "Eine neue Version der {appName} Desktop App (Version {version}) steht zur Installation bereit.",
     "renderer.downloadsDropdown.remaining": "verbleibend",
     "renderer.downloadsDropdown.Downloads": "Downloads",


### PR DESCRIPTION
"runterladen" is _very_ colloquial German and not a good fit. "**He**runterladen" is the correct term. See also, above, where it is correct.