### PR TITLE
[MM-58357] Disable window scaling for OSes that aren't Windows

### DIFF
--- a/src/main/windows/mainWindow.test.js
+++ b/src/main/windows/mainWindow.test.js
@@ -129,7 +129,12 @@ describe('main/windows/mainWindow', () => {
             }));
         });
 
-        it('should set scaled window size using bounds read from file', () => {
+        it('should set scaled window size on Windows using bounds read from file', () => {
+            const originalPlatform = process.platform;
+            Object.defineProperty(process, 'platform', {
+                value: 'win32',
+            });
+
             screen.getDisplayMatching.mockImplementation(() => ({scaleFactor: 2, bounds: {x: 0, y: 0, width: 1920, height: 1080}}));
             const mainWindow = new MainWindow();
             mainWindow.init();
@@ -141,6 +146,33 @@ describe('main/windows/mainWindow', () => {
                 maximized: false,
                 fullscreen: false,
             }));
+
+            Object.defineProperty(process, 'platform', {
+                value: originalPlatform,
+            });
+        });
+
+        it('should NOT set scaled window size on Mac using bounds read from file', () => {
+            const originalPlatform = process.platform;
+            Object.defineProperty(process, 'platform', {
+                value: 'darwin',
+            });
+
+            screen.getDisplayMatching.mockImplementation(() => ({scaleFactor: 2, bounds: {x: 0, y: 0, width: 1920, height: 1080}}));
+            const mainWindow = new MainWindow();
+            mainWindow.init();
+            expect(BrowserWindow).toHaveBeenCalledWith(expect.objectContaining({
+                x: 400,
+                y: 300,
+                width: 1280,
+                height: 700,
+                maximized: false,
+                fullscreen: false,
+            }));
+
+            Object.defineProperty(process, 'platform', {
+                value: originalPlatform,
+            });
         });
 
         it('should set default window size when failing to read bounds from file', () => {

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -258,12 +258,15 @@ export class MainWindow extends EventEmitter {
             if (!(matchingScreen && (isInsideRectangle(matchingScreen.bounds, savedWindowState) || savedWindowState.maximized))) {
                 throw new Error('Provided bounds info are outside the bounds of your screen, using defaults instead.');
             }
+
             // We check for the monitor's scale factor when we want to set these bounds
             // This is due to a long running Electron issue: https://github.com/electron/electron/issues/10862
+            // This only needs to be done on Windows, it causes strange behaviour on Mac otherwise
+            const scaleFactor = process.platform === 'win32' ? matchingScreen.scaleFactor : 1;
             return {
                 ...savedWindowState,
-                width: Math.floor(savedWindowState.width / matchingScreen.scaleFactor),
-                height: Math.floor(savedWindowState.height / matchingScreen.scaleFactor),
+                width: Math.floor(savedWindowState.width / scaleFactor),
+                height: Math.floor(savedWindowState.height / scaleFactor),
             };
         } catch (e) {
             log.error(e);


### PR DESCRIPTION
#### Summary
When I fixed the window scaling issue on Windows causing the `setSize` call to size the window strangely, on Mac some displays were misreporting the `scaleFactor` based on other factors (ie. the Retina Display technically having a higher pixel density, setting the `scaleFactor` to 2). This would cause some mini windows to popup that were 1/4 the size they should be.

To fix this, I just limited the window scaling fix to Windows since it seems to report just based on the user's scale factor.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58357

```release-note
NONE
```
