### PR TITLE
[MM-58286] Fix cp_artifacts to avoid weird naming changes

### DIFF
--- a/scripts/cp_artifacts.sh
+++ b/scripts/cp_artifacts.sh
@@ -2,120 +2,19 @@
 set -eu
 
 VERSION="$(jq -r '.version' <package.json)"
-SRC="${1}/${VERSION}"
-DEST="${2}/${VERSION}"
-SOMETHING_COPIED=0
-if [[ ! -d "${DEST}" ]]; then
-    echo "Can't find destination. Creating \"${DEST}\""
-    mkdir -p "${DEST}"
+SRC="${1}"
+DEST="${2}"
+if [[ ! -d "${DEST}/${VERSION}" ]]; then
+    echo "Can't find destination. Creating \"${DEST}/${VERSION}\""
+    mkdir -p "${DEST}/${VERSION}"
 fi
 
-if [[ -f "${SRC}/mattermost-desktop-${VERSION}-win-x64.zip" ]]; then
-    echo -e "Copying Win64\n"
-    cp "${SRC}/mattermost-desktop-${VERSION}-win-x64.zip" "${DEST}/mattermost-desktop-${VERSION}-win64.zip"
-    SOMETHING_COPIED=$((SOMETHING_COPIED + 1))
-fi
-if [[ -f "${SRC}/mattermost-desktop-${VERSION}-win-arm64.zip" ]]; then
-    echo -e "Copying Win64\n"
-    cp "${SRC}/mattermost-desktop-${VERSION}-win-arm64.zip" "${DEST}/mattermost-desktop-${VERSION}-arm64.zip"
-    SOMETHING_COPIED=$((SOMETHING_COPIED + 2))
-fi
-if [[ ${MM_WIN_INSTALLERS-0} -eq 1 && -f "${SRC}/mattermost-desktop-setup-${VERSION}-win.exe" ]]; then
-    echo -e "Copying win-no-arch\n"
-    cp "${SRC}/mattermost-desktop-setup-${VERSION}-win.exe" "${DEST}/"
-    SOMETHING_COPIED=$((SOMETHING_COPIED + 3))
-fi
-if [[ ${MM_WIN_INSTALLERS-0} -eq 1 && -f "${SRC}/mattermost-desktop-${VERSION}-win-x64.msi" ]]; then
-    echo -e "Copying win-msi-x64\n"
-    cp "${SRC}/mattermost-desktop-${VERSION}-win-x64.msi" "${DEST}/"
-    SOMETHING_COPIED=$((SOMETHING_COPIED + 4))
-fi
-if [[ ${MM_WIN_INSTALLERS-0} -eq 1 && -f "${SRC}/mattermost-desktop-${VERSION}-win-arm64.msi" ]]; then
-    echo -e "Copying win-msi-arm64\n"
-    cp "${SRC}/mattermost-desktop-${VERSION}-win-arm64.msi" "${DEST}/"
-    SOMETHING_COPIED=$((SOMETHING_COPIED + 5))
-fi
-
-if [[ -f "${SRC}/mattermost-desktop-${VERSION}-mac.zip" ]]; then
-    echo -e "Copying mac\n"
-    cp "${SRC}"/mattermost-desktop-*-mac*.* "${DEST}/"
-    if [[ -f "${SRC}"/mattermost-desktop-${VERSION}-mac.dmg ]]; then
-        cp "${SRC}"/*.blockmap "${DEST}/"
-    fi
-    SOMETHING_COPIED=$((SOMETHING_COPIED + 6))
-fi
-if [[ -f "${SRC}/mattermost-desktop-${VERSION}-mac-x64.zip" ]]; then
-    echo -e "Copying mac-x64\n"
-    cp "${SRC}/mattermost-desktop-${VERSION}-mac-x64.zip" "${DEST}/mattermost-desktop-${VERSION}-mac-x64.zip"
-    if [[ -f "${SRC}"/mattermost-desktop-${VERSION}-mac-x64.dmg ]]; then
-        cp "${SRC}/mattermost-desktop-${VERSION}-mac-x64.dmg.blockmap" "${DEST}/mattermost-desktop-${VERSION}-mac-x64.dmg.blockmap"
-        cp "${SRC}/mattermost-desktop-${VERSION}-mac-x64.dmg" "${DEST}/mattermost-desktop-${VERSION}-mac-x64.dmg"
-    fi
-    SOMETHING_COPIED=$((SOMETHING_COPIED + 7))
-fi
-if [[ -f "${SRC}/mattermost-desktop-${VERSION}-mac-arm64.zip" ]]; then
-    echo -e "Copying mac-arm64\n"
-    cp "${SRC}/mattermost-desktop-${VERSION}-mac-arm64.zip" "${DEST}/mattermost-desktop-${VERSION}-mac-arm64.zip"
-    if [[ -f "${SRC}"/mattermost-desktop-${VERSION}-mac-arm64.dmg ]]; then
-        cp "${SRC}/mattermost-desktop-${VERSION}-mac-arm64.dmg.blockmap" "${DEST}/mattermost-desktop-${VERSION}-mac-arm64.dmg.blockmap"
-        cp "${SRC}/mattermost-desktop-${VERSION}-mac-arm64.dmg" "${DEST}/mattermost-desktop-${VERSION}-mac-arm64.dmg"
-    fi
-    SOMETHING_COPIED=$((SOMETHING_COPIED + 8))
-fi
-if [[ -f "${SRC}/mattermost-desktop-${VERSION}-mac-universal.zip" ]]; then
-    echo -e "Copying mac-universal\n"
-    cp "${SRC}/mattermost-desktop-${VERSION}-mac-universal.zip" "${DEST}/mattermost-desktop-${VERSION}-mac-universal.zip"
-    if [[ -f "${SRC}"/mattermost-desktop-${VERSION}-mac-universal.dmg ]]; then
-        cp "${SRC}/mattermost-desktop-${VERSION}-mac-universal.dmg.blockmap" "${DEST}/mattermost-desktop-${VERSION}-mac-universal.dmg.blockmap"
-        cp "${SRC}/mattermost-desktop-${VERSION}-mac-universal.dmg" "${DEST}/mattermost-desktop-${VERSION}-mac-universal.dmg"
-    fi
-    SOMETHING_COPIED=$((SOMETHING_COPIED + 9))
-fi
-
-if [[ -f "${SRC}"/mattermost-desktop-${VERSION}-linux-x64.tar.gz ]]; then
-    echo -e "Copying linux\n"
-    cp "${SRC}"/mattermost-desktop-*-linux-x64* "${DEST}/"
-    SOMETHING_COPIED=$((SOMETHING_COPIED + 10))
-fi
-
-if [[ -f "${SRC}"/mattermost-desktop-${VERSION}-linux-arm64.tar.gz ]]; then
-    echo -e "Copying linux\n"
-    cp "${SRC}"/mattermost-desktop-*-linux-arm64* "${DEST}/"
-    SOMETHING_COPIED=$((SOMETHING_COPIED + 11))
-fi
-
-if [[ -f "${SRC}"/mattermost-desktop-*-linux-x86_64* ]]; then
-    echo -e "Copying linux-rpm\n"
-    cp "${SRC}"/mattermost-desktop-*-linux-x86_64* "${DEST}/"
-    SOMETHING_COPIED=$((SOMETHING_COPIED + 12))
-fi
-
-if [[ -f "${SRC}"/mattermost-desktop-*-linux-aarch64* ]]; then
-    echo -e "Copying linux-rpm\n"
-    cp "${SRC}"/mattermost-desktop-*-linux-aarch64* "${DEST}/"
-    SOMETHING_COPIED=$((SOMETHING_COPIED + 13))
-fi
-
-if [[ -f "${SRC}"/mattermost-desktop_${VERSION}-1_amd64*.deb ]]; then
-    echo -e "Copying linux-deb\n"
-    cp "${SRC}"/mattermost-desktop_"${VERSION}"-1_amd64*.deb "${DEST}/"
-    SOMETHING_COPIED=$((SOMETHING_COPIED + 14))
-fi
-
-if [[ -f "${SRC}"/mattermost-desktop_${VERSION}-1_arm64*.deb ]]; then
-    echo -e "Copying linux-deb\n"
-    cp "${SRC}"/mattermost-desktop_"${VERSION}"-1_arm64*.deb "${DEST}/"
-    SOMETHING_COPIED=$((SOMETHING_COPIED + 15))
-fi
-
-if [[ $SOMETHING_COPIED -eq 0 ]]; then
-    echo "Didn't find anything to copy, it seems like something failed"
-    # Bash only returns 0-255 values
+if [[ ! -d "${SRC}/${VERSION}" ]]; then
+    echo "Can't find source directory, exiting."
     exit 1
 fi
 
-cp "${1}"/*.yml "${2}/"
+cp -rv "${SRC}/${VERSION}" "${DEST}/"
+cp -v "${SRC}"/*.yml "${DEST}/"
 
-# exit $SOMETHING_COPIED
 exit 0
-


### PR DESCRIPTION
#### Summary
Changes in the build process seem to constantly be breaking this script, which I believe was there to make sure we didn't include extra files. However, we now drop all of our artifacts into the same folder (tagged with the release version) so it's easier to just copy the folder.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58286
Closes #3036

```release-note
NONE
```
