### PR TITLE
Build all windows targets on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,7 +104,7 @@ jobs:
           PFX: ${{ secrets.MM_DESKTOP_MSI_INSTALLER_PFX }}
           CSC_LINK: ${{ secrets.MM_DESKTOP_MSI_INSTALLER_CSC_LINK }}
         run: |
-          npm run package:windows-installers
+          npm run package:windows
       - name: release/package
         run: |
           mkdir -p ./build/win-release


### PR DESCRIPTION
#### Summary
I missed adding the Windows ZIPs to the `release` pipeline. This PR adds those.

```release-note
NONE
```
