### PR TITLE
[MM-57912] Disable `--inspect` on built application

### DIFF
--- a/scripts/afterpack.js
+++ b/scripts/afterpack.js
@@ -42,6 +42,7 @@ exports.default = async function afterPack(context) {
             {
                 version: FuseVersion.V1,
                 [FuseV1Options.RunAsNode]: false, // Disables ELECTRON_RUN_AS_NODE
+                [FuseV1Options.EnableNodeCliInspectArguments]: false, // Disables --inspect
             });
 
         if (context.electronPlatformName === 'linux') {


### PR DESCRIPTION
#### Summary
`--inspect` can be used for permissions escalation, so we're disabling it on the built application.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-57912

```release-note
Disabled `--inspect` tag
```
