### PR TITLE
[MM-48518] Include renderer process logs in main process log and log file

### DIFF
--- a/src/main/views/webContentEvents.ts
+++ b/src/main/views/webContentEvents.ts
@@ -1,10 +1,12 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import path from 'path';
+
 import {BrowserWindow, session, shell, WebContents, Event} from 'electron';
 
 import Config from 'common/config';
-import {Logger} from 'common/log';
+import {Logger, getLevel} from 'common/log';
 import ServerManager from 'common/servers/serverManager';
 import {
     isAdminUrl,
@@ -38,6 +40,13 @@ import {composeUserAgent} from '../utils';
 
 type CustomLogin = {
     inProgress: boolean;
+}
+
+enum ConsoleMessageLevel {
+    Verbose,
+    Info,
+    Warning,
+    Error
 }
 
 const log = new Logger('WebContentsEventManager');
@@ -289,6 +298,30 @@ export class WebContentsEventManager {
         };
     };
 
+    private generateHandleConsoleMessage = (webContentsId: number) => (_: Event, level: number, message: string, line: number, sourceId: string) => {
+        const wcLog = this.log(webContentsId).withPrefix('renderer');
+        let logFn = wcLog.verbose;
+        switch (level) {
+        case ConsoleMessageLevel.Error:
+            logFn = wcLog.error;
+            break;
+        case ConsoleMessageLevel.Warning:
+            logFn = wcLog.warn;
+            break;
+        case ConsoleMessageLevel.Info:
+            logFn = wcLog.info;
+            break;
+        }
+
+        // Only include line entries if we're debugging
+        const entries = [message];
+        if (['debug', 'silly'].includes(getLevel())) {
+            entries.push(`(${path.basename(sourceId)}:${line})`);
+        }
+
+        logFn(...entries);
+    }
+
     removeWebContentsListeners = (id: number) => {
         if (this.listeners[id]) {
             this.listeners[id]();
@@ -324,12 +357,16 @@ export class WebContentsEventManager {
         const newWindow = this.generateNewWindowListener(contents.id, spellcheck);
         contents.setWindowOpenHandler(newWindow);
 
+        const consoleMessage = this.generateHandleConsoleMessage(contents.id);
+        contents.on('console-message', consoleMessage);
+
         addListeners?.(contents);
 
         const removeWebContentsListeners = () => {
             try {
                 contents.removeListener('will-navigate', willNavigate);
                 contents.removeListener('did-start-navigation', didStartNavigation);
+                contents.removeListener('console-message', consoleMessage);
                 removeListeners?.(contents);
             } catch (e) {
                 this.log(contents.id).error(`Error while trying to detach listeners, this might be ok if the process crashed: ${e}`);


### PR DESCRIPTION
#### Summary
This PR adds the `console-message` hook to each `WebContents` object, logging all of the messages that would hit the Chrome Dev Tools console in the log file and in the Electron process job.

This should make debugging easier in cases where the front-end code or the Mattermost Web App is misbehaving or causing issues otherwise.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48518

```release-note
NONE
```
