### PR TITLE
[MM-61919] Wrap potential crash in try/catch for thumbnails, fall back to `createFromPath`

### DIFF
--- a/src/main/downloadsManager.ts
+++ b/src/main/downloadsManager.ts
@@ -635,10 +635,11 @@ export class DownloadsManager extends JsonFileManager<DownloadedItems> {
                 if (item.getReceivedBytes() < 1000000) {
                     thumbnailData = (await nativeImage.createFromPath(overridePath ?? item.getSavePath())).toDataURL();
                 }
-            }
+            };
+
             // Linux doesn't support the thumbnail creation so we have to use the base function
             if (process.platform === 'linux') {
-                await fallback()
+                await fallback();
             } else {
                 // This has been known to fail on Windows, see: https://github.com/mattermost/desktop/issues/3140
                 try {

--- a/src/main/downloadsManager.ts
+++ b/src/main/downloadsManager.ts
@@ -630,14 +630,22 @@ export class DownloadsManager extends JsonFileManager<DownloadedItems> {
 
         let thumbnailData;
         if (state === 'completed' && item.getMimeType().toLowerCase().startsWith('image/')) {
-            // Linux doesn't support the thumbnail creation so we have to use the base function
-            if (process.platform === 'linux') {
+            const fallback = async () => {
                 // We also will cap this at 1MB so as to not inflate the memory usage of the downloads dropdown
                 if (item.getReceivedBytes() < 1000000) {
                     thumbnailData = (await nativeImage.createFromPath(overridePath ?? item.getSavePath())).toDataURL();
                 }
+            }
+            // Linux doesn't support the thumbnail creation so we have to use the base function
+            if (process.platform === 'linux') {
+                await fallback()
             } else {
-                thumbnailData = (await nativeImage.createThumbnailFromPath(overridePath ?? item.getSavePath(), {height: 32, width: 32})).toDataURL();
+                // This has been known to fail on Windows, see: https://github.com/mattermost/desktop/issues/3140
+                try {
+                    thumbnailData = (await nativeImage.createThumbnailFromPath(overridePath ?? item.getSavePath(), {height: 32, width: 32})).toDataURL();
+                } catch {
+                    await fallback();
+                }
             }
         }
 


### PR DESCRIPTION
#### Summary
There seems to be a Windows-only crash case where calling `createThumbnailFromPath` would throw an error failing to get the thumbnail from a local cache (see https://github.com/electron/electron/blob/main/shell/common/api/electron_api_native_image_win.cc#L69). I'm not certain but I'm guessing it has something to do with files that do not have thumbnails pre-generated by the OS, and Electron expects that they are always there. This causes a hard crash since that method throws an error.

This PR simply adds an error boundary to fallback to `createFromPath` in those situations where a thumbnail cannot be retrieved, to avoid having the app crash hard.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61919
Closes https://github.com/mattermost/desktop/issues/3140

```release-note
Fixed an issue where the app could crash loading a thumbnail on Windows
```
