### PR TITLE
Cherry-pick of #3237, #3238, #3239 to `release-5.9`

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -181,7 +181,8 @@
     "include": "scripts/installer.nsh"
   },
   "msi": {
-    "additionalWixArgs": ["-ext", "WixUtilExtension"]
+    "additionalWixArgs": ["-ext", "WixUtilExtension"],
+    "upgradeCode": "{8523DAF0-699D-4CC7-9A65-C5E696A9DE6D}"
   },
   "rpm": {
     "fpm": ["--rpm-rpmbuild-define", "_build_id_links none"]

--- a/patches/app-builder-lib+24.13.3.patch
+++ b/patches/app-builder-lib+24.13.3.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/app-builder-lib/templates/msi/template.xml b/node_modules/app-builder-lib/templates/msi/template.xml
-index 2d5cd3c..0ce1b74 100644
+index 2d5cd3c..172339e 100644
 --- a/node_modules/app-builder-lib/templates/msi/template.xml
 +++ b/node_modules/app-builder-lib/templates/msi/template.xml
 @@ -1,5 +1,8 @@
@@ -72,7 +72,7 @@ index 2d5cd3c..0ce1b74 100644
  
      <ComponentGroup Id="ProductComponents" Directory="APPLICATIONFOLDER">
 +      <Component Directory="resourcesDir">
-+        <Condition>(NOT ALLUSERS = 1) AND DISABLEAUTOUPDATE = 0</Condition>
++        <Condition>(NOT ALLUSERS = 1) AND MSIINSTALLPERUSER = 1 AND DISABLEAUTOUPDATE = 0</Condition>
 +        <File Name="app-update.yml" Source="$(var.appDir)\..\msi-app-update.yml" ReadOnly="yes" KeyPath="yes"/>
 +      </Component>
        {{-files}}

--- a/patches/app-builder-lib+24.13.3.patch
+++ b/patches/app-builder-lib+24.13.3.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/app-builder-lib/templates/msi/template.xml b/node_modules/app-builder-lib/templates/msi/template.xml
-index 2d5cd3c..172339e 100644
+index 2d5cd3c..3c2d128 100644
 --- a/node_modules/app-builder-lib/templates/msi/template.xml
 +++ b/node_modules/app-builder-lib/templates/msi/template.xml
 @@ -1,5 +1,8 @@
@@ -23,7 +23,18 @@ index 2d5cd3c..172339e 100644
      <MajorUpgrade AllowSameVersionUpgrades="yes" DowngradeErrorMessage='A newer version of "[ProductName]" is already installed.'/>
      <MediaTemplate CompressionLevel="${compressionLevel}" EmbedCab="yes"/>
  
-@@ -26,6 +33,27 @@
+@@ -20,12 +27,38 @@
+     <Property Id="ApplicationFolderName" Value="${installationDirectoryWixName}"/>
+     <Property Id="WixAppFolder" Value="WixPerUserFolder"/>
+     <Property Id="DISABLEADVTSHORTCUTS" Value="1"/>
++    <Property Id="EXEINSTALLEREXISTS">
++      <DirectorySearch Path="[LocalAppDataFolder]\Programs\mattermost-desktop" Depth="0">
++        <FileSearch Id="SearchEXEUninstaller" Name="Uninstall ${productName}.exe" />
++      </DirectorySearch>
++    </Property>
+ 
+     {{ if (iconPath) { }}
+     <Icon Id="${iconId}" SourceFile="${iconPath}"/>
      <Property Id="ARPPRODUCTICON" Value="${iconId}"/>
      {{ } -}}
  
@@ -45,13 +56,13 @@ index 2d5cd3c..172339e 100644
 +    <InstallExecuteSequence>
 +      <Custom Action="WixCloseApplications" Before="InstallValidate"/>
 +      <Custom Action="WixCloseApplicationsDeferred" After="InstallInitialize"/>
-+      <Custom Action="removeExeInstaller" After="InstallInitialize"/>
++      <Custom Action="removeExeInstaller" After="RemoveExistingProducts">EXEINSTALLEREXISTS</Custom>
 +    </InstallExecuteSequence>
 +
      {{ if (isRunAfterFinish) { }}
        <CustomAction Id="runAfterFinish" FileKey="mainExecutable" ExeCommand="" Execute="immediate" Impersonate="yes" Return="asyncNoWait"/>
        {{ if (!isAssisted) { }}
-@@ -42,6 +70,7 @@
+@@ -42,6 +75,7 @@
        <Property Id="ALLUSERS" Secure="yes" Value="2"/>
      {{ } -}}
      <Property Id="MSIINSTALLPERUSER" Secure="yes" Value="1"/>
@@ -59,7 +70,7 @@ index 2d5cd3c..172339e 100644
  
      {{ if (isAssisted) { }}
        <WixVariable Id="WixUISupportPerUser" Value="1" Overridable="yes"/>
-@@ -80,6 +109,7 @@
+@@ -80,6 +114,7 @@
        </UI>
      {{ } -}}
  
@@ -67,7 +78,7 @@ index 2d5cd3c..172339e 100644
      <Directory Id="TARGETDIR" Name="SourceDir">
        <Directory Id="${programFilesId}">
          {{ if (menuCategory) { }}
-@@ -110,6 +140,10 @@
+@@ -110,6 +145,10 @@
      {{-dirs}}
  
      <ComponentGroup Id="ProductComponents" Directory="APPLICATIONFOLDER">

--- a/patches/app-builder-lib+24.13.3.patch
+++ b/patches/app-builder-lib+24.13.3.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/app-builder-lib/templates/msi/template.xml b/node_modules/app-builder-lib/templates/msi/template.xml
-index 2d5cd3c..92a0556 100644
+index 2d5cd3c..0ce1b74 100644
 --- a/node_modules/app-builder-lib/templates/msi/template.xml
 +++ b/node_modules/app-builder-lib/templates/msi/template.xml
 @@ -1,5 +1,8 @@
@@ -12,7 +12,18 @@ index 2d5cd3c..92a0556 100644
    <!-- https://blogs.msdn.microsoft.com/gremlininthemachine/2006/12/05/msi-wix-and-unicode/ -->
    <Product Id="*" Name="${productName}" UpgradeCode="${upgradeCode}" Version="${version}" Language="1033" Codepage="65001" Manufacturer="${manufacturer}">
      <Package Compressed="yes" InstallerVersion="500"/>
-@@ -26,6 +29,27 @@
+@@ -13,6 +16,10 @@
+ 
+       So, AllowSameVersionUpgrades="yes" allows to build and test MSI with the same version, and previously installed app will be removed.
+     -->
++    <!-- Remove versions of newer MSI using the wrong UpgradeCode -->
++    <Upgrade Id="{0F183CAA-DF79-5400-A71F-684F563AF31C}">
++      <UpgradeVersion Property="PREVMSIINSTALLER" IncludeMaximum="yes" Maximum="${version}" MigrateFeatures="yes" OnlyDetect="no"/>
++    </Upgrade>
+     <MajorUpgrade AllowSameVersionUpgrades="yes" DowngradeErrorMessage='A newer version of "[ProductName]" is already installed.'/>
+     <MediaTemplate CompressionLevel="${compressionLevel}" EmbedCab="yes"/>
+ 
+@@ -26,6 +33,27 @@
      <Property Id="ARPPRODUCTICON" Value="${iconId}"/>
      {{ } -}}
  
@@ -40,7 +51,7 @@ index 2d5cd3c..92a0556 100644
      {{ if (isRunAfterFinish) { }}
        <CustomAction Id="runAfterFinish" FileKey="mainExecutable" ExeCommand="" Execute="immediate" Impersonate="yes" Return="asyncNoWait"/>
        {{ if (!isAssisted) { }}
-@@ -42,6 +66,7 @@
+@@ -42,6 +70,7 @@
        <Property Id="ALLUSERS" Secure="yes" Value="2"/>
      {{ } -}}
      <Property Id="MSIINSTALLPERUSER" Secure="yes" Value="1"/>
@@ -48,7 +59,7 @@ index 2d5cd3c..92a0556 100644
  
      {{ if (isAssisted) { }}
        <WixVariable Id="WixUISupportPerUser" Value="1" Overridable="yes"/>
-@@ -80,6 +105,7 @@
+@@ -80,6 +109,7 @@
        </UI>
      {{ } -}}
  
@@ -56,7 +67,7 @@ index 2d5cd3c..92a0556 100644
      <Directory Id="TARGETDIR" Name="SourceDir">
        <Directory Id="${programFilesId}">
          {{ if (menuCategory) { }}
-@@ -110,6 +136,10 @@
+@@ -110,6 +140,10 @@
      {{-dirs}}
  
      <ComponentGroup Id="ProductComponents" Directory="APPLICATIONFOLDER">


### PR DESCRIPTION
#### Summary
Manual cherry-pick of #3237, #3238, #3239 to `release-5.9`
Done manually to avoid `patch-package` issues.

```release-note
NONE
```
