### PR TITLE
Fix shouldNotify notification reason

### DIFF
--- a/src/main/notifications/index.ts
+++ b/src/main/notifications/index.ts
@@ -44,7 +44,7 @@ class NotificationManager {
             return {status: 'error', reason: 'missing_view'};
         }
         if (!view.view.shouldNotify) {
-            return {status: 'error', reason: 'view_should_not_notify'};
+            return {status: 'not_sent', reason: 'view_should_not_notify'};
         }
         const serverName = view.view.server.name;
 


### PR DESCRIPTION
#### Summary
I erroneously set the `shouldNotify` check to `error` which it isn't, this should only happen when the Playbooks tab (or some other tab) receives the notification and it shouldn't be sent. The main tab will send it, so this is just something else to track as not sent.

```release-note
NONE
```
