### PR TITLE
[MM-62395] Don't attempt to set boundaries for a window that is no longer attached

### DIFF
--- a/src/main/views/modalView.ts
+++ b/src/main/views/modalView.ts
@@ -66,7 +66,9 @@ export class ModalView<T, T2> {
 
         // Linux sometimes doesn't have the bound initialized correctly initially, so we wait to set them
         const setBoundsFunction = () => {
-            this.view.setBounds(getWindowBoundaries(this.windowAttached!));
+            if (this.windowAttached) {
+                this.view.setBounds(getWindowBoundaries(this.windowAttached));
+            }
         };
         if (process.platform === 'linux') {
             setTimeout(setBoundsFunction, 10);


### PR DESCRIPTION
#### Summary
When modals are removed from the window, we unset the attached window property. This caused an issue with our resizing code for modals on Linux (which is required to run a little after the window changes since the values seem to be delayed) where the window bounds were not available as the window had been detached, causing a crash.

This PR checks to see if the window is still attached before trying to call set bounds.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62395

```release-note
Fixed an issue for Linux users where the app could crash when trying to add the first server.
```
