### PR TITLE
MM-60782 - use default download directory on windows

### DIFF
--- a/src/app/serverViewState.test.js
+++ b/src/app/serverViewState.test.js
@@ -15,6 +15,9 @@ import MainWindow from 'main/windows/mainWindow';
 import {ServerViewState} from './serverViewState';
 
 jest.mock('electron', () => ({
+    app: {
+        getPath: jest.fn(() => '/valid/downloads/path'),
+    },
     ipcMain: {
         on: jest.fn(),
         handle: jest.fn(),

--- a/src/common/config/defaultPreferences.ts
+++ b/src/common/config/defaultPreferences.ts
@@ -5,6 +5,8 @@
 import os from 'os';
 import path from 'path';
 
+import {app} from 'electron';
+
 /**
  * Default user preferences. End-users can change these parameters by editing config.json
  * @param {number} version - Scheme version. (Not application version)
@@ -24,7 +26,7 @@ export const getDefaultDownloadLocation = (): string | undefined => {
         return process.env.XDG_DOWNLOAD_DIR;
     }
 
-    return path.join(os.homedir(), 'Downloads');
+    return app.getPath('downloads') || path.join(os.homedir(), 'Downloads');
 };
 
 const defaultPreferences: ConfigV3 = {

--- a/src/common/config/index.test.js
+++ b/src/common/config/index.test.js
@@ -94,6 +94,12 @@ jest.mock('common/config/RegistryConfig', () => {
     return jest.fn();
 });
 
+jest.mock('electron', () => ({
+    app: {
+        getPath: jest.fn(() => '/valid/downloads/path'),
+    },
+}));
+
 describe('common/config', () => {
     it('should load buildConfig', () => {
         const config = new Config();

--- a/src/common/config/upgradePreferences.test.js
+++ b/src/common/config/upgradePreferences.test.js
@@ -18,6 +18,12 @@ jest.mock('common/views/View', () => ({
     }),
 }));
 
+jest.mock('electron', () => ({
+    app: {
+        getPath: jest.fn(() => '/valid/downloads/path'),
+    },
+}));
+
 describe('common/config/upgradePreferences', () => {
     describe('upgradeV0toV1', () => {
         it('should upgrade from v0', () => {

--- a/src/main/downloadsManager.test.js
+++ b/src/main/downloadsManager.test.js
@@ -28,6 +28,7 @@ jest.mock('electron', () => {
     return {
         app: {
             getAppPath: jest.fn(),
+            getPath: jest.fn(() => '/valid/downloads/path'),
         },
         BrowserView: jest.fn().mockImplementation(() => ({
             webContents: {

--- a/src/main/tray/tray.test.js
+++ b/src/main/tray/tray.test.js
@@ -30,6 +30,7 @@ jest.mock('electron', () => {
             getAppPath: () => '/path/to/app',
             isReady: jest.fn(),
             setPath: jest.fn(),
+            getPath: jest.fn(() => '/valid/downloads/path'),
         },
         ipcMain: {
             emit: jest.fn(),

--- a/src/main/views/MattermostBrowserView.test.js
+++ b/src/main/views/MattermostBrowserView.test.js
@@ -17,6 +17,7 @@ import MainWindow from '../windows/mainWindow';
 jest.mock('electron', () => ({
     app: {
         getVersion: () => '5.0.0',
+        getPath: jest.fn(() => '/valid/downloads/path'),
     },
     BrowserView: jest.fn().mockImplementation(() => ({
         webContents: {

--- a/src/main/views/downloadsDropdownMenuView.test.js
+++ b/src/main/views/downloadsDropdownMenuView.test.js
@@ -28,6 +28,7 @@ jest.mock('electron', () => {
     return {
         app: {
             getAppPath: () => '',
+            getPath: jest.fn(() => '/valid/downloads/path'),
         },
         BrowserView: jest.fn().mockImplementation(() => ({
             webContents: {

--- a/src/main/views/downloadsDropdownView.test.js
+++ b/src/main/views/downloadsDropdownView.test.js
@@ -36,6 +36,7 @@ jest.mock('electron', () => {
     return {
         app: {
             getAppPath: () => '',
+            getPath: jest.fn(() => '/valid/downloads/path'),
         },
         BrowserView: jest.fn().mockImplementation(() => ({
             webContents: {

--- a/src/main/views/serverDropdownView.test.js
+++ b/src/main/views/serverDropdownView.test.js
@@ -25,6 +25,9 @@ jest.mock('electron', () => ({
     ipcMain: {
         on: jest.fn(),
     },
+    app: {
+        getPath: jest.fn(() => '/valid/downloads/path'),
+    },
 }));
 jest.mock('main/windows/mainWindow', () => ({
     on: jest.fn(),

--- a/src/main/views/viewManager.test.js
+++ b/src/main/views/viewManager.test.js
@@ -18,6 +18,7 @@ import {ViewManager} from './viewManager';
 jest.mock('electron', () => ({
     app: {
         getAppPath: () => '/path/to/app',
+        getPath: jest.fn(() => '/valid/downloads/path'),
     },
     dialog: {
         showErrorBox: jest.fn(),


### PR DESCRIPTION
#### Summary
During the definition of the default config values, we were hardcoding the download directory and not letting the app to find it by itself. With this change, we make sure to load the default download directory set via the OS.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60782

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [ ] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [ ] executed `npm run lint:js` for proper code formatting
- [ ] Run E2E tests by adding label `Run Desktop E2E Tests`

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<img width="1277" alt="Screenshot 2024-10-08 at 10 29 29" src="https://github.com/user-attachments/assets/be0fcda0-22d3-4429-9a3a-79d23f143936">
<img width="1281" alt="Screenshot 2024-10-08 at 12 01 29" src="https://github.com/user-attachments/assets/bb545538-3211-4638-98f5-4a7356d8a623">


#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
