### PR TITLE
MM-60233 - fix issue in kde of focus after minimize

### DIFF
--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -153,3 +153,9 @@ export function openScreensharePermissionsSettingsMacOS() {
     return exec('open "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"',
         {timeout: 1000});
 }
+
+export function isKDE() {
+    return (process.env.XDG_CURRENT_DESKTOP ?? '').toUpperCase() === 'KDE' ||
+    (process.env.DESKTOP_SESSION ?? '').toLowerCase() === 'plasma' ||
+    (process.env.KDE_FULL_SESSION ?? '').toLowerCase() === 'true';
+}

--- a/src/main/windows/mainWindow.test.js
+++ b/src/main/windows/mainWindow.test.js
@@ -68,6 +68,7 @@ jest.mock('../contextMenu', () => jest.fn());
 jest.mock('../utils', () => ({
     isInsideRectangle: jest.fn(),
     getLocalPreload: jest.fn(),
+    isKDE: jest.fn(),
 }));
 
 jest.mock('main/i18nManager', () => ({
@@ -513,6 +514,9 @@ describe('main/windows/mainWindow', () => {
         });
 
         it('should add override shortcuts for the top menu on Linux to stop it showing up', () => {
+            const {isKDE} = require('../utils');
+            isKDE.mockReturnValue(false);
+
             const originalPlatform = process.platform;
             Object.defineProperty(process, 'platform', {
                 value: 'linux',
@@ -536,14 +540,13 @@ describe('main/windows/mainWindow', () => {
         });
 
         it('should not register global shortcuts when window is minimized on KDE/KWin', () => {
+            const {isKDE} = require('../utils');
+            isKDE.mockReturnValue(true);
+
             const originalPlatform = process.platform;
             Object.defineProperty(process, 'platform', {
                 value: 'linux',
             });
-            process.env.XDG_CURRENT_DESKTOP = 'KDE';
-            process.env.DESKTOP_SESSION = 'plasma';
-            process.env.KDE_FULL_SESSION = 'true';
-
             const window = {
                 ...baseWindow,
                 isMinimized: jest.fn().mockReturnValue(true),
@@ -553,7 +556,6 @@ describe('main/windows/mainWindow', () => {
                     }
                 }),
             };
-
             BrowserWindow.mockImplementation(() => window);
             const mainWindow = new MainWindow();
             mainWindow.getBounds = jest.fn();
@@ -563,9 +565,6 @@ describe('main/windows/mainWindow', () => {
             Object.defineProperty(process, 'platform', {
                 value: originalPlatform,
             });
-            delete process.env.XDG_CURRENT_DESKTOP;
-            delete process.env.DESKTOP_SESSION;
-            delete process.env.KDE_FULL_SESSION;
         });
     });
 

--- a/src/main/windows/mainWindow.test.js
+++ b/src/main/windows/mainWindow.test.js
@@ -539,7 +539,7 @@ describe('main/windows/mainWindow', () => {
             expect(globalShortcut.registerAll).toHaveBeenCalledWith(['Alt+F', 'Alt+E', 'Alt+V', 'Alt+H', 'Alt+W', 'Alt+P'], expect.any(Function));
         });
 
-        it('should not register global shortcuts when window is minimized on KDE/KWin', () => {
+        it('should register global shortcuts even when window is minimized on KDE/KWin', () => {
             const {isKDE} = require('../utils');
             isKDE.mockReturnValue(true);
 
@@ -561,7 +561,7 @@ describe('main/windows/mainWindow', () => {
             mainWindow.getBounds = jest.fn();
             mainWindow.init();
 
-            expect(globalShortcut.registerAll).not.toHaveBeenCalled();
+            expect(globalShortcut.registerAll).toHaveBeenCalled();
             Object.defineProperty(process, 'platform', {
                 value: originalPlatform,
             });

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -324,7 +324,9 @@ export class MainWindow extends EventEmitter {
     private onFocus = () => {
         // Only add shortcuts when window is in focus
         if (process.platform === 'linux') {
-            const isKDE = process.env.XDG_CURRENT_DESKTOP === 'KDE' || process.env.DESKTOP_SESSION === 'plasma' || process.env.KDE_FULL_SESSION === 'true';
+            const isKDE = (process.env.XDG_CURRENT_DESKTOP ?? '').toUpperCase() === 'KDE' ||
+                (process.env.DESKTOP_SESSION ?? '').toLowerCase() === 'plasma' ||
+                (process.env.KDE_FULL_SESSION ?? '').toLowerCase() === 'true';
             if ((!this.win || this.win.isMinimized()) && isKDE) {
                 return;
             }

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -324,13 +324,15 @@ export class MainWindow extends EventEmitter {
     private onFocus = () => {
         // Only add shortcuts when window is in focus
         if (process.platform === 'linux') {
-            const kde = isKDE();
-            if ((!this.win || this.win.isMinimized()) && kde) {
-                return;
-            }
             globalShortcut.registerAll(ALT_MENU_KEYS, () => {
                 // do nothing because we want to supress the menu popping up
             });
+
+            // check if KDE + windows is minimized to prevent unwanted focus event
+            // that was causing an error not allowing minimization (MM-60233)
+            if ((!this.win || this.win.isMinimized()) && isKDE()) {
+                return;
+            }
         }
 
         this.emit(MAIN_WINDOW_RESIZED, this.getBounds());

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -38,7 +38,7 @@ import {localizeMessage} from 'main/i18nManager';
 import type {SavedWindowState} from 'types/mainWindow';
 
 import ContextMenu from '../contextMenu';
-import {getLocalPreload, isInsideRectangle} from '../utils';
+import {getLocalPreload, isInsideRectangle, isKDE} from '../utils';
 
 const log = new Logger('MainWindow');
 const ALT_MENU_KEYS = ['Alt+F', 'Alt+E', 'Alt+V', 'Alt+H', 'Alt+W', 'Alt+P'];
@@ -324,10 +324,8 @@ export class MainWindow extends EventEmitter {
     private onFocus = () => {
         // Only add shortcuts when window is in focus
         if (process.platform === 'linux') {
-            const isKDE = (process.env.XDG_CURRENT_DESKTOP ?? '').toUpperCase() === 'KDE' ||
-                (process.env.DESKTOP_SESSION ?? '').toLowerCase() === 'plasma' ||
-                (process.env.KDE_FULL_SESSION ?? '').toLowerCase() === 'true';
-            if ((!this.win || this.win.isMinimized()) && isKDE) {
+            const kde = isKDE();
+            if ((!this.win || this.win.isMinimized()) && kde) {
                 return;
             }
             globalShortcut.registerAll(ALT_MENU_KEYS, () => {

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -42,6 +42,14 @@ import {getLocalPreload, isInsideRectangle} from '../utils';
 
 const log = new Logger('MainWindow');
 const ALT_MENU_KEYS = ['Alt+F', 'Alt+E', 'Alt+V', 'Alt+H', 'Alt+W', 'Alt+P'];
+const isLinux = process.platform === 'linux';
+const env = process.env;
+
+let isKDE = false;
+
+if (isLinux) {
+    isKDE = env.XDG_CURRENT_DESKTOP === 'KDE' || env.DESKTOP_SESSION === 'plasma' || env.KDE_FULL_SESSION === 'true';
+}
 
 export class MainWindow extends EventEmitter {
     private win?: BrowserWindow;
@@ -93,7 +101,7 @@ export class MainWindow extends EventEmitter {
         });
         log.debug('main window options', windowOptions);
 
-        if (process.platform === 'linux') {
+        if (isLinux) {
             windowOptions.icon = path.join(path.resolve(app.getAppPath(), 'assets'), 'linux', 'app_icon.png');
         }
 
@@ -196,7 +204,7 @@ export class MainWindow extends EventEmitter {
         // Workaround for linux maximizing/minimizing, which doesn't work properly because of these bugs:
         // https://github.com/electron/electron/issues/28699
         // https://github.com/electron/electron/issues/28106
-        if (process.platform === 'linux') {
+        if (isLinux) {
             const size = this.win.getSize();
             return {...this.win.getContentBounds(), width: size[0], height: size[1]};
         }
@@ -231,7 +239,7 @@ export class MainWindow extends EventEmitter {
     };
 
     private shouldStartFullScreen = () => {
-        if (process.platform === 'linux') {
+        if (isLinux) {
             return false;
         }
 
@@ -323,7 +331,10 @@ export class MainWindow extends EventEmitter {
 
     private onFocus = () => {
         // Only add shortcuts when window is in focus
-        if (process.platform === 'linux') {
+        if (isLinux) {
+            if ((!this.win || this.win.isMinimized()) && isKDE) {
+                return;
+            }
             globalShortcut.registerAll(ALT_MENU_KEYS, () => {
                 // do nothing because we want to supress the menu popping up
             });
@@ -549,7 +560,7 @@ export class MainWindow extends EventEmitter {
     };
 
     private handleUpdateTitleBarOverlay = () => {
-        if (process.platform === 'linux') {
+        if (isLinux) {
             this.win?.setTitleBarOverlay?.(this.getTitleBarOverlay());
         }
     };

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -42,14 +42,6 @@ import {getLocalPreload, isInsideRectangle} from '../utils';
 
 const log = new Logger('MainWindow');
 const ALT_MENU_KEYS = ['Alt+F', 'Alt+E', 'Alt+V', 'Alt+H', 'Alt+W', 'Alt+P'];
-const isLinux = process.platform === 'linux';
-const env = process.env;
-
-let isKDE = false;
-
-if (isLinux) {
-    isKDE = env.XDG_CURRENT_DESKTOP === 'KDE' || env.DESKTOP_SESSION === 'plasma' || env.KDE_FULL_SESSION === 'true';
-}
 
 export class MainWindow extends EventEmitter {
     private win?: BrowserWindow;
@@ -101,7 +93,7 @@ export class MainWindow extends EventEmitter {
         });
         log.debug('main window options', windowOptions);
 
-        if (isLinux) {
+        if (process.platform === 'linux') {
             windowOptions.icon = path.join(path.resolve(app.getAppPath(), 'assets'), 'linux', 'app_icon.png');
         }
 
@@ -204,7 +196,7 @@ export class MainWindow extends EventEmitter {
         // Workaround for linux maximizing/minimizing, which doesn't work properly because of these bugs:
         // https://github.com/electron/electron/issues/28699
         // https://github.com/electron/electron/issues/28106
-        if (isLinux) {
+        if (process.platform === 'linux') {
             const size = this.win.getSize();
             return {...this.win.getContentBounds(), width: size[0], height: size[1]};
         }
@@ -239,7 +231,7 @@ export class MainWindow extends EventEmitter {
     };
 
     private shouldStartFullScreen = () => {
-        if (isLinux) {
+        if (process.platform === 'linux') {
             return false;
         }
 
@@ -331,7 +323,8 @@ export class MainWindow extends EventEmitter {
 
     private onFocus = () => {
         // Only add shortcuts when window is in focus
-        if (isLinux) {
+        if (process.platform === 'linux') {
+            const isKDE = process.env.XDG_CURRENT_DESKTOP === 'KDE' || process.env.DESKTOP_SESSION === 'plasma' || process.env.KDE_FULL_SESSION === 'true';
             if ((!this.win || this.win.isMinimized()) && isKDE) {
                 return;
             }
@@ -560,7 +553,7 @@ export class MainWindow extends EventEmitter {
     };
 
     private handleUpdateTitleBarOverlay = () => {
-        if (isLinux) {
+        if (process.platform === 'linux') {
             this.win?.setTitleBarOverlay?.(this.getTitleBarOverlay());
         }
     };


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
MM-60233: Fix window minimizing issue on KDE/KWin environments. The app window was immediately being focus after being minimized, and it caused it to restore instead of stay minimized. This happened because the onFocus event was being  triggered after minimizing, and then the actions within the onFocus handler was causing the window to re obtain the focus.

This PR resolves this by modifying the onFocus event handler by checking if the application was running on KDE/KWin (plasma) and if the window is also minimized. If both of the conditions are present, then the handler will return early and will not execute further actions avoiding the window to obtain focus unwanted.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60233
Closes #3130

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [ ] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [ ] executed `npm run lint:js` for proper code formatting
- [ ] Run E2E tests by adding label `Run Desktop E2E Tests`

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->
Kubuntu:
Operating System: Kubuntu 24.04
KDE Plasma Version: 5.27.11
KDE Frameworks Version: 5.115.0
Qt Version: 5.15.13
Kernel Version: 6.8.0-45-generic (64-bit)
Graphics Platform: X11
Processors: 2
Memory: 1.9 GiB of RAM
Graphics Processor: virgl
Manufacturer: Parallels International GmbH.
Product Name: Parallels ARM Virtual Machine
System Version: 0.1

#### Screenshots
Before:

https://github.com/user-attachments/assets/fde8432e-894c-47fd-b88a-eb7827303ea2



After:

https://github.com/user-attachments/assets/7931d933-99c8-46d0-a7e8-32a5a74df4c4




#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
