### PR TITLE
[MM-58158] Make sure closing the permissions dialog results in a Deny instead of an Allow

### DIFF
--- a/src/main/permissionsManager.test.js
+++ b/src/main/permissionsManager.test.js
@@ -145,7 +145,7 @@ describe('main/PermissionsManager', () => {
         const permissionsManager = new PermissionsManager('anyfile.json');
         permissionsManager.writeToFile = jest.fn();
         const cb = jest.fn();
-        dialog.showMessageBox.mockReturnValue(Promise.resolve({response: 0}));
+        dialog.showMessageBox.mockReturnValue(Promise.resolve({response: 2}));
         await permissionsManager.handlePermissionRequest({id: 2}, 'media', cb, {securityOrigin: 'http://anyurl.com'});
         expect(permissionsManager.json['http://anyurl.com'].media.allowed).toBe(true);
         expect(permissionsManager.writeToFile).toHaveBeenCalled();
@@ -156,7 +156,7 @@ describe('main/PermissionsManager', () => {
         const permissionsManager = new PermissionsManager('anyfile.json');
         permissionsManager.writeToFile = jest.fn();
         const cb = jest.fn();
-        dialog.showMessageBox.mockReturnValue(Promise.resolve({response: 1}));
+        dialog.showMessageBox.mockReturnValue(Promise.resolve({response: 0}));
         await permissionsManager.handlePermissionRequest({id: 2}, 'media', cb, {securityOrigin: 'http://anyurl.com'});
         expect(permissionsManager.json['http://anyurl.com'].media.allowed).toBe(false);
         expect(permissionsManager.writeToFile).toHaveBeenCalled();
@@ -167,7 +167,7 @@ describe('main/PermissionsManager', () => {
         const permissionsManager = new PermissionsManager('anyfile.json');
         permissionsManager.writeToFile = jest.fn();
         const cb = jest.fn();
-        dialog.showMessageBox.mockReturnValue(Promise.resolve({response: 2}));
+        dialog.showMessageBox.mockReturnValue(Promise.resolve({response: 1}));
         await permissionsManager.handlePermissionRequest({id: 2}, 'media', cb, {securityOrigin: 'http://anyurl.com'});
         expect(permissionsManager.json['http://anyurl.com'].media.allowed).toBe(false);
         expect(permissionsManager.json['http://anyurl.com'].media.alwaysDeny).toBe(true);
@@ -179,7 +179,7 @@ describe('main/PermissionsManager', () => {
         const permissionsManager = new PermissionsManager('anyfile.json');
         permissionsManager.writeToFile = jest.fn();
         const cb = jest.fn();
-        dialog.showMessageBox.mockReturnValue(Promise.resolve({response: 0}));
+        dialog.showMessageBox.mockReturnValue(Promise.resolve({response: 2}));
         await Promise.all([
             permissionsManager.handlePermissionRequest({id: 2}, 'notifications', cb, {requestingUrl: 'http://anyurl.com'}),
             permissionsManager.handlePermissionRequest({id: 2}, 'notifications', cb, {requestingUrl: 'http://anyurl.com'}),
@@ -199,7 +199,7 @@ describe('main/PermissionsManager', () => {
         const permissionsManager = new PermissionsManager('anyfile.json');
         permissionsManager.writeToFile = jest.fn();
         const cb = jest.fn();
-        dialog.showMessageBox.mockReturnValue(Promise.resolve({response: 0}));
+        dialog.showMessageBox.mockReturnValue(Promise.resolve({response: 2}));
         await permissionsManager.handlePermissionRequest({id: 2}, 'media', cb, {securityOrigin: 'http://anyurl.com'});
         expect(dialog.showMessageBox).toHaveBeenCalled();
     });
@@ -208,7 +208,7 @@ describe('main/PermissionsManager', () => {
         const permissionsManager = new PermissionsManager('anyfile.json');
         permissionsManager.writeToFile = jest.fn();
         const cb = jest.fn();
-        dialog.showMessageBox.mockReturnValue(Promise.resolve({response: 0}));
+        dialog.showMessageBox.mockReturnValue(Promise.resolve({response: 2}));
         await permissionsManager.handlePermissionRequest({id: 2}, 'openExternal', cb, {requestingUrl: 'http://anyurl.com', externalURL: 'ms-excel://differenturl.com'});
         expect(dialog.showMessageBox).toHaveBeenCalled();
     });

--- a/src/main/permissionsManager.ts
+++ b/src/main/permissionsManager.ts
@@ -152,16 +152,16 @@ export class PermissionsManager extends JsonFileManager<Permissions> {
                 detail: localizeMessage(`main.permissionsManager.checkPermission.dialog.detail.${permission}`, 'Would you like to grant {appName} this permission?', {appName: app.name}),
                 type: 'question',
                 buttons: [
-                    localizeMessage('label.allow', 'Allow'),
                     localizeMessage('label.deny', 'Deny'),
                     localizeMessage('label.denyPermanently', 'Deny Permanently'),
+                    localizeMessage('label.allow', 'Allow'),
                 ],
             });
 
             // Save their response
             const newPermission = {
-                allowed: response === 0,
-                alwaysDeny: (response === 2) ? true : undefined,
+                allowed: response === 2,
+                alwaysDeny: (response === 1) ? true : undefined,
             };
             this.json[parsedURL.origin] = {
                 ...this.json[parsedURL.origin],
@@ -171,7 +171,7 @@ export class PermissionsManager extends JsonFileManager<Permissions> {
 
             this.inflightPermissionChecks.delete(permissionKey);
 
-            if (response > 0) {
+            if (response < 2) {
                 return false;
             }
         }


### PR DESCRIPTION
#### Summary
When the permissions dialog pops to ask permission, if you close the dialog using the X on Windows/Linux, it returns a response of `0` which was resulting in an Allow. This seems counterintuitive to the user experience and could result in users allowing permissions they didn't expect.

This PR changes the ordering so that Allow is now 2, and Deny is 0 such that closing the dialog results in a Deny.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58158

```release-note
Fixed the permission prompt to Deny on closing the dialog
```
