### PR TITLE
[MM-46634] Force window to be focused after navigation on notification click

### DIFF
--- a/src/main/notifications/index.test.ts
+++ b/src/main/notifications/index.test.ts
@@ -4,8 +4,8 @@
 'use strict';
 import notMockedCP from 'child_process';
 
-import type {BrowserWindow, WebContents} from 'electron';
-import {Notification as NotMockedNotification, shell, app} from 'electron';
+import type {BrowserWindow, IpcMain, IpcMainEvent, WebContents} from 'electron';
+import {Notification as NotMockedNotification, shell, app, ipcMain as NotMockedIpcMain} from 'electron';
 import {getDoNotDisturb as notMockedGetDarwinDoNotDisturb} from 'macos-notification-state';
 import {getFocusAssist as notMockedGetFocusAssist} from 'windows-focus-assist';
 
@@ -28,6 +28,7 @@ const Config = jest.mocked(notMockedConfig);
 const MainWindow = jest.mocked(notMockedMainWindow);
 const localizeMessage = jest.mocked(notMockedLocalizeMessage);
 const cp = jest.mocked(notMockedCP);
+const ipcMain = jest.mocked(NotMockedIpcMain);
 
 const mentions: Array<{body: string; value: any}> = [];
 
@@ -68,6 +69,10 @@ jest.mock('electron', () => {
             dock: {
                 bounce: jest.fn(),
             },
+        },
+        ipcMain: {
+            on: jest.fn(),
+            off: jest.fn(),
         },
         Notification: NotificationMock,
         shell: {
@@ -273,7 +278,12 @@ describe('main/notifications', () => {
             });
         });
 
-        it('should switch view when clicking on notification', async () => {
+        it('should switch view when clicking on notification, but after the navigation has happened', async () => {
+            let listener: (event: IpcMainEvent, ...args: any[]) => void;
+            ipcMain.on.mockImplementation((channel: string, cb: (event: IpcMainEvent, ...args: any[]) => void): IpcMain => {
+                listener = cb;
+                return ipcMain;
+            });
             await NotificationManager.displayMention(
                 'click_test',
                 'mention_click_body',
@@ -286,6 +296,12 @@ describe('main/notifications', () => {
             );
             const mention = mentions.find((m) => m.body === 'mention_click_body');
             mention?.value.click();
+            expect(MainWindow.show).not.toHaveBeenCalled();
+            expect(ViewManager.showById).not.toHaveBeenCalledWith('server_id');
+
+            // @ts-expect-error "Set by the click handler"
+            listener?.({} as unknown as IpcMainEvent);
+
             expect(MainWindow.show).toHaveBeenCalled();
             expect(ViewManager.showById).toHaveBeenCalledWith('server_id');
         });


### PR DESCRIPTION
#### Summary
When the webapp is focused, we make a call to mark the current channel as read. When a notification is clicked, we make a call to both focus the window and navigate to the new route if needed. This introduces a race condition in which the channel the user was on before switching to the one where the notification was triggered from would be marked read instead, causing the perception that an unread was missed.

This doesn't really happen much on the web side, as the calls are all run as part of a single thread and the `push()` action will likely update the `currentChannel` value before the focus handle can get in the way, but on Desktop App the focus action is called much earlier and done as a result of Electron telling the renderer process to focus. Then afterwards an IPC messages takes care of the routing.

This PR waits for the navigation callback from the webapp before focusing the application ensuring that the webapp will have switched to the new location before the focus trigger happens.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46634

```release-note
Fixed an issue where clicking a notification would clear unreads for the wrong channel.
```
