### PR TITLE
[MM-56882] Fix a potential crash in diagnostics

### DIFF
--- a/src/main/diagnostics/steps/internal/utils.ts
+++ b/src/main/diagnostics/steps/internal/utils.ts
@@ -72,10 +72,14 @@ export async function isOnline(logger: ElectronLog = log, url = IS_ONLINE_ENDPOI
             resp.on('end', () => {
                 logger.debug('resp.on.end', {data, url});
                 if (data.length) {
-                    const respBody = JSON.parse(data);
-                    if (respBody.status === 'OK') {
-                        resolve(true);
-                        return;
+                    try {
+                        const respBody = JSON.parse(data);
+                        if (respBody.status === 'OK') {
+                            resolve(true);
+                            return;
+                        }
+                    } catch (e) {
+                        logger.error('Cannot parse response')
                     }
                 }
                 resolve(false);


### PR DESCRIPTION
#### Summary
A server URL that does point to a Mattermost server, or if the diagnostics do not receive a valid JSON response, running the diagnostics will cause the app to crash.

This PR adds the proper error handling to stop that from happening.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-56882


```release-note
Fix a potential crash in diagnostics
```
