### PR TITLE
[MM-62741] Fix loading screen flash between transitions

### DIFF
--- a/src/main/views/loadingScreen.ts
+++ b/src/main/views/loadingScreen.ts
@@ -73,7 +73,16 @@ export class LoadingScreen {
     };
 
     private create = () => {
-        this.view = new WebContentsView({webPreferences: {preload: getLocalPreload('internalAPI.js')}});
+        this.view = new WebContentsView({
+            webPreferences: {
+                preload: getLocalPreload('internalAPI.js'),
+
+                // For some reason this is required to make the background transparent
+                // for the loading screen, even though the docs say it's the default.
+                // See: https://www.electronjs.org/docs/latest/api/structures/web-preferences
+                transparent: true,
+            }},
+        );
         performanceMonitor.registerView('LoadingScreen', this.view.webContents);
         this.view.webContents.loadURL('mattermost-desktop://renderer/loadingScreen.html');
     };


### PR DESCRIPTION
#### Summary
An issue caused either by the migration to WebContentsView, or by the branding changes brought back a bug where the loading screen flashes white between transitions, which isn't a great UX. This seems to be caused by the removal of `transparent: true` from the `webPreferences` object, which shouldn't need to be there as it's set to `true` by default according to the docs.

This PR adds that back anyways and leaves a comment explaining why it's there.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62741

#### Release Note
```release-note
NONE
```
