### PR TITLE
Fixes for the MSI installer

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -180,6 +180,9 @@
     "uninstallDisplayName": "${productName}",
     "include": "scripts/installer.nsh"
   },
+  "msi": {
+    "additionalWixArgs": ["-ext", "WixUtilExtension"]
+  },
   "rpm": {
     "fpm": ["--rpm-rpmbuild-define", "_build_id_links none"]
   }

--- a/patches/app-builder-lib+24.13.3.patch
+++ b/patches/app-builder-lib+24.13.3.patch
@@ -1,20 +1,46 @@
 diff --git a/node_modules/app-builder-lib/templates/msi/template.xml b/node_modules/app-builder-lib/templates/msi/template.xml
-index 2d5cd3c..1e7223d 100644
+index 2d5cd3c..92a0556 100644
 --- a/node_modules/app-builder-lib/templates/msi/template.xml
 +++ b/node_modules/app-builder-lib/templates/msi/template.xml
-@@ -26,6 +26,11 @@
+@@ -1,5 +1,8 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+-<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
++<Wix
++  xmlns="http://wixtoolset.org/schemas/v4/wxs"
++  xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util"
++>
+   <!-- https://blogs.msdn.microsoft.com/gremlininthemachine/2006/12/05/msi-wix-and-unicode/ -->
+   <Product Id="*" Name="${productName}" UpgradeCode="${upgradeCode}" Version="${version}" Language="1033" Codepage="65001" Manufacturer="${manufacturer}">
+     <Package Compressed="yes" InstallerVersion="500"/>
+@@ -26,6 +29,27 @@
      <Property Id="ARPPRODUCTICON" Value="${iconId}"/>
      {{ } -}}
  
-+    <CustomAction Id="removeExeInstaller" Directory="APPLICATIONFOLDER" ExeCommand="[APPLICATIONFOLDER]Uninstall ${productName}.exe /S" Execute="immediate" Impersonate="yes" Return="ignore"/>
++    <util:CloseApplication
++      Id="closeApplication"
++      Description="Mattermost is still running. Please ensure to manually close before continuing installation."
++      Target="Mattermost.exe"
++      RebootPrompt="no"
++      PromptToContinue="yes"
++    />
++    <CustomAction
++      Id="removeExeInstaller"
++      Directory="APPLICATIONFOLDER"
++      ExeCommand="[APPLICATIONFOLDER]Uninstall ${productName}.exe /S"
++      Execute="immediate"
++      Impersonate="yes"
++      Return="ignore"
++    />
 +    <InstallExecuteSequence>
-+      <Custom Action="removeExeInstaller" Before="InstallInitialize"/>
++      <Custom Action="WixCloseApplications" Before="InstallValidate"/>
++      <Custom Action="WixCloseApplicationsDeferred" After="InstallInitialize"/>
++      <Custom Action="removeExeInstaller" After="InstallInitialize"/>
 +    </InstallExecuteSequence>
 +
      {{ if (isRunAfterFinish) { }}
        <CustomAction Id="runAfterFinish" FileKey="mainExecutable" ExeCommand="" Execute="immediate" Impersonate="yes" Return="asyncNoWait"/>
        {{ if (!isAssisted) { }}
-@@ -42,6 +47,7 @@
+@@ -42,6 +66,7 @@
        <Property Id="ALLUSERS" Secure="yes" Value="2"/>
      {{ } -}}
      <Property Id="MSIINSTALLPERUSER" Secure="yes" Value="1"/>
@@ -22,7 +48,7 @@ index 2d5cd3c..1e7223d 100644
  
      {{ if (isAssisted) { }}
        <WixVariable Id="WixUISupportPerUser" Value="1" Overridable="yes"/>
-@@ -80,6 +86,7 @@
+@@ -80,6 +105,7 @@
        </UI>
      {{ } -}}
  
@@ -30,7 +56,7 @@ index 2d5cd3c..1e7223d 100644
      <Directory Id="TARGETDIR" Name="SourceDir">
        <Directory Id="${programFilesId}">
          {{ if (menuCategory) { }}
-@@ -110,6 +117,10 @@
+@@ -110,6 +136,10 @@
      {{-dirs}}
  
      <ComponentGroup Id="ProductComponents" Directory="APPLICATIONFOLDER">

--- a/patches/app-builder-lib+24.13.3.patch
+++ b/patches/app-builder-lib+24.13.3.patch
@@ -1,12 +1,12 @@
 diff --git a/node_modules/app-builder-lib/templates/msi/template.xml b/node_modules/app-builder-lib/templates/msi/template.xml
-index 2d5cd3c..04ed672 100644
+index 2d5cd3c..1e7223d 100644
 --- a/node_modules/app-builder-lib/templates/msi/template.xml
 +++ b/node_modules/app-builder-lib/templates/msi/template.xml
 @@ -26,6 +26,11 @@
      <Property Id="ARPPRODUCTICON" Value="${iconId}"/>
      {{ } -}}
  
-+    <CustomAction Id="removeExeInstaller" Directory="APPLICATIONFOLDER" ExeCommand="[APPLICATIONFOLDER]Uninstall ${productName}.exe /S" Execute="immediate" Impersonate="yes" Return="asyncWait"/>
++    <CustomAction Id="removeExeInstaller" Directory="APPLICATIONFOLDER" ExeCommand="[APPLICATIONFOLDER]Uninstall ${productName}.exe /S" Execute="immediate" Impersonate="yes" Return="ignore"/>
 +    <InstallExecuteSequence>
 +      <Custom Action="removeExeInstaller" Before="InstallInitialize"/>
 +    </InstallExecuteSequence>


### PR DESCRIPTION
#### Summary
I found two issues with the MSI installer that I've been able to remedy:
- At times, the MSI install when trying to remove the NSIS installation would just delete `Mattermost.exe` and appear to install successfully, but not actually. This was caused by the NSIS uninstallation running asynchronously with the MSI installer, so I've moved that to run synchronously instead.
- If the application is running the MSI installer is supposed to prompt you to close it, which it does, but it's doing so using the `WM_CLOSE` message which only (sometimes) closes the window and will not close the whole app. This can cause the installer to fail since the existing executable is still running, so I've added a custom prompt that tells the user to close the app manually (like the EXE installer used to do) before making any changes.

A couple known issues I've listed below, none of which require fixes at this time.

```release-note
Known Issues:
- Sometimes the app will not restart after auto-update. This is normal, and if this occurs the app can be safely launched manually.
- Sometimes during installation you may see this message: `Warning 1946. Property 'System.AppUserModel.ID' for shortcut 'Mattermost.Ink' could not be set.`. This can be safely ignored.
```
