### PR TITLE
release.sh patch

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -137,7 +137,9 @@ case "${1}" in
         if [[ "${branch_name}" =~ "release-" ]]; then
             print_info "Releasing v${current_version}"
             new_pkg_version="${current_version}"
-            write_package_version "${new_pkg_version}"
+            if [[ "${pkg_version}" != "${new_pkg_version}" ]]; then
+                write_package_version "${new_pkg_version}"
+            fi
             tag "${new_pkg_version}" "Released on $(date -u)"
             print_info "Locally created an final version. In order to build you'll have to:"
             print_info "$ git push --follow-tags ${git_origin} ${branch_name}:${branch_name}"


### PR DESCRIPTION
#### Summary
Thought I fixed this last time around - `release.sh` expects that on the final release day we need to patch the version number again, but since we do that for the MAS approval first, we don't need to force it anymore.

This PR addresses that.

```release-note
NONE
```
