### PR TITLE
[MM-58455] Add error handling when FocusStatus is not authorized on macOS

### DIFF
--- a/src/main/app/initialize.test.js
+++ b/src/main/app/initialize.test.js
@@ -143,6 +143,7 @@ jest.mock('main/CriticalErrorHandler', () => ({
 }));
 jest.mock('main/notifications', () => ({
     displayDownloadCompleted: jest.fn(),
+    getDoNotDisturb: jest.fn(),
 }));
 jest.mock('main/ParseArgs', () => jest.fn());
 jest.mock('common/servers/serverManager', () => ({

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -47,6 +47,7 @@ import {configPath, updatePaths} from 'main/constants';
 import CriticalErrorHandler from 'main/CriticalErrorHandler';
 import downloadsManager from 'main/downloadsManager';
 import i18nManager from 'main/i18nManager';
+import {getDoNotDisturb} from 'main/notifications';
 import parseArgs from 'main/ParseArgs';
 import PermissionsManager from 'main/permissionsManager';
 import Tray from 'main/tray/tray';
@@ -373,6 +374,9 @@ async function initializeAfterAppReady() {
             }
         }
     }
+
+    // Call this to initiate a permissions check for DND state
+    getDoNotDisturb();
 
     // listen for status updates and pass on to renderer
     UserActivityMonitor.on('status', (status) => {

--- a/src/main/notifications/index.ts
+++ b/src/main/notifications/index.ts
@@ -27,6 +27,11 @@ class NotificationManager {
     private upgradeNotification?: NewVersionNotification;
     private restartToUpgradeNotification?: UpgradeNotification;
 
+    constructor() {
+        // Run this very early to perform an early permission check
+        getDoNotDisturb();
+    }
+
     public async displayMention(title: string, body: string, channelId: string, teamId: string, url: string, silent: boolean, webcontents: Electron.WebContents, soundName: string) {
         log.debug('displayMention', {title, channelId, teamId, url, silent, soundName});
 

--- a/src/main/notifications/index.ts
+++ b/src/main/notifications/index.ts
@@ -27,11 +27,6 @@ class NotificationManager {
     private upgradeNotification?: NewVersionNotification;
     private restartToUpgradeNotification?: UpgradeNotification;
 
-    constructor() {
-        // Run this very early to perform an early permission check
-        getDoNotDisturb();
-    }
-
     public async displayMention(title: string, body: string, channelId: string, teamId: string, url: string, silent: boolean, webcontents: Electron.WebContents, soundName: string) {
         log.debug('displayMention', {title, channelId, teamId, url, silent, soundName});
 
@@ -202,7 +197,7 @@ class NotificationManager {
     }
 }
 
-async function getDoNotDisturb() {
+export async function getDoNotDisturb() {
     if (process.platform === 'win32') {
         return getWindowsDoNotDisturb();
     }

--- a/src/main/notifications/index.ts
+++ b/src/main/notifications/index.ts
@@ -204,7 +204,13 @@ async function getDoNotDisturb() {
 
     // We have to turn this off for dev mode because the Electron binary doesn't have the focus center API entitlement
     if (process.platform === 'darwin' && !isDev) {
-        return getDarwinDoNotDisturb();
+        try {
+            const dnd = await getDarwinDoNotDisturb();
+            return dnd;
+        } catch (e) {
+            log.warn('macOS DND check threw an error', e);
+            return false;
+        }
     }
 
     if (process.platform === 'linux') {


### PR DESCRIPTION
#### Summary
A recent change that allowed the macOS app to correctly use the `FocusStatus` to prevent notifications under DND was completely stopping notifications if permission wasn't given. This was caused by the app not performing any error handling from the DND check, which would throw an error if the app wasn't authorized to check the status.

This PR adds that error handling, and logs a warning in the logs to denote that the check failed.

#### Ticket Link
Closes https://github.com/mattermost/desktop/issues/3052
https://mattermost.atlassian.net/browse/MM-58455

```release-note
Fixed an issue where notifications would not show on macOS in certain cases.
```
