### PR TITLE
[MM-60232] Fix a crash in Linux when trying to create a thumbnail from an image

### DIFF
--- a/src/main/downloadsManager.ts
+++ b/src/main/downloadsManager.ts
@@ -641,7 +641,6 @@ export class DownloadsManager extends JsonFileManager<DownloadedItems> {
             } else {
                 thumbnailData = (await nativeImage.createThumbnailFromPath(overridePath ?? item.getSavePath(), {height: 32, width: 32})).toDataURL();
             }
-            
         }
 
         return {

--- a/src/main/downloadsManager.ts
+++ b/src/main/downloadsManager.ts
@@ -636,9 +636,11 @@ export class DownloadsManager extends JsonFileManager<DownloadedItems> {
         let thumbnailData;
         if (state === 'completed' && item.getMimeType().toLowerCase().startsWith('image/')) {
             // Linux doesn't support the thumbnail creation so we have to use the base function
-            // We also will cap this at 1MB so as to not inflate the memory usage of the downloads dropdown
-            if (process.platform === 'linux' && item.getReceivedBytes() < 1000000) {
-                thumbnailData = (await nativeImage.createFromPath(overridePath ?? item.getSavePath())).toDataURL();
+            if (process.platform === 'linux') {
+                // We also will cap this at 1MB so as to not inflate the memory usage of the downloads dropdown
+                if (item.getReceivedBytes() < 1000000) {
+                    thumbnailData = (await nativeImage.createFromPath(overridePath ?? item.getSavePath())).toDataURL();
+                }
             } else {
                 thumbnailData = (await nativeImage.createThumbnailFromPath(overridePath ?? item.getSavePath(), {height: 32, width: 32})).toDataURL();
             }

--- a/src/main/downloadsManager.ts
+++ b/src/main/downloadsManager.ts
@@ -636,7 +636,8 @@ export class DownloadsManager extends JsonFileManager<DownloadedItems> {
         let thumbnailData;
         if (state === 'completed' && item.getMimeType().toLowerCase().startsWith('image/')) {
             // Linux doesn't support the thumbnail creation so we have to use the base function
-            if (process.platform === 'linux') {
+            // We also will cap this at 1MB so as to not inflate the memory usage of the downloads dropdown
+            if (process.platform === 'linux' && item.getReceivedBytes() < 1000000) {
                 thumbnailData = (await nativeImage.createFromPath(overridePath ?? item.getSavePath())).toDataURL();
             } else {
                 thumbnailData = (await nativeImage.createThumbnailFromPath(overridePath ?? item.getSavePath(), {height: 32, width: 32})).toDataURL();

--- a/src/main/downloadsManager.ts
+++ b/src/main/downloadsManager.ts
@@ -635,7 +635,13 @@ export class DownloadsManager extends JsonFileManager<DownloadedItems> {
 
         let thumbnailData;
         if (state === 'completed' && item.getMimeType().toLowerCase().startsWith('image/')) {
-            thumbnailData = (await nativeImage.createThumbnailFromPath(overridePath ?? item.getSavePath(), {height: 32, width: 32})).toDataURL();
+            // Linux doesn't support the thumbnail creation so we have to use the base function
+            if (process.platform === 'linux') {
+                thumbnailData = (await nativeImage.createFromPath(overridePath ?? item.getSavePath())).toDataURL();
+            } else {
+                thumbnailData = (await nativeImage.createThumbnailFromPath(overridePath ?? item.getSavePath(), {height: 32, width: 32})).toDataURL();
+            }
+            
         }
 
         return {


### PR DESCRIPTION
#### Summary
When we made the fix to disallow the `file:` protocol, we started using `createThumbnailFromPath` to process images. Unfortunately, this function is simply not defined on Linux, causing a crash.

This PR falls back to using the `createFromPath` function for Linux only, which creates a full version of the image. I've capped the image size to use at 1MB so that we don't inflate the memory usage of the downloads dropdown too much.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60232
Closes #3129

```release-note
Fix a crash in Linux when trying to create a thumbnail from an image
```
