### PR TITLE
Switch to Xcode 16.2 for CI

### DIFF
--- a/.github/workflows/build-for-pr.yml
+++ b/.github/workflows/build-for-pr.yml
@@ -158,7 +158,7 @@ jobs:
         run: |
           brew install yq
           jq '.mac.target=["zip"]' electron-builder.json | jq '.mac.gatekeeperAssess=false' > /tmp/electron-builder.json && cp /tmp/electron-builder.json .
-          sudo xcode-select -s /Applications/Xcode_16.1.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
           npm ci
       - name: ci/build
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -158,7 +158,7 @@ jobs:
         run: |
           brew install yq
           jq '.mac.target=["zip"]' electron-builder.json | jq '.mac.gatekeeperAssess=false' > /tmp/electron-builder.json && cp /tmp/electron-builder.json .
-          sudo xcode-select -s /Applications/Xcode_16.1.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
           npm ci
       - name: ci/test
         uses: ./.github/actions/test

--- a/.github/workflows/nightly-main.yml
+++ b/.github/workflows/nightly-main.yml
@@ -129,7 +129,7 @@ jobs:
       - name: nightly/install-dependencies
         run: |
           brew install yq
-          sudo xcode-select -s /Applications/Xcode_16.1.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
           npm ci
       - name: nightly/copy-provisioning-profile
         run: echo $MAS_PROFILE | base64 -D > ./mas.provisionprofile
@@ -160,7 +160,7 @@ jobs:
       - name: nightly/install-dependencies
         run: |
           brew install yq rename
-          sudo xcode-select -s /Applications/Xcode_16.1.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
           npm ci
       - name: nightly/test
         uses: ./.github/actions/test

--- a/.github/workflows/nightly-rainforest.yml
+++ b/.github/workflows/nightly-rainforest.yml
@@ -88,7 +88,7 @@ jobs:
       - name: nightly/install-dependencies
         run: |
           brew install yq rename
-          sudo xcode-select -s /Applications/Xcode_16.1.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
           npm ci
       - name: nightly/test
         uses: ./.github/actions/test

--- a/.github/workflows/release-mas.yaml
+++ b/.github/workflows/release-mas.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: release/install-dependencies
         run: |
           brew install yq
-          sudo xcode-select -s /Applications/Xcode_16.1.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
           npm ci
       - name: release/copy-provisioning-profile
         run: echo $MAS_PROFILE | base64 -D > ./mas.provisionprofile

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -136,7 +136,7 @@ jobs:
       - name: release/install-dependencies
         run: |
           brew install yq rename
-          sudo xcode-select -s /Applications/Xcode_16.1.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
           npm ci
       - name: release/test
         uses: ./.github/actions/test


### PR DESCRIPTION
Apparently GitHub has shifted the Xcode image to 16.2, which broke our workflow again. For some reason there doesn't seem to be a static place to select the Xcode SDK, so we're stuck manually upgrading it everytime they do...

Perhaps they will have an answer for me [here](https://github.com/actions/runner-images/issues/11021#issuecomment-2573225187) but for now we'll use this to get us back up and running.

```release-note
NONE
```
