### PR TITLE
[MM-62196] Add support for downgrades using the MSI

### DIFF
--- a/patches/app-builder-lib+24.13.3.patch
+++ b/patches/app-builder-lib+24.13.3.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/app-builder-lib/templates/msi/template.xml b/node_modules/app-builder-lib/templates/msi/template.xml
-index 2d5cd3c..3c2d128 100644
+index 2d5cd3c..9bf447e 100644
 --- a/node_modules/app-builder-lib/templates/msi/template.xml
 +++ b/node_modules/app-builder-lib/templates/msi/template.xml
 @@ -1,5 +1,8 @@
@@ -12,21 +12,23 @@ index 2d5cd3c..3c2d128 100644
    <!-- https://blogs.msdn.microsoft.com/gremlininthemachine/2006/12/05/msi-wix-and-unicode/ -->
    <Product Id="*" Name="${productName}" UpgradeCode="${upgradeCode}" Version="${version}" Language="1033" Codepage="65001" Manufacturer="${manufacturer}">
      <Package Compressed="yes" InstallerVersion="500"/>
-@@ -13,6 +16,10 @@
+@@ -13,19 +16,50 @@
  
        So, AllowSameVersionUpgrades="yes" allows to build and test MSI with the same version, and previously installed app will be removed.
      -->
+-    <MajorUpgrade AllowSameVersionUpgrades="yes" DowngradeErrorMessage='A newer version of "[ProductName]" is already installed.'/>
 +    <!-- Remove versions of newer MSI using the wrong UpgradeCode -->
 +    <Upgrade Id="{0F183CAA-DF79-5400-A71F-684F563AF31C}">
 +      <UpgradeVersion Property="PREVMSIINSTALLER" IncludeMaximum="yes" Maximum="${version}" MigrateFeatures="yes" OnlyDetect="no"/>
 +    </Upgrade>
-     <MajorUpgrade AllowSameVersionUpgrades="yes" DowngradeErrorMessage='A newer version of "[ProductName]" is already installed.'/>
++    <MajorUpgrade AllowDowngrades='yes'/>
      <MediaTemplate CompressionLevel="${compressionLevel}" EmbedCab="yes"/>
- 
-@@ -20,12 +27,38 @@
+   
+     <Property Id="WIXUI_INSTALLDIR" Value="APPLICATIONFOLDER"/>
      <Property Id="ApplicationFolderName" Value="${installationDirectoryWixName}"/>
      <Property Id="WixAppFolder" Value="WixPerUserFolder"/>
      <Property Id="DISABLEADVTSHORTCUTS" Value="1"/>
++    <Property Id="REINSTALLMODE" Value="amus" />
 +    <Property Id="EXEINSTALLEREXISTS">
 +      <DirectorySearch Path="[LocalAppDataFolder]\Programs\mattermost-desktop" Depth="0">
 +        <FileSearch Id="SearchEXEUninstaller" Name="Uninstall ${productName}.exe" />
@@ -62,7 +64,7 @@ index 2d5cd3c..3c2d128 100644
      {{ if (isRunAfterFinish) { }}
        <CustomAction Id="runAfterFinish" FileKey="mainExecutable" ExeCommand="" Execute="immediate" Impersonate="yes" Return="asyncNoWait"/>
        {{ if (!isAssisted) { }}
-@@ -42,6 +75,7 @@
+@@ -42,6 +76,7 @@
        <Property Id="ALLUSERS" Secure="yes" Value="2"/>
      {{ } -}}
      <Property Id="MSIINSTALLPERUSER" Secure="yes" Value="1"/>
@@ -70,7 +72,7 @@ index 2d5cd3c..3c2d128 100644
  
      {{ if (isAssisted) { }}
        <WixVariable Id="WixUISupportPerUser" Value="1" Overridable="yes"/>
-@@ -80,6 +114,7 @@
+@@ -80,6 +115,7 @@
        </UI>
      {{ } -}}
  
@@ -78,7 +80,7 @@ index 2d5cd3c..3c2d128 100644
      <Directory Id="TARGETDIR" Name="SourceDir">
        <Directory Id="${programFilesId}">
          {{ if (menuCategory) { }}
-@@ -110,6 +145,10 @@
+@@ -110,6 +146,10 @@
      {{-dirs}}
  
      <ComponentGroup Id="ProductComponents" Directory="APPLICATIONFOLDER">


### PR DESCRIPTION
#### Summary
An issue was noted while testing the MSI and trying to install an older version over top. An error would be thrown and the MSI would technically install, but would miss the main EXE file causing the app to not work at all.

This PR makes a couple template changes to actually support downgrading properly (as of the installer that this is released in) and fixes the error and missing EXE.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62196

```release-note
Add support for downgrading using the MSI installer
```
