### PR TITLE
Remove build hash from release builds

### DIFF
--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -14,7 +14,7 @@ const webpack = require('webpack');
 const VERSION = childProcess.execSync('git rev-parse --short HEAD').toString();
 const isProduction = process.env.NODE_ENV === 'production';
 const isTest = process.env.NODE_ENV === 'test';
-const isRelease = process.env.CIRCLE_BRANCH && process.env.CIRCLE_BRANCH.startsWith('release-');
+const isRelease = process.env.GITHUB_WORKFLOW && process.env.GITHUB_WORKFLOW.startsWith('release');
 
 const codeDefinitions = {
     __HASH_VERSION__: !isRelease && JSON.stringify(VERSION),


### PR DESCRIPTION
#### Summary
When we migrated to GitHub Actions, the hash got stuck in release builds, because we were still checking for the old CircleCI env variables. This PR switches over to the GitHub Actions one.

```release-note
NONE
```
