### PR TITLE
[MM-61890] Add support for marking as ESR for release script, add help, remove update YML for ESR patch releases

### DIFF
--- a/scripts/patch_updater_yml.sh
+++ b/scripts/patch_updater_yml.sh
@@ -11,6 +11,13 @@ if [ "$RELEASE_VERSION" == "" ]; then
     RELEASE_VERSION="latest"
 fi
 
+# If we are on a ESR branch, we don't want to generate the auto-updater yml for patch releases
+if [ -e .esr ] && [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[1-9][0-9]* ]]; then
+    echo "ESR branch, skipping auto-updater yml generation"
+    rm ./release/"${RELEASE_VERSION}"*.yml
+    exit 0
+fi
+
 echo "${RELEASE_VERSION}"
 if compgen -G "./release/${RELEASE_VERSION}*.yml" > /dev/null; then
     for i in ./release/${RELEASE_VERSION}*.yml; do


### PR DESCRIPTION
#### Summary
We ran into an issue with our ESR releases where if we ran the patch release process after another newer version had gone out, we would end up overwriting the latest YML file pointing to the newest updated version, meaning that people would end up upgrading backwards/users on the newest minor version wouldn't get updates.

This PR changes the release script to add a `.esr` file on the branch of ESR releases, which forces some changes in the script that patches the YML file. If we're working with the ESR branch and doing a patch release, we remove the YML file so it doesn't mess up the auto-updating.

I've also taken some time to change up the release script a bit, and add some help functionality in case anyone else needs to use it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61890

```release-note
NONE
```
