### PR TITLE
[MM-62652] Replace `Button` from `react-bootstrap` with `button`

### DIFF
--- a/src/renderer/components/DownloadsDropdown/Update/UpdateAvailable.tsx
+++ b/src/renderer/components/DownloadsDropdown/Update/UpdateAvailable.tsx
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 import React, {useState} from 'react';
-import {Button} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
 import LoadingWrapper from 'renderer/components/SaveButton/LoadingWrapper';
@@ -47,10 +46,9 @@ const UpdateAvailable = ({item, appName}: OwnProps) => {
                         }}
                     />
                 </div>
-                <Button
+                <button
                     id='downloadUpdateButton'
                     className='primary-button DownloadsDropdown__Update__Details__Button'
-                    variant='primary'
                     onClick={onButtonClick}
                     disabled={isProcessing}
                 >
@@ -68,7 +66,7 @@ const UpdateAvailable = ({item, appName}: OwnProps) => {
                             defaultMessage='Download Update'
                         />
                     </LoadingWrapper>
-                </Button>
+                </button>
             </div>
         </div>
     );

--- a/src/renderer/components/DownloadsDropdown/Update/UpdateDownloaded.tsx
+++ b/src/renderer/components/DownloadsDropdown/Update/UpdateDownloaded.tsx
@@ -3,7 +3,6 @@
 
 import classNames from 'classnames';
 import React from 'react';
-import {Button} from 'react-bootstrap';
 import {FormattedMessage, useIntl} from 'react-intl';
 
 import type {DownloadedItem} from 'types/downloads';
@@ -39,7 +38,7 @@ const UpdateAvailable = ({item, appName}: OwnProps) => {
                     >
                         <FileSizeAndStatus item={item}/>
                     </div>
-                    <Button
+                    <button
                         id='restartAndUpdateButton'
                         className='primary-button'
                         onClick={onButtonClick}
@@ -48,7 +47,7 @@ const UpdateAvailable = ({item, appName}: OwnProps) => {
                             id='renderer.downloadsDropdown.Update.RestartAndUpdate'
                             defaultMessage={'Restart & update'}
                         />
-                    </Button>
+                    </button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
#### Summary
At one point I think we were a bit overzealous with our use of `react-bootstrap`, as this simply required replacing `Button` with `button` and seems to work the same.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62652

```release-note
NONE
```
