### PR TITLE
[MM-59252] Fix resizing app when welcome screen is open on macOS, force button to always appear on welcome screen

### DIFF
--- a/src/main/preload/internalAPI.js
+++ b/src/main/preload/internalAPI.js
@@ -93,6 +93,7 @@ import {
     OPEN_WINDOWS_CAMERA_PREFERENCES,
     OPEN_WINDOWS_MICROPHONE_PREFERENCES,
     GET_MEDIA_ACCESS_STATUS,
+    VIEW_FINISHED_RESIZING,
 } from 'common/communication';
 
 console.log('Preload initialized');
@@ -178,6 +179,7 @@ contextBridge.exposeInMainWorld('desktop', {
     openWindowsCameraPreferences: () => ipcRenderer.send(OPEN_WINDOWS_CAMERA_PREFERENCES),
     openWindowsMicrophonePreferences: () => ipcRenderer.send(OPEN_WINDOWS_MICROPHONE_PREFERENCES),
     getMediaAccessStatus: (mediaType) => ipcRenderer.invoke(GET_MEDIA_ACCESS_STATUS, mediaType),
+    viewFinishedResizing: () => ipcRenderer.send(VIEW_FINISHED_RESIZING),
 
     downloadsDropdown: {
         toggleDownloadsDropdownMenu: (payload) => ipcRenderer.send(TOGGLE_DOWNLOADS_DROPDOWN_MENU, payload),

--- a/src/renderer/components/WelcomeScreen/WelcomeScreen.tsx
+++ b/src/renderer/components/WelcomeScreen/WelcomeScreen.tsx
@@ -36,6 +36,12 @@ function WelcomeScreen({
 
     useEffect(() => {
         setShowContent(true);
+
+        // Let the main process know when the window has finished resizing
+        // This is to reduce the amount of white box that happens when expand the BrowserView
+        window.addEventListener('resize', () => {
+            window.desktop.viewFinishedResizing();
+        });
     }, []);
 
     const slides = useMemo(() => [

--- a/src/renderer/css/components/LoadingScreen.css
+++ b/src/renderer/css/components/LoadingScreen.css
@@ -9,7 +9,7 @@ body {
     --stipple-opacity: 0.08;
     
     display: flex;
-    justify-content: center;
+    justify-content: flex-end;
     align-items: center;
     position: absolute;
     top: 0px;

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -97,6 +97,7 @@ declare global {
             openWindowsCameraPreferences: () => void;
             openWindowsMicrophonePreferences: () => void;
             getMediaAccessStatus: (mediaType: 'microphone' | 'camera' | 'screen') => Promise<'not-determined' | 'granted' | 'denied' | 'restricted' | 'unknown'>;
+            viewFinishedResizing: () => void;
 
             modals: {
                 cancelModal: <T>(data?: T) => void;


### PR DESCRIPTION
#### Summary
When you resize the window on the welcome screen, if you make the height too small the Get Started button disappears. This PR just forces the flex items to align to the bottom so that it will always show at the bottom no matter how small. A follow-up here might be to find a way to scale the contents properly when resizing.

Additionally, I fixed a longstanding issue for macOS where the welcome screen couldn't be resized at all.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59252

```release-note
Fix resizing app when welcome screen is open on macOS, force button to always appear on welcome screen
```
