### PR TITLE
[MM-58065] Force the packager to create the version directory before packing

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -40,6 +40,7 @@
       ]
     }
   ],
+  "beforePack": "scripts/beforepack.js",
   "afterPack": "scripts/afterpack.js",
   "afterAllArtifactBuild": "scripts/afterbuild.js",
   "deb": {

--- a/scripts/beforepack.js
+++ b/scripts/beforepack.js
@@ -1,0 +1,14 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+var fs = require('fs');
+var path = require('path');
+
+exports.default = async function beforePack(context) {
+    // The debian packager (fpm) complains when the directory to output the package to doesn't exist
+    // So we have to manually create it first
+    var dir = path.join(context.outDir, context.packager.appInfo.version)
+    if (!fs.existsSync(dir)){
+        fs.mkdirSync(dir);
+    }
+};


### PR DESCRIPTION
#### Summary
An issue I introduced when cleaning up the `package.json` is that `fpm` (the packager for .deb packages) was complaining if the directory it needs to store the .deb file doesn't exist. This wasn't happening before because we had to run the .tar.gz packager first, which we don't need to do anymore. However, now what we have to do is manually create that sub-directory in the release folder so that this doesn't complain.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58065

```release-note
NONE
```
