### PR TITLE
[MM-61994] Fix UpgradeCode to use the old one, allow MSI to uninstall both

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -181,7 +181,8 @@
     "include": "scripts/installer.nsh"
   },
   "msi": {
-    "additionalWixArgs": ["-ext", "WixUtilExtension"]
+    "additionalWixArgs": ["-ext", "WixUtilExtension"],
+    "upgradeCode": "{8523DAF0-699D-4CC7-9A65-C5E696A9DE6D}"
   },
   "rpm": {
     "fpm": ["--rpm-rpmbuild-define", "_build_id_links none", "--rpm-digest=sha256"]

--- a/patches/app-builder-lib+24.13.3.patch
+++ b/patches/app-builder-lib+24.13.3.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/app-builder-lib/templates/msi/template.xml b/node_modules/app-builder-lib/templates/msi/template.xml
-index 2d5cd3c..92a0556 100644
+index 2d5cd3c..0ce1b74 100644
 --- a/node_modules/app-builder-lib/templates/msi/template.xml
 +++ b/node_modules/app-builder-lib/templates/msi/template.xml
 @@ -1,5 +1,8 @@
@@ -12,7 +12,18 @@ index 2d5cd3c..92a0556 100644
    <!-- https://blogs.msdn.microsoft.com/gremlininthemachine/2006/12/05/msi-wix-and-unicode/ -->
    <Product Id="*" Name="${productName}" UpgradeCode="${upgradeCode}" Version="${version}" Language="1033" Codepage="65001" Manufacturer="${manufacturer}">
      <Package Compressed="yes" InstallerVersion="500"/>
-@@ -26,6 +29,27 @@
+@@ -13,6 +16,10 @@
+ 
+       So, AllowSameVersionUpgrades="yes" allows to build and test MSI with the same version, and previously installed app will be removed.
+     -->
++    <!-- Remove versions of newer MSI using the wrong UpgradeCode -->
++    <Upgrade Id="{0F183CAA-DF79-5400-A71F-684F563AF31C}">
++      <UpgradeVersion Property="PREVMSIINSTALLER" IncludeMaximum="yes" Maximum="${version}" MigrateFeatures="yes" OnlyDetect="no"/>
++    </Upgrade>
+     <MajorUpgrade AllowSameVersionUpgrades="yes" DowngradeErrorMessage='A newer version of "[ProductName]" is already installed.'/>
+     <MediaTemplate CompressionLevel="${compressionLevel}" EmbedCab="yes"/>
+ 
+@@ -26,6 +33,27 @@
      <Property Id="ARPPRODUCTICON" Value="${iconId}"/>
      {{ } -}}
  
@@ -40,7 +51,7 @@ index 2d5cd3c..92a0556 100644
      {{ if (isRunAfterFinish) { }}
        <CustomAction Id="runAfterFinish" FileKey="mainExecutable" ExeCommand="" Execute="immediate" Impersonate="yes" Return="asyncNoWait"/>
        {{ if (!isAssisted) { }}
-@@ -42,6 +66,7 @@
+@@ -42,6 +70,7 @@
        <Property Id="ALLUSERS" Secure="yes" Value="2"/>
      {{ } -}}
      <Property Id="MSIINSTALLPERUSER" Secure="yes" Value="1"/>
@@ -48,7 +59,7 @@ index 2d5cd3c..92a0556 100644
  
      {{ if (isAssisted) { }}
        <WixVariable Id="WixUISupportPerUser" Value="1" Overridable="yes"/>
-@@ -80,6 +105,7 @@
+@@ -80,6 +109,7 @@
        </UI>
      {{ } -}}
  
@@ -56,7 +67,7 @@ index 2d5cd3c..92a0556 100644
      <Directory Id="TARGETDIR" Name="SourceDir">
        <Directory Id="${programFilesId}">
          {{ if (menuCategory) { }}
-@@ -110,6 +136,10 @@
+@@ -110,6 +140,10 @@
      {{-dirs}}
  
      <ComponentGroup Id="ProductComponents" Directory="APPLICATIONFOLDER">


### PR DESCRIPTION
#### Summary
An issue with the newer MSI installer (present since v5.9) was that it would not uninstall previous versions installed by the old MSI installer. This was due to a change in the `UpgradeCode`, which was manually created for the old MSI, and automatically generated by `electron-builder` for the new one. `electron-builder` did support a way to prescribe it, but I had missed adding that.

This PR both adds the original `UpgradeCode` that we used from the old MSI, as well as adds another step to the new installer that will uninstall versions v5.9 and v5.10 that used the auto-generated `UpgradeCode`. This alongside the script that uninstalls the EXE should make sure the app uninstalls all other versions of the Desktop App before proceeding to install the new one.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61994

```release-note
Fixed an issue where the new MSI installer would not uninstall versions before v5.9 installed via MSI
```
