### PR TITLE
Fix settings window disappearing on macOS when dragged to another monitor

### DIFF
--- a/src/main/app/app.ts
+++ b/src/main/app/app.ts
@@ -50,7 +50,11 @@ export function handleAppBrowserWindowCreated(event: Event, newWindow: BrowserWi
     log.debug('handleAppBrowserWindowCreated');
 
     // Screen cannot be required before app is ready
-    resizeScreen(newWindow);
+    if (app.isReady()) {
+        resizeScreen(newWindow);
+    } else {
+        newWindow.once('restore', () => resizeScreen(newWindow));
+    }
 }
 
 export function handleAppWillFinishLaunching() {

--- a/src/main/app/utils.test.js
+++ b/src/main/app/utils.test.js
@@ -7,6 +7,7 @@ import {dialog, screen} from 'electron';
 
 import JsonFileManager from 'common/JsonFileManager';
 import {updatePaths} from 'main/constants';
+import MainWindow from 'main/windows/mainWindow';
 
 import {getDeeplinkingURL, resizeScreen, migrateMacAppStore} from './utils';
 
@@ -52,7 +53,9 @@ jest.mock('main/menus/app', () => ({}));
 jest.mock('main/menus/tray', () => ({}));
 jest.mock('main/tray/tray', () => ({}));
 jest.mock('main/views/viewManager', () => ({}));
-jest.mock('main/windows/mainWindow', () => ({}));
+jest.mock('main/windows/mainWindow', () => ({
+    get: jest.fn(),
+}));
 
 jest.mock('./initialize', () => ({
     mainProtocol: 'mattermost',
@@ -129,6 +132,21 @@ describe('main/app/utils', () => {
             resizeScreen(browserWindow);
             expect(browserWindow.setPosition).not.toHaveBeenCalled();
             expect(browserWindow.center).toHaveBeenCalled();
+        });
+
+        it('should snap to main window if it exists', () => {
+            MainWindow.get.mockReturnValue({
+                getPosition: () => [450, 350],
+            });
+            const browserWindow = {
+                getPosition: () => [500, 400],
+                getSize: () => [1280, 720],
+                setPosition: jest.fn(),
+                center: jest.fn(),
+                once: jest.fn(),
+            };
+            resizeScreen(browserWindow);
+            expect(browserWindow.setPosition).toHaveBeenCalledWith(450, 350);
         });
     });
 

--- a/src/main/app/utils.test.js
+++ b/src/main/app/utils.test.js
@@ -55,6 +55,7 @@ jest.mock('main/tray/tray', () => ({}));
 jest.mock('main/views/viewManager', () => ({}));
 jest.mock('main/windows/mainWindow', () => ({
     get: jest.fn(),
+    getSize: jest.fn(),
 }));
 
 jest.mock('./initialize', () => ({
@@ -137,6 +138,7 @@ describe('main/app/utils', () => {
         it('should snap to main window if it exists', () => {
             MainWindow.get.mockReturnValue({
                 getPosition: () => [450, 350],
+                getSize: () => [1280, 720],
             });
             const browserWindow = {
                 getPosition: () => [500, 400],
@@ -147,6 +149,22 @@ describe('main/app/utils', () => {
             };
             resizeScreen(browserWindow);
             expect(browserWindow.setPosition).toHaveBeenCalledWith(450, 350);
+        });
+
+        it('should snap to the middle of the main window', () => {
+            MainWindow.get.mockReturnValue({
+                getPosition: () => [450, 350],
+                getSize: () => [1280, 720],
+            });
+            const browserWindow = {
+                getPosition: () => [500, 400],
+                getSize: () => [800, 600],
+                setPosition: jest.fn(),
+                center: jest.fn(),
+                once: jest.fn(),
+            };
+            resizeScreen(browserWindow);
+            expect(browserWindow.setPosition).toHaveBeenCalledWith(690, 410);
         });
     });
 

--- a/src/main/app/utils.ts
+++ b/src/main/app/utils.ts
@@ -144,8 +144,24 @@ function getValidWindowPosition(state: Rectangle) {
     return {x: state.x, y: state.y};
 }
 
+function getNewWindowPosition(browserWindow: BrowserWindow) {
+    const mainWindow = MainWindow.get();
+    if (!mainWindow) {
+        return browserWindow.getPosition();
+    }
+
+    const newWindowSize = browserWindow.getSize();
+    const mainWindowSize = mainWindow.getSize();
+    const mainWindowPosition = mainWindow.getPosition();
+
+    return [
+        mainWindowPosition[0] + ((mainWindowSize[0] - newWindowSize[0]) / 2),
+        mainWindowPosition[1] + ((mainWindowSize[1] - newWindowSize[1]) / 2),
+    ];
+}
+
 export function resizeScreen(browserWindow: BrowserWindow) {
-    const position = MainWindow.get()?.getPosition() ?? browserWindow.getPosition();
+    const position = getNewWindowPosition(browserWindow);
     const size = browserWindow.getSize();
     const validPosition = getValidWindowPosition({
         x: position[0],

--- a/src/main/app/utils.ts
+++ b/src/main/app/utils.ts
@@ -145,25 +145,19 @@ function getValidWindowPosition(state: Rectangle) {
 }
 
 export function resizeScreen(browserWindow: BrowserWindow) {
-    function handle() {
-        log.debug('resizeScreen.handle');
-        const position = browserWindow.getPosition();
-        const size = browserWindow.getSize();
-        const validPosition = getValidWindowPosition({
-            x: position[0],
-            y: position[1],
-            width: size[0],
-            height: size[1],
-        });
-        if (typeof validPosition.x !== 'undefined' || typeof validPosition.y !== 'undefined') {
-            browserWindow.setPosition(validPosition.x || 0, validPosition.y || 0);
-        } else {
-            browserWindow.center();
-        }
+    const position = MainWindow.get()?.getPosition() ?? browserWindow.getPosition();
+    const size = browserWindow.getSize();
+    const validPosition = getValidWindowPosition({
+        x: position[0],
+        y: position[1],
+        width: size[0],
+        height: size[1],
+    });
+    if (typeof validPosition.x !== 'undefined' || typeof validPosition.y !== 'undefined') {
+        browserWindow.setPosition(validPosition.x || 0, validPosition.y || 0);
+    } else {
+        browserWindow.center();
     }
-
-    browserWindow.once('restore', handle);
-    handle();
 }
 
 export function flushCookiesStore() {

--- a/src/main/windows/settingsWindow.ts
+++ b/src/main/windows/settingsWindow.ts
@@ -46,7 +46,6 @@ export class SettingsWindow {
         const preload = getLocalPreload('internalAPI.js');
         const spellcheck = (typeof Config.useSpellChecker === 'undefined' ? true : Config.useSpellChecker);
         this.win = new BrowserWindow({
-            parent: mainWindow,
             title: 'Desktop App Settings',
             fullscreen: false,
             webPreferences: {


### PR DESCRIPTION
#### Summary
On macOS, if you drag the settings window to another monitor, it will disappear and you cannot get it back without restarting the application. This is due to a bug in Electron with parent windows: https://github.com/electron/electron/issues/38760

As a workaround, I am setting the settings window to no longer be the parent of the main window, which means that the window is not forced always on top, or to the same screen as the main window. To remedy this, I've added some code to force all new browser windows to render on top of the main window initially.

```release-note
Fix the settings window disappearing on macOS when dragged to another monitor
```
