### PR TITLE
[MM-58357] Account for monitor scale factor when creating the window from saved bounds

### DIFF
--- a/src/common/Validator.ts
+++ b/src/common/Validator.ts
@@ -179,7 +179,7 @@ export function validateArgs(data: Args) {
 }
 
 // validate bounds_info.json
-export function validateBoundsInfo(data: SavedWindowState) {
+export function validateBoundsInfo(data: SavedWindowState | null) {
     return validateAgainstSchema(data, boundsInfoSchema);
 }
 

--- a/src/main/windows/mainWindow.test.js
+++ b/src/main/windows/mainWindow.test.js
@@ -104,7 +104,7 @@ describe('main/windows/mainWindow', () => {
             BrowserWindow.mockImplementation(() => baseWindow);
             fs.readFileSync.mockImplementation(() => '{"x":400,"y":300,"width":1280,"height":700,"maximized":false,"fullscreen":false}');
             path.join.mockImplementation(() => 'anyfile.txt');
-            screen.getDisplayMatching.mockImplementation(() => ({bounds: {x: 0, y: 0, width: 1920, height: 1080}}));
+            screen.getDisplayMatching.mockImplementation(() => ({scaleFactor: 1, bounds: {x: 0, y: 0, width: 1920, height: 1080}}));
             isInsideRectangle.mockReturnValue(true);
             Validator.validateBoundsInfo.mockImplementation((data) => data);
             ContextMenu.mockImplementation(() => ({
@@ -124,6 +124,20 @@ describe('main/windows/mainWindow', () => {
                 y: 300,
                 width: 1280,
                 height: 700,
+                maximized: false,
+                fullscreen: false,
+            }));
+        });
+
+        it('should set scaled window size using bounds read from file', () => {
+            screen.getDisplayMatching.mockImplementation(() => ({scaleFactor: 2, bounds: {x: 0, y: 0, width: 1920, height: 1080}}));
+            const mainWindow = new MainWindow();
+            mainWindow.init();
+            expect(BrowserWindow).toHaveBeenCalledWith(expect.objectContaining({
+                x: 400,
+                y: 300,
+                width: 640,
+                height: 350,
                 maximized: false,
                 fullscreen: false,
             }));


### PR DESCRIPTION
#### Summary
When we create the main window of the app using saved bounds from the disk, if the screen that we are putting the window is scaled to a higher value than 100%, the window will try to render outside the boundaries of the screen in a multi-monitor environment.

This is due to a bug in Electron (https://github.com/electron/electron/issues/10862) where the `setBounds()` function of the `BrowserWindow` seems to ignore scale factor altogether. This PR contains a workaround that will manually resize the saved bounds using the scale factor of the target monitor to put the window back correctly, avoiding any multi-monitor overlap.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58357
Closes https://github.com/mattermost/desktop/issues/3039

```release-note
Fixed an issue where scaled monitors in a multi-monitor setup may cause the window to be opened across 2 screens.
```
