### PR TITLE
[MM-57348] Change `result` to `status` as a better descriptor of the notification status

### DIFF
--- a/api-types/index.ts
+++ b/api-types/index.ts
@@ -30,7 +30,7 @@ export type DesktopAPI = {
     onLogout: () => void;
 
     // Unreads/mentions/notifications
-    sendNotification: (title: string, body: string, channelId: string, teamId: string, url: string, silent: boolean, soundName: string) => Promise<{result: string; reason?: string; data?: string}>;
+    sendNotification: (title: string, body: string, channelId: string, teamId: string, url: string, silent: boolean, soundName: string) => Promise<{status: string; reason?: string; data?: string}>;
     onNotificationClicked: (listener: (channelId: string, teamId: string, url: string) => void) => () => void;
     setUnreadsAndMentions: (isUnread: boolean, mentionCount: number) => void;
 

--- a/api-types/lib/index.d.ts
+++ b/api-types/lib/index.d.ts
@@ -23,7 +23,7 @@ export type DesktopAPI = {
     onLogin: () => void;
     onLogout: () => void;
     sendNotification: (title: string, body: string, channelId: string, teamId: string, url: string, silent: boolean, soundName: string) => Promise<{
-        result: string;
+        status: string;
         reason?: string;
         data?: string;
     }>;

--- a/api-types/package-lock.json
+++ b/api-types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mattermost/desktop-api",
-  "version": "5.8.0-1",
+  "version": "5.8.0-5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mattermost/desktop-api",
-      "version": "5.8.0-1",
+      "version": "5.8.0-5",
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^4.3.0 || ^5.0.0"

--- a/api-types/package.json
+++ b/api-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/desktop-api",
-  "version": "5.8.0-4",
+  "version": "5.8.0-5",
   "description": "Shared types for the Desktop App API provided to the Web App",
   "keywords": [
     "mattermost"
@@ -29,6 +29,6 @@
     "build": "tsc --build --verbose",
     "run": "tsc --watch --preserveWatchOutput",
     "clean": "rm -rf tsconfig.tsbuildinfo ./lib",
-    "prepublish": "npm run build && rm -rf tsconfig.tsbuildinfo"
+    "prepublishOnly": "npm run build && rm -rf ./lib/tsconfig.tsbuildinfo"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
     },
     "api-types": {
       "name": "@mattermost/desktop-api",
-      "version": "5.8.0-4",
+      "version": "5.8.0-5",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/src/main/notifications/index.ts
+++ b/src/main/notifications/index.ts
@@ -32,19 +32,19 @@ class NotificationManager {
 
         if (!Notification.isSupported()) {
             log.error('notification not supported');
-            return {result: 'error', reason: 'notification_api', data: 'notification not supported'};
+            return {status: 'error', reason: 'notification_api', data: 'notification not supported'};
         }
 
         if (await getDoNotDisturb()) {
-            return {result: 'not_sent', reason: 'os_dnd'};
+            return {status: 'not_sent', reason: 'os_dnd'};
         }
 
         const view = ViewManager.getViewByWebContentsId(webcontents.id);
         if (!view) {
-            return {result: 'error', reason: 'missing_view'};
+            return {status: 'error', reason: 'missing_view'};
         }
         if (!view.view.shouldNotify) {
-            return {result: 'error', reason: 'view_should_not_notify'};
+            return {status: 'error', reason: 'view_should_not_notify'};
         }
         const serverName = view.view.server.name;
 
@@ -56,7 +56,7 @@ class NotificationManager {
         };
 
         if (!await PermissionsManager.doPermissionRequest(webcontents.id, 'notifications', view.view.server.url.toString())) {
-            return {result: 'not_sent', reason: 'notifications_permission_disallowed'};
+            return {status: 'not_sent', reason: 'notifications_permission_disallowed'};
         }
 
         const mention = new Mention(options, channelId, teamId);
@@ -81,7 +81,7 @@ class NotificationManager {
         return new Promise((resolve) => {
             // If mention never shows somehow, resolve the promise after 10s
             const timeout = setTimeout(() => {
-                resolve({result: 'error', reason: 'notification_timeout'});
+                resolve({status: 'error', reason: 'notification_timeout'});
             }, 10000);
 
             mention.on('show', () => {
@@ -102,13 +102,13 @@ class NotificationManager {
                 }
                 flashFrame(true);
                 clearTimeout(timeout);
-                resolve({result: 'success'});
+                resolve({status: 'success'});
             });
 
             mention.on('failed', (_, error) => {
                 this.allActiveNotifications.delete(mention.uId);
                 clearTimeout(timeout);
-                resolve({result: 'error', reason: 'electron_notification_failed', data: error});
+                resolve({status: 'error', reason: 'electron_notification_failed', data: error});
             });
             mention.show();
         });

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -456,7 +456,7 @@ export class MainWindow extends EventEmitter {
         if (this.isMaximized && !this.win?.isMaximized()) {
             this.win?.maximize();
         }
-    }
+    };
 
     private onEnterFullScreen = () => {
         this.win?.webContents.send('enter-full-screen');


### PR DESCRIPTION
#### Summary
For consistency, and overall better naming, I'm changing the field name for the notification status to `status` instead of result. This keeps it in line with the server descriptors/constants.

```release-note
NONE
```
