### PR TITLE
Fixed issues with loading the app from cold when deep linking

### DIFF
--- a/src/main/app/app.ts
+++ b/src/main/app/app.ts
@@ -29,7 +29,6 @@ export function handleAppSecondInstance(event: Event, argv: string[]) {
 
     // Protocol handler for win32
     // argv: An array of the second instance’s (command line / deep linked) arguments
-    MainWindow.show();
     const deeplinkingURL = getDeeplinkingURL(argv);
     if (deeplinkingURL) {
         openDeepLink(deeplinkingURL);

--- a/src/main/app/utils.ts
+++ b/src/main/app/utils.ts
@@ -8,7 +8,7 @@ import type {BrowserWindow, Rectangle} from 'electron';
 import {app, Menu, session, dialog, nativeImage, screen} from 'electron';
 import isDev from 'electron-is-dev';
 
-import {APP_MENU_WILL_CLOSE} from 'common/communication';
+import {APP_MENU_WILL_CLOSE, MAIN_WINDOW_CREATED} from 'common/communication';
 import Config from 'common/config';
 import JsonFileManager from 'common/JsonFileManager';
 import {Logger} from 'common/log';
@@ -38,8 +38,12 @@ const log = new Logger('App.Utils');
 
 export function openDeepLink(deeplinkingUrl: string) {
     try {
-        MainWindow.show();
-        ViewManager.handleDeepLink(deeplinkingUrl);
+        if (MainWindow.get()) {
+            MainWindow.show();
+            ViewManager.handleDeepLink(deeplinkingUrl);
+        } else {
+            MainWindow.on(MAIN_WINDOW_CREATED, () => ViewManager.handleDeepLink(deeplinkingUrl));
+        }
     } catch (err) {
         log.error(`There was an error opening the deeplinking url: ${err}`);
     }

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -92,9 +92,11 @@ export class ViewManager {
     }
 
     private init = () => {
-        LoadingScreen.show();
-        ServerManager.getAllServers().forEach((server) => this.loadServer(server));
-        this.showInitial();
+        if (ServerManager.hasServers()) {
+            LoadingScreen.show();
+            ServerManager.getAllServers().forEach((server) => this.loadServer(server));
+            this.showInitial();
+        }
     };
 
     private handleDeveloperModeUpdated = (json: DeveloperSettings) => {


### PR DESCRIPTION
#### Summary
While working on https://github.com/mattermost/desktop/pull/3200 I found an issue with deep linking when booting the app from cold. The application would fail to load the initial server, and the dropdown menu would also not load. This was caused by the main window creation call happening too early, before a bunch of other setup code could be run.

This PR fixes the issue by having the application wait for the main window to be created normally, before attempting to deep link.

```release-note
Fixed issues with loading the app from cold when deep linking
```
