### PR TITLE
[MM-61864] Fix issue where the app will not restore when opened again from cold, fix issue where deep linking from cold didn't work on Linux

### DIFF
--- a/src/main/app/app.ts
+++ b/src/main/app/app.ts
@@ -32,6 +32,8 @@ export function handleAppSecondInstance(event: Event, argv: string[]) {
     const deeplinkingURL = getDeeplinkingURL(argv);
     if (deeplinkingURL) {
         openDeepLink(deeplinkingURL);
+    } else if (MainWindow.get()) {
+        MainWindow.show();
     }
 }
 

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -395,7 +395,7 @@ async function initializeAfterAppReady() {
     let deeplinkingURL;
 
     // Protocol handler for win32
-    if (process.platform === 'win32') {
+    if (process.platform !== 'darwin') {
         const args = process.argv.slice(1);
         if (Array.isArray(args) && args.length > 0) {
             deeplinkingURL = getDeeplinkingURL(args);

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -394,7 +394,7 @@ async function initializeAfterAppReady() {
 
     let deeplinkingURL;
 
-    // Protocol handler for win32
+    // Protocol handler for win32 and linux
     if (process.platform !== 'darwin') {
         const args = process.argv.slice(1);
         if (Array.isArray(args) && args.length > 0) {


### PR DESCRIPTION
#### Summary
After fixing https://github.com/mattermost/desktop/pull/3201, I introduced a bug where the app would not restore its window when booting a second instance, due to the removal of `MainWindow.show()`, which was removed since it interfered with the normal app boot process from cold. I also noticed that from cold, Linux would ignore deep links.

This PR fixes both of the above issues.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61864

```release-note
Fix issue where the app will not restore when opened again from cold
Fix issue where deep linking from cold didn't work on Linux
```
