### PR TITLE
[MM-62670] Update certificate error message

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -24,7 +24,7 @@
   "main.app.app.handleAppCertificateError.certError.button.cancelConnection": "Cancel Connection",
   "main.app.app.handleAppCertificateError.certError.button.moreDetails": "More Details",
   "main.app.app.handleAppCertificateError.certError.dialog.detail": "{extraDetail}origin: {origin}\nError: {error}",
-  "main.app.app.handleAppCertificateError.certError.dialog.message": "There is a configuration issue with this Mattermost server, or someone is trying to intercept your connection. You also may need to sign into the Wi-Fi you are connected to using your web browser.",
+  "main.app.app.handleAppCertificateError.certError.dialog.message": "There is a problem with the security certificate for this server or for embedded content in a message. Please contact your Mattermost admin or IT department to resolve this issue.",
   "main.app.app.handleAppCertificateError.certError.dialog.title": "Certificate Error",
   "main.app.app.handleAppCertificateError.certNotTrusted.button.cancelConnection": "Cancel Connection",
   "main.app.app.handleAppCertificateError.certNotTrusted.button.trustInsecureCertificate": "Trust Insecure Certificate",

--- a/src/main/app/app.ts
+++ b/src/main/app/app.ts
@@ -130,7 +130,7 @@ export async function handleAppCertificateError(event: Event, webContents: WebCo
         try {
             let result = await dialog.showMessageBox(mainWindow, {
                 title: localizeMessage('main.app.app.handleAppCertificateError.certError.dialog.title', 'Certificate Error'),
-                message: localizeMessage('main.app.app.handleAppCertificateError.certError.dialog.message', 'There is a configuration issue with this Mattermost server, or someone is trying to intercept your connection. You also may need to sign into the Wi-Fi you are connected to using your web browser.'),
+                message: localizeMessage('main.app.app.handleAppCertificateError.certError.dialog.message', 'There is a problem with the security certificate for this server or for embedded content in a message. Please contact your Mattermost admin or IT department to resolve this issue.'),
                 type: 'error',
                 detail,
                 buttons: [


### PR DESCRIPTION
#### Summary
The old certificate error was somewhat cryptic, and a little scary sounding. This PR updates it to be clearer, and to give the user steps to help resolve the issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62670

#### Screenshots
![image](https://github.com/user-attachments/assets/e90f7353-9e10-4293-9dbc-8f66c9d54c9f)

```release-note
Update certificate error message
```
