### PR TITLE
Update build environment for GitHub Actions from macOS 12 to 15

### DIFF
--- a/.github/workflows/build-for-pr.yml
+++ b/.github/workflows/build-for-pr.yml
@@ -139,7 +139,7 @@ jobs:
           retention-days: 10 ## No need to keep CI builds more than 10 days
 
   build-mac-for-pr:
-    runs-on: macos-12
+    runs-on: macos-15
     if: ${{ github.event.label.name == 'Build Apps for PR' }}
     steps:
       - name: ci/checkout-repo

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,7 +142,7 @@ jobs:
           retention-days: 10 ## No need to keep CI builds more than 10 days
 
   build-mac-no-dmg:
-    runs-on: macos-12
+    runs-on: macos-15
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/nightly-main.yml
+++ b/.github/workflows/nightly-main.yml
@@ -106,7 +106,7 @@ jobs:
           retention-days: 5 ## No need to keep them since they are uploaded on S3
 
   mac-app-store-preflight:
-    runs-on: macos-12
+    runs-on: macos-15
     env:
       MAS_PROFILE: ${{ secrets.MM_DESKTOP_MAC_APP_STORE_MAS_PROFILE }}
       MACOS_API_KEY_ID: ${{ secrets.MM_DESKTOP_MAC_APP_STORE_MACOS_API_KEY_ID }}
@@ -142,7 +142,7 @@ jobs:
         run: fastlane publish_test path:"$(find . -name \*.pkg -print -quit)"
 
   build-mac-installer:
-    runs-on: macos-12
+    runs-on: macos-15
     needs:
       - mac-app-store-preflight
     steps:

--- a/.github/workflows/nightly-rainforest.yml
+++ b/.github/workflows/nightly-rainforest.yml
@@ -73,7 +73,7 @@ jobs:
           retention-days: 5 ## No need to keep them since they are uploaded on S3
 
   build-mac-installer:
-    runs-on: macos-12
+    runs-on: macos-15
     steps:
       - name: nightly/checkout-repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/release-mas.yaml
+++ b/.github/workflows/release-mas.yaml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   mac-app-store-preflight:
-    runs-on: macos-12
+    runs-on: macos-15
     env:
       MAS_PROFILE: ${{ secrets.MM_DESKTOP_MAC_APP_STORE_MAS_PROFILE }}
       MACOS_API_KEY_ID: ${{ secrets.MM_DESKTOP_MAC_APP_STORE_MACOS_API_KEY_ID }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,7 +119,7 @@ jobs:
           retention-days: 14
 
   build-mac-installer:
-    runs-on: macos-12
+    runs-on: macos-15
     needs:
       - begin-notification
     steps:


### PR DESCRIPTION
#### Summary
The macOS 12 runner has been deprecated by GitHub, so I've upgraded us to macOS 15.

```release-note
NONE
```
