### PR TITLE
Reload server info on retry

### DIFF
--- a/src/main/views/MattermostWebContentsView.test.js
+++ b/src/main/views/MattermostWebContentsView.test.js
@@ -64,6 +64,9 @@ jest.mock('../utils', () => ({
 jest.mock('main/developerMode', () => ({
     get: jest.fn(),
 }));
+jest.mock('main/app/utils', () => ({
+    updateServerInfos: jest.fn(),
+}));
 jest.mock('main/performanceMonitor', () => ({
     registerView: jest.fn(),
     registerServerView: jest.fn(),

--- a/src/main/views/MattermostWebContentsView.test.js
+++ b/src/main/views/MattermostWebContentsView.test.js
@@ -8,6 +8,8 @@ import {LOAD_FAILED, UPDATE_TARGET_URL} from 'common/communication';
 import {MattermostServer} from 'common/servers/MattermostServer';
 import ServerManager from 'common/servers/serverManager';
 import MessagingView from 'common/views/MessagingView';
+import {updateServerInfos} from 'main/app/utils';
+import {getServerAPI} from 'main/server/serverAPI';
 
 import {MattermostWebContentsView} from './MattermostWebContentsView';
 
@@ -81,6 +83,9 @@ jest.mock('common/servers/serverManager', () => ({
         silly: jest.fn(),
     }),
     on: jest.fn(),
+}));
+jest.mock('main/server/serverAPI', () => ({
+    getServerAPI: jest.fn(),
 }));
 
 const server = new MattermostServer({name: 'server_name', url: 'http://server-1.com'});
@@ -207,6 +212,24 @@ describe('main/views/MattermostWebContentsView', () => {
             expect(mattermostView.status).toBe(-1);
             jest.runAllTimers();
             expect(retryInBackgroundFn).toBeCalled();
+        });
+    });
+
+    describe('retryInBackground', () => {
+        const window = {on: jest.fn()};
+        const mattermostView = new MattermostWebContentsView(view, {}, {});
+        mattermostView.reload = jest.fn();
+
+        beforeEach(() => {
+            MainWindow.get.mockReturnValue(window);
+            mattermostView.webContentsView.webContents.loadURL.mockImplementation(() => Promise.resolve());
+            getServerAPI.mockImplementation((url, isAuth, onSuccess) => onSuccess());
+        });
+
+        it('should call updateServerInfos and reload on successful retry', async () => {
+            await mattermostView.retryInBackground('http://server-1.com')();
+            expect(updateServerInfos).toBeCalled();
+            expect(mattermostView.reload).toBeCalled();
         });
     });
 

--- a/src/main/views/MattermostWebContentsView.ts
+++ b/src/main/views/MattermostWebContentsView.ts
@@ -24,6 +24,7 @@ import ServerManager from 'common/servers/serverManager';
 import {RELOAD_INTERVAL, MAX_SERVER_RETRIES, SECOND, MAX_LOADING_SCREEN_SECONDS} from 'common/utils/constants';
 import {isInternalURL, parseURL} from 'common/utils/url';
 import {TAB_MESSAGING, type MattermostView} from 'common/views/View';
+import {updateServerInfos} from 'main/app/utils';
 import DeveloperMode from 'main/developerMode';
 import performanceMonitor from 'main/performanceMonitor';
 import {getServerAPI} from 'main/server/serverAPI';
@@ -411,7 +412,10 @@ export class MattermostWebContentsView extends EventEmitter {
             getServerAPI(
                 parsedURL,
                 false,
-                () => this.reload(loadURL),
+                async () => {
+                    await updateServerInfos([this.view.server]);
+                    this.reload(loadURL);
+                },
                 () => {},
                 (error: Error) => {
                     this.log.debug(`Cannot reach server: ${error}`);


### PR DESCRIPTION
#### Summary
For the incompatible view, if your server is unavailable when the app loads, after you reload it will show the incompatible screen until you switch back from another server. This PR stops that.

```release-note
NONE
```
