### PR TITLE
chore(ci): update CI badge with GitHub Actions' one

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Originally created as "electron-mattermost" by Yuya Ochiai.
 
 ![mm-desktop-screenshot](https://user-images.githubusercontent.com/52460000/146078917-e1ba8c1f-24e5-4613-8b4b-f3507422f4f2.png)
 
-[![Circle CI](https://circleci.com/gh/mattermost/desktop.svg?style=shield)](https://circleci.com/gh/mattermost/desktop)
+[![nightly-builds](https://github.com/mattermost/desktop/actions/workflows/nightly-builds.yaml/badge.svg)](https://github.com/mattermost/desktop/actions/workflows/nightly-builds.yaml)
 
 ## Features
 


### PR DESCRIPTION
- Follows up #2516

#### Summary

While #2516 deprecated use of CircleCI, the badge has been for CircleCI. This updates it with GitHub Actions' one per #2516.

#### Ticket Link

n/a

#### Checklist

- [ ] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [ ] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)

#### Device Information

n/a

#### Screenshots

n/a

#### Release Note

```release-note
NONE
```