### PR TITLE
[MM-45780] Update to macos-notification-state 3.0, update entitlements and provisioning profile to allow Communication Notification access

### DIFF
--- a/.github/workflows/build-for-pr.yml
+++ b/.github/workflows/build-for-pr.yml
@@ -163,7 +163,9 @@ jobs:
           CSC_FOR_PULL_REQUEST: true
           CSC_KEY_PASSWORD: ${{ secrets.MM_DESKTOP_MAC_INSTALLER_CSC_KEY_PASSWORD }}
           CSC_LINK: ${{ secrets.MM_DESKTOP_MAC_INSTALLER_CSC_LINK }}
+          MAC_PROFILE: ${{ secrets.MM_DESKTOP_MAC_INSTALLER_DMG_PROFILE }}
         run: |
+          echo $MAC_PROFILE | base64 -D > ./mac.provisionprofile
           mkdir -p ./build/macos
           npm run package:mac
           bash -x ./scripts/patch_updater_yml.sh

--- a/.github/workflows/nightly-main.yml
+++ b/.github/workflows/nightly-main.yml
@@ -172,7 +172,9 @@ jobs:
           CSC_FOR_PULL_REQUEST: true
           CSC_KEY_PASSWORD: ${{ secrets.MM_DESKTOP_MAC_INSTALLER_CSC_KEY_PASSWORD }}
           CSC_LINK: ${{ secrets.MM_DESKTOP_MAC_INSTALLER_CSC_LINK }}
+          MAC_PROFILE: ${{ secrets.MM_DESKTOP_MAC_INSTALLER_DMG_PROFILE }}
         run: |
+          echo $MAC_PROFILE | base64 -D > ./mac.provisionprofile
           mkdir -p ./build/macos-release
           npm run package:mac-with-universal
           bash -x ./scripts/patch_updater_yml.sh

--- a/.github/workflows/nightly-rainforest.yml
+++ b/.github/workflows/nightly-rainforest.yml
@@ -102,7 +102,9 @@ jobs:
           CSC_FOR_PULL_REQUEST: true
           CSC_KEY_PASSWORD: ${{ secrets.MM_DESKTOP_MAC_INSTALLER_CSC_KEY_PASSWORD }}
           CSC_LINK: ${{ secrets.MM_DESKTOP_MAC_INSTALLER_CSC_LINK }}
+          MAC_PROFILE: ${{ secrets.MM_DESKTOP_MAC_INSTALLER_DMG_PROFILE }}
         run: |
+          echo $MAC_PROFILE | base64 -D > ./mac.provisionprofile
           mkdir -p ./build/macos
           npm run package:mac-with-universal
           bash -x ./scripts/patch_updater_yml.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -144,7 +144,9 @@ jobs:
           CSC_FOR_PULL_REQUEST: true
           CSC_KEY_PASSWORD: ${{ secrets.MM_DESKTOP_MAC_INSTALLER_CSC_KEY_PASSWORD }}
           CSC_LINK: ${{ secrets.MM_DESKTOP_MAC_INSTALLER_CSC_LINK }}
+          MAC_PROFILE: ${{ secrets.MM_DESKTOP_MAC_INSTALLER_DMG_PROFILE }}
         run: |
