### PR TITLE
[MM-59480] Fix crash on Windows caused by titlebar overlay

### DIFF
--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -560,7 +560,9 @@ export class MainWindow extends EventEmitter {
     };
 
     private handleUpdateTitleBarOverlay = () => {
-        this.win?.setTitleBarOverlay?.(this.getTitleBarOverlay());
+        if (process.platform === 'linux') {
+            this.win?.setTitleBarOverlay?.(this.getTitleBarOverlay());
+        }
     };
 }
 


### PR DESCRIPTION
#### Summary
Adding the `titleBarOverlay` for just Linux crashes Windows when the app tries to load (apparently calling the `set` function will crash if it's not enabled :(). This PR makes sure we're on Linux and that it's enabled before we try to set it.

```release-note
NONE
```
