### PR TITLE
[MM-60201] Fixed a potential crash on removing server

### DIFF
--- a/src/app/serverViewState.ts
+++ b/src/app/serverViewState.ts
@@ -208,11 +208,11 @@ export class ServerViewState {
                     this.currentServerId = remainingServers[0].id;
                 }
 
+                ServerManager.removeServer(server.id);
+
                 if (!remainingServers.length) {
                     delete this.currentServerId;
                 }
-
-                ServerManager.removeServer(server.id);
             }
         }).catch((e) => {
             // e is undefined for user cancellation


### PR DESCRIPTION
#### Summary
Wasn't able to reproduce the exact crash, other than this possible case where it's possible that the current server ID isn't set before the menu regenerates, causing a crash where the app menu might be re-rendered before the last server is removed. This PR just reverses those statements so that it's less likely that the `currentServerId` isn't set.

#### Ticket Link
Closes https://github.com/mattermost/desktop/issues/3122
https://mattermost.atlassian.net/browse/MM-60201

```release-note
Fix a potential crash where the app menu might regenerate when `currentServerId` isn't set.
```
