### PR TITLE
[MM-59480] Remove logging of the title/body of notifications

### DIFF
--- a/src/main/app/intercom.ts
+++ b/src/main/app/intercom.ts
@@ -113,7 +113,7 @@ export function handleWelcomeScreenModal() {
 }
 
 export function handleMentionNotification(event: IpcMainInvokeEvent, title: string, body: string, channelId: string, teamId: string, url: string, silent: boolean, soundName: string) {
-    log.debug('handleMentionNotification', {title, body, channelId, teamId, url, silent, soundName});
+    log.debug('handleMentionNotification', {channelId, teamId, url, silent, soundName});
     return NotificationManager.displayMention(title, body, channelId, teamId, url, silent, event.sender, soundName);
 }
 

--- a/src/main/notifications/index.ts
+++ b/src/main/notifications/index.ts
@@ -32,7 +32,7 @@ class NotificationManager {
     }
 
     public async displayMention(title: string, body: string, channelId: string, teamId: string, url: string, silent: boolean, webcontents: Electron.WebContents, soundName: string) {
-        log.debug('displayMention', {title, channelId, teamId, url, silent, soundName});
+        log.debug('displayMention', {channelId, teamId, url, silent, soundName});
 
         if (!Notification.isSupported()) {
             log.error('notification not supported');


### PR DESCRIPTION
#### Summary
We were still the title of notifications in DEBUG logging mode, and `handleMentionNotification` was still logging the body, which could be a privacy concern. This PR removes those fields from the log since they aren't generally necessary for debugging anything with the Desktop App.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59490

```release-note
NONE
```
