### PR TITLE
Upgrade`windows-focus-assist` to 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "react-select": "5.8.0",
         "uuid": "9.0.1",
         "valid-url": "1.0.9",
-        "windows-focus-assist": "1.3.0",
+        "windows-focus-assist": "1.4.0",
         "winreg-utf8": "0.1.1",
         "yargs": "17.7.2"
       },
@@ -17276,9 +17276,9 @@
       "dev": true
     },
     "node_modules/windows-focus-assist": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/windows-focus-assist/-/windows-focus-assist-1.3.0.tgz",
-      "integrity": "sha512-V4FsWiPFiauRFrn49G2oB6zW6afYSp1/EmOFHmU6kmis6J9N3v1JbHmoPlIedHG1Th8YooCSws+LgbM8HgPlVg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/windows-focus-assist/-/windows-focus-assist-1.4.0.tgz",
+      "integrity": "sha512-AmiJc0FVjOFNij+eDfEObS+j9fJ1eWkNyxSjxx+jLMr87996WsscZ9WgsoQg6CizPmxxfHnxYhv5DCuTJldoPg==",
       "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "react-select": "5.8.0",
     "uuid": "9.0.1",
     "valid-url": "1.0.9",
-    "windows-focus-assist": "1.3.0",
+    "windows-focus-assist": "1.4.0",
     "winreg-utf8": "0.1.1",
     "yargs": "17.7.2"
   }


### PR DESCRIPTION
#### Summary
An issue I missed with Windows build when upgrading to Electron v33 caused the release to fail. This was caused by `windows-focus-assist`. This upgrade fixes the build issue.

```release-note
NONE
```
