### PR TITLE
[MM-58780] Don't account for scaleFactor on Windows when resizing if the matching screen is the primary monitor

### DIFF
--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -260,9 +260,10 @@ export class MainWindow extends EventEmitter {
             }
 
             // We check for the monitor's scale factor when we want to set these bounds
+            // But only if it's not the primary monitor, otherwise it works fine as is
             // This is due to a long running Electron issue: https://github.com/electron/electron/issues/10862
             // This only needs to be done on Windows, it causes strange behaviour on Mac otherwise
-            const scaleFactor = process.platform === 'win32' ? matchingScreen.scaleFactor : 1;
+            const scaleFactor = process.platform === 'win32' && matchingScreen.id !== screen.getPrimaryDisplay().id ? matchingScreen.scaleFactor : 1;
             return {
                 ...savedWindowState,
                 width: Math.floor(savedWindowState.width / scaleFactor),


### PR DESCRIPTION
#### Summary
Further to the fix I did for the Electron bug here: https://github.com/electron/electron/issues/10862
The primary monitor on Windows doesn't need to care about the scale factor, and will respect it when resetting its window bounds. This PR checks to see if the primary monitor is the matching screen and won't use the `scaleFactor` if the windows bounds aren't set.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58780
Closes https://github.com/mattermost/desktop/issues/3067

```release-note
Fixed an issue where the window size will get smaller on Windows after a restart if the primary monitor is used and is scaled
```
