### PR TITLE
[MM-61821] Automatically allow permission checks for supported permission types through for GPO configured servers

### DIFF
--- a/src/main/permissionsManager.test.js
+++ b/src/main/permissionsManager.test.js
@@ -40,7 +40,7 @@ jest.mock('common/utils/url', () => ({
 
 jest.mock('common/config', () => ({
     registryData: {
-        servers: []
+        servers: [],
     },
 }));
 
@@ -97,7 +97,7 @@ describe('main/PermissionsManager', () => {
             Config.registryData.servers = [
                 {
                     url: 'http://gposerver.com',
-                }
+                },
             ];
         });
 

--- a/src/main/permissionsManager.ts
+++ b/src/main/permissionsManager.ts
@@ -22,6 +22,7 @@ import {
     OPEN_WINDOWS_MICROPHONE_PREFERENCES,
     UPDATE_PATHS,
 } from 'common/communication';
+import Config from 'common/config';
 import JsonFileManager from 'common/JsonFileManager';
 import {Logger} from 'common/log';
 import type {MattermostServer} from 'common/servers/MattermostServer';
@@ -141,7 +142,7 @@ export class PermissionsManager extends JsonFileManager<PermissionsByOrigin> {
             return false;
         }
 
-        let serverURL;
+        let serverURL: URL | undefined;
         if (CallsWidgetWindow.isCallsWidget(webContentsId)) {
             serverURL = CallsWidgetWindow.getViewURL();
         } else {
@@ -150,6 +151,11 @@ export class PermissionsManager extends JsonFileManager<PermissionsByOrigin> {
 
         if (!serverURL) {
             return false;
+        }
+
+        // For GPO servers, we always allow permissions since they are trusted
+        if (Config.registryData?.servers?.some((s) => parseURL(s.url)?.href === serverURL.href)) {
+            return true;
         }
 
         // Exception for embedded videos such as YouTube

--- a/src/main/permissionsManager.ts
+++ b/src/main/permissionsManager.ts
@@ -154,7 +154,8 @@ export class PermissionsManager extends JsonFileManager<PermissionsByOrigin> {
         }
 
         // For GPO servers, we always allow permissions since they are trusted
-        if (Config.registryData?.servers?.some((s) => parseURL(s.url)?.href === serverURL.href)) {
+        const serverHref = serverURL.href;
+        if (Config.registryData?.servers?.some((s) => parseURL(s.url)?.href === serverHref)) {
             return true;
         }
 


### PR DESCRIPTION
#### Summary
This is a small QoL improvement for enterprise users who have their Desktop App configured for them by their system administrator. Normally the application will ask for permission to send notifications, access the camera/microphone, and other system related permissions on a per-server basis. However, if the server is configured using Group Policy on Windows, we can make an assumption that the server is trusted since it is configured at the registry level.

This PR just removes the permission check for those servers.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61821

```release-note
Skip per-server permission checks for GPO-configured servers on Windows
```
