### PR TITLE
[MM-60605] Fix the Download button being hidden on Windows/Linux

### DIFF
--- a/src/renderer/components/MainPage.tsx
+++ b/src/renderer/components/MainPage.tsx
@@ -483,6 +483,7 @@ class MainPage extends React.PureComponent<Props, State> {
                         developerMode={this.state.developerMode}
                     />
                     {downloadsDropdownButton}
+                    <span style={{width: `${window.innerWidth - (window.navigator.windowControlsOverlay?.getTitlebarAreaRect().width ?? 0)}px`}}/>
                     {window.process.platform !== 'darwin' && this.state.fullScreen &&
                         <span className='title-bar-btns'>
                             <div

--- a/src/renderer/components/MainPage.tsx
+++ b/src/renderer/components/MainPage.tsx
@@ -483,7 +483,9 @@ class MainPage extends React.PureComponent<Props, State> {
                         developerMode={this.state.developerMode}
                     />
                     {downloadsDropdownButton}
-                    <span style={{width: `${window.innerWidth - (window.navigator.windowControlsOverlay?.getTitlebarAreaRect().width ?? 0)}px`}}/>
+                    {window.process.platform !== 'darwin' &&
+                        <span style={{width: `${window.innerWidth - (window.navigator.windowControlsOverlay?.getTitlebarAreaRect().width ?? 0)}px`}}/>
+                    }
                     {window.process.platform !== 'darwin' && this.state.fullScreen &&
                         <span className='title-bar-btns'>
                             <div

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -155,4 +155,10 @@ declare global {
             };
         };
     }
+
+    interface Navigator {
+        windowControlsOverlay?: {
+            getTitlebarAreaRect: () => DOMRect;
+        }
+    }
 }


### PR DESCRIPTION
#### Summary
When we made the change to switch to the titleBarOverlay for Windows and Linux, the Downloads dropdown button has disappeared. This is because it was hidden behind the new overlay.

This PR adds a `span` to force the Downloads dropdown in front of the title bar buttons.

NOTE: Will have to update this when cherry-picking to v5.9, as Windows doesn't use these new buttons on v5.9.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60605

```release-note
Fix the Download button being hidden on Windows/Linux
```
