### PR TITLE
Fixed #2977 - Fixed the dark-mode style for the download location box in settings

### DIFF
--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -472,6 +472,7 @@ class SettingsPage extends React.PureComponent<Props, State> {
                 padding: '0.4em 0',
             },
             downloadLocationInput: {
+                display: 'inline',
                 marginRight: '3px',
                 marginTop: '8px',
                 width: '320px',
@@ -638,7 +639,7 @@ class SettingsPage extends React.PureComponent<Props, State> {
                         style={settingsPage.container}
                         key='containerInputSpellcheckerURL'
                     >
-                        <input
+                        <FormControl
                             disabled={!this.state.useSpellChecker}
                             style={settingsPage.downloadLocationInput}
                             key='inputSpellCheckerURL'
@@ -1058,7 +1059,7 @@ class SettingsPage extends React.PureComponent<Props, State> {
                         defaultMessage='Download Location'
                     />
                 </div>
-                <input
+                <FormControl
                     disabled={true}
                     style={settingsPage.downloadLocationInput}
                     key='inputDownloadLocation'


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
Fixed the dark-mode style for the download location box in settings.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/desktop/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes https://github.com/mattermost/desktop/issues/2977


#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ x read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [x] executed `npm run lint:js` for proper code formatting
- [ ] Run E2E tests by adding label `Run Desktop E2E Tests`

#### Device Information
This PR was tested on: `Fedora 40`

#### Screenshots
![image](https://github.com/user-attachments/assets/8c5180c7-f6f1-4a7c-9167-9e9ce2b02940)


#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Fixed dark-mode style for download location in settings
```
