### PR TITLE
Fix Digest Mismatch error on Enterprise Linux installations when FIPS mode enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,5 +184,10 @@
     "windows-focus-assist": "1.4.0",
     "winreg-utf8": "0.1.1",
     "yargs": "17.7.2"
+  },
+  "rpm": {
+    "fpm": [
+      "--rpm-digest=sha256"
+    ]
   }
 }


### PR DESCRIPTION
#### Summary
Added fpm argument to the package.json file to change the hashing algorithm from md5 to sha256. This fixes an issue introduced in RHEL8+ and/or clones where if FIPS mode is enabled rpm digests must be hashed with at minimum sha256 to be allowed to be installed without bypassing security measures put in place by the FIPS standards. 

#### Ticket Link
https://github.com/mattermost/desktop/issues/3190

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [x] executed `npm run lint:js` for proper code formatting

#### Device Information
This PR was tested on: RHEL 8, RHEL 9, Rocky9, Rocky8

#### Release Note
```release-note
Modified rpm-digest to utilize sha256 instead of md5 to all for rpm installation on FIPS mode enabled Enterprise Linux systems.
```

