### PR TITLE
[MM-59046] Flip fuses for cookie encryption, node options and ASAR integrity

### DIFF
--- a/scripts/afterpack.js
+++ b/scripts/afterpack.js
@@ -43,6 +43,11 @@ exports.default = async function afterPack(context) {
                 version: FuseVersion.V1,
                 [FuseV1Options.RunAsNode]: false, // Disables ELECTRON_RUN_AS_NODE
                 [FuseV1Options.EnableNodeCliInspectArguments]: false, // Disables --inspect
+                [FuseV1Options.EnableCookieEncryption]: true,
+                [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false, // Disables NODE_OPTIONS and NODE_EXTRA_CA_CERTS
+                // Can only verify on macOS right now, electron-builder doesn't support Windows ASAR integrity verification
+                [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: context.electronPlatformName === 'darwin' || context.electronPlatformName === 'mas',
+                [FuseV1Options.OnlyLoadAppFromAsar]: true,
             });
 
         if (context.electronPlatformName === 'linux') {


### PR DESCRIPTION
#### Summary
This PR flips a few more fuses in our app to disable certain functionality that can cause vulnerabilities. The fuses and their descriptions are detailed in this document: https://www.electronjs.org/docs/latest/tutorial/fuses.

One note is that the ASAR integrity fuse cannot be flipped on for anything but macOS currently. It's supported on Windows as of Electron v30, but `electron-builder` does not support it yet, so we can only turn it on for macOS right now.

I have yet to flip the `GrantFileProtocolExtraPrivileges` fuse, since it required a LOT more changes that I think are too risky to release right away, that change is [here](https://github.com/mattermost/desktop/pull/3095)

These cannot be tested outside of the built application as a note.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59046

```release-note
NONE
```
