### PR TITLE
Upgrade to Electron v29.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "copy-webpack-plugin": "10.2.4",
         "cross-env": "7.0.3",
         "css-loader": "6.7.1",
-        "electron": "29.0.0",
+        "electron": "29.3.0",
         "electron-builder": "24.13.3",
         "electron-connect": "0.6.3",
         "electron-mocha": "12.2.0",
@@ -9676,9 +9676,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-29.0.0.tgz",
-      "integrity": "sha512-HhrRC5vWb6fAbWXP3A6ABwKUO9JvYSC4E141RzWFgnDBqNiNtabfmgC8hsVeCR65RQA2MLSDgC8uP52I9zFllQ==",
+      "version": "29.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-29.3.0.tgz",
+      "integrity": "sha512-ZxFKm0/v48GSoBuO3DdnMlCYXefEUKUHLMsKxyXY4nZGgzbBKpF/X8haZa2paNj23CLfsCKBOtfc2vsEQiOOsA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/mattermost/desktop.git"
   },
   "config": {
-    "target": "29.0.0",
+    "target": "29.3.0",
     "arch": "x64",
     "target_arch": "x64",
     "disturl": "https://electronjs.org/headers",
@@ -152,7 +152,7 @@
     "copy-webpack-plugin": "10.2.4",
     "cross-env": "7.0.3",
     "css-loader": "6.7.1",
-    "electron": "29.0.0",
+    "electron": "29.3.0",
     "electron-builder": "24.13.3",
     "electron-connect": "0.6.3",
     "electron-mocha": "12.2.0",


### PR DESCRIPTION
#### Summary
Upgrading to Electron v29.3.0 ahead of the v5.8 release.

```release-note
Upgrade to Electron v29.3.0
```
