### PR TITLE
[MM-62787] Fix warning state colour on welcome screen URL input

### DIFF
--- a/src/renderer/css/components/Input.scss
+++ b/src/renderer/css/components/Input.scss
@@ -10,7 +10,7 @@
 }
 
 .warning {
-    color: var(--away-indicator-dark);
+    color: var(--away-indicator);
 }
 
 .success {


### PR DESCRIPTION
#### Summary
Quick fix to a colour that was using a variable that no longer exists/isn't needed anymore.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62787

#### Screenshots
Before:
![image](https://github.com/user-attachments/assets/3d927335-1754-4cc5-a848-e8602d1deaa3)
After:
![image](https://github.com/user-attachments/assets/09f1ffee-fffc-4f7c-bede-c8fdd658b7aa)

```release-note
NONE
```
