### PR TITLE
[MM-59489] Change logged in tracking code for new API, check for `/` when navigating tabs

### DIFF
--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -98,7 +98,7 @@ export const NO_UPDATE_AVAILABLE = 'no-update-available';
 export const BROWSER_HISTORY_PUSH = 'browser-history-push';
 export const APP_LOGGED_IN = 'app-logged-in';
 export const APP_LOGGED_OUT = 'app-logged-out';
-export const TAB_LOGGED_IN = 'tab-logged-in';
+export const TAB_LOGIN_CHANGED = 'tab-login-changed';
 
 export const GET_AVAILABLE_SPELL_CHECKER_LANGUAGES = 'get-available-spell-checker-languages';
 

--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -98,6 +98,7 @@ export const NO_UPDATE_AVAILABLE = 'no-update-available';
 export const BROWSER_HISTORY_PUSH = 'browser-history-push';
 export const APP_LOGGED_IN = 'app-logged-in';
 export const APP_LOGGED_OUT = 'app-logged-out';
+export const TAB_LOGGED_IN = 'tab-logged-in';
 
 export const GET_AVAILABLE_SPELL_CHECKER_LANGUAGES = 'get-available-spell-checker-languages';
 

--- a/src/main/preload/externalAPI.ts
+++ b/src/main/preload/externalAPI.ts
@@ -41,7 +41,7 @@ import {
     GET_DESKTOP_SOURCES,
     UNREADS_AND_MENTIONS,
     LEGACY_OFF,
-    TAB_LOGGED_IN,
+    TAB_LOGIN_CHANGED,
 } from 'common/communication';
 
 import type {ExternalAPI} from 'types/externalAPI';
@@ -73,8 +73,8 @@ const desktopAPI: DesktopAPI = {
     setSessionExpired: (isExpired) => ipcRenderer.send(SESSION_EXPIRED, isExpired),
     onUserActivityUpdate: (listener) => createListener(USER_ACTIVITY_UPDATE, listener),
 
-    onLogin: () => ipcRenderer.send(TAB_LOGGED_IN, true),
-    onLogout: () => ipcRenderer.send(TAB_LOGGED_IN, false),
+    onLogin: () => ipcRenderer.send(TAB_LOGIN_CHANGED, true),
+    onLogout: () => ipcRenderer.send(TAB_LOGIN_CHANGED, false),
 
     // Unreads/mentions/notifications
     sendNotification: (title, body, channelId, teamId, url, silent, soundName) =>

--- a/src/main/preload/externalAPI.ts
+++ b/src/main/preload/externalAPI.ts
@@ -41,6 +41,7 @@ import {
     GET_DESKTOP_SOURCES,
     UNREADS_AND_MENTIONS,
     LEGACY_OFF,
+    TAB_LOGGED_IN,
 } from 'common/communication';
 
 import type {ExternalAPI} from 'types/externalAPI';
@@ -72,8 +73,8 @@ const desktopAPI: DesktopAPI = {
     setSessionExpired: (isExpired) => ipcRenderer.send(SESSION_EXPIRED, isExpired),
     onUserActivityUpdate: (listener) => createListener(USER_ACTIVITY_UPDATE, listener),
 
-    onLogin: () => ipcRenderer.send(APP_LOGGED_IN),
-    onLogout: () => ipcRenderer.send(APP_LOGGED_OUT),
+    onLogin: () => ipcRenderer.send(TAB_LOGGED_IN, true),
+    onLogout: () => ipcRenderer.send(TAB_LOGGED_IN, false),
 
     // Unreads/mentions/notifications
     sendNotification: (title, body, channelId, teamId, url, silent, soundName) =>

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -33,7 +33,7 @@ import {
     REQUEST_BROWSER_HISTORY_STATUS,
     LEGACY_OFF,
     UNREADS_AND_MENTIONS,
-    TAB_LOGGED_IN,
+    TAB_LOGIN_CHANGED,
 } from 'common/communication';
 import Config from 'common/config';
 import {Logger} from 'common/log';
@@ -81,7 +81,7 @@ export class ViewManager {
         ipcMain.on(BROWSER_HISTORY_PUSH, this.handleBrowserHistoryPush);
         ipcMain.on(APP_LOGGED_IN, this.handleAppLoggedIn);
         ipcMain.on(APP_LOGGED_OUT, this.handleAppLoggedOut);
-        ipcMain.on(TAB_LOGGED_IN, this.handleTabLoggedIn);
+        ipcMain.on(TAB_LOGIN_CHANGED, this.handleTabLoginChanged);
         ipcMain.on(RELOAD_CURRENT_VIEW, this.handleReloadCurrentView);
         ipcMain.on(UNREAD_RESULT, this.handleUnreadChanged);
         ipcMain.on(UNREADS_AND_MENTIONS, this.handleUnreadsAndMentionsChanged);
@@ -506,7 +506,7 @@ export class ViewManager {
         flushCookiesStore();
     };
 
-    private handleTabLoggedIn = (event: IpcMainEvent, loggedIn: boolean) => {
+    private handleTabLoginChanged = (event: IpcMainEvent, loggedIn: boolean) => {
         log.debug('handleTabLoggedIn', event.sender.id);
         const view = this.getViewByWebContentsId(event.sender.id);
         if (!view) {


### PR DESCRIPTION
#### Summary
One of the changes to the Desktop API was that individual tabs report their login change directly to the Desktop App instead of relying on local storage to do so. At some point it appears that `localStorage` was not syncing to inactive tabs, which makes sense given that that doesn't happen on Chrome either unless the tab is focused. This caused no issue on web app, but the navigation code on Desktop App was effected in that if you logged out of another tab, logged back in on the main tab and tried to navigate to the other tab using a link of some kind, the other tab would try to load and not be logged in correctly before it tried to navigate, causing a session expiry.

This PR fixes the log in tracking code for the new API, forcing each individual tab to reload if necessary (like the old code, but this time just the individual tab is responsible for forcing the reload), and also checks to make sure that on logout, we go back to the Channels tab, since it seems like that wasn't always happening either.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59489

```release-note
Fixed an issue where logging out from the Boards/Playbooks tabs and trying to navigate after logging back in would force an unexpected logout
```
