### PR TITLE
Fix issue with media permissions on Linux

### DIFF
--- a/src/main/permissionsManager.test.js
+++ b/src/main/permissionsManager.test.js
@@ -60,13 +60,15 @@ jest.mock('main/windows/mainWindow', () => ({
 
 describe('main/PermissionsManager', () => {
     describe('setForServer', () => {
-        it('should ask for media permission when is not granted but the user explicitly granted it', () => {
-            systemPreferences.getMediaAccessStatus.mockReturnValue('denied');
-            const permissionsManager = new PermissionsManager('anyfile.json');
-            permissionsManager.setForServer({url: new URL('http://anyurl.com')}, {media: {allowed: true}});
-            expect(systemPreferences.askForMediaAccess).toHaveBeenNthCalledWith(1, 'microphone');
-            expect(systemPreferences.askForMediaAccess).toHaveBeenNthCalledWith(2, 'camera');
-        });
+        if (process.platform !== 'linux') {
+            it('should ask for media permission when is not granted but the user explicitly granted it', () => {
+                systemPreferences.getMediaAccessStatus.mockReturnValue('denied');
+                const permissionsManager = new PermissionsManager('anyfile.json');
+                permissionsManager.setForServer({url: new URL('http://anyurl.com')}, {media: {allowed: true}});
+                expect(systemPreferences.askForMediaAccess).toHaveBeenNthCalledWith(1, 'microphone');
+                expect(systemPreferences.askForMediaAccess).toHaveBeenNthCalledWith(2, 'camera');
+            });
+        }
     });
 
     describe('handlePermissionRequest', () => {

--- a/src/main/permissionsManager.ts
+++ b/src/main/permissionsManager.ts
@@ -95,7 +95,7 @@ export class PermissionsManager extends JsonFileManager<PermissionsByOrigin> {
     };
 
     setForServer = (server: MattermostServer, permissions: Permissions) => {
-        if (permissions.media?.allowed) {
+        if (permissions.media?.allowed && (process.platform === 'win32' || process.platform === 'darwin')) {
             this.checkMediaAccess('microphone');
             this.checkMediaAccess('camera');
         }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
Fixes persistence of microphone and camera access on Linux by checking the platform before calling `systemPreferences.getMediaAccessStatus`, which is only implemented on Windows and macOS (https://www.electronjs.org/docs/latest/api/system-preferences#systempreferencesgetmediaaccessstatusmediatype-windows-macos)

<!--
#### Ticket Link
-->
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/desktop/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [x] executed `npm run lint:js` for proper code formatting
- [ ] Run E2E tests by adding label `Run Desktop E2E Tests`

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) --> Ubuntu 22.04

<!--
#### Screenshots
If the PR includes UI changes, include screenshots/GIFs.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```
