### PR TITLE
Fix: Adjust dropdown menu item layout for better text fitting

### DIFF
--- a/src/common/utils/constants.ts
+++ b/src/common/utils/constants.ts
@@ -32,8 +32,8 @@ export const CALLS_PLUGIN_ID = 'com.mattermost.calls';
 export const DOWNLOADS_DROPDOWN_HEIGHT = 360;
 export const DOWNLOADS_DROPDOWN_WIDTH = 280;
 export const DOWNLOADS_DROPDOWN_PADDING = 24;
-export const DOWNLOADS_DROPDOWN_MENU_HEIGHT = 160;
-export const DOWNLOADS_DROPDOWN_MENU_WIDTH = 154;
+export const DOWNLOADS_DROPDOWN_MENU_HEIGHT = 260;
+export const DOWNLOADS_DROPDOWN_MENU_WIDTH = 200;
 export const DOWNLOADS_DROPDOWN_MENU_PADDING = 12;
 
 // In  order to display the box-shadow & radius on the left + right, use this WIDTH in the webContentsView for downloadsDropdown

--- a/src/renderer/css/downloadsDropdownMenu.scss
+++ b/src/renderer/css/downloadsDropdownMenu.scss
@@ -23,8 +23,8 @@ body {
     background-color: transparent;
     font-family: Open Sans;
     overflow: hidden;
-    height: 172px; // 160 + 12
-    width: 176px; // 154 + 12
+    min-height: fit-content;
+    width: 224px; // 200 + 12 + 12
 
     #app {
         background-color: transparent;
@@ -40,7 +40,6 @@ body {
             display: flex;
             flex-direction: column;
             height: 100%;
-            overflow: hidden;
             padding: 8px 0px;
             width: 100%;
 
@@ -52,9 +51,12 @@ body {
                 display: flex;
                 font-size: 14px;
                 font-weight: 400;
-                height: 25%;
+                flex-grow: 1;
+                height: fit-content(25%);
                 justify-content: flex-start;
-                padding-left: 20px;
+                padding: 8px 20px;
+                min-height: 36px;
+                width: 100%;
 
                 &:hover {
                     background-color: rgba(63, 67, 80, 0.08);


### PR DESCRIPTION
#### Summary

- Updated the styling of `.DownloadsDropdownMenu__MenuItem` to improve text fitting and prevent text overlap.
- Changed `height` to `fit-content(25%)` to ensure the menu items dynamically adjust to content size.
- Added `flex-grow: 1` to allow the items to expand and occupy available space within the menu.
- Added padding-right: 20px to ensure text does not touch the right edge of the menu.

#### Device Information
This PR was tested on: Ubuntu 22.04

#### Screenshots
I have tested it in 3 different languages (English, Russian, French). Some of them had problems with text overlapping in the download menu tab. Other languages with long translations also have overlapping text.

##### Before Changes:

<details>
  <summary>English</summary>
  <img src="https://github.com/user-attachments/assets/783c6955-a2e2-4ff6-a227-a1eac477db82" alt="Before Changes (English)">
</details>

<details>
  <summary>French</summary>
  <img src="https://github.com/user-attachments/assets/d90e9e4e-ebe4-4914-af1d-76e18868ba97" alt="Before Changes (French)">
</details>

<details>
  <summary>Russian</summary>
  <img src="https://github.com/user-attachments/assets/5da91388-48a5-4cfd-90da-b5bc0a9fbf8b" alt="Before Changes (Russian)">
</details>


##### After Changes:

<details>
  <summary>English</summary>
  <img src="https://github.com/user-attachments/assets/0a90e67b-702f-4373-adca-3ae6f1d88a79" alt="After Changes (English)">
</details>

<details>
  <summary>French</summary>
  <img src="https://github.com/user-attachments/assets/3e2e7311-6e0d-49e2-9aef-dc3f6fd9e23e" alt="After Changes (French)">
</details>

<details>
  <summary>Russian</summary>
  <img src="https://github.com/user-attachments/assets/a2d12f19-5f6a-4f2a-a0a9-48aa8da3a5c5" alt="After Changes (Russian)">
</details>


```release-note
Updated the styling of `Downloads Menu` to improve text fitting and prevent text overlap.
```