### PR TITLE
Disable full screen mode on Linux

### DIFF
--- a/src/main/menus/app.ts
+++ b/src/main/menus/app.ts
@@ -231,7 +231,7 @@ export function createTemplate(config: Config, updateManager: UpdateManager) {
         ]);
     }
 
-    const viewSubMenu = [{
+    const viewSubMenu: Electron.MenuItemConstructorOptions[] = [{
         label: localizeMessage('main.menus.app.view.find', 'Find..'),
         accelerator: 'CmdOrCtrl+F',
         click() {
@@ -250,11 +250,17 @@ export function createTemplate(config: Config, updateManager: UpdateManager) {
             session.defaultSession.clearCache();
             ViewManager.reload();
         },
-    }, {
-        role: 'togglefullscreen',
-        label: localizeMessage('main.menus.app.view.fullscreen', 'Toggle Full Screen'),
-        accelerator: isMac ? 'Ctrl+Cmd+F' : 'F11',
-    }, separatorItem, {
+    }];
+
+    if (process.platform !== 'linux') {
+        viewSubMenu.push({
+            role: 'togglefullscreen',
+            label: localizeMessage('main.menus.app.view.fullscreen', 'Toggle Full Screen'),
+            accelerator: isMac ? 'Ctrl+Cmd+F' : 'F11',
+        });
+    }
+
+    viewSubMenu.push(separatorItem, {
         label: localizeMessage('main.menus.app.view.actualSize', 'Actual Size'),
         role: 'resetZoom',
         accelerator: 'CmdOrCtrl+0',
@@ -284,7 +290,7 @@ export function createTemplate(config: Config, updateManager: UpdateManager) {
     }, separatorItem, {
         label: localizeMessage('main.menus.app.view.devToolsSubMenu', 'Developer Tools'),
         submenu: devToolsSubMenu,
-    }];
+    });
 
     if (process.platform !== 'darwin' && process.platform !== 'win32') {
         viewSubMenu.push(separatorItem);

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -74,7 +74,7 @@ export class MainWindow extends EventEmitter {
 
         const windowOptions: BrowserWindowConstructorOptions = Object.assign({}, this.savedWindowState, {
             title: app.name,
-            fullscreenable: true,
+            fullscreenable: process.platform !== 'linux',
             show: false, // don't start the window until it is ready and only if it isn't hidden
             paintWhenInitiallyHidden: true, // we want it to start painting to get info from the webapp
             minWidth: MINIMUM_WINDOW_WIDTH,
@@ -231,6 +231,10 @@ export class MainWindow extends EventEmitter {
     };
 
     private shouldStartFullScreen = () => {
+        if (process.platform === 'linux') {
+            return false;
+        }
+
         if (global?.args?.fullscreen !== undefined) {
             return global.args.fullscreen;
         }

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -982,32 +982,34 @@ class SettingsPage extends React.PureComponent<Props, State> {
             </FormCheck>,
         );
 
-        options.push(
-            <FormCheck
-                key='inputStartInFullScreen'
-            >
-                <FormCheck.Input
-                    type='checkbox'
-                    id='inputStartInFullScreen'
-                    ref={this.startInFullscreenRef}
-                    checked={this.state.startInFullscreen}
-                    onChange={this.handleChangeStartInFullscreen}
-                />
-                <FormattedMessage
-                    id='renderer.components.settingsPage.fullscreen'
-                    defaultMessage='Open app in fullscreen'
-                />
-                <FormText>
-                    <FormattedMessage
-                        id='renderer.components.settingsPage.fullscreen.description'
-                        defaultMessage='If enabled, the {appName} application will always open in full screen'
-                        values={{
-                            appName: this.state.appName,
-                        }}
+        if (process.platform !== 'linux') {
+            options.push(
+                <FormCheck
+                    key='inputStartInFullScreen'
+                >
+                    <FormCheck.Input
+                        type='checkbox'
+                        id='inputStartInFullScreen'
+                        ref={this.startInFullscreenRef}
+                        checked={this.state.startInFullscreen}
+                        onChange={this.handleChangeStartInFullscreen}
                     />
-                </FormText>
-            </FormCheck>,
-        );
+                    <FormattedMessage
+                        id='renderer.components.settingsPage.fullscreen'
+                        defaultMessage='Open app in fullscreen'
+                    />
+                    <FormText>
+                        <FormattedMessage
+                            id='renderer.components.settingsPage.fullscreen.description'
+                            defaultMessage='If enabled, the {appName} application will always open in full screen'
+                            values={{
+                                appName: this.state.appName,
+                            }}
+                        />
+                    </FormText>
+                </FormCheck>,
+            );
+        }
 
         options.push(
             <div


### PR DESCRIPTION
#### Summary
We have made the decision to disable full screen mode on Linux, for a number of reasons:
- Most notably, the buttons for minimize/maximize/restore/close are not able to be hidden on Linux, as per this Electron issue: https://github.com/electron/electron/issues/43030. Under full screen mode on Windows, these are hidden automatically, but under Linux they remain. This behaviour would continue under native Linux titlebars.
- Use of the above buttons consistently puts the window in a really weird state where the window is not in full screen mode, but it thinks it is and is stuck and not able to be moved or resized.
- Every window manager handles the sizing and abilities of this window while it's in full screen mode, causing some inconsistencies that are impossible to account for.
- When entering full screen mode, it is common for renderer artifacts to show up where either certain events aren't fired (causing buttons to appear in the wrong spot) or window elements are not visible or sized improperly. I've seen this on both X11 and Wayland.
- It is too easy to accidentally enter full screen mode by accidentally pressing F11, which has caused some false positives around bugs.

The thinking is that this feature is not widely used, and can be mostly replicated by just maximizing the window, which only leaves some screen exclusivity as the one miss here. 

I'll be willing to return this functionality if both
a) We find this is used by a number of users
b) Electron provides more stable APIs/workarounds for the issues we are experiencing.

#### Ticket Link
Closes https://github.com/mattermost/desktop/issues/3143

```release-note
Disable full screen mode on Linux
```
