### PR TITLE
[MM-59840] Add Linux title bar buttons using `titleBarOverlay` field of `BrowserWindow`

### DIFF
--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import type {BrowserWindowConstructorOptions, Event, Input, IpcMainEvent} from 'electron';
+import type {BrowserWindowConstructorOptions, Event, Input} from 'electron';
 import {app, BrowserWindow, dialog, globalShortcut, ipcMain, screen} from 'electron';
 import {EventEmitter} from 'events';
 
@@ -254,7 +254,7 @@ export class MainWindow extends EventEmitter {
             color: Config.darkMode ? '#2e2e2e' : '#efefef',
             height: TAB_BAR_HEIGHT,
         };
-    }
+    };
 
     private getSavedWindowState = (): Partial<SavedWindowState> => {
         try {
@@ -559,11 +559,9 @@ export class MainWindow extends EventEmitter {
         this.win?.webContents.send(UPDATE_MENTIONS, viewId, newMentions, newUnreads, isExpired);
     };
 
-    private handleUpdateTitleBarOverlay = (event: IpcMainEvent) => {
-        if (this.win) {
-            this.win.setTitleBarOverlay(this.getTitleBarOverlay());
-        }
-    }
+    private handleUpdateTitleBarOverlay = () => {
+        this.win?.setTitleBarOverlay?.(this.getTitleBarOverlay());
+    };
 }
 
 const mainWindow = new MainWindow();

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import type {BrowserWindowConstructorOptions, Event, Input} from 'electron';
+import type {BrowserWindowConstructorOptions, Event, Input, IpcMainEvent} from 'electron';
 import {app, BrowserWindow, dialog, globalShortcut, ipcMain, screen} from 'electron';
 import {EventEmitter} from 'events';
 
@@ -24,11 +24,12 @@ import {
     MAIN_WINDOW_FOCUSED,
     VIEW_FINISHED_RESIZING,
     TOGGLE_SECURE_INPUT,
+    EMIT_CONFIGURATION,
 } from 'common/communication';
 import Config from 'common/config';
 import {Logger} from 'common/log';
 import ServerManager from 'common/servers/serverManager';
-import {DEFAULT_WINDOW_HEIGHT, DEFAULT_WINDOW_WIDTH, MINIMUM_WINDOW_HEIGHT, MINIMUM_WINDOW_WIDTH, SECOND} from 'common/utils/constants';
+import {DEFAULT_WINDOW_HEIGHT, DEFAULT_WINDOW_WIDTH, MINIMUM_WINDOW_HEIGHT, MINIMUM_WINDOW_WIDTH, SECOND, TAB_BAR_HEIGHT} from 'common/utils/constants';
 import Utils from 'common/utils/util';
 import * as Validator from 'common/Validator';
 import {boundsInfoPath} from 'main/constants';
@@ -61,6 +62,7 @@ export class MainWindow extends EventEmitter {
 
         ipcMain.handle(GET_FULL_SCREEN_STATUS, () => this.win?.isFullScreen());
         ipcMain.on(VIEW_FINISHED_RESIZING, this.handleViewFinishedResizing);
+        ipcMain.on(EMIT_CONFIGURATION, this.handleUpdateTitleBarOverlay);
 
         ServerManager.on(SERVERS_UPDATE, this.handleUpdateConfig);
 
@@ -81,6 +83,7 @@ export class MainWindow extends EventEmitter {
             frame: !this.isFramelessWindow(),
             fullscreen: this.shouldStartFullScreen(),
             titleBarStyle: 'hidden' as const,
+            titleBarOverlay: process.platform === 'linux' ? this.getTitleBarOverlay() : false,
             trafficLightPosition: {x: 12, y: 12},
             backgroundColor: '#fff', // prevents blurry text: https://electronjs.org/docs/faq#the-font-looks-blurry-what-is-this-and-what-can-i-do
             webPreferences: {
@@ -245,6 +248,13 @@ export class MainWindow extends EventEmitter {
     private isFramelessWindow = () => {
         return os.platform() === 'darwin' || (os.platform() === 'win32' && Utils.isVersionGreaterThanOrEqualTo(os.release(), '6.2'));
     };
+
+    private getTitleBarOverlay = () => {
+        return {
+            color: Config.darkMode ? '#2e2e2e' : '#efefef',
+            height: TAB_BAR_HEIGHT,
+        };
+    }
 
     private getSavedWindowState = (): Partial<SavedWindowState> => {
         try {
@@ -548,6 +558,12 @@ export class MainWindow extends EventEmitter {
     private handleUpdateAppStateForViewId = (viewId: string, isExpired: boolean, newMentions: number, newUnreads: boolean) => {
         this.win?.webContents.send(UPDATE_MENTIONS, viewId, newMentions, newUnreads, isExpired);
     };
+
+    private handleUpdateTitleBarOverlay = (event: IpcMainEvent) => {
+        if (this.win) {
+            this.win.setTitleBarOverlay(this.getTitleBarOverlay());
+        }
+    }
 }
 
 const mainWindow = new MainWindow();


### PR DESCRIPTION
#### Summary
With the upgrade to Electron v30, they seem to have quietly taken away the default window frame for Linux clients, or something else has broken in the configuration. However, they have given us a way to add native window buttons to Linux apps now, so this PR adds that overlay in the same way used by macOS.

This will require some follow-up for the next release to re-work how we do these window buttons for macOS and Windows, but this will fix the immediate issue for Linux users.

#### Ticket Link
Closes https://github.com/mattermost/desktop/issues/3102
https://mattermost.atlassian.net/browse/MM-59840

```release-note
Changed the window buttons on the Linux client to use the native ones provided by Electron, removed the frame
```
