### PR TITLE
Allow for env variable to set the username for E2E tests

### DIFF
--- a/e2e/modules/environment.js
+++ b/e2e/modules/environment.js
@@ -267,19 +267,21 @@ module.exports = {
         await window.waitForSelector('#input_password-input');
         await window.waitForSelector('#saveSetting');
 
-        let username;
-        switch (process.platform) {
-        case 'darwin':
-            username = 'success+sysadmin+macos@simulator.amazonses.com';
-            break;
-        case 'linux':
-            username = 'success+sysadmin+linux@simulator.amazonses.com';
-            break;
-        case 'win32':
-            username = 'success+sysadmin+windows@simulator.amazonses.com';
-            break;
-        default:
-            throw new Error('Unsupported platform');
+        let username = process.env.MM_TEST_USERNAME;
+        if (!username) {
+            switch (process.platform) {
+            case 'darwin':
+                username = 'success+sysadmin+macos@simulator.amazonses.com';
+                break;
+            case 'linux':
+                username = 'success+sysadmin+linux@simulator.amazonses.com';
+                break;
+            case 'win32':
+                username = 'success+sysadmin+windows@simulator.amazonses.com';
+                break;
+            default:
+                throw new Error('Unsupported platform');
+            }
         }
 
         await window.type('#input_loginId', username);


### PR DESCRIPTION
#### Summary
Bringing back the env variable here so that I can configure my E2E tests to run locally during development.

```release-note
NONE
```
