### PR TITLE
[MM-60086][MM-60610] Implement performanceMonitor, collect CPU/memory usage data and send via API

### DIFF
--- a/api-types/index.ts
+++ b/api-types/index.ts
@@ -79,6 +79,8 @@ export type DesktopAPI = {
     openCallsUserSettings: () => void;
     onOpenCallsUserSettings: (listener: () => void) => () => void;
 
+    onSendMetrics: (listener: (metricsMap: Map<string, {cpu?: number; memory?: number}>) => void) => () => void;
+
     // Utility
     unregister: (channel: string) => void;
 }

--- a/api-types/lib/index.d.ts
+++ b/api-types/lib/index.d.ts
@@ -65,5 +65,9 @@ export type DesktopAPI = {
     onOpenStopRecordingModal: (listener: (channelID: string) => void) => () => void;
     openCallsUserSettings: () => void;
     onOpenCallsUserSettings: (listener: () => void) => () => void;
+    onSendMetrics: (listener: (metricsMap: Map<string, {
+        cpu?: number;
+        memory?: number;
+    }>) => void) => () => void;
     unregister: (channel: string) => void;
 };

--- a/api-types/package-lock.json
+++ b/api-types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mattermost/desktop-api",
-  "version": "5.10.0-1",
+  "version": "5.10.0-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mattermost/desktop-api",
-      "version": "5.10.0-1",
+      "version": "5.10.0-2",
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^4.3.0 || ^5.0.0"

