### PR TITLE
[MM-58586] Calls: Add startingCall parameter to calls widget startup params

### DIFF
--- a/api-types/index.ts
+++ b/api-types/index.ts
@@ -46,6 +46,7 @@ export type DesktopAPI = {
         title: string;
         rootID: string;
         channelURL: string;
+        startingCall?: boolean;
     }) => Promise<{callID: string; sessionID: string}>;
     leaveCall: () => void;
 

--- a/api-types/lib/index.d.ts
+++ b/api-types/lib/index.d.ts
@@ -41,6 +41,7 @@ export type DesktopAPI = {
         title: string;
         rootID: string;
         channelURL: string;
+        startingCall?: boolean;
     }) => Promise<{
         callID: string;
         sessionID: string;

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {IpcMainEvent, Rectangle, Event, IpcMainInvokeEvent} from 'electron';
+import type {Event, IpcMainEvent, IpcMainInvokeEvent, Rectangle} from 'electron';
 import {BrowserWindow, desktopCapturer, ipcMain, systemPreferences} from 'electron';
 
 import ServerViewState from 'app/serverViewState';
@@ -36,10 +36,7 @@ import ViewManager from 'main/views/viewManager';
 import webContentsEventManager from 'main/views/webContentEvents';
 import MainWindow from 'main/windows/mainWindow';
 
-import type {
-    CallsJoinCallMessage,
-    CallsWidgetWindowConfig,
-} from 'types/calls';
+import type {CallsJoinCallMessage, CallsWidgetWindowConfig} from 'types/calls';
 
 const log = new Logger('CallsWidgetWindow');
 
@@ -124,6 +121,9 @@ export class CallsWidgetWindow {
         }
         if (this.options?.rootID) {
             u.searchParams.append('root_id', this.options.rootID);
+        }
+        if (this.options?.startingCall) {
+            u.searchParams.append('starting_call', this.options.startingCall ? 'true' : 'false');
         }
 
         return u.toString();
@@ -475,6 +475,7 @@ export class CallsWidgetWindow {
             title: msg.title,
             rootID: msg.rootID,
             channelURL: msg.channelURL,
+            startingCall: msg.startingCall,
         });
 
         return promise;

--- a/src/types/calls.ts
+++ b/src/types/calls.ts
@@ -5,6 +5,7 @@ export type CallsWidgetWindowConfig = {
     title: string;
     rootID: string;
     channelURL: string;
+    startingCall?: boolean;
 }
 
 export type CallsJoinCallMessage = CallsWidgetWindowConfig;


### PR DESCRIPTION
#### Summary
- To support https://github.com/mattermost/mattermost-plugin-calls/pull/767 we needed to send whether the widget was being used to start a call or join a call. 
- using `startingCall` allows us to default to `Joining...` as the message for older versions of desktop.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-58586

#### Release Note
```release-note
NONE
```
