### PR TITLE
[MM-61725] Remove unnecessary macOS entitlements

### DIFF
--- a/resources/mac/entitlements.mac.inherit.plist
+++ b/resources/mac/entitlements.mac.inherit.plist
@@ -2,9 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.cs.allow-jit</key>
-	<true/>
-	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.inherit</key>
     <true/>

--- a/resources/mac/entitlements.mac.plist
+++ b/resources/mac/entitlements.mac.plist
@@ -10,8 +10,6 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
-	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-	<true/>
 	<key>com.apple.developer.usernotifications.communication</key>
 	<true/>
 </dict>

--- a/resources/mac/entitlements.mac.plist
+++ b/resources/mac/entitlements.mac.plist
@@ -12,8 +12,6 @@
 	<true/>
 	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
 	<true/>
-	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
-	<true/>
 	<key>com.apple.developer.usernotifications.communication</key>
 	<true/>
 </dict>

--- a/resources/mac/entitlements.mas.plist
+++ b/resources/mac/entitlements.mas.plist
@@ -14,8 +14,6 @@
 	<true/>
 	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
 	<true/>
-	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
-	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/resources/mac/entitlements.mas.plist
+++ b/resources/mac/entitlements.mas.plist
@@ -12,8 +12,6 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
-	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>


### PR DESCRIPTION
#### Summary
These entitlements are not necessary for the app to function under macOS anymore, as they are from older Electron versions. This PR removes these entitlements.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61725

```release-note
NONE
```