+          echo $MAC_PROFILE | base64 -D > ./mac.provisionprofile
           mkdir -p ./build/macos-release
           npm run package:mac-with-universal
           bash -x ./scripts/patch_updater_yml.sh

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -104,8 +104,10 @@
     "extendInfo": {
       "NSMicrophoneUsageDescription": "Microphone access may be used by Mattermost plugins, such as Jitsi video conferencing.",
       "NSCameraUsageDescription": "Camera access may be used by Mattermost plugins, such as Jitsi video conferencing.",
+      "NSFocusStatusUsageDescription": "Focus status is used by Mattermost to determine whether to send notifications or not.",
       "LSFileQuarantineEnabled": true
-  }
+    },
+    "provisioningProfile": "./mac.provisionprofile"
   },
   "mas": {
     "hardenedRuntime": false,
@@ -119,7 +121,7 @@
     "singleArchFiles": "*"
   },
   "masDev": {
-    "provisioningProfile": "./mas-dev.provisionprofile"
+    "provisioningProfile": "./dev.provisionprofile"
   },
   "dmg": {
     "background": "src/assets/osx/DMG_BG.png",

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -100,7 +100,7 @@
     "hardenedRuntime": true,
     "gatekeeperAssess": true,
     "entitlements": "./entitlements.mac.plist",
-    "entitlementsInherit": "./entitlements.mac.plist",
+    "entitlementsInherit": "./entitlements.mac.inherit.plist",
     "extendInfo": {
       "NSMicrophoneUsageDescription": "Microphone access may be used by Mattermost plugins, such as Jitsi video conferencing.",
       "NSCameraUsageDescription": "Camera access may be used by Mattermost plugins, such as Jitsi video conferencing.",

--- a/entitlements.mac.inherit.plist
+++ b/entitlements.mac.inherit.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.inherit</key>
+    <true/>
+</dict>
+</plist>

--- a/entitlements.mac.plist
+++ b/entitlements.mac.plist
@@ -14,5 +14,11 @@
 	<true/>
 	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
 	<true/>
+	<key>com.apple.application-identifier</key>
+	<string>UQ8HT4Q2XM.Mattermost.Desktop</string>
+	<key>com.apple.developer.team-identifier</key>
+	<string>UQ8HT4Q2XM</string>
+	<key>com.apple.developer.usernotifications.communication</key>
+	<true/>
 </dict>
 </plist>

--- a/entitlements.mac.plist
+++ b/entitlements.mac.plist
@@ -14,10 +14,6 @@
 	<true/>
 	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
 	<true/>
-	<key>com.apple.application-identifier</key>
-	<string>UQ8HT4Q2XM.Mattermost.Desktop</string>
-	<key>com.apple.developer.team-identifier</key>
-	<string>UQ8HT4Q2XM</string>
 	<key>com.apple.developer.usernotifications.communication</key>
 	<true/>
 </dict>

--- a/entitlements.mas.plist
+++ b/entitlements.mas.plist
@@ -36,5 +36,7 @@
 	<true/>
 	<key>com.apple.security.files.bookmarks.document-scope</key>
 	<true/>
+	<key>com.apple.developer.usernotifications.communication</key>
+	<true/>
 </dict>
 </plist>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "macos-notification-state": "2.0.2",
+        "macos-notification-state": "3.0.0",
         "windows-focus-assist": "1.3.0"
       },
       "devDependencies": {
@@ -17523,13 +17523,19 @@
       }
     },
     "node_modules/macos-notification-state": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/macos-notification-state/-/macos-notification-state-2.0.2.tgz",
-      "integrity": "sha512-rTKda+694hvxXm4s00I5LEwlQxGwwCZKaCXogxEXyGagmsP7mGfLiyoI6MX360GQ0V6lmHOCqivg4LLQPFYb6A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/macos-notification-state/-/macos-notification-state-3.0.0.tgz",
+      "integrity": "sha512-tvFDZajIcwIsYg1WQAXGtrJFljlL1PEOK2cCoPDrN//XxIwTiVNvaXznxLjV4mYkyXctIDVs0ujGdrbGzeOY/w==",
       "hasInstallScript": true,
       "dependencies": {
-        "bindings": "^1.5.0"
+        "bindings": "^1.5.0",
+        "node-addon-api": "3.0.0"
       }
+    },
+    "node_modules/macos-notification-state/node_modules/node-addon-api": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.0.tgz",
+      "integrity": "sha512-sSHCgWfJ+Lui/u+0msF3oyCgvdkhxDbkCS6Q8uiJquzOimkJBvX6hl5aSSA7DR1XbMpdM8r7phjcF63sF4rkKg=="
     },
     "node_modules/magic-string": {
       "version": "0.30.8",

--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
     "yargs": "17.4.0"
   },
   "dependencies": {
-    "macos-notification-state": "2.0.2",
+    "macos-notification-state": "3.0.0",
     "windows-focus-assist": "1.3.0"
   }
 }

