### PR TITLE
[MM-62781] Wait for nonce before requesting info that will update the server dropdown component

### DIFF
--- a/src/renderer/dropdown.tsx
+++ b/src/renderer/dropdown.tsx
@@ -139,11 +139,12 @@ class ServerDropdown extends React.PureComponent<Record<string, never>, State> {
     };
 
     componentDidMount() {
-        window.desktop.serverDropdown.requestInfo();
         window.addEventListener('click', this.closeMenu);
         window.addEventListener('keydown', this.handleKeyboardShortcuts);
         window.desktop.getNonce().then((nonce) => {
-            this.setState({nonce});
+            this.setState({nonce}, () => {
+                window.desktop.serverDropdown.requestInfo();
+            });
         });
     }
 


### PR DESCRIPTION
#### Summary
A change made in https://github.com/mattermost/desktop/pull/3120 has caused a potential race condition in the server dropdown menu, where the dropdown info to populate the server dropdown would arrive before the component was able to be rendered because of a missing nonce. This would mean that the size value would still be effectively 0x0 and would not get refreshed until the component was updated by something else (either a new server or just blurring the window)

This PR forces an ordering in which the component must have the nonce and be renderable before trying to get the dropdown info, so that we can assume the size sent up from the component to accurately size the WebContentsView is correct.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62781

```release-note
Fixed an issue where the server dropdown wouldn't renderer properly on first load.
```
