### PR TITLE
[MM-54872] Ensure matched subpaths are exact and not substrings of each other

### DIFF
--- a/src/common/servers/serverManager.test.js
+++ b/src/common/servers/serverManager.test.js
@@ -13,7 +13,7 @@ jest.mock('common/config', () => ({
 jest.mock('common/utils/url', () => ({
     parseURL: jest.fn(),
     isInternalURL: jest.fn(),
-    getFormattedPathName: (pathname) => (pathname.length ? pathname : '/'),
+    getFormattedPathName: (pathname) => (pathname.endsWith('/') ? pathname : `${pathname}/`),
 }));
 jest.mock('common/utils/util', () => ({
     isVersionGreaterThanOrEqualTo: jest.fn(),
@@ -126,6 +126,11 @@ describe('common/servers/serverManager', () => {
         it('should match the correct server with a subpath - base URL', () => {
             const inputURL = new URL('http://server-2.com/subpath');
             expect(serverManager.lookupViewByURL(inputURL)).toStrictEqual({id: 'view-2', url: new URL('http://server-2.com/subpath')});
+        });
+
+        it('should not match a server where the subpaths are substrings of each other ', () => {
+            const inputURL = new URL('http://server-2.com/subpath2');
+            expect(serverManager.lookupViewByURL(inputURL)).toBe(undefined);
         });
 
         it('should match the correct server with a subpath - base view', () => {

--- a/src/common/servers/serverManager.ts
+++ b/src/common/servers/serverManager.ts
@@ -123,7 +123,7 @@ export class ServerManager extends EventEmitter {
         }
         const server = this.getAllServers().find((server) => {
             return isInternalURL(parsedURL, server.url, ignoreScheme) &&
-                getFormattedPathName(parsedURL.pathname).startsWith(server.url.pathname);
+                getFormattedPathName(parsedURL.pathname).startsWith(getFormattedPathName(server.url.pathname));
         });
         if (!server) {
             return undefined;
@@ -134,7 +134,7 @@ export class ServerManager extends EventEmitter {
         views.
             filter((view) => view && view.type !== TAB_MESSAGING).
             forEach((view) => {
-                if (getFormattedPathName(parsedURL.pathname).startsWith(view.url.pathname)) {
+                if (getFormattedPathName(parsedURL.pathname).startsWith(getFormattedPathName(view.url.pathname))) {
                     selectedView = view;
                 }
             });


### PR DESCRIPTION
#### Summary
If you tried to add a server on a subpath, where the domains were the same and the second server's subpath was a substring of the first server's subpath, the app would erroneously claim it was the same server. This is because we weren't comparing the server subpaths as though they were the last in the chain.

This PR adds the `getFormattedPathName` call around the original subpath as well as the first to ensure we're comparing them correctly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54872
Closes https://github.com/mattermost/mattermost/issues/24891

```release-note
Fixed an issue where you couldn't add a second server with a similar subpath as a configured server
```