--- a/src/main/notifications/index.test.ts
+++ b/src/main/notifications/index.test.ts
@@ -121,7 +121,7 @@ describe('main/notifications', () => {
             PermissionsManager.doPermissionRequest.mockReturnValue(Promise.resolve(true));
             Notification.isSupported.mockImplementation(() => true);
             getFocusAssist.mockReturnValue({value: 0, name: ''});
-            getDarwinDoNotDisturb.mockReturnValue(false);
+            getDarwinDoNotDisturb.mockReturnValue(Promise.resolve(false));
             Config.notifications = {
                 flashWindow: 0,
                 bounceIcon: false,
@@ -184,7 +184,7 @@ describe('main/notifications', () => {
                 value: 'darwin',
             });
 
-            getDarwinDoNotDisturb.mockReturnValue(true);
+            getDarwinDoNotDisturb.mockReturnValue(Promise.resolve(true));
             await NotificationManager.displayMention(
                 'test',
                 'test body',
@@ -389,13 +389,13 @@ describe('main/notifications', () => {
         beforeEach(() => {
             Notification.isSupported.mockImplementation(() => true);
             getFocusAssist.mockReturnValue({value: 0, name: ''});
-            getDarwinDoNotDisturb.mockReturnValue(false);
+            getDarwinDoNotDisturb.mockReturnValue(Promise.resolve(false));
         });
 
-        it('should open file when clicked', () => {
-            getDarwinDoNotDisturb.mockReturnValue(false);
+        it('should open file when clicked', async () => {
+            getDarwinDoNotDisturb.mockReturnValue(Promise.resolve(false));
             localizeMessage.mockReturnValue('test_filename');
-            NotificationManager.displayDownloadCompleted(
+            await NotificationManager.displayDownloadCompleted(
                 'test_filename',
                 '/path/to/file',
                 'server_name',

--- a/src/main/notifications/index.ts
+++ b/src/main/notifications/index.ts
@@ -34,7 +34,7 @@ class NotificationManager {
             return;
         }
 
-        if (getDoNotDisturb()) {
+        if (await getDoNotDisturb()) {
             return;
         }
 
@@ -102,7 +102,7 @@ class NotificationManager {
         mention.show();
     }
 
-    public displayDownloadCompleted(fileName: string, path: string, serverName: string) {
+    public async displayDownloadCompleted(fileName: string, path: string, serverName: string) {
         log.debug('displayDownloadCompleted', {fileName, path, serverName});
 
         if (!Notification.isSupported()) {
@@ -110,7 +110,7 @@ class NotificationManager {
             return;
         }
 
-        if (getDoNotDisturb()) {
+        if (await getDoNotDisturb()) {
             return;
         }
 
@@ -136,12 +136,12 @@ class NotificationManager {
         download.show();
     }
 
-    public displayUpgrade(version: string, handleUpgrade: () => void): void {
+    public async displayUpgrade(version: string, handleUpgrade: () => void) {
         if (!Notification.isSupported()) {
             log.error('notification not supported');
             return;
         }
-        if (getDoNotDisturb()) {
+        if (await getDoNotDisturb()) {
             return;
         }
 
@@ -156,12 +156,12 @@ class NotificationManager {
         this.upgradeNotification.show();
     }
 
-    public displayRestartToUpgrade(version: string, handleUpgrade: () => void): void {
+    public async displayRestartToUpgrade(version: string, handleUpgrade: () => void) {
         if (!Notification.isSupported()) {
             log.error('notification not supported');
             return;
         }
-        if (getDoNotDisturb()) {
+        if (await getDoNotDisturb()) {
             return;
         }
 
@@ -174,7 +174,7 @@ class NotificationManager {
     }
 }
 
-function getDoNotDisturb() {
+async function getDoNotDisturb() {
     if (process.platform === 'win32') {
         return getWindowsDoNotDisturb();
     }


### PR DESCRIPTION
#### Summary
The DND status was being blocked for MAS users and users on Ventura (macOS 13) or higher. This was caused by Apple's change in the way they communicate their notification status to apps. There is now an API called Communication Notifications that controls this, and it needed to be enabled in Apple Developer to work.

This change does the following things:
- Upgrades us to `macos-notification-state` 3.0, which supports the new API
- Adds entitlements for both DMG and MAS builds to be able to request focus status.
- Adds a provisioning profile for the DMG build to allow it to access the focus status.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45780

```release-note
Fixed an issue for macOS 13+ users on the MAS build where the OS-level DND status was not respected
```
