### PR TITLE
Automated cherry pick of #3157

### DIFF
--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -149,3 +149,9 @@ export function openScreensharePermissionsSettingsMacOS() {
     return exec('open "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"',
         {timeout: 1000});
 }
+
+export function isKDE() {
+    return (process.env.XDG_CURRENT_DESKTOP ?? '').toUpperCase() === 'KDE' ||
+    (process.env.DESKTOP_SESSION ?? '').toLowerCase() === 'plasma' ||
+    (process.env.KDE_FULL_SESSION ?? '').toLowerCase() === 'true';
+}

--- a/src/main/windows/mainWindow.test.js
+++ b/src/main/windows/mainWindow.test.js
@@ -68,6 +68,7 @@ jest.mock('../contextMenu', () => jest.fn());
 jest.mock('../utils', () => ({
     isInsideRectangle: jest.fn(),
     getLocalPreload: jest.fn(),
+    isKDE: jest.fn(),
 }));
 
 jest.mock('main/i18nManager', () => ({
@@ -95,6 +96,7 @@ describe('main/windows/mainWindow', () => {
             isMaximized: jest.fn(),
             isFullScreen: jest.fn(),
             getBounds: jest.fn(),
+            isMinimized: jest.fn().mockReturnValue(false),
         };
 
         beforeEach(() => {
@@ -512,6 +514,9 @@ describe('main/windows/mainWindow', () => {
         });
 
         it('should add override shortcuts for the top menu on Linux to stop it showing up', () => {
+            const {isKDE} = require('../utils');
+            isKDE.mockReturnValue(false);
+
             const originalPlatform = process.platform;
             Object.defineProperty(process, 'platform', {
                 value: 'linux',
@@ -532,6 +537,34 @@ describe('main/windows/mainWindow', () => {
                 value: originalPlatform,
             });
             expect(globalShortcut.registerAll).toHaveBeenCalledWith(['Alt+F', 'Alt+E', 'Alt+V', 'Alt+H', 'Alt+W', 'Alt+P'], expect.any(Function));
+        });
+
+        it('should register global shortcuts even when window is minimized on KDE/KWin', () => {
+            const {isKDE} = require('../utils');
+            isKDE.mockReturnValue(true);
+
+            const originalPlatform = process.platform;
+            Object.defineProperty(process, 'platform', {
+                value: 'linux',
+            });
+            const window = {
+                ...baseWindow,
+                isMinimized: jest.fn().mockReturnValue(true),
+                on: jest.fn().mockImplementation((event, cb) => {
+                    if (event === 'focus') {
+                        cb();
+                    }
+                }),
+            };
+            BrowserWindow.mockImplementation(() => window);
+            const mainWindow = new MainWindow();
+            mainWindow.getBounds = jest.fn();
+            mainWindow.init();
+
+            expect(globalShortcut.registerAll).toHaveBeenCalled();
+            Object.defineProperty(process, 'platform', {
+                value: originalPlatform,
+            });
         });
     });
 

--- a/src/main/windows/mainWindow.ts
+++ b/src/main/windows/mainWindow.ts
@@ -38,7 +38,7 @@ import {localizeMessage} from 'main/i18nManager';
 import type {SavedWindowState} from 'types/mainWindow';
 
 import ContextMenu from '../contextMenu';
-import {getLocalPreload, isInsideRectangle} from '../utils';
+import {getLocalPreload, isInsideRectangle, isKDE} from '../utils';
 
 const log = new Logger('MainWindow');
 const ALT_MENU_KEYS = ['Alt+F', 'Alt+E', 'Alt+V', 'Alt+H', 'Alt+W', 'Alt+P'];
@@ -326,6 +326,12 @@ export class MainWindow extends EventEmitter {
             globalShortcut.registerAll(ALT_MENU_KEYS, () => {
                 // do nothing because we want to supress the menu popping up
             });
+
+            // check if KDE + windows is minimized to prevent unwanted focus event
+            // that was causing an error not allowing minimization (MM-60233)
+            if ((!this.win || this.win.isMinimized()) && isKDE()) {
+                return;
+            }
         }
 
         this.emit(MAIN_WINDOW_RESIZED, this.getBounds());


### PR DESCRIPTION
Cherry pick of #3157 on release-5.9.

/cc  @pvev

```release-note
NONE
```