### PR TITLE
[MM-62205] Dynamically toggle widget window visibility when popout opens/closes

### DIFF
--- a/src/main/windows/callsWidgetWindow.test.js
+++ b/src/main/windows/callsWidgetWindow.test.js
@@ -152,6 +152,13 @@ describe('main/windows/callsWidgetWindow', () => {
                 value: originalEnv,
             });
         });
+
+        it('widget window visibility should have been toggled', async () => {
+            callsWidgetWindow.onShow();
+            expect(callsWidgetWindow.win.setVisibleOnAllWorkspaces).toHaveBeenCalledWith(true, {skipTransformProcessType: true, visibleOnFullScreen: true});
+            expect(callsWidgetWindow.win.setAlwaysOnTop).toHaveBeenCalledWith(true, 'screen-saver');
+            expect(callsWidgetWindow.win.focus).toHaveBeenCalled();
+        });
     });
 
     describe('close', () => {
@@ -415,7 +422,22 @@ describe('main/windows/callsWidgetWindow', () => {
         };
 
         const callsWidgetWindow = new CallsWidgetWindow();
+        callsWidgetWindow.win = {
+            setVisibleOnAllWorkspaces: jest.fn(),
+            setAlwaysOnTop: jest.fn(),
+            focus: jest.fn(),
+        };
+
+        expect(callsWidgetWindow.win.setVisibleOnAllWorkspaces).not.toHaveBeenCalled();
+        expect(callsWidgetWindow.win.setAlwaysOnTop).not.toHaveBeenCalled();
+
         callsWidgetWindow.onPopOutCreate(popOut);
+
+        // Verify widget visibility has been toggled
+        expect(callsWidgetWindow.win.setVisibleOnAllWorkspaces).toHaveBeenCalledWith(false);
+        expect(callsWidgetWindow.win.setAlwaysOnTop).toHaveBeenCalledWith(false);
+        expect(callsWidgetWindow.win.focus).not.toHaveBeenCalled();
+
         expect(callsWidgetWindow.popOut).toBe(popOut);
         expect(WebContentsEventManager.addWebContentsEventListeners).toHaveBeenCalledWith(popOut.webContents);
         expect(redirectListener).toBeDefined();
@@ -432,6 +454,11 @@ describe('main/windows/callsWidgetWindow', () => {
         closedListener();
         expect(callsWidgetWindow.popOut).not.toBeDefined();
         expect(mockContextMenuDispose).toHaveBeenCalled();
+
+        // Verify widget visibility has been toggled
+        expect(callsWidgetWindow.win.setVisibleOnAllWorkspaces).toHaveBeenCalledWith(true, {skipTransformProcessType: true, visibleOnFullScreen: true});
+        expect(callsWidgetWindow.win.setAlwaysOnTop).toHaveBeenCalledWith(true, 'screen-saver');
+        expect(callsWidgetWindow.win.focus).toHaveBeenCalled();
     });
 
     it('getViewURL', () => {

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -233,14 +233,14 @@ export class CallsWidgetWindow {
         ev.preventDefault();
     };
 
-    private toggleWidgetVisibility = (flag: boolean) => {
-        log.debug('toggleWidgetVisibility', flag);
+    private setWidgetWindowStacking = ({onTop}: {onTop: boolean}) => {
+        log.debug('setWidgetWindowStacking', onTop);
 
         if (!this.win) {
             return;
         }
 
-        if (flag) {
+        if (onTop) {
             this.win.setVisibleOnAllWorkspaces(true, {visibleOnFullScreen: true, skipTransformProcessType: true});
             this.win.setAlwaysOnTop(true, 'screen-saver');
             this.win.focus();
@@ -257,7 +257,7 @@ export class CallsWidgetWindow {
             return;
         }
 
-        this.toggleWidgetVisibility(true);
+        this.setWidgetWindowStacking({onTop: true});
 
         const bounds = this.win.getBounds();
         const mainBounds = mainWindow.getBounds();
@@ -303,7 +303,7 @@ export class CallsWidgetWindow {
     private onPopOutCreate = (win: BrowserWindow) => {
         this.popOut = win;
 
-        this.toggleWidgetVisibility(false);
+        this.setWidgetWindowStacking({onTop: false});
 
         // Let the webContentsEventManager handle links that try to open a new window.
         webContentsEventManager.addWebContentsEventListeners(this.popOut.webContents);
@@ -321,7 +321,7 @@ export class CallsWidgetWindow {
         this.popOut.on('closed', () => {
             delete this.popOut;
             contextMenu.dispose();
-            this.toggleWidgetVisibility(true);
+            this.setWidgetWindowStacking({onTop: true});
         });
 
         // Set the userAgent so that the widget's popout is considered a desktop window in the webapp code.

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -233,6 +233,23 @@ export class CallsWidgetWindow {
         ev.preventDefault();
     };
 
+    private toggleWidgetVisibility = (flag: boolean) => {
+        log.debug('toggleWidgetVisibility', flag);
+
+        if (!this.win) {
+            return;
+        }
+
+        if (flag) {
+            this.win.setVisibleOnAllWorkspaces(true, {visibleOnFullScreen: true, skipTransformProcessType: true});
+            this.win.setAlwaysOnTop(true, 'screen-saver');
+            this.win.focus();
+        } else {
+            this.win.setAlwaysOnTop(false);
+            this.win.setVisibleOnAllWorkspaces(false);
+        }
+    };
+
     private onShow = () => {
         log.debug('onShow');
         const mainWindow = MainWindow.get();
@@ -240,9 +257,7 @@ export class CallsWidgetWindow {
             return;
         }
 
-        this.win.focus();
-        this.win.setVisibleOnAllWorkspaces(true, {visibleOnFullScreen: true, skipTransformProcessType: true});
-        this.win.setAlwaysOnTop(true, 'screen-saver');
+        this.toggleWidgetVisibility(true);
 
         const bounds = this.win.getBounds();
         const mainBounds = mainWindow.getBounds();
@@ -288,6 +303,8 @@ export class CallsWidgetWindow {
     private onPopOutCreate = (win: BrowserWindow) => {
         this.popOut = win;
 
+        this.toggleWidgetVisibility(false);
+
         // Let the webContentsEventManager handle links that try to open a new window.
         webContentsEventManager.addWebContentsEventListeners(this.popOut.webContents);
 
@@ -304,6 +321,7 @@ export class CallsWidgetWindow {
         this.popOut.on('closed', () => {
             delete this.popOut;
             contextMenu.dispose();
+            this.toggleWidgetVisibility(true);
         });
 
         // Set the userAgent so that the widget's popout is considered a desktop window in the webapp code.


### PR DESCRIPTION
#### Summary

PR adds some logic to dynamically change the global Calls widget visibility when the popout window is open. This is to address the inconvenience of having this window always on top even when focusing on the popout.

Hiding the widget completely is also possible, but I still feel it's a more impactful change in behavior. My hope is that the proposed changes are enough to address the reported issue. That said, let me know if you feel strongly about this.

The previous conversation for extra context is at https://hub.mattermost.com/private-core/pl/wbf4jd67g7fnpmon8fafwnxmuy

#### Video

https://github.com/user-attachments/assets/c58e7dee-36a4-4b6c-a043-0acfd4b7da92

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-62205

#### Release Note

```release-note
Calls: while the popout window is open, the widget window's visibility will change so that it is not always on top of other windows.
```

