### PR TITLE
Add NSUserActivityTypes to Info.plist

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -120,7 +120,8 @@
     "entitlementsLoginHelper": "./resources/mac/entitlements.mas.inherit.plist",
     "provisioningProfile": "./mas.provisionprofile",
     "extendInfo": {
-      "ITSAppUsesNonExemptEncryption": false
+      "ITSAppUsesNonExemptEncryption": false,
+      "NSUserActivityTypes": ["INSendMessageIntent"]
     },
     "singleArchFiles": "*"
   },


### PR DESCRIPTION
#### Summary
With the recent changes to use the communication entitlement, Apple wants us to state our intent for sending notifications, so I've added that here to the MAS build.

```release-note
NONE
```
