### PR TITLE
[MM-57690] Emit status when removing a view

### DIFF
--- a/src/common/appState.ts
+++ b/src/common/appState.ts
@@ -49,6 +49,8 @@ export class AppState extends EventEmitter {
         this.expired.delete(viewId);
         this.mentions.delete(viewId);
         this.unreads.delete(viewId);
+
+        this.emitStatusForView(viewId);
     };
 
     emitStatus = () => {


### PR DESCRIPTION
#### Summary
A regression from one of the server manager refactors was that we weren't clearing mentions properly when a server was removed. This happened because we were actually clearing the mentions, but we didn't update the state properly for that view, so the front-end had no idea it was supposed to remove those mentions. This PR forces that to happen correctly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57690

```release-note
Fixed an issue where mentions and unreads were not cleared when a server was removed
```
