### PR TITLE
[MM-58291] Show context menu in Calls popout

### DIFF
--- a/src/main/windows/callsWidgetWindow.test.js
+++ b/src/main/windows/callsWidgetWindow.test.js
@@ -74,6 +74,17 @@ jest.mock('../utils', () => ({
     composeUserAgent: jest.fn(),
 }));
 
+const mockContextMenuReload = jest.fn();
+const mockContextMenuDispose = jest.fn();
+jest.mock('../contextMenu', () => {
+    return jest.fn().mockImplementation(() => {
+        return {
+            reload: mockContextMenuReload,
+            dispose: mockContextMenuDispose,
+        };
+    });
+});
+
 describe('main/windows/callsWidgetWindow', () => {
     describe('onShow', () => {
         const callsWidgetWindow = new CallsWidgetWindow();
@@ -385,8 +396,11 @@ describe('main/windows/callsWidgetWindow', () => {
                 },
                 id: 'webContentsId',
                 getURL: () => ('http://myurl.com'),
+                removeListener: jest.fn(),
             },
+            off: jest.fn(),
             loadURL: jest.fn(),
+            isDestroyed: jest.fn(() => false),
         };
 
         const callsWidgetWindow = new CallsWidgetWindow();
@@ -395,6 +409,7 @@ describe('main/windows/callsWidgetWindow', () => {
         expect(WebContentsEventManager.addWebContentsEventListeners).toHaveBeenCalledWith(popOut.webContents);
         expect(redirectListener).toBeDefined();
         expect(frameFinishedLoadListener).toBeDefined();
+        expect(mockContextMenuReload).toHaveBeenCalledTimes(1);
 
         const event = {preventDefault: jest.fn()};
         redirectListener(event);
@@ -405,6 +420,7 @@ describe('main/windows/callsWidgetWindow', () => {
 
         closedListener();
         expect(callsWidgetWindow.popOut).not.toBeDefined();
+        expect(mockContextMenuDispose).toHaveBeenCalled();
     });
 
     it('getViewURL', () => {

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -43,6 +43,8 @@ import type {
     CallsWidgetWindowConfig,
 } from 'types/calls';
 
+import ContextMenu from '../contextMenu';
+
 const log = new Logger('CallsWidgetWindow');
 
 export class CallsWidgetWindow {
@@ -294,8 +296,12 @@ export class CallsWidgetWindow {
             event.preventDefault();
         });
 
+        const contextMenu = new ContextMenu({}, this.popOut);
+        contextMenu.reload();
+
         this.popOut.on('closed', () => {
             delete this.popOut;
+            contextMenu.dispose();
         });
 
         // Set the userAgent so that the widget's popout is considered a desktop window in the webapp code.


### PR DESCRIPTION
#### Summary

PR adds the expected context menu upon right-clicking inside the Calls pop-out window.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-58291

#### Screenshots

![image](https://github.com/mattermost/desktop/assets/1832946/16e496a4-1fff-4dd9-9266-7e37a380b1ab)

#### Release Note

```release-note
Fixed missing context menu upon right-click in calls popout window
```


