### PR TITLE
[MM-62001] Calls: switch tab on actions requiring focus

### DIFF
--- a/src/main/windows/callsWidgetWindow.test.js
+++ b/src/main/windows/callsWidgetWindow.test.js
@@ -74,6 +74,7 @@ jest.mock('main/performanceMonitor', () => ({
 jest.mock('main/views/viewManager', () => ({
     getView: jest.fn(),
     getViewByWebContentsId: jest.fn(),
+    showById: jest.fn(),
 }));
 jest.mock('../utils', () => ({
     openScreensharePermissionsSettingsMacOS: jest.fn(),
@@ -786,6 +787,7 @@ describe('main/windows/callsWidgetWindow', () => {
 
     describe('forwardToMainApp', () => {
         const view = {
+            id: 'main-view',
             view: {
                 server: {
                     id: 'server-1',
@@ -812,6 +814,7 @@ describe('main/windows/callsWidgetWindow', () => {
             const func = callsWidgetWindow.forwardToMainApp('some-channel');
             func({sender: {id: 1}}, 'thecallchannelid');
             expect(ServerViewState.switchServer).toHaveBeenCalledWith('server-1');
+            expect(ViewManager.showById).toHaveBeenCalledWith('main-view');
             expect(focus).toHaveBeenCalled();
             expect(view.sendToRenderer).toBeCalledWith('some-channel', 'thecallchannelid');
         });
@@ -819,6 +822,7 @@ describe('main/windows/callsWidgetWindow', () => {
 
     describe('handleCallsLinkClick', () => {
         const view = {
+            id: 'main-view',
             view: {
                 server: {
                     id: 'server-1',
@@ -845,10 +849,11 @@ describe('main/windows/callsWidgetWindow', () => {
             ViewManager.handleDeepLink = jest.fn();
         });
 
-        it('should switch server, focus and send history push event', () => {
+        it('should switch server, tab and focus and send history push event', () => {
             const url = '/team/channel';
             callsWidgetWindow.handleCallsLinkClick({sender: {id: 1}}, url);
             expect(ServerViewState.switchServer).toHaveBeenCalledWith('server-1');
+            expect(ViewManager.showById).toHaveBeenCalledWith('main-view');
             expect(focus).toHaveBeenCalled();
             expect(view.sendToRenderer).toBeCalledWith(BROWSER_HISTORY_PUSH, url);
         });
@@ -884,6 +889,7 @@ describe('main/windows/callsWidgetWindow', () => {
 
     describe('handleCallsOpenThread', () => {
         const view = {
+            id: 'main-view',
             view: {
                 server: {
                     id: 'server-1',
@@ -903,10 +909,11 @@ describe('main/windows/callsWidgetWindow', () => {
             ViewManager.handleDeepLink = jest.fn();
         });
 
-        it('should switch server, focus and send open thread event', () => {
+        it('should switch server, tab and focus and send open thread event', () => {
             const threadID = 'call-thread-id';
             callsWidgetWindow.handleCallsOpenThread({sender: {id: 1}}, threadID);
             expect(ServerViewState.switchServer).toHaveBeenCalledWith('server-1');
+            expect(ViewManager.showById).toHaveBeenCalledWith('main-view');
             expect(focus).toHaveBeenCalled();
             expect(view.sendToRenderer).toBeCalledWith(CALLS_WIDGET_OPEN_THREAD, threadID);
         });
@@ -914,6 +921,7 @@ describe('main/windows/callsWidgetWindow', () => {
 
     describe('handleCallsOpenStopRecordingModal', () => {
         const view = {
+            id: 'main-view',
             view: {
                 server: {
                     id: 'server-1',
@@ -932,12 +940,49 @@ describe('main/windows/callsWidgetWindow', () => {
             ViewManager.getView.mockReturnValue(view);
         });
 
-        it('should switch server, focus and send open modal event', () => {
+        it('should switch server, tab and focus and send open modal event', () => {
             const channelID = 'call-channel-id';
             callsWidgetWindow.handleCallsOpenStopRecordingModal({sender: {id: 1}}, channelID);
             expect(ServerViewState.switchServer).toHaveBeenCalledWith('server-1');
+            expect(ViewManager.showById).toHaveBeenCalledWith('main-view');
             expect(focus).toHaveBeenCalled();
             expect(view.sendToRenderer).toBeCalledWith(CALLS_WIDGET_OPEN_STOP_RECORDING_MODAL, channelID);
+        });
+    });
+
+    describe('focusChannelView', () => {
+        const view = {
+            id: 'main-view',
+            view: {
+                server: {
+                    id: 'server-1',
+                },
+            },
+            sendToRenderer: jest.fn(),
+        };
+
+        const callsWidgetWindow = new CallsWidgetWindow();
+
+        const focus = jest.fn();
+
+        beforeEach(() => {
+            MainWindow.get.mockReturnValue({focus});
+            ViewManager.getView.mockReturnValue(view);
+        });
+
+        it('noop if not initialized', () => {
+            callsWidgetWindow.focusChannelView();
+            expect(ServerViewState.switchServer).not.toHaveBeenCalled();
+            expect(ViewManager.showById).not.toHaveBeenCalled();
+            expect(focus).not.toHaveBeenCalled();
+        });
+
+        it('should switch server, tab and focus', () => {
+            callsWidgetWindow.mainView = view;
+            callsWidgetWindow.focusChannelView();
+            expect(ServerViewState.switchServer).toHaveBeenCalledWith('server-1');
+            expect(ViewManager.showById).toHaveBeenCalledWith('main-view');
+            expect(focus).toHaveBeenCalled();
         });
     });
 });

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -501,6 +501,16 @@ export class CallsWidgetWindow {
         this.close();
     };
 
+    private focusChannelView() {
+        if (!this.serverID || !this.mainView) {
+            return;
+        }
+
+        ServerViewState.switchServer(this.serverID);
+        MainWindow.get()?.focus();
+        ViewManager.showById(this.mainView.id);
+    }
+
     private forwardToMainApp = (channel: string) => {
         return (event: IpcMainEvent, ...args: any) => {
             log.debug('forwardToMainApp', channel, ...args);
@@ -513,8 +523,7 @@ export class CallsWidgetWindow {
                 return;
             }
 
-            ServerViewState.switchServer(this.serverID);
-            MainWindow.get()?.focus();
+            this.focusChannelView();
             this.mainView?.sendToRenderer(channel, ...args);
         };
     };
@@ -547,8 +556,7 @@ export class CallsWidgetWindow {
         // If parsing above fails it means it's a relative path (e.g.
         // pointing to a channel).
 
-        ServerViewState.switchServer(this.serverID);
-        MainWindow.get()?.focus();
+        this.focusChannelView();
         this.mainView?.sendToRenderer(BROWSER_HISTORY_PUSH, url);
     };
 }


### PR DESCRIPTION
#### Summary

For calls widget actions requiring focus on the main channel view (e.g., channel link click, showing screen sharing selection modal), we were not handling the possibility that the tab was something other than messaging. We fix this by switching to the expected tab.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-62001

#### Release Note

```release-note
Fixed an issue preventing the screen sharing selection modal to show when the app was focused on a different tab (e.g. Playbooks, Boards)
```

