### PR TITLE
[MM-57348] Support notification metrics from the Desktop App client

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+api-types/lib

--- a/api-types/index.ts
+++ b/api-types/index.ts
@@ -28,7 +28,7 @@ export type DesktopAPI = {
     ) => void) => () => void;
 
     // Unreads/mentions/notifications
-    sendNotification: (title: string, body: string, channelId: string, teamId: string, url: string, silent: boolean, soundName: string) => void;
+    sendNotification: (title: string, body: string, channelId: string, teamId: string, url: string, silent: boolean, soundName: string) => Promise<{result: string; reason?: string; data?: string}>;
     onNotificationClicked: (listener: (channelId: string, teamId: string, url: string) => void) => () => void;
     setUnreadsAndMentions: (isUnread: boolean, mentionCount: number) => void;
 

--- a/api-types/lib/index.d.ts
+++ b/api-types/lib/index.d.ts
@@ -1,6 +1,4 @@
-// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
-// See LICENSE.txt for license information.
-export declare type DesktopSourcesOptions = {
+export type DesktopSourcesOptions = {
     types: Array<'screen' | 'window'>;
     thumbnailSize?: {
         height: number;
@@ -8,12 +6,12 @@ export declare type DesktopSourcesOptions = {
     };
     fetchWindowIcons?: boolean;
 };
-export declare type DesktopCaptureSource = {
+export type DesktopCaptureSource = {
     id: string;
     name: string;
     thumbnailURL: string;
 };
-export declare type DesktopAPI = {
+export type DesktopAPI = {
     isDev: () => Promise<boolean>;
     getAppInfo: () => Promise<{
         name: string;
@@ -22,7 +20,11 @@ export declare type DesktopAPI = {
     reactAppInitialized: () => void;
     setSessionExpired: (isExpired: boolean) => void;
     onUserActivityUpdate: (listener: (userIsActive: boolean, idleTime: number, isSystemEvent: boolean) => void) => () => void;
-    sendNotification: (title: string, body: string, channelId: string, teamId: string, url: string, silent: boolean, soundName: string) => void;
+    sendNotification: (title: string, body: string, channelId: string, teamId: string, url: string, silent: boolean, soundName: string) => Promise<{
+        result: string;
+        reason?: string;
+        data?: string;
+    }>;
     onNotificationClicked: (listener: (channelId: string, teamId: string, url: string) => void) => () => void;
     setUnreadsAndMentions: (isUnread: boolean, mentionCount: number) => void;
     requestBrowserHistoryStatus: () => Promise<{

--- a/api-types/lib/index.js
+++ b/api-types/lib/index.js
@@ -1,7 +1,4 @@
+"use strict";
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-'use strict';
-
-// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
-// See LICENSE.txt for license information.
-Object.defineProperty(exports, '__esModule', {value: true});
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/api-types/package.json
+++ b/api-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/desktop-api",
-  "version": "5.8.0-1",
+  "version": "5.8.0-3",
   "description": "Shared types for the Desktop App API provided to the Web App",
   "keywords": [
     "mattermost"

--- a/api-types/tsconfig.json
+++ b/api-types/tsconfig.json
@@ -12,7 +12,8 @@
         "jsx": "react",
         "outDir": "./lib",
         "rootDir": ".",
-        "composite": true
+        "composite": true,
+        "types": []
     },
     "include": [
         "./index.ts"

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -248,7 +248,7 @@ function initializeBeforeAppReady() {
 }
 
 function initializeInterCommunicationEventListeners() {
-    ipcMain.on(NOTIFY_MENTION, handleMentionNotification);
+    ipcMain.handle(NOTIFY_MENTION, handleMentionNotification);
     ipcMain.handle(GET_APP_INFO, handleAppVersion);
     ipcMain.on(UPDATE_SHORTCUT_MENU, handleUpdateMenuEvent);
     ipcMain.on(FOCUS_BROWSERVIEW, ViewManager.focusCurrentView);

--- a/src/main/app/intercom.ts
+++ b/src/main/app/intercom.ts
@@ -112,9 +112,9 @@ export function handleWelcomeScreenModal() {
     }
 }
 
-export function handleMentionNotification(event: IpcMainEvent, title: string, body: string, channelId: string, teamId: string, url: string, silent: boolean, soundName: string) {
+export function handleMentionNotification(event: IpcMainInvokeEvent, title: string, body: string, channelId: string, teamId: string, url: string, silent: boolean, soundName: string) {
     log.debug('handleMentionNotification', {title, body, channelId, teamId, url, silent, soundName});
-    NotificationManager.displayMention(title, body, channelId, teamId, url, silent, event.sender, soundName);
+    return NotificationManager.displayMention(title, body, channelId, teamId, url, silent, event.sender, soundName);
 }
 
 export function handleOpenAppMenu() {

--- a/src/main/notifications/index.ts
+++ b/src/main/notifications/index.ts
@@ -32,19 +32,19 @@ class NotificationManager {
 
         if (!Notification.isSupported()) {
             log.error('notification not supported');
-            return;
+            return {result: 'error', reason: 'notification_api', data: 'notification not supported'};
         }
 
         if (await getDoNotDisturb()) {
-            return;
+            return {result: 'not_sent', reason: 'os_dnd'};
         }
 
         const view = ViewManager.getViewByWebContentsId(webcontents.id);
         if (!view) {
-            return;
+            return {result: 'error', reason: 'missing_view'};
         }
         if (!view.view.shouldNotify) {
-            return;
+            return {result: 'error', reason: 'view_should_not_notify'};
         }
         const serverName = view.view.server.name;
 
@@ -56,31 +56,12 @@ class NotificationManager {
         };
 
         if (!await PermissionsManager.doPermissionRequest(webcontents.id, 'notifications', view.view.server.url.toString())) {
-            return;
+            return {result: 'not_sent', reason: 'notifications_permission_disallowed'};
         }
 
         const mention = new Mention(options, channelId, teamId);
         const mentionKey = `${mention.teamId}:${mention.channelId}`;
         this.allActiveNotifications.set(mention.uId, mention);
-
-        mention.on('show', () => {
-            log.debug('displayMention.show');
-
-            // On Windows, manually dismiss notifications from the same channel and only show the latest one
-            if (process.platform === 'win32') {
-                if (this.mentionsPerChannel.has(mentionKey)) {
-                    log.debug(`close ${mentionKey}`);
-                    this.mentionsPerChannel.get(mentionKey)?.close();
-                    this.mentionsPerChannel.delete(mentionKey);
-                }
-                this.mentionsPerChannel.set(mentionKey, mention);
-            }
-            const notificationSound = mention.getNotificationSound();
-            if (notificationSound) {
-                MainWindow.sendToRenderer(PLAY_SOUND, notificationSound);
-            }
-            flashFrame(true);
-        });
 
         mention.on('click', () => {
             log.debug('notification click', serverName, mention);
@@ -97,10 +78,33 @@ class NotificationManager {
             this.allActiveNotifications.delete(mention.uId);
         });
 
-        mention.on('failed', () => {
-            this.allActiveNotifications.delete(mention.uId);
+        return new Promise((resolve) => {
+            mention.on('show', () => {
+                log.debug('displayMention.show');
+
+                // On Windows, manually dismiss notifications from the same channel and only show the latest one
+                if (process.platform === 'win32') {
+                    if (this.mentionsPerChannel.has(mentionKey)) {
+                        log.debug(`close ${mentionKey}`);
+                        this.mentionsPerChannel.get(mentionKey)?.close();
+                        this.mentionsPerChannel.delete(mentionKey);
+                    }
+                    this.mentionsPerChannel.set(mentionKey, mention);
+                }
+                const notificationSound = mention.getNotificationSound();
+                if (notificationSound) {
+                    MainWindow.sendToRenderer(PLAY_SOUND, notificationSound);
+                }
+                flashFrame(true);
+                resolve({result: 'success'});
+            });
+
+            mention.on('failed', (_, error) => {
+                this.allActiveNotifications.delete(mention.uId);
+                resolve({result: 'error', reason: 'electron_notification_failed', data: error});
+            });
+            mention.show();
         });
-        mention.show();
     }
 
     public async displayDownloadCompleted(fileName: string, path: string, serverName: string) {

--- a/src/main/notifications/index.ts
+++ b/src/main/notifications/index.ts
@@ -79,6 +79,11 @@ class NotificationManager {
         });
 
         return new Promise((resolve) => {
+            // If mention never shows somehow, resolve the promise after 10s
+            const timeout = setTimeout(() => {
+                resolve({result: 'error', reason: 'notification_timeout'});
+            }, 10000);
+
             mention.on('show', () => {
                 log.debug('displayMention.show');
 
@@ -96,11 +101,13 @@ class NotificationManager {
                     MainWindow.sendToRenderer(PLAY_SOUND, notificationSound);
                 }
                 flashFrame(true);
+                clearTimeout(timeout);
                 resolve({result: 'success'});
             });
 
             mention.on('failed', (_, error) => {
                 this.allActiveNotifications.delete(mention.uId);
+                clearTimeout(timeout);
                 resolve({result: 'error', reason: 'electron_notification_failed', data: error});
             });
             mention.show();

--- a/src/main/preload/externalAPI.ts
+++ b/src/main/preload/externalAPI.ts
@@ -72,7 +72,7 @@ const desktopAPI: DesktopAPI = {
 
     // Unreads/mentions/notifications
     sendNotification: (title, body, channelId, teamId, url, silent, soundName) =>
-        ipcRenderer.send(NOTIFY_MENTION, title, body, channelId, teamId, url, silent, soundName),
+        ipcRenderer.invoke(NOTIFY_MENTION, title, body, channelId, teamId, url, silent, soundName),
     onNotificationClicked: (listener) => createListener(NOTIFICATION_CLICKED, listener),
     setUnreadsAndMentions: (isUnread, mentionCount) => ipcRenderer.send(UNREADS_AND_MENTIONS, isUnread, mentionCount),
 
@@ -286,7 +286,7 @@ window.addEventListener('message', ({origin, data = {}}: {origin?: string; data?
     case 'dispatch-notification': {
         const {title, body, channel, teamId, url, silent, data: messageData} = message;
         channels.set(channel.id, channel);
-        ipcRenderer.send(NOTIFY_MENTION, title, body, channel.id, teamId, url, silent, messageData.soundName);
+        ipcRenderer.invoke(NOTIFY_MENTION, title, body, channel.id, teamId, url, silent, messageData.soundName);
         break;
     }
     case BROWSER_HISTORY_PUSH: {


### PR DESCRIPTION
#### Summary
This PR enables the Desktop App to return data around whether a notification was successful or not. It relays that data back to the web clients that support it, and the web client will push that data through the websocket as needed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57348

```release-note
NONE
```
