### PR TITLE
[GH-3069] Fix release script to use correct filenames for Windows ZIPs

### DIFF
--- a/scripts/generate_release_markdown.sh
+++ b/scripts/generate_release_markdown.sh
@@ -26,8 +26,8 @@ $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win-x64.msi")
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win-arm64.msi") (beta)
 
 #### Windows - zip files
-$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win64.zip")
-$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-arm64.zip") (beta)
+$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win-x64.zip")
+$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win-arm64.zip") (beta)
 
 #### Mac
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-mac-universal.dmg")


### PR DESCRIPTION
#### Summary
It was pointed out that I messed up the release script for the GitHub release, when I changed up the release build process. This PR fixes the script so that it uses the right filenames.

#### Ticket Link
Closes https://github.com/mattermost/desktop/issues/3069

```release-note
NONE
```
