### PR TITLE
[MM-51514] Allow Calls widget to open user settings

### DIFF
--- a/api-types/index.ts
+++ b/api-types/index.ts
@@ -76,6 +76,9 @@ export type DesktopAPI = {
     openStopRecordingModal: (channelID: string) => void;
     onOpenStopRecordingModal: (listener: (channelID: string) => void) => () => void;
 
+    openCallsUserSettings: () => void;
+    onOpenCallsUserSettings: (listener: () => void) => () => void;
+
     // Utility
     unregister: (channel: string) => void;
 }

--- a/api-types/lib/index.d.ts
+++ b/api-types/lib/index.d.ts
@@ -63,5 +63,7 @@ export type DesktopAPI = {
     onOpenThreadForCalls: (listener: (threadID: string) => void) => () => void;
     openStopRecordingModal: (channelID: string) => void;
     onOpenStopRecordingModal: (listener: (channelID: string) => void) => () => void;
+    openCallsUserSettings: () => void;
+    onOpenCallsUserSettings: (listener: () => void) => () => void;
     unregister: (channel: string) => void;
 };

--- a/api-types/package-lock.json
+++ b/api-types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mattermost/desktop-api",
-  "version": "5.9.0-2",
+  "version": "5.10.0-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mattermost/desktop-api",
-      "version": "5.9.0-2",
+      "version": "5.10.0-1",
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^4.3.0 || ^5.0.0"

--- a/api-types/package-lock.json
+++ b/api-types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mattermost/desktop-api",
-  "version": "5.9.0-1",
+  "version": "5.9.0-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mattermost/desktop-api",
-      "version": "5.9.0-1",
+      "version": "5.9.0-2",
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^4.3.0 || ^5.0.0"

--- a/api-types/package.json
+++ b/api-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/desktop-api",
-  "version": "5.9.0-1",
+  "version": "5.9.0-2",
   "description": "Shared types for the Desktop App API provided to the Web App",
   "keywords": [
     "mattermost"

--- a/api-types/package.json
+++ b/api-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/desktop-api",
-  "version": "5.9.0-2",
+  "version": "5.10.0-1",
   "description": "Shared types for the Desktop App API provided to the Web App",
   "keywords": [
     "mattermost"

--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -134,6 +134,7 @@ export const CALLS_ERROR = 'calls-error';
 export const CALLS_JOIN_REQUEST = 'calls-join-request';
 export const CALLS_WIDGET_OPEN_THREAD = 'calls-widget-open-thread';
 export const CALLS_WIDGET_OPEN_STOP_RECORDING_MODAL = 'calls-widget-open-stop-recording-modal';
+export const CALLS_WIDGET_OPEN_USER_SETTINGS = 'calls-widget-open-user-settings';
 
 export const REQUEST_CLEAR_DOWNLOADS_DROPDOWN = 'request-clear-downloads-dropdown';
 export const CLOSE_DOWNLOADS_DROPDOWN = 'close-downloads-dropdown';

--- a/src/main/preload/externalAPI.ts
+++ b/src/main/preload/externalAPI.ts
@@ -38,6 +38,7 @@ import {
     CALLS_POPOUT_FOCUS,
     CALLS_WIDGET_OPEN_THREAD,
     CALLS_WIDGET_OPEN_STOP_RECORDING_MODAL,
+    CALLS_WIDGET_OPEN_USER_SETTINGS,
     GET_DESKTOP_SOURCES,
     UNREADS_AND_MENTIONS,
     LEGACY_OFF,
@@ -116,6 +117,9 @@ const desktopAPI: DesktopAPI = {
 
     openStopRecordingModal: (channelID) => ipcRenderer.send(CALLS_WIDGET_OPEN_STOP_RECORDING_MODAL, channelID),
     onOpenStopRecordingModal: (listener) => createListener(CALLS_WIDGET_OPEN_STOP_RECORDING_MODAL, listener),
+
+    openCallsUserSettings: () => ipcRenderer.send(CALLS_WIDGET_OPEN_USER_SETTINGS),
+    onOpenCallsUserSettings: (listener) => createListener(CALLS_WIDGET_OPEN_USER_SETTINGS, listener),
 
     // Utility
     unregister: (channel) => ipcRenderer.removeAllListeners(channel),

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -19,6 +19,7 @@ import {
     CALLS_WIDGET_SHARE_SCREEN,
     CALLS_WIDGET_OPEN_THREAD,
     CALLS_WIDGET_OPEN_STOP_RECORDING_MODAL,
+    CALLS_WIDGET_OPEN_USER_SETTINGS,
     DESKTOP_SOURCES_MODAL_REQUEST,
     GET_DESKTOP_SOURCES,
     UPDATE_SHORTCUT_MENU,
@@ -77,6 +78,7 @@ export class CallsWidgetWindow {
         ipcMain.on(CALLS_JOIN_REQUEST, this.forwardToMainApp(CALLS_JOIN_REQUEST));
         ipcMain.on(CALLS_WIDGET_OPEN_THREAD, this.handleCallsOpenThread);
         ipcMain.on(CALLS_WIDGET_OPEN_STOP_RECORDING_MODAL, this.handleCallsOpenStopRecordingModal);
+        ipcMain.on(CALLS_WIDGET_OPEN_USER_SETTINGS, this.forwardToMainApp(CALLS_WIDGET_OPEN_USER_SETTINGS));
 
         // deprecated in favour of CALLS_LINK_CLICK
         ipcMain.on(CALLS_WIDGET_CHANNEL_LINK_CLICK, this.handleCallsWidgetChannelLinkClick);

--- a/src/types/externalAPI.ts
+++ b/src/types/externalAPI.ts
@@ -24,4 +24,5 @@ export interface ExternalAPI {
     createListener(event: 'desktop-sources-modal-request', listener: () => void): () => void;
     createListener(event: 'calls-widget-open-thread', listener: (threadID: string) => void): () => void;
     createListener(event: 'calls-widget-open-stop-recording-modal', listener: (channelID: string) => void): () => void;
+    createListener(event: 'calls-widget-open-user-settings', listener: () => void): () => void;
 }


### PR DESCRIPTION
#### Summary

As we are implementing persistent Calls preferences and settings, we'd like a way to open the modal from within a call. PR implements a new `openCallsUserSettings` method to allow triggering this functionality from the global widget window.

#### Example

https://github.com/user-attachments/assets/c3521aac-69de-4daf-8b06-d8d7d7bbdff1


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51514

#### Release Note

```release-note
NONE
```
