### PR TITLE
[MM-62581] Prevent URL view from ever taking focus by always returning focus to the current server view

### DIFF
--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -362,6 +362,14 @@ export class ViewManager {
             const localURL = `mattermost-desktop://renderer/urlView.html?url=${encodeURIComponent(urlString)}`;
             performanceMonitor.registerView('URLView', urlView.webContents);
             urlView.webContents.loadURL(localURL);
+
+            // This is a workaround for an issue where the URL view would steal focus from the main window
+            // See: https://github.com/electron/electron/issues/42339
+            urlView.webContents.on('focus', () => {
+                log.debug('URL view focus prevented');
+                this.getCurrentView()?.focus();
+            });
+
             MainWindow.get()?.contentView.addChildView(urlView);
             const boundaries = this.views.get(this.currentView || '')?.getBounds() ?? MainWindow.getBounds();
 


### PR DESCRIPTION
#### Summary
When we migrated to `WebContentsView`, all calls to `addChildView` which is called to put the correct view on top or add a new view, would also give focus to whatever view was added/put on top. This causes an accessibility issue in the Desktop App where tabbing through the application and highlighting an external link would trap focus into the URL view that is created and shown.

Unfortunately there is no way currently to prevent this from happening, see: https://github.com/electron/electron/issues/42339

This PR prevents the URL view from ever taking focus by always returning focus to the current Mattermost server view anytime the URL view takes focus, which allowing tabbing to continue to work freely.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62581

```release-note
Fixed an issue where the URL view would trap focus when tabbing over a link
```
