### PR TITLE
[MM-55134] Don't blank the Site URL when it's not properly configured on an otherwise working server

### DIFF
--- a/src/app/serverViewState.test.js
+++ b/src/app/serverViewState.test.js
@@ -446,6 +446,22 @@ describe('app/serverViewState', () => {
             expect(result.validatedURL).toBe('https://mainserver.com/');
         });
 
+        it('should not update the users URL when the Site URL is blank', async () => {
+            ServerInfo.mockImplementation(() => ({
+                fetchConfigData: jest.fn().mockImplementation(() => {
+                    return {
+                        serverVersion: '7.8.0',
+                        siteName: 'Mattermost',
+                        siteURL: '',
+                    };
+                }),
+            }));
+
+            const result = await serverViewState.handleServerURLValidation({}, 'https://server.com');
+            expect(result.status).toBe(URLValidationStatus.OK);
+            expect(result.validatedURL).toBe('https://server.com/');
+        });
+
         it('should warn the user when the Site URL is different but unreachable', async () => {
             ServerInfo.mockImplementation(({url}) => ({
                 fetchConfigData: jest.fn().mockImplementation(() => {

--- a/src/app/serverViewState.ts
+++ b/src/app/serverViewState.ts
@@ -300,7 +300,7 @@ export class ServerViewState {
             return {status: URLValidationStatus.URLUpdated, serverVersion: remoteInfo.serverVersion, serverName: remoteInfo.siteName, validatedURL: remoteInfo.siteURL};
         }
 
-        return {status: URLValidationStatus.OK, serverVersion: remoteInfo.serverVersion, serverName: remoteInfo.siteName, validatedURL: remoteInfo.siteURL};
+        return {status: URLValidationStatus.OK, serverVersion: remoteInfo.serverVersion, serverName: remoteInfo.siteName, validatedURL: remoteURL.toString()};
     };
 
     private handleCloseView = (event: IpcMainEvent, viewId: string) => {


### PR DESCRIPTION
#### Summary
As part of server validation, we are checking against the Site URL on the configured server. However, when the URL wasn't configured we weren't doing any further validation, but we were assuming that there was a Site URL there, which would blank out the URL for users.

This PR assumes that if the user's URL is okay and there's no Site URL configured, to use the user's provided URL.

#### Ticket Link
Closes https://github.com/mattermost/desktop/issues/2891
https://mattermost.atlassian.net/browse/MM-55134

```release-note
Fixed an issue where the user's URL would be cleared after being entered in the Add Server modal
```
