### PR TITLE
[MM-61058] Upgrade `electron-log`, turn on async logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "electron-context-menu": "3.6.1",
         "electron-extension-installer": "1.2.0",
         "electron-is-dev": "2.0.0",
-        "electron-log": "5.1.1",
+        "electron-log": "5.2.0",
         "electron-updater": "6.3.0",
         "joi": "17.12.2",
         "macos-notification-state": "3.0.0",
@@ -89,7 +89,7 @@
     },
     "api-types": {
       "name": "@mattermost/desktop-api",
-      "version": "5.10.0-1",
+      "version": "5.10.0-2",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -7488,9 +7488,9 @@
       }
     },
     "node_modules/electron-log": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.1.1.tgz",
-      "integrity": "sha512-If7HU4Slbh2xfjOXOLxifkbgu6HmWDNJyXPLW+XNTOHMfFKisg0trA3d/7syyu25S+lHosfsd0VMfDSjGn1+Pw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.2.0.tgz",
+      "integrity": "sha512-VjLkvaLmbP3AOGOh5Fob9M8bFU0mmeSAb5G2EoTBx+kQLf2XA/0byzjsVGBTHhikbT+m1AB27NEQUv9wX9nM8w==",
       "engines": {
         "node": ">= 14"
       }

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "electron-context-menu": "3.6.1",
     "electron-extension-installer": "1.2.0",
     "electron-is-dev": "2.0.0",
-    "electron-log": "5.1.1",
+    "electron-log": "5.2.0",
     "electron-updater": "6.3.0",
     "joi": "17.12.2",
     "macos-notification-state": "3.0.0",

--- a/src/common/log.ts
+++ b/src/common/log.ts
@@ -6,6 +6,10 @@ import log from 'electron-log';
 
 import Util from 'common/utils/util';
 
+// Turn off sync logging to prevent blocking the main thread
+// One downside to this is that some logs may not be written to the log file when the app closes
+log.transports.file.sync = false;
+
 export const setLoggingLevel = (level: string) => {
     if (log.transports.file.level === level) {
         return;


### PR DESCRIPTION
#### Summary
This PR turns on async logging for the Desktop App, as the default behaviour of `electron-log` is to write synchronously and wait on the main thread. Also I have upgraded `electron-log` to the latest released version.

This should address issues for those with endpoint security/AV software running, or users on a weaker/slower disk that are experiencing slowness in the app, especially while on a higher logging level.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61058

```release-note
Upgrade `electron-log`, turn on async logging
```
