### PR TITLE
Support new notice-file-generator version

### DIFF
--- a/.config/notice-file/config.yaml
+++ b/.config/notice-file/config.yaml
@@ -8,8 +8,7 @@ reviewers:
   - mattermost/team-desktop
 search:
   - "package.json"
-dependencies:
-  - "wix"
-devDependencies: []
-
+additionalDependencies:
+  - wix
+includeDevDependencies: true
 ...


### PR DESCRIPTION
#### Summary

This PR adapts the notice-file-generator config to the new schema. It should be merged only after [the corresponding changes are themselves merged](https://github.com/mattermost/notice-file-generator/pull/17).

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-7792

#### Release Note
```release-note
NONE
```
