### PR TITLE
[MM-58593] Ensure desktop app reloads the current URL when reloading manually

### DIFF
--- a/src/main/views/viewManager.test.js
+++ b/src/main/views/viewManager.test.js
@@ -158,6 +158,25 @@ describe('main/views/viewManager', () => {
         });
     });
 
+    describe('reload', () => {
+        const viewManager = new ViewManager();
+        const currentView = {
+            currentURL: new URL('http://server-1.com/team/channel'),
+            reload: jest.fn(),
+        };
+        viewManager.views.set('view1', currentView);
+        viewManager.currentView = 'view1';
+
+        afterEach(() => {
+            jest.resetAllMocks();
+        });
+
+        it('should reload using the current URL', () => {
+            viewManager.reload();
+            expect(currentView.reload).toBeCalledWith(new URL('http://server-1.com/team/channel'));
+        });
+    });
+
     describe('handleReloadConfiguration', () => {
         const viewManager = new ViewManager();
 

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -165,7 +165,7 @@ export class ViewManager {
         const currentView = this.getCurrentView();
         if (currentView) {
             LoadingScreen.show();
-            currentView.reload();
+            currentView.reload(currentView.currentURL);
         }
     };
 


### PR DESCRIPTION
#### Summary
The Desktop App was always reloading the base URL when hitting `Cmd/Ctrl+R`, which would usually work when the current channel was the one you were on, but would sometimes navigate you elsewhere. This could be observed when reloading on the Threads view.

This PR changes the behaviour to reload the current URL when available, so that we try to stay on the same page.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58593

```release-note
Fixed an issue where reloading the webapp would not always take you back to the same URL
```
