### PR TITLE
Upgrade electron-log to v5.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "electron-context-menu": "3.6.1",
         "electron-extension-installer": "1.2.0",
         "electron-is-dev": "2.0.0",
-        "electron-log": "4.4.8",
+        "electron-log": "5.1.1",
         "electron-mocha": "12.2.0",
         "electron-updater": "6.1.8",
         "eslint": "8.57.0",
@@ -11148,10 +11148,13 @@
       }
     },
     "node_modules/electron-log": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.4.8.tgz",
-      "integrity": "sha512-QQ4GvrXO+HkgqqEOYbi+DHL7hj5JM+nHi/j+qrN9zeeXVKy8ZABgbu4CnG+BBqDZ2+tbeq9tUC4DZfIWFU5AZA==",
-      "dev": true
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.1.1.tgz",
+      "integrity": "sha512-If7HU4Slbh2xfjOXOLxifkbgu6HmWDNJyXPLW+XNTOHMfFKisg0trA3d/7syyu25S+lHosfsd0VMfDSjGn1+Pw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/electron-mocha": {
       "version": "12.2.0",

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "electron-context-menu": "3.6.1",
     "electron-extension-installer": "1.2.0",
     "electron-is-dev": "2.0.0",
-    "electron-log": "4.4.8",
+    "electron-log": "5.1.1",
     "electron-mocha": "12.2.0",
     "electron-updater": "6.1.8",
     "eslint": "8.57.0",

--- a/src/main/diagnostics/index.ts
+++ b/src/main/diagnostics/index.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {shell} from 'electron';
-import type {ElectronLog} from 'electron-log';
+import type {MainLogger} from 'electron-log';
 import log from 'electron-log';
 
 import type {DiagnosticsReport} from 'types/diagnostics';
@@ -42,7 +42,7 @@ class DiagnosticsModule {
     stepCurrent = 0;
     stepTotal = 0;
     report: DiagnosticsReport = [];
-    logger: ElectronLog = log.create('diagnostics-logger');
+    logger: MainLogger = log.create({logId: 'diagnostics-logger'});
 
     run = async () => {
         try {

--- a/src/main/diagnostics/steps/internal/loggerHooks.ts
+++ b/src/main/diagnostics/steps/internal/loggerHooks.ts
@@ -1,14 +1,14 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {ElectronLog} from 'electron-log';
+import type {MainLogger} from 'electron-log';
 
 import {obfuscateByType} from './obfuscators';
 
-type ElectronLogHook = ElectronLog['hooks'][number];
-type ElectronLogHookCreator = (l: ElectronLog) => ElectronLogHook;
+type MainLoggerHook = MainLogger['hooks'][number];
+type MainLoggerHookCreator = (l: MainLogger) => MainLoggerHook;
 
-export const maskMessageDataHook: ElectronLogHookCreator = (logger) => (message, transport) => {
+export const maskMessageDataHook: MainLoggerHookCreator = (logger) => (message, transport) => {
     if (transport !== logger.transports.file) {
         return message;
     }
@@ -21,7 +21,7 @@ export const maskMessageDataHook: ElectronLogHookCreator = (logger) => (message,
     return message;
 };
 
-const loggerHooks: (logger: ElectronLog) => ElectronLog['hooks'] = (logger) => [
+const loggerHooks: (logger: MainLogger) => MainLogger['hooks'] = (logger) => [
     maskMessageDataHook(logger),
 ];
 

--- a/src/main/diagnostics/steps/internal/utils.ts
+++ b/src/main/diagnostics/steps/internal/utils.ts
@@ -5,7 +5,7 @@ import https from 'https';
 import readline from 'readline';
 
 import type {BrowserWindow, Rectangle, WebContents} from 'electron';
-import type {ElectronLog, LogLevel} from 'electron-log';
+import type {MainLogger, LogLevel} from 'electron-log';
 import log from 'electron-log';
 
 import {IS_ONLINE_ENDPOINT, LOGS_MAX_STRING_LENGTH, REGEX_LOG_FILE_LINE} from 'common/constants';
@@ -60,7 +60,7 @@ export function truncateString(str: string, maxLength = LOGS_MAX_STRING_LENGTH):
     return str;
 }
 
-export async function isOnline(logger: ElectronLog = log, url = IS_ONLINE_ENDPOINT): Promise<boolean> {
+export async function isOnline(logger: MainLogger = log, url = IS_ONLINE_ENDPOINT): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
         https.get(url, (resp) => {
             let data = '';

--- a/src/main/diagnostics/steps/step.template.ts
+++ b/src/main/diagnostics/steps/step.template.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {ElectronLog} from 'electron-log';
+import type {MainLogger} from 'electron-log';
 
 import type {DiagnosticStepResponse} from 'types/diagnostics';
 
@@ -12,7 +12,7 @@ const stepDescriptiveName = 'Template';
 
 // COPY & PASTE this file to create a new step
 
-const run = async (logger: ElectronLog): Promise<DiagnosticStepResponse> => {
+const run = async (logger: MainLogger): Promise<DiagnosticStepResponse> => {
     try {
         await Promise.resolve();
         return {

--- a/src/main/diagnostics/steps/step0.logLevel.ts
+++ b/src/main/diagnostics/steps/step0.logLevel.ts
@@ -4,7 +4,7 @@
 import path from 'path';
 
 import {app} from 'electron';
-import type {ElectronLog} from 'electron-log';
+import type {MainLogger} from 'electron-log';
 
 import type {DiagnosticStepResponse} from 'types/diagnostics';
 
@@ -16,7 +16,7 @@ import DiagnosticsStep from '../DiagnosticStep';
 const stepName = 'Step-0';
 const stepDescriptiveName = 'logConfig';
 
-const run = async (logger: ElectronLog): Promise<DiagnosticStepResponse> => {
+const run = async (logger: MainLogger): Promise<DiagnosticStepResponse> => {
     try {
         const filename = `diagnostics_${dateTimeInFilename()}.txt`;
         const pathToFile = path.join(app.getPath('userData'), `diagnostics/${filename}`);

--- a/src/main/diagnostics/steps/step1.internetConnection.ts
+++ b/src/main/diagnostics/steps/step1.internetConnection.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {ElectronLog} from 'electron-log';
+import type {MainLogger} from 'electron-log';
 
 import type {DiagnosticStepResponse} from 'types/diagnostics';
 
@@ -12,7 +12,7 @@ import DiagnosticsStep from '../DiagnosticStep';
 const stepName = 'Step-1';
 const stepDescriptiveName = 'internetConnection';
 
-const run = async (logger: ElectronLog): Promise<DiagnosticStepResponse> => {
+const run = async (logger: MainLogger): Promise<DiagnosticStepResponse> => {
     try {
         const success = await isOnline(logger);
         if (success) {

--- a/src/main/diagnostics/steps/step10.crashReports.ts
+++ b/src/main/diagnostics/steps/step10.crashReports.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import path from 'path';
 
 import {app} from 'electron';
-import type {ElectronLog} from 'electron-log';
+import type {MainLogger} from 'electron-log';
 
 import type {DiagnosticStepResponse} from 'types/diagnostics';
 
@@ -13,7 +13,7 @@ import DiagnosticsStep from '../DiagnosticStep';
 const stepName = 'Step-10';
 const stepDescriptiveName = 'CrashReports';
 
-const run = async (logger: ElectronLog): Promise<DiagnosticStepResponse> => {
+const run = async (logger: MainLogger): Promise<DiagnosticStepResponse> => {
     try {
         const pathOfCrashReports = app.getPath('userData');
         const allDirFiles = await fs.promises.readdir(pathOfCrashReports);

--- a/src/main/diagnostics/steps/step11.auth.ts
+++ b/src/main/diagnostics/steps/step11.auth.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {session} from 'electron';
-import type {ElectronLog} from 'electron-log';
+import type {MainLogger} from 'electron-log';
 
 import type {DiagnosticStepResponse} from 'types/diagnostics';
 
@@ -11,7 +11,7 @@ import DiagnosticsStep from '../DiagnosticStep';
 const stepName = 'Step-11';
 const stepDescriptiveName = 'AuthSSO';
 
-const run = async (logger: ElectronLog): Promise<DiagnosticStepResponse> => {
+const run = async (logger: MainLogger): Promise<DiagnosticStepResponse> => {
     try {
         const cookies = await session.defaultSession.cookies.get({});
 

--- a/src/main/diagnostics/steps/step2.configValidation.ts
+++ b/src/main/diagnostics/steps/step2.configValidation.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 import fs from 'fs';
 
-import type {ElectronLog} from 'electron-log';
+import type {MainLogger} from 'electron-log';
 
 import Config from 'common/config';
 import * as Validator from 'common/Validator';
@@ -15,7 +15,7 @@ import DiagnosticsStep from '../DiagnosticStep';
 const stepName = 'Step-2';
 const stepDescriptiveName = 'configValidation';
 
-const run = async (logger: ElectronLog): Promise<DiagnosticStepResponse> => {
+const run = async (logger: MainLogger): Promise<DiagnosticStepResponse> => {
     try {
         const configData = JSON.parse(fs.readFileSync(configPath, 'utf8'));
 

--- a/src/main/diagnostics/steps/step3.serverConnectivity.ts
+++ b/src/main/diagnostics/steps/step3.serverConnectivity.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {ElectronLog} from 'electron-log';
+import type {MainLogger} from 'electron-log';
 
 import ServerManager from 'common/servers/serverManager';
 import {parseURL} from 'common/utils/url';
@@ -15,7 +15,7 @@ import DiagnosticsStep from '../DiagnosticStep';
 const stepName = 'Step-3';
 const stepDescriptiveName = 'serverConnectivity';
 
-const run = async (logger: ElectronLog): Promise<DiagnosticStepResponse> => {
+const run = async (logger: MainLogger): Promise<DiagnosticStepResponse> => {
     try {
         const servers = ServerManager.getAllServers();
 

--- a/src/main/diagnostics/steps/step4.sessionDataValidation.ts
+++ b/src/main/diagnostics/steps/step4.sessionDataValidation.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {session} from 'electron';
-import type {ElectronLog} from 'electron-log';
+import type {MainLogger} from 'electron-log';
 
 import {COOKIE_NAME_AUTH_TOKEN, COOKIE_NAME_CSRF, COOKIE_NAME_USER_ID} from 'common/constants';
 
@@ -13,7 +13,7 @@ import DiagnosticsStep from '../DiagnosticStep';
 const stepName = 'Step-4';
 const stepDescriptiveName = 'sessionDataValidation';
 
-const run = async (logger: ElectronLog): Promise<DiagnosticStepResponse> => {
+const run = async (logger: MainLogger): Promise<DiagnosticStepResponse> => {
     try {
         const cookies = await session.defaultSession.cookies.get({});
         if (!cookies) {

--- a/src/main/diagnostics/steps/step5.browserWindows.ts
+++ b/src/main/diagnostics/steps/step5.browserWindows.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {ElectronLog} from 'electron-log';
+import type {MainLogger} from 'electron-log';
 
 import MainWindow from 'main/windows/mainWindow';
 
@@ -14,7 +14,7 @@ import DiagnosticsStep from '../DiagnosticStep';
 const stepName = 'Step-5';
 const stepDescriptiveName = 'BrowserWindowsChecks';
 
-const run = async (logger: ElectronLog): Promise<DiagnosticStepResponse> => {
+const run = async (logger: MainLogger): Promise<DiagnosticStepResponse> => {
     try {
         /** Main window check */
         if (!MainWindow.isReady) {

--- a/src/main/diagnostics/steps/step6.permissions.ts
+++ b/src/main/diagnostics/steps/step6.permissions.ts
@@ -3,7 +3,7 @@
 import fs from 'fs';
 
 import {Notification, systemPreferences} from 'electron';
-import type {ElectronLog} from 'electron-log';
+import type {MainLogger} from 'electron-log';
 import log from 'electron-log';
 
 import config from 'common/config';
@@ -20,7 +20,7 @@ const stepDescriptiveName = 'PermissionsCheck';
 const isDarwin = process.platform === 'darwin';
 const isWin32 = process.platform === 'win32';
 
-const run = async (logger: ElectronLog): Promise<DiagnosticStepResponse> => {
+const run = async (logger: MainLogger): Promise<DiagnosticStepResponse> => {
     try {
         const downloadsFileAccess = await checkPathPermissions(config.downloadLocation, fs.constants.W_OK);
         const logsFileAccess = await checkPathPermissions(log.transports.file.getFile().path, fs.constants.W_OK);

--- a/src/main/diagnostics/steps/step7.performance.ts
+++ b/src/main/diagnostics/steps/step7.performance.ts
@@ -3,7 +3,7 @@
 import path from 'path';
 
 import {app, powerMonitor} from 'electron';
-import type {ElectronLog} from 'electron-log';
+import type {MainLogger} from 'electron-log';
 
 import type {DiagnosticStepResponse} from 'types/diagnostics';
 
@@ -14,7 +14,7 @@ import DiagnosticsStep from '../DiagnosticStep';
 const stepName = 'Step-7';
 const stepDescriptiveName = 'PerformanceAndMemory';
 
-const run = async (logger: ElectronLog): Promise<DiagnosticStepResponse> => {
+const run = async (logger: MainLogger): Promise<DiagnosticStepResponse> => {
     try {
         const heapSnapshotFilepath = path.join(app.getAppPath(), `heapSnapshots/heap_snap_${dateTimeInFilename()}.txt`);
 

--- a/src/main/diagnostics/steps/step8.logHeuristics.ts
+++ b/src/main/diagnostics/steps/step8.logHeuristics.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {ElectronLog} from 'electron-log';
+import type {MainLogger} from 'electron-log';
 import log from 'electron-log';
 
 import {getPercentage} from 'main/utils';
@@ -15,7 +15,7 @@ import DiagnosticsStep from '../DiagnosticStep';
 const stepName = 'Step-8';
 const stepDescriptiveName = 'LogHeuristics';
 
-const run = async (logger: ElectronLog): Promise<DiagnosticStepResponse> => {
+const run = async (logger: MainLogger): Promise<DiagnosticStepResponse> => {
     try {
         const mainLogFilePath = log.transports.file.getFile().path;
         const fileData = await readFileLineByLine(mainLogFilePath);

--- a/src/main/diagnostics/steps/step9.config.ts
+++ b/src/main/diagnostics/steps/step9.config.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {ElectronLog} from 'electron-log';
+import type {MainLogger} from 'electron-log';
 
 import config from 'common/config';
 
@@ -12,7 +12,7 @@ import DiagnosticsStep from '../DiagnosticStep';
 const stepName = 'Step-9';
 const stepDescriptiveName = 'Config';
 
-const run = async (logger: ElectronLog): Promise<DiagnosticStepResponse> => {
+const run = async (logger: MainLogger): Promise<DiagnosticStepResponse> => {
     try {
         const payload = config.data;
 

--- a/src/types/diagnostics.ts
+++ b/src/types/diagnostics.ts
@@ -1,12 +1,12 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {ElectronLog, LogLevel} from 'electron-log';
+import type {MainLogger, LogLevel} from 'electron-log';
 
 export type DiagnosticsStepConstructorPayload = {
     name: string;
     retries: number;
-    run: (logger: ElectronLog) => Promise<DiagnosticStepResponse>;
+    run: (logger: MainLogger) => Promise<DiagnosticStepResponse>;
 }
 
 export type DiagnosticStepResponse = {
@@ -22,8 +22,8 @@ export type DiagnosticsReportObject = DiagnosticStepResponse & {
 }
 
 export type AddDurationToFnReturnObject =
-    (run: (logger: ElectronLog) => Promise<DiagnosticStepResponse>)
-    => (logger: ElectronLog)
+    (run: (logger: MainLogger) => Promise<DiagnosticStepResponse>)
+    => (logger: MainLogger)
     => Promise<Omit<DiagnosticStepResponse, 'duration'> & {duration: number}>;
 
 export type DiagnosticsReport = DiagnosticsReportObject[];


### PR DESCRIPTION
#### Summary
Upgrade `electron-log` to v5.1.1. This also includes a bunch of type changes (mostly just a rename of `ElectronLog` to `MainLogger`)

```release-note
NONE
```
