### PR TITLE
Stop Apple from killing the Electron dev process when a notification is received

### DIFF
--- a/src/main/notifications/index.ts
+++ b/src/main/notifications/index.ts
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {app, shell, Notification} from 'electron';
+import isDev from 'electron-is-dev';
 import {getDoNotDisturb as getDarwinDoNotDisturb} from 'macos-notification-state';
 
 import {PLAY_SOUND, NOTIFICATION_CLICKED} from 'common/communication';
@@ -179,7 +180,8 @@ async function getDoNotDisturb() {
         return getWindowsDoNotDisturb();
     }
 
-    if (process.platform === 'darwin') {
+    // We have to turn this off for dev mode because the Electron binary doesn't have the focus center API entitlement
+    if (process.platform === 'darwin' && !isDev) {
         return getDarwinDoNotDisturb();
     }
 


### PR DESCRIPTION
#### Summary
With the check for DND being bound to Apple's focus center API and `macos-notification-state` choosing to only use that API, in Dev Mode Apple will force-close any app that doesn't have its entitlements set correctly, which Electron doesn't.

So for dev mode, we just disable the check.

```release-note
NONE
```
