### PR TITLE
[MM-61406] Upgrade to Electron v33.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "copy-webpack-plugin": "10.2.4",
         "cross-env": "7.0.3",
         "css-loader": "6.7.1",
-        "electron": "33.0.2",
+        "electron": "33.2.0",
         "electron-builder": "24.13.3",
         "electron-connect": "0.6.3",
         "eslint": "8.57.0",
@@ -7219,11 +7219,12 @@
       }
     },
     "node_modules/electron": {
-      "version": "33.0.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-33.0.2.tgz",
-      "integrity": "sha512-C2WksfP0COsMHbYXSJG68j6S3TjuGDrw/YT42B526yXalIlNQZ2GeAYKryg6AEMkIp3p8TUfDRD0+HyiyCt/nw==",
+      "version": "33.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-33.2.0.tgz",
+      "integrity": "sha512-PVw1ICAQDPsnnsmpNFX/b1i/49h67pbSPxuIENd9K9WpGO1tsRaQt+K2bmXqTuoMJsbzIc75Ce8zqtuwBPqawA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^20.9.0",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "copy-webpack-plugin": "10.2.4",
     "cross-env": "7.0.3",
     "css-loader": "6.7.1",
-    "electron": "33.0.2",
+    "electron": "33.2.0",
     "electron-builder": "24.13.3",
     "electron-connect": "0.6.3",
     "eslint": "8.57.0",

--- a/patches/electron+33.2.0.patch
+++ b/patches/electron+33.2.0.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/electron/electron.d.ts b/node_modules/electron/electron.d.ts
-index 2de7557..0d0fa34 100644
+index 3fa42e0..93762d8 100644
 --- a/node_modules/electron/electron.d.ts
 +++ b/node_modules/electron/electron.d.ts
-@@ -9847,23 +9847,23 @@ declare namespace Electron {
+@@ -9867,23 +9867,23 @@ declare namespace Electron {
       *
       * @platform darwin,win32
       */


### PR DESCRIPTION
#### Summary
An issue was occurring where the application wouldn't focus the browser when opening an external link. This was caused by an Electron bug, fixed here: https://github.com/electron/electron/pull/44468

This PR updates our app to use the newer fixed Electron version.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61406
Closes https://github.com/mattermost/desktop/issues/3227

```release-note
Upgrade to Electron v33.2.0
Fixed an issue where the application would not focus your browser window when opening an external link
```