--- a/api-types/package.json
+++ b/api-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/desktop-api",
-  "version": "5.10.0-1",
+  "version": "5.10.0-2",
   "description": "Shared types for the Desktop App API provided to the Web App",
   "keywords": [
     "mattermost"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -218,6 +218,8 @@
   "renderer.components.settingsPage.downloadLocation.description": "Specify the folder where files will download.",
   "renderer.components.settingsPage.enableHardwareAcceleration": "Use GPU hardware acceleration",
   "renderer.components.settingsPage.enableHardwareAcceleration.description": "If enabled, {appName} UI is rendered more efficiently but can lead to decreased stability for some systems.",
+  "renderer.components.settingsPage.enableMetrics": "Send anonymous usage data to your configured servers",
+  "renderer.components.settingsPage.enableMetrics.description": "Sends usage data about the application and its performance to your configured servers that accept it.",
   "renderer.components.settingsPage.flashWindow": "Flash taskbar icon when a new message is received",
   "renderer.components.settingsPage.flashWindow.description": "If enabled, the taskbar icon will flash for a few seconds when a new message is received.",
   "renderer.components.settingsPage.flashWindow.description.linuxFunctionality": "This functionality may not work with all Linux window managers.",

--- a/src/common/Validator.ts
+++ b/src/common/Validator.ts
@@ -150,6 +150,7 @@ const configDataSchemaV3 = Joi.object<ConfigV3>({
     alwaysClose: Joi.boolean(),
     logLevel: Joi.string().default('info'),
     appLanguage: Joi.string().allow(''),
+    enableMetrics: Joi.boolean(),
 });
 
 // eg. data['community.mattermost.com'] = { data: 'certificate data', issuerName: 'COMODO RSA Domain Validation Secure Server CA'};

--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -197,3 +197,7 @@ export const GET_NONCE = 'get-nonce';
 export const DEVELOPER_MODE_UPDATED = 'developer-mode-updated';
 export const IS_DEVELOPER_MODE_ENABLED = 'is-developer-mode-enabled';
 export const GET_DEVELOPER_MODE_SETTING = 'get-developer-mode-setting';
+
+export const METRICS_SEND = 'metrics-send';
+export const METRICS_RECEIVE = 'metrics-receive';
+export const METRICS_REQUEST = 'metrics-request';

--- a/src/common/config/defaultPreferences.ts
+++ b/src/common/config/defaultPreferences.ts
@@ -49,6 +49,7 @@ const defaultPreferences: ConfigV3 = {
     downloadLocation: getDefaultDownloadLocation(),
     startInFullscreen: false,
     logLevel: 'info',
+    enableMetrics: true,
 };
 
 export default defaultPreferences;

--- a/src/common/config/index.ts
+++ b/src/common/config/index.ts
@@ -241,6 +241,10 @@ export class Config extends EventEmitter {
         return this.combinedData?.appLanguage;
     }
 
+    get enableMetrics() {
+        return this.combinedData?.enableMetrics;
+    }
+
     /**
      * Gets the servers from registry into the config object and reload
      *

--- a/src/common/config/migrationPreferences.ts
+++ b/src/common/config/migrationPreferences.ts
@@ -27,5 +27,11 @@ export default function migrateConfigItems(config: Config) {
         didMigrate = true;
     }
 
+    if (!migrationPrefs.getValue('enableMetrics')) {
+        config.enableMetrics = true;
+        migrationPrefs.setValue('enableMetrics', true);
+        didMigrate = true;
+    }
+
     return didMigrate;
 }

--- a/src/main/app/initialize.test.js
+++ b/src/main/app/initialize.test.js
@@ -77,7 +77,9 @@ jest.mock('electron', () => ({
         handle: jest.fn(),
     },
 }));
-
+jest.mock('main/performanceMonitor', () => ({
+    init: jest.fn(),
+}));
 jest.mock('main/i18nManager', () => ({
     localizeMessage: jest.fn(),
     setLocale: jest.fn(),

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -50,6 +50,7 @@ import i18nManager from 'main/i18nManager';
 import NonceManager from 'main/nonceManager';
 import {getDoNotDisturb} from 'main/notifications';
 import parseArgs from 'main/ParseArgs';
+import PerformanceMonitor from 'main/performanceMonitor';
 import PermissionsManager from 'main/permissionsManager';
 import Tray from 'main/tray/tray';
 import TrustedOriginsStore from 'main/trustedOrigins';
@@ -448,6 +449,10 @@ async function initializeAfterAppReady() {
     AppVersionManager.lastAppVersion = app.getVersion();
 
     handleMainWindowIsShown();
+
+    // The metrics won't start collecting for another minute
+    // so we can assume if we start now everything should be loaded by the time we're done
+    PerformanceMonitor.init();
 }
 
 function onUserActivityStatus(status: {

--- a/src/main/performanceMonitor.test.js
+++ b/src/main/performanceMonitor.test.js
@@ -1,0 +1,255 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {app, ipcMain, powerMonitor} from 'electron';
+
+import {EMIT_CONFIGURATION, METRICS_RECEIVE, METRICS_REQUEST, METRICS_SEND} from 'common/communication';
+import Config from 'common/config';
+
+import {PerformanceMonitor} from './performanceMonitor';
+
+jest.mock('electron', () => ({
+    app: {
+        getAppMetrics: jest.fn(),
+    },
+    ipcMain: {
+        on: jest.fn(),
+        off: jest.fn(),
+    },
+    powerMonitor: {
+        on: jest.fn(),
+    },
+}));
+
+jest.mock('common/config', () => ({
+    enableMetrics: true,
+}));
+
+describe('main/performanceMonitor', () => {
+    let makeWebContents;
+    beforeAll(() => {
+        jest.useFakeTimers();
+        jest.spyOn(global, 'setInterval');
+        jest.spyOn(global, 'clearInterval');
+    });
+
+    beforeEach(() => {
+        app.getAppMetrics.mockReturnValue([]);
+
+        let cb;
+        ipcMain.on.mockImplementation((channel, listener) => {
+            if (channel === METRICS_RECEIVE) {
+                cb = listener;
+            }
+        });
+
+        makeWebContents = (id, resolve) => ({
+            send: jest.fn().mockImplementation((channel, arg1, arg2) => {
+                if (channel === METRICS_REQUEST) {
+                    cb({sender: {id}}, arg1, {serverId: arg2, cpu: id, memory: id * 100});
+                }
+                if (channel === METRICS_SEND) {
+                    resolve(arg1);
+                }
+            }),
+            on: (_, listener) => listener(),
+            id,
+        });
+    });
+
+    afterEach(() => {
+        Config.enableMetrics = true;
+    });
+
+    it('should start and stop with config changes', () => {
+        let emitConfigCb;
+        ipcMain.on.mockImplementation((channel, listener) => {
+            if (channel === EMIT_CONFIGURATION) {
+                emitConfigCb = listener;
+            }
+        });
+
+        const performanceMonitor = new PerformanceMonitor();
+        performanceMonitor.init();
+        expect(setInterval).toHaveBeenCalled();
+
+        Config.enableMetrics = false;
+        emitConfigCb();
+        expect(clearInterval).toHaveBeenCalled();
+
+        Config.enableMetrics = true;
+        emitConfigCb();
+        expect(setInterval).toHaveBeenCalledTimes(2);
+    });
+
+    it('should start and stop with power monitor changes', () => {
+        const listeners = new Map();
+        powerMonitor.on.mockImplementation((channel, listener) => {
+            listeners.set(channel, listener);
+        });
+
+        const performanceMonitor = new PerformanceMonitor();
+        performanceMonitor.init();
+        expect(setInterval).toHaveBeenCalled();
+
+        listeners.get('suspend')();
+        expect(clearInterval).toHaveBeenCalled();
+
+        setInterval.mockClear();
+        clearInterval.mockClear();
+
+        listeners.get('resume')();
+        expect(setInterval).toHaveBeenCalled();
+
+        listeners.get('lock-screen')();
+        expect(clearInterval).toHaveBeenCalled();
+
+        setInterval.mockClear();
+        clearInterval.mockClear();
+
+        listeners.get('unlock-screen')();
+        expect(setInterval).toHaveBeenCalled();
+
+        listeners.get('speed-limit-change')(50);
+        expect(clearInterval).toHaveBeenCalled();
+
+        setInterval.mockClear();
+        clearInterval.mockClear();
+
+        listeners.get('speed-limit-change')(100);
+        expect(setInterval).toHaveBeenCalled();
+    });
+
+    describe('init', () => {
+        it('should not start until init', () => {
+            const performanceMonitor = new PerformanceMonitor();
+            expect(setInterval).not.toHaveBeenCalled();
+
+            performanceMonitor.init();
+            expect(setInterval).toHaveBeenCalled();
+        });
+
+        it('should run app metrics for node on init', () => {
+            const performanceMonitor = new PerformanceMonitor();
+            performanceMonitor.init();
+            expect(app.getAppMetrics).toHaveBeenCalled();
+        });
+
+        it('should not start if disabled by config', () => {
+            Config.enableMetrics = false;
+
+            const performanceMonitor = new PerformanceMonitor();
+            expect(setInterval).not.toHaveBeenCalled();
+
+            performanceMonitor.init();
+            expect(setInterval).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('registerView', () => {
+        it('should send metrics to registered server views', async () => {
+            const performanceMonitor = new PerformanceMonitor();
+            performanceMonitor.init();
+
+            const sendValue = new Promise((resolve) => {
+                performanceMonitor.registerServerView('view-1', makeWebContents(1, resolve), 'server-1');
+            });
+
+            jest.runOnlyPendingTimers();
+
+            expect(await sendValue).toEqual(new Map([['view-1', {cpu: 1, memory: 100, serverId: 'server-1'}]]));
+        });
+
+        it('should send metrics for other tabs to registered server views', async () => {
+            const performanceMonitor = new PerformanceMonitor();
+            performanceMonitor.init();
+
+            const sendValue = new Promise((resolve) => {
+                performanceMonitor.registerServerView('view-1', makeWebContents(1, resolve), 'server-1');
+                performanceMonitor.registerView('view-2', makeWebContents(2, resolve), 'server-1');
+            });
+
+            jest.runOnlyPendingTimers();
+
+            expect(await sendValue).toEqual(new Map([['view-2', {cpu: 2, memory: 200, serverId: 'server-1'}], ['view-1', {cpu: 1, memory: 100, serverId: 'server-1'}]]));
+        });
+
+        it('should not send metrics for tabs of other servers to registered server views', async () => {
+            const performanceMonitor = new PerformanceMonitor();
+            performanceMonitor.init();
+
+            const sendValue = new Promise((resolve) => {
+                performanceMonitor.registerServerView('view-1', makeWebContents(1, resolve), 'server-1');
+                performanceMonitor.registerView('view-2', makeWebContents(2, resolve), 'server-2');
+            });
+
+            jest.runOnlyPendingTimers();
+
+            expect(await sendValue).toEqual(new Map([['view-1', {cpu: 1, memory: 100, serverId: 'server-1'}]]));
+        });
+
+        it('should always include node metrics', async () => {
+            app.getAppMetrics.mockReturnValue([{
+                name: 'main',
+                type: 'Browser',
+                cpu: {percentCPUUsage: 50},
+                memory: {privateBytes: 1000},
+            }]);
+
+            const performanceMonitor = new PerformanceMonitor();
+            performanceMonitor.init();
+
+            const sendValue = new Promise((resolve) => {
+                performanceMonitor.registerServerView('view-1', makeWebContents(1, resolve), 'server-1');
+            });
+
+            jest.runOnlyPendingTimers();
+
+            expect(await sendValue).toEqual(new Map([['view-1', {cpu: 1, memory: 100, serverId: 'server-1'}], ['main', {cpu: 50, memory: 1000}]]));
+        });
+
+        it('should never include tabs from getAppMetrics', async () => {
+            app.getAppMetrics.mockReturnValue([{
+                name: 'other-server',
+                type: 'Tab',
+                cpu: {percentCPUUsage: 50},
+                memory: {privateBytes: 1000},
+            }]);
+
+            const performanceMonitor = new PerformanceMonitor();
+            performanceMonitor.init();
+
+            const sendValue = new Promise((resolve) => {
+                performanceMonitor.registerServerView('view-1', makeWebContents(1, resolve), 'server-1');
+            });
+
+            jest.runOnlyPendingTimers();
+
+            expect(await sendValue).toEqual(new Map([['view-1', {cpu: 1, memory: 100, serverId: 'server-1'}]]));
+        });
+    });
+
+    describe('unregisterView', () => {
+        it('should not send after the view is removed', async () => {
+            const performanceMonitor = new PerformanceMonitor();
+            performanceMonitor.init();
+
+            const sendValue = new Promise((resolve) => {
+                performanceMonitor.registerServerView('view-1', makeWebContents(1, resolve), 'server-1');
+                performanceMonitor.registerServerView('view-2', makeWebContents(2, resolve), 'server-1');
+            });
+
+            jest.runOnlyPendingTimers();
+            expect(await sendValue).toEqual(new Map([['view-1', {cpu: 1, memory: 100, serverId: 'server-1'}], ['view-2', {cpu: 2, memory: 200, serverId: 'server-1'}]]));
+
+            // Have to re-register to make sure the promise resolves
+            const sendValue2 = new Promise((resolve) => {
+                performanceMonitor.unregisterView(2);
+                performanceMonitor.registerServerView('view-1', makeWebContents(1, resolve), 'server-1');
+            });
+
+            jest.runOnlyPendingTimers();
+            expect(await sendValue2).toEqual(new Map([['view-1', {cpu: 1, memory: 100, serverId: 'server-1'}]]));
+        });
+    });
+});

--- a/src/main/performanceMonitor.ts
+++ b/src/main/performanceMonitor.ts
@@ -1,0 +1,171 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {app, ipcMain, type IpcMainEvent, powerMonitor, type WebContents} from 'electron';
+
+import {EMIT_CONFIGURATION, METRICS_RECEIVE, METRICS_REQUEST, METRICS_SEND} from 'common/communication';
+import Config from 'common/config';
+import {Logger} from 'common/log';
+
+const METRIC_SEND_INTERVAL = 60000;
+const log = new Logger('PerformanceMonitor');
+
+type MetricsView = {
+    name: string;
+    webContents: WebContents;
+    serverId?: string;
+}
+
+type Metrics = {
+    serverId?: string;
+    cpu?: number;
+    memory?: number;
+}
+
+export class PerformanceMonitor {
+    private updateInterval?: NodeJS.Timeout;
+    private views: Map<number, MetricsView>;
+    private serverViews: Map<number, MetricsView>;
+    private isInitted: boolean;
+
+    constructor() {
+        this.views = new Map();
+        this.serverViews = new Map();
+        this.isInitted = false;
+
+        powerMonitor.on('suspend', this.stop);
+        powerMonitor.on('resume', this.start);
+        powerMonitor.on('lock-screen', this.stop);
+        powerMonitor.on('unlock-screen', this.start);
+        powerMonitor.on('speed-limit-change', this.handleSpeedLimitChange);
+
+        ipcMain.on(EMIT_CONFIGURATION, this.handleConfigUpdate);
+    }
+
+    init = () => {
+        // Set that it's initted so that the powerMonitor functions correctly
+        this.isInitted = true;
+
+        // Run once because the first CPU value is always 0
+        this.runMetrics();
+
+        if (Config.enableMetrics) {
+            this.start();
+        }
+    };
+
+    registerView = (name: string, webContents: WebContents, serverId?: string) => {
+        log.debug('registerView', webContents.id, name);
+
+        webContents.on('did-finish-load', () => {
+            this.views.set(webContents.id, {name, webContents, serverId});
+        });
+    };
+
+    registerServerView = (name: string, webContents: WebContents, serverId: string) => {
+        log.debug('registerServerView', webContents.id, serverId);
+
+        webContents.on('did-finish-load', () => {
+            this.serverViews.set(webContents.id, {name, webContents, serverId});
+        });
+    };
+
+    unregisterView = (webContentsId: number) => {
+        log.debug('unregisterView', webContentsId);
+
+        this.views.delete(webContentsId);
+        this.serverViews.delete(webContentsId);
+    };
+
+    private start = () => {
+        if (!this.isInitted) {
+            return;
+        }
+
+        if (!Config.enableMetrics) {
+            return;
+        }
+
+        log.verbose('start');
+
+        if (this.updateInterval) {
+            clearInterval(this.updateInterval);
+        }
+        this.updateInterval = setInterval(this.sendMetrics, METRIC_SEND_INTERVAL);
+    };
+
+    private stop = () => {
+        log.verbose('stop');
+
+        clearInterval(this.updateInterval);
+        delete this.updateInterval;
+    };
+
+    private runMetrics = async () => {
+        const metricsMap: Map<string, Metrics> = new Map();
+
+        // Collect metrics for all of the Node processes
+        app.getAppMetrics().
+            filter((metric) => metric.type !== 'Tab').
+            forEach((metric) => {
+                metricsMap.set(metric.name ?? metric.type, {
+                    cpu: metric.cpu.percentCPUUsage,
+                    memory: metric.memory.privateBytes ?? metric.memory.workingSetSize,
+                });
+            });
+
+        const viewResolves: Map<number, () => void> = new Map();
+        const listener = (event: IpcMainEvent, name: string, metrics: Metrics) => {
+            metricsMap.set(name, metrics);
+            viewResolves.get(event.sender.id)?.();
+        };
+        ipcMain.on(METRICS_RECEIVE, listener);
+        const viewPromises = [...this.views.values(), ...this.serverViews.values()].map((view) => {
+            return new Promise<void>((resolve) => {
+                viewResolves.set(view.webContents.id, resolve);
+                view.webContents.send(METRICS_REQUEST, view.name, view.serverId);
+            });
+        });
+        await Promise.all(viewPromises);
+        ipcMain.off(METRICS_RECEIVE, listener);
+        return metricsMap;
+    };
+
+    private sendMetrics = async () => {
+        const metricsMap = await this.runMetrics();
+        for (const view of this.serverViews.values()) {
+            const serverId = view.serverId;
+            if (!serverId) {
+                log.error(`Cannot send metrics for ${view.name}  - missing server id`);
+                continue;
+            }
+
+            if (!view.webContents) {
+                log.error(`Cannot send metrics for ${view.name}  - missing web contents`);
+                continue;
+            }
+
+            const serverMetricsMap = new Map([...metricsMap].filter((value) => !value[1].serverId || value[1].serverId === view.serverId));
+            view.webContents?.send(METRICS_SEND, serverMetricsMap);
+        }
+    };
+
+    private handleConfigUpdate = () => {
+        if (!Config.enableMetrics && this.updateInterval) {
+            this.stop();
+        } else if (!this.updateInterval) {
+            this.start();
+        }
+    };
+
+    private handleSpeedLimitChange = (limit: number) => {
+        if (limit < 100) {
+            this.stop();
+        } else {
+            this.start();
+        }
+    };
+}
+
+const performanceMonitor = new PerformanceMonitor();
+export default performanceMonitor;

--- a/src/main/preload/internalAPI.js
+++ b/src/main/preload/internalAPI.js
@@ -93,6 +93,8 @@ import {
     VIEW_FINISHED_RESIZING,
     GET_NONCE,
     IS_DEVELOPER_MODE_ENABLED,
+    METRICS_REQUEST,
+    METRICS_RECEIVE,
 } from 'common/communication';
 
 console.log('Preload initialized');
@@ -258,3 +260,10 @@ const createKeyDownListener = () => {
 };
 createKeyDownListener();
 
+ipcRenderer.on(METRICS_REQUEST, async (_, name) => {
+    const memory = await process.getProcessMemoryInfo();
+    ipcRenderer.send(METRICS_RECEIVE, name, {cpu: process.getCPUUsage().percentCPUUsage, memory: memory.residentSet ?? memory.private});
+});
+
+// Call this once to unset it to 0
+process.getCPUUsage();

--- a/src/main/tray/tray.test.js
+++ b/src/main/tray/tray.test.js
@@ -58,6 +58,9 @@ jest.mock('main/AutoLauncher', () => ({
 jest.mock('main/badge', () => ({
     setUnreadBadgeSetting: jest.fn(),
 }));
+jest.mock('main/performanceMonitor', () => ({
+    registerView: jest.fn(),
+}));
 jest.mock('main/windows/mainWindow', () => ({
     sendToRenderer: jest.fn(),
     on: jest.fn(),

--- a/src/main/views/MattermostBrowserView.test.js
+++ b/src/main/views/MattermostBrowserView.test.js
@@ -61,6 +61,11 @@ jest.mock('../utils', () => ({
 jest.mock('main/developerMode', () => ({
     get: jest.fn(),
 }));
+jest.mock('main/performanceMonitor', () => ({
+    registerView: jest.fn(),
+    registerServerView: jest.fn(),
+    unregisterView: jest.fn(),
+}));
 
 const server = new MattermostServer({name: 'server_name', url: 'http://server-1.com'});
 const view = new MessagingView(server, true);

--- a/src/main/views/downloadsDropdownMenuView.test.js
+++ b/src/main/views/downloadsDropdownMenuView.test.js
@@ -51,6 +51,9 @@ jest.mock('macos-notification-state', () => ({
     getDoNotDisturb: jest.fn(),
 }));
 jest.mock('main/downloadsManager', () => ({}));
+jest.mock('main/performanceMonitor', () => ({
+    registerView: jest.fn(),
+}));
 jest.mock('main/windows/mainWindow', () => ({
     on: jest.fn(),
     get: jest.fn(),

--- a/src/main/views/downloadsDropdownMenuView.ts
+++ b/src/main/views/downloadsDropdownMenuView.ts
@@ -27,6 +27,7 @@ import {
     TAB_BAR_HEIGHT,
 } from 'common/utils/constants';
 import downloadsManager from 'main/downloadsManager';
+import performanceMonitor from 'main/performanceMonitor';
 import {getLocalPreload} from 'main/utils';
 import MainWindow from 'main/windows/mainWindow';
 
@@ -75,6 +76,7 @@ export class DownloadsDropdownMenuView {
             // @ts-ignore
             transparent: true,
         }});
+        performanceMonitor.registerView('DownloadsDropdownMenuView', this.view.webContents);
         this.view.webContents.loadURL('mattermost-desktop://renderer/downloadsDropdownMenu.html');
         MainWindow.get()?.addBrowserView(this.view);
     };

--- a/src/main/views/downloadsDropdownView.test.js
+++ b/src/main/views/downloadsDropdownView.test.js
@@ -64,6 +64,9 @@ jest.mock('main/downloadsManager', () => ({
     onOpen: jest.fn(),
     onClose: jest.fn(),
 }));
+jest.mock('main/performanceMonitor', () => ({
+    registerView: jest.fn(),
+}));
 jest.mock('main/windows/mainWindow', () => ({
     on: jest.fn(),
     get: jest.fn(),

--- a/src/main/views/downloadsDropdownView.ts
+++ b/src/main/views/downloadsDropdownView.ts
@@ -21,6 +21,7 @@ import Config from 'common/config';
 import {Logger} from 'common/log';
 import {TAB_BAR_HEIGHT, DOWNLOADS_DROPDOWN_WIDTH, DOWNLOADS_DROPDOWN_HEIGHT, DOWNLOADS_DROPDOWN_FULL_WIDTH} from 'common/utils/constants';
 import downloadsManager from 'main/downloadsManager';
+import performanceMonitor from 'main/performanceMonitor';
 import {getLocalPreload} from 'main/utils';
 import MainWindow from 'main/windows/mainWindow';
 
@@ -65,6 +66,7 @@ export class DownloadsDropdownView {
             transparent: true,
         }});
 
+        performanceMonitor.registerView('DownloadsDropdownView', this.view.webContents);
         this.view.webContents.loadURL('mattermost-desktop://renderer/downloadsDropdown.html');
         MainWindow.get()?.addBrowserView(this.view);
     };

--- a/src/main/views/loadingScreen.test.js
+++ b/src/main/views/loadingScreen.test.js
@@ -10,7 +10,9 @@ jest.mock('electron', () => ({
         on: jest.fn(),
     },
 }));
-
+jest.mock('main/performanceMonitor', () => ({
+    registerView: jest.fn(),
+}));
 jest.mock('main/windows/mainWindow', () => ({
     get: jest.fn(),
     on: jest.fn(),

--- a/src/main/views/loadingScreen.ts
+++ b/src/main/views/loadingScreen.ts
@@ -5,6 +5,7 @@ import {BrowserView, app, ipcMain} from 'electron';
 
 import {DARK_MODE_CHANGE, LOADING_SCREEN_ANIMATION_FINISHED, MAIN_WINDOW_RESIZED, TOGGLE_LOADING_SCREEN_VISIBILITY} from 'common/communication';
 import {Logger} from 'common/log';
+import performanceMonitor from 'main/performanceMonitor';
 import {getLocalPreload, getWindowBoundaries} from 'main/utils';
 import MainWindow from 'main/windows/mainWindow';
 
@@ -86,6 +87,8 @@ export class LoadingScreen {
             transparent: true,
         }});
         const localURL = 'mattermost-desktop://renderer/loadingScreen.html';
+
+        performanceMonitor.registerView('LoadingScreen', this.view.webContents);
         this.view.webContents.loadURL(localURL);
     };
 

--- a/src/main/views/modalView.test.js
+++ b/src/main/views/modalView.test.js
@@ -27,6 +27,10 @@ jest.mock('../contextMenu', () => jest.fn());
 jest.mock('../utils', () => ({
     getWindowBoundaries: jest.fn(),
 }));
+jest.mock('main/performanceMonitor', () => ({
+    registerView: jest.fn(),
+    unregisterView: jest.fn(),
+}));
 
 describe('main/views/modalView', () => {
     describe('show', () => {

--- a/src/main/views/modalView.ts
+++ b/src/main/views/modalView.ts
@@ -5,6 +5,7 @@ import type {BrowserWindow} from 'electron';
 import {BrowserView} from 'electron';
 
 import {Logger} from 'common/log';
+import performanceMonitor from 'main/performanceMonitor';
 
 import ContextMenu from '../contextMenu';
 import {getWindowBoundaries} from '../utils';
@@ -50,6 +51,7 @@ export class ModalView<T, T2> {
 
         this.status = Status.ACTIVE;
         try {
+            performanceMonitor.registerView(`Modal-${key}`, this.view.webContents);
             this.view.webContents.loadURL(this.html);
         } catch (e) {
             this.log.error('there was an error loading the modal:');
@@ -99,6 +101,7 @@ export class ModalView<T, T2> {
                 this.view.webContents.closeDevTools();
             }
             this.windowAttached.removeBrowserView(this.view);
+            performanceMonitor.unregisterView(this.view.webContents.id);
             this.view.webContents.close();
 
             delete this.windowAttached;

--- a/src/main/views/serverDropdownView.test.js
+++ b/src/main/views/serverDropdownView.test.js
@@ -26,6 +26,9 @@ jest.mock('electron', () => ({
         on: jest.fn(),
     },
 }));
+jest.mock('main/performanceMonitor', () => ({
+    registerView: jest.fn(),
+}));
 jest.mock('main/windows/mainWindow', () => ({
     on: jest.fn(),
     get: jest.fn(),

--- a/src/main/views/serverDropdownView.ts
+++ b/src/main/views/serverDropdownView.ts
@@ -22,6 +22,7 @@ import Config from 'common/config';
 import {Logger} from 'common/log';
 import ServerManager from 'common/servers/serverManager';
 import {TAB_BAR_HEIGHT, THREE_DOT_MENU_WIDTH, THREE_DOT_MENU_WIDTH_MAC, MENU_SHADOW_WIDTH} from 'common/utils/constants';
+import performanceMonitor from 'main/performanceMonitor';
 import {getLocalPreload} from 'main/utils';
 
 import type {UniqueServer} from 'types/config';
@@ -83,6 +84,7 @@ export class ServerDropdownView {
             // @ts-ignore
             transparent: true,
         }});
+        performanceMonitor.registerView('ServerDropdownView', this.view.webContents);
         this.view.webContents.loadURL('mattermost-desktop://renderer/dropdown.html');
 
         this.setOrderedServers();

--- a/src/main/views/viewManager.test.js
+++ b/src/main/views/viewManager.test.js
@@ -81,6 +81,9 @@ jest.mock('main/windows/mainWindow', () => ({
     get: jest.fn(),
     on: jest.fn(),
 }));
+jest.mock('main/performanceMonitor', () => ({
+    registerView: jest.fn(),
+}));
 jest.mock('common/servers/serverManager', () => ({
     getOrderedTabsForServer: jest.fn(),
     getAllServers: jest.fn(),

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -48,6 +48,7 @@ import {TAB_MESSAGING} from 'common/views/View';
 import {flushCookiesStore} from 'main/app/utils';
 import DeveloperMode from 'main/developerMode';
 import {localizeMessage} from 'main/i18nManager';
+import performanceMonitor from 'main/performanceMonitor';
 import PermissionsManager from 'main/permissionsManager';
 import MainWindow from 'main/windows/mainWindow';
 
@@ -373,6 +374,7 @@ export class ViewManager {
                     transparent: true,
                 }});
             const localURL = `mattermost-desktop://renderer/urlView.html?url=${encodeURIComponent(urlString)}`;
+            performanceMonitor.registerView('URLView', urlView.webContents);
             urlView.webContents.loadURL(localURL);
             MainWindow.get()?.addBrowserView(urlView);
             const boundaries = this.views.get(this.currentView || '')?.getBounds() ?? MainWindow.getBounds();
@@ -385,6 +387,7 @@ export class ViewManager {
                     log.error('Failed to remove URL view', e);
                 }
 
+                performanceMonitor.unregisterView(urlView.webContents.id);
                 urlView.webContents.close();
             };
 

--- a/src/main/windows/callsWidgetWindow.test.js
+++ b/src/main/windows/callsWidgetWindow.test.js
@@ -67,6 +67,10 @@ jest.mock('main/windows/mainWindow', () => ({
 jest.mock('app/serverViewState', () => ({
     switchServer: jest.fn(),
 }));
+jest.mock('main/performanceMonitor', () => ({
+    registerView: jest.fn(),
+    unregisterView: jest.fn(),
+}));
 jest.mock('main/views/viewManager', () => ({
     getView: jest.fn(),
     getViewByWebContentsId: jest.fn(),
@@ -156,6 +160,9 @@ describe('main/windows/callsWidgetWindow', () => {
             on: jest.fn(),
             close: jest.fn(),
             isDestroyed: jest.fn(),
+            webContents: {
+                id: 1,
+            },
         };
 
         beforeEach(() => {

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -28,6 +28,7 @@ import {Logger} from 'common/log';
 import {CALLS_PLUGIN_ID, MINIMUM_CALLS_WIDGET_HEIGHT, MINIMUM_CALLS_WIDGET_WIDTH} from 'common/utils/constants';
 import {getFormattedPathName, isCallsPopOutURL, parseURL} from 'common/utils/url';
 import Utils from 'common/utils/util';
+import performanceMonitor from 'main/performanceMonitor';
 import PermissionsManager from 'main/permissionsManager';
 import {
     composeUserAgent,
@@ -173,6 +174,7 @@ export class CallsWidgetWindow {
         if (!widgetURL) {
             return;
         }
+        performanceMonitor.registerView('CallsWidgetWindow', this.win.webContents);
         this.win?.loadURL(widgetURL, {
             userAgent: composeUserAgent(),
         }).catch((reason) => {
@@ -195,6 +197,7 @@ export class CallsWidgetWindow {
                 return;
             }
             this.win?.on('closed', resolve);
+            performanceMonitor.unregisterView(this.win.webContents.id);
             this.win?.close();
         });
     };

--- a/src/main/windows/mainWindow.test.js
+++ b/src/main/windows/mainWindow.test.js
@@ -73,6 +73,9 @@ jest.mock('../utils', () => ({
 jest.mock('main/i18nManager', () => ({
     localizeMessage: jest.fn(),
 }));
+jest.mock('main/performanceMonitor', () => ({
+    registerView: jest.fn(),
+}));
 
 describe('main/windows/mainWindow', () => {
     describe('init', () => {

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -34,6 +34,7 @@ import Utils from 'common/utils/util';
 import * as Validator from 'common/Validator';
 import {boundsInfoPath} from 'main/constants';
 import {localizeMessage} from 'main/i18nManager';
+import performanceMonitor from 'main/performanceMonitor';
 
 import type {SavedWindowState} from 'types/mainWindow';
 
@@ -152,6 +153,7 @@ export class MainWindow extends EventEmitter {
         contextMenu.reload();
 
         const localURL = 'mattermost-desktop://renderer/index.html';
+        performanceMonitor.registerView('MainWindow', this.win.webContents);
         this.win.loadURL(localURL).catch(
             (reason) => {
                 log.error('failed to load', reason);

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -67,6 +67,7 @@ class SettingsPage extends React.PureComponent<Props, State> {
     autoCheckForUpdatesRef: React.RefObject<HTMLInputElement>;
     logLevelRef: React.RefObject<HTMLSelectElement>;
     appLanguageRef: React.RefObject<HTMLSelectElement>;
+    enableMetricsRef: React.RefObject<HTMLInputElement>;
 
     saveQueue: SaveQueueItem[];
 
@@ -106,6 +107,7 @@ class SettingsPage extends React.PureComponent<Props, State> {
         this.autoCheckForUpdatesRef = React.createRef();
         this.logLevelRef = React.createRef();
         this.appLanguageRef = React.createRef();
+        this.enableMetricsRef = React.createRef();
 
         this.saveQueue = [];
         this.selectedSpellCheckerLocales = [];
@@ -216,6 +218,13 @@ class SettingsPage extends React.PureComponent<Props, State> {
                 this.setState({savingState});
             }
         }, 2000);
+    };
+
+    handleEnableMetrics = () => {
+        window.timers.setImmediate(this.saveSetting, CONFIG_TYPE_APP_OPTIONS, {key: 'enableMetrics', data: this.enableMetricsRef.current?.checked});
+        this.setState({
+            enableMetrics: this.enableMetricsRef.current?.checked,
+        });
     };
 
     handleChangeShowTrayIcon = () => {
@@ -708,6 +717,30 @@ class SettingsPage extends React.PureComponent<Props, State> {
                     </FormText>
                 </FormCheck>);
         }
+
+        options.push(
+            <FormCheck
+                key='enableMetrics'
+            >
+                <FormCheck.Input
+                    type='checkbox'
+                    key='inputEnableMetrics'
+                    id='inputEnableMetrics'
+                    ref={this.enableMetricsRef}
+                    checked={this.state.enableMetrics}
+                    onChange={this.handleEnableMetrics}
+                />
+                <FormattedMessage
+                    id='renderer.components.settingsPage.enableMetrics'
+                    defaultMessage='Send anonymous usage data to your server administrator'
+                />
+                <FormText>
+                    <FormattedMessage
+                        id='renderer.components.settingsPage.enableMetrics.description'
+                        defaultMessage='Sends usage data about the application and its performance to your local servers that accept it.'
+                    />
+                </FormText>
+            </FormCheck>);
 
         if (window.process.platform === 'win32' || window.process.platform === 'linux') {
             options.push(

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -732,12 +732,12 @@ class SettingsPage extends React.PureComponent<Props, State> {
                 />
                 <FormattedMessage
                     id='renderer.components.settingsPage.enableMetrics'
-                    defaultMessage='Send anonymous usage data to your server administrator'
+                    defaultMessage='Send anonymous usage data to your configured servers'
                 />
                 <FormText>
                     <FormattedMessage
                         id='renderer.components.settingsPage.enableMetrics.description'
-                        defaultMessage='Sends usage data about the application and its performance to your local servers that accept it.'
+                        defaultMessage='Sends usage data about the application and its performance to your configured servers that accept it.'
                     />
                 </FormText>
             </FormCheck>);

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -59,6 +59,7 @@ export type ConfigV3 = {
     alwaysClose?: boolean;
     logLevel?: string;
     appLanguage?: string;
+    enableMetrics?: boolean;
 }
 
 export type ConfigV2 =
@@ -131,4 +132,5 @@ export type MigrationInfo = {
     updateTrayIconWin32: boolean;
     masConfigs: boolean;
     closeExtraTabs: boolean;
+    enableMetrics: boolean;
 }

--- a/src/types/externalAPI.ts
+++ b/src/types/externalAPI.ts
@@ -25,4 +25,5 @@ export interface ExternalAPI {
     createListener(event: 'calls-widget-open-thread', listener: (threadID: string) => void): () => void;
     createListener(event: 'calls-widget-open-stop-recording-modal', listener: (channelID: string) => void): () => void;
     createListener(event: 'calls-widget-open-user-settings', listener: () => void): () => void;
+    createListener(event: 'metrics-send', listener: (metricsMap: Map<string, {cpu?: number; memory?: number}>) => void): () => void;
 }


### PR DESCRIPTION
#### Summary
This PR contains a new module called `performanceMonitor`, which is responsible for:
- Collect metrics from the main process and various utility processes
- Dispatch requests to the renderer processes for their respective metrics
- Collect all metrics and make any transformations necessary
- Send those metrics to the servers that are able to accept and display them at a set interval

This monitoring will take CPU and memory usage data and send it to servers that have elected to subscribe to the Desktop App for performance data. This data will then be available to administrators via Prometheus. 

The idea behind this is to get a better idea of how hard users are getting hit in terms of system resources by various parts of our app. The data is divided up by unique process, so that should give us some idea of which part of the app is causing issues if there is a lot of system resources being dedicated to a process.

Not in scope for this change are load times, which we will calculate and send as part of a separate API created later.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60610
https://mattermost.atlassian.net/browse/MM-60086

#### Screenshots
![image](https://github.com/user-attachments/assets/866bb02a-6302-4efa-8c65-c130ace6d0d8)

```release-note
Implement a performanceMonitor to collect and send anonymous usage data to server dashboards.
```
