### PR TITLE
[MM-59412] Reinstate the resize listener for Windows and the exception for willResize

### DIFF
--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -138,7 +138,7 @@ export class MainWindow extends EventEmitter {
             // This is mostly a fix for Windows 11 snapping
             this.win.on('moved', this.onResized);
         }
-        if (process.platform === 'linux') {
+        if (process.platform !== 'darwin') {
             this.win.on('resize', this.onResize);
         }
         this.win.webContents.on('before-input-event', this.onBeforeInputEvent);
@@ -515,8 +515,8 @@ export class MainWindow extends EventEmitter {
     private onResize = () => {
         log.silly('onResize');
 
-        // Workaround for macOS to stop the window from sending too many resize calls to the BrowserViews
-        if (process.platform === 'darwin' && this.isResizing) {
+        // Workaround for Windows to stop the window from sending too many resize calls to the BrowserViews
+        if (process.platform === 'win32' && this.isResizing) {
             return;
         }
         this.emitBounds();


### PR DESCRIPTION
#### Summary
On Windows, removing the window from snapped to unsnapped using the Windows+Arrow Keys, or when moving between screens using Shift+Windows+Arrow Keys, the BrowserViews inside would not resize correctly.

This PR brings back the `onResize` handler for Windows (which I believe was removed to try and improve performance) but includes an exception that if `onWillResize` is being called simultaneously it won't resize the window twice.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59412

```release-note
Fixed an issue where snapping the window on Windows would sometimes cause the inner BrowserView not to resize
```
