### PR TITLE
[MM-59492] Fixed `isInsideRectangle`, and removed null check for matchingScreen since it will always return something

### DIFF
--- a/src/main/utils.test.js
+++ b/src/main/utils.test.js
@@ -162,4 +162,19 @@ describe('main/utils', () => {
             expect(Utils.shouldIncrementFilename('filename.txt')).toBe('filename (1).txt');
         });
     });
+
+    describe('isInsideRectangle', () => {
+        it.each([
+            [{x: 0, y: 0, width: 1920, height: 1080}, {x: 100, y: 100, width: 1280, height: 720}, true],
+            [{x: 0, y: 0, width: 1920, height: 1080}, {x: -100, y: 100, width: 1280, height: 720}, false],
+            [{x: 0, y: 0, width: 1920, height: 1080}, {x: 100, y: -100, width: 1280, height: 720}, false],
+            [{x: 0, y: 0, width: 1920, height: 1080}, {x: 100, y: 100, width: 2560, height: 720}, false],
+            [{x: 0, y: 0, width: 1920, height: 1080}, {x: 100, y: 100, width: 1280, height: 1440}, false],
+            [{x: -1920, y: 0, width: 1920, height: 1080}, {x: 100, y: 100, width: 1280, height: 720}, false],
+            [{x: -1920, y: 0, width: 1920, height: 1080}, {x: -1820, y: 100, width: 1280, height: 720}, true],
+            [{x: 0, y: -1080, width: 1920, height: 1080}, {x: 100, y: -980, width: 1280, height: 720}, true],
+        ])('should match case', (a, b, expected) => {
+            expect(Utils.isInsideRectangle(a, b)).toBe(expected);
+        });
+    });
 });

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -18,7 +18,23 @@ import Utils from 'common/utils/util';
 import type {Args} from 'types/args';
 
 export function isInsideRectangle(container: Electron.Rectangle, rect: Electron.Rectangle) {
-    return container.x <= rect.x && container.y <= rect.y && container.width >= rect.width && container.height >= rect.height;
+    if (container.x > rect.x) {
+        return false;
+    }
+
+    if (container.x + container.width < rect.x + rect.width) {
+        return false;
+    }
+
+    if (container.y > rect.y) {
+        return false;
+    }
+
+    if (container.y + container.height < rect.y + rect.height) {
+        return false;
+    }
+
+    return true;
 }
 
 export function shouldBeHiddenOnStartup(parsedArgv: Args) {

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -254,8 +254,8 @@ export class MainWindow extends EventEmitter {
                 throw new Error('Provided bounds info file does not validate, using defaults instead.');
             }
             const matchingScreen = screen.getDisplayMatching(savedWindowState);
-            log.debug('matching screen for main window', matchingScreen);
-            if (!(matchingScreen && (isInsideRectangle(matchingScreen.bounds, savedWindowState) || savedWindowState.maximized))) {
+            log.debug('closest matching screen for main window', matchingScreen);
+            if (!(isInsideRectangle(matchingScreen.bounds, savedWindowState) || savedWindowState.maximized)) {
                 throw new Error('Provided bounds info are outside the bounds of your screen, using defaults instead.');
             }
 


### PR DESCRIPTION
#### Summary
There was a case as described in the ticket below where a user could get the window to display off the screen. This was due to a flaw in `isInsideRectangle` where we weren't checking the bounds correctly (we were only checking that it was inside from the top-left corner, which is fine in single-monitor setups, but not multi-monitor). Additionally, I had expected `getMatchingScreen` to return `false` if it doesn't find one, but it always just gets the primary screen in the worse case.

This PR fixes and adds tests for `isInsideRectangle`, as well removes the null check for `getMatchingScreen`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59492
Closes https://github.com/mattermost/desktop/issues/3087

```release-note
Fixed an issue where the window might be rendered off-screen in multi-monitor setups
```
