### PR TITLE
[MM-53799] Stop autocompleting while the user is typing `https://`

### DIFF
--- a/src/app/serverViewState.test.js
+++ b/src/app/serverViewState.test.js
@@ -437,7 +437,11 @@ describe('app/serverViewState', () => {
             expect(result.status).toBe(URLValidationStatus.Invalid);
             result = await serverViewState.handleServerURLValidation({}, 'http');
             expect(result.status).toBe(URLValidationStatus.Invalid);
+            result = await serverViewState.handleServerURLValidation({}, 'HTTP');
+            expect(result.status).toBe(URLValidationStatus.Invalid);
             result = await serverViewState.handleServerURLValidation({}, 'https');
+            expect(result.status).toBe(URLValidationStatus.Invalid);
+            result = await serverViewState.handleServerURLValidation({}, 'HTTPS');
             expect(result.status).toBe(URLValidationStatus.Invalid);
             result = await serverViewState.handleServerURLValidation({}, 'https:');
             expect(result.status).toBe(URLValidationStatus.Invalid);

--- a/src/app/serverViewState.test.js
+++ b/src/app/serverViewState.test.js
@@ -428,6 +428,27 @@ describe('app/serverViewState', () => {
             expect(result.validatedURL).toBe('https://server.com/');
         });
 
+        it('should not update the URL if the user is typing https://', async () => {
+            let result = await serverViewState.handleServerURLValidation({}, 'h');
+            expect(result.status).toBe(URLValidationStatus.Invalid);
+            result = await serverViewState.handleServerURLValidation({}, 'ht');
+            expect(result.status).toBe(URLValidationStatus.Invalid);
+            result = await serverViewState.handleServerURLValidation({}, 'htt');
+            expect(result.status).toBe(URLValidationStatus.Invalid);
+            result = await serverViewState.handleServerURLValidation({}, 'http');
+            expect(result.status).toBe(URLValidationStatus.Invalid);
+            result = await serverViewState.handleServerURLValidation({}, 'https');
+            expect(result.status).toBe(URLValidationStatus.Invalid);
+            result = await serverViewState.handleServerURLValidation({}, 'https:');
+            expect(result.status).toBe(URLValidationStatus.Invalid);
+            result = await serverViewState.handleServerURLValidation({}, 'https:/');
+            expect(result.status).toBe(URLValidationStatus.Invalid);
+            result = await serverViewState.handleServerURLValidation({}, 'https://');
+            expect(result.status).toBe(URLValidationStatus.Invalid);
+            result = await serverViewState.handleServerURLValidation({}, 'https://a');
+            expect(result.status).toBe(URLValidationStatus.OK);
+        });
+
         it('should attempt HTTP when HTTPS fails, and generate a warning', async () => {
             ServerInfo.mockImplementation(({url}) => ({
                 fetchConfigData: jest.fn().mockImplementation(() => {
@@ -477,7 +498,7 @@ describe('app/serverViewState', () => {
 
             const result = await serverViewState.handleServerURLValidation({}, 'https://not-server.com');
             expect(result.status).toBe(URLValidationStatus.NotMattermost);
-            expect(result.validatedURL).toBe('https://not-server.com/');
+            expect(result.validatedURL).toBe('https://not-server.com');
         });
 
         it('should update the users URL when the Site URL is different', async () => {

--- a/src/app/serverViewState.test.js
+++ b/src/app/serverViewState.test.js
@@ -449,6 +449,13 @@ describe('app/serverViewState', () => {
             expect(result.status).toBe(URLValidationStatus.OK);
         });
 
+        it('should update the URL if the user is typing something other than http', async () => {
+            let result = await serverViewState.handleServerURLValidation({}, 'abchttp');
+            expect(result.status).toBe(URLValidationStatus.OK);
+            result = await serverViewState.handleServerURLValidation({}, 'abchttps');
+            expect(result.status).toBe(URLValidationStatus.OK);
+        });
+
         it('should attempt HTTP when HTTPS fails, and generate a warning', async () => {
             ServerInfo.mockImplementation(({url}) => ({
                 fetchConfigData: jest.fn().mockImplementation(() => {

--- a/src/app/serverViewState.ts
+++ b/src/app/serverViewState.ts
@@ -241,7 +241,7 @@ export class ServerViewState {
             // If it already includes the protocol, force it to HTTPS
             if (isValidURI(url) && !url.startsWith('http')) {
                 httpUrl = url.replace(/^((.+):\/\/)?/, 'https://');
-            } else if (!url.match(/^(h|ht|htt|http|https):?\/?\/?$/)) {
+            } else if (!'https://'.startsWith(url) && !'http://'.startsWith(url)) {
                 // Check if they're starting to type `http(s)`, otherwise add HTTPS for them
                 httpUrl = `https://${url}`;
             }

--- a/src/app/serverViewState.ts
+++ b/src/app/serverViewState.ts
@@ -238,11 +238,11 @@ export class ServerViewState {
 
         let httpUrl = url;
         if (!isValidURL(url)) {
-            // If it already includes the protocol, tell them it's invalid
-            if (isValidURI(url)) {
+            // If it already includes the protocol, force it to HTTPS
+            if (isValidURI(url) && !url.startsWith('http')) {
                 httpUrl = url.replace(/^((.+):\/\/)?/, 'https://');
-            } else {
-                // Otherwise add HTTPS for them
+            } else if (!url.match(/^(h|ht|htt|http|https):?\/?\/?$/)) {
+                // Check if they're starting to type `http(s)`, otherwise add HTTPS for them
                 httpUrl = `https://${url}`;
             }
         }
@@ -279,8 +279,9 @@ export class ServerViewState {
 
         // If we can't get the remote info, warn the user that this might not be the right URL
         // If the original URL was invalid, don't replace that as they probably have a typo somewhere
+        // Also strip the trailing slash if it's there so that the user can keep typing
         if (!remoteInfo) {
-            return {status: URLValidationStatus.NotMattermost, validatedURL: parsedURL.toString()};
+            return {status: URLValidationStatus.NotMattermost, validatedURL: parsedURL.toString().replace(/\/$/, '')};
         }
 
         const remoteServerName = remoteInfo.siteName === 'Mattermost' ? remoteURL.host.split('.')[0] : remoteInfo.siteName;

--- a/src/app/serverViewState.ts
+++ b/src/app/serverViewState.ts
@@ -239,9 +239,9 @@ export class ServerViewState {
         let httpUrl = url;
         if (!isValidURL(url)) {
             // If it already includes the protocol, force it to HTTPS
-            if (isValidURI(url) && !url.startsWith('http')) {
+            if (isValidURI(url) && !url.toLowerCase().startsWith('http')) {
                 httpUrl = url.replace(/^((.+):\/\/)?/, 'https://');
-            } else if (!'https://'.startsWith(url) && !'http://'.startsWith(url)) {
+            } else if (!'https://'.startsWith(url.toLowerCase()) && !'http://'.startsWith(url.toLowerCase())) {
                 // Check if they're starting to type `http(s)`, otherwise add HTTPS for them
                 httpUrl = `https://${url}`;
             }


### PR DESCRIPTION
#### Summary
In circumstances where the user stopped typing, or was slow typing the beginning of their server URL, the URL validation would kick in and erroneously mistake the beginning of a URL (ie. any substring of `https://`) as a hostname, and try to add `https://` for the user. This would cause some confusion and frustration for users trying to type.

This PR fixes the validation to recognize any leading substring of `https://` as an invalid URL before it tries to call it a hostname. This stops the user from having to backspace and correct themselves while typing, and should still server to help people typing without the leading `https://`. Additionally, I added a QoL fix to stop the trailing `/` from appearing while you were typing a host name, so that if you do stop, you don't have to backspace the `/` first to keep typing the name.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53799

```release-note
Stop autocompleting while the user is typing `https://`
```
