### PR TITLE
[MM-63265] Use constants for modal keys

### DIFF
--- a/src/app/serverViewState.ts
+++ b/src/app/serverViewState.ts
@@ -25,6 +25,7 @@ import {
     REMOVE_SERVER,
 } from 'common/communication';
 import Config from 'common/config';
+import {ModalConstants} from 'common/constants';
 import {Logger} from 'common/log';
 import {MattermostServer} from 'common/servers/MattermostServer';
 import ServerManager from 'common/servers/serverManager';
@@ -146,7 +147,7 @@ export class ServerViewState {
         }
 
         const modalPromise = ModalManager.addModal<{prefillURL?: string}, Server>(
-            'newServer',
+            ModalConstants.NEW_SERVER_MODAL,
             'mattermost-desktop://renderer/newServer.html',
             getLocalPreload('internalAPI.js'),
             {prefillURL},
@@ -187,7 +188,7 @@ export class ServerViewState {
         }
 
         const modalPromise = ModalManager.addModal<UniqueServerWithPermissions, {server: Server; permissions: Permissions}>(
-            'editServer',
+            ModalConstants.EDIT_SERVER_MODAL,
             'mattermost-desktop://renderer/editServer.html',
             getLocalPreload('internalAPI.js'),
             {server: server.toUniqueServer(), permissions: PermissionsManager.getForServer(server) ?? {}},
@@ -219,7 +220,7 @@ export class ServerViewState {
         }
 
         const modalPromise = ModalManager.addModal<null, boolean>(
-            'removeServer',
+            ModalConstants.REMOVE_SERVER_MODAL,
             'mattermost-desktop://renderer/removeServer.html',
             getLocalPreload('internalAPI.js'),
             null,

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -49,3 +49,15 @@ export const DEFAULT_ACADEMY_LINK = 'https://academy.mattermost.com/';
 export const DEFAULT_TE_REPORT_PROBLEM_LINK = 'https://mattermost.com/pl/report-a-bug';
 export const DEFAULT_EE_REPORT_PROBLEM_LINK = 'https://support.mattermost.com/hc/en-us/requests/new';
 export const DEFAULT_UPGRADE_LINK = 'https://forum.mattermost.com/t/mattermost-desktop-app-5-11-important-compatibility-notice/22599';
+
+export const ModalConstants = {
+    SETTINGS_MODAL: 'settingsModal',
+    NEW_SERVER_MODAL: 'newServer',
+    EDIT_SERVER_MODAL: 'editServer',
+    REMOVE_SERVER_MODAL: 'removeServer',
+    WELCOME_SCREEN_MODAL: 'welcomeScreen',
+    CERTIFICATE_MODAL: 'certificateModal',
+    LOGIN_MODAL: 'loginModal',
+    PROXY_LOGIN_MODAL: 'proxyLoginModal',
+    PERMISSION_MODAL: 'permissionModal',
+};

--- a/src/main/app/intercom.ts
+++ b/src/main/app/intercom.ts
@@ -5,6 +5,7 @@ import type {IpcMainEvent, IpcMainInvokeEvent} from 'electron';
 import {app, Menu} from 'electron';
 
 import ServerViewState from 'app/serverViewState';
+import {ModalConstants} from 'common/constants';
 import {Logger} from 'common/log';
 import ServerManager from 'common/servers/serverManager';
 import {ping} from 'common/utils/requests';
@@ -98,7 +99,7 @@ export function handleWelcomeScreenModal(prefillURL?: string) {
     if (!mainWindow) {
         return;
     }
-    const modalPromise = ModalManager.addModal<{prefillURL?: string}, UniqueServer>('welcomeScreen', html, preload, {prefillURL}, mainWindow, !ServerManager.hasServers());
+    const modalPromise = ModalManager.addModal<{prefillURL?: string}, UniqueServer>(ModalConstants.WELCOME_SCREEN_MODAL, html, preload, {prefillURL}, mainWindow, !ServerManager.hasServers());
     if (modalPromise) {
         modalPromise.then((data) => {
             let initialLoadURL;
@@ -177,7 +178,7 @@ export function handleShowSettingsModal() {
     }
 
     ModalManager.addModal(
-        'settingsModal',
+        ModalConstants.SETTINGS_MODAL,
         'mattermost-desktop://renderer/settings.html',
         getLocalPreload('internalAPI.js'),
         null,

--- a/src/main/authManager.test.js
+++ b/src/main/authManager.test.js
@@ -111,7 +111,7 @@ describe('main/authManager', () => {
                     host: 'anormalurl',
                 });
             expect(ModalManager.addModal).toBeCalledWith(
-                'proxy-anormalurl',
+                'proxyLoginModal-anormalurl',
                 expect.any(String),
                 expect.any(String),
                 expect.any(Object),
@@ -124,7 +124,7 @@ describe('main/authManager', () => {
                     host: 'anormalurl',
                 });
             expect(ModalManager.addModal).toBeCalledWith(
-                'login-http://anormalurl.com',
+                'loginModal-http://anormalurl.com',
                 expect.any(String),
                 expect.any(String),
                 expect.any(Object),

--- a/src/main/authManager.ts
+++ b/src/main/authManager.ts
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 import type {AuthenticationResponseDetails, AuthInfo, WebContents, Event} from 'electron';
 
+import {ModalConstants} from 'common/constants';
 import {Logger} from 'common/log';
 import {BASIC_AUTH_PERMISSION} from 'common/permissions';
 import {isTrustedURL, parseURL} from 'common/utils/url';
@@ -57,7 +58,8 @@ export class AuthManager {
         if (!mainWindow) {
             return;
         }
-        const modalPromise = modalManager.addModal<LoginModalData, LoginModalResult>(authInfo.isProxy ? `proxy-${authInfo.host}` : `login-${request.url}`, loginModalHtml, preload, {request, authInfo}, mainWindow);
+        const modalKey = authInfo.isProxy ? `${ModalConstants.PROXY_LOGIN_MODAL}-${authInfo.host}` : `${ModalConstants.LOGIN_MODAL}-${request.url}`;
+        const modalPromise = modalManager.addModal<LoginModalData, LoginModalResult>(modalKey, loginModalHtml, preload, {request, authInfo}, mainWindow);
         if (modalPromise) {
             modalPromise.then((data) => {
                 const {username, password} = data;
@@ -76,7 +78,7 @@ export class AuthManager {
         if (!mainWindow) {
             return;
         }
-        const modalPromise = modalManager.addModal(`permission-${request.url}`, permissionModalHtml, preload, {url: request.url, permission}, mainWindow);
+        const modalPromise = modalManager.addModal(`${ModalConstants.PERMISSION_MODAL}-${request.url}`, permissionModalHtml, preload, {url: request.url, permission}, mainWindow);
         if (modalPromise) {
             modalPromise.then(() => {
                 this.handlePermissionGranted(request.url, permission);

--- a/src/main/certificateManager.ts
+++ b/src/main/certificateManager.ts
@@ -3,6 +3,7 @@
 
 import type {Certificate, WebContents, Event} from 'electron';
 
+import {ModalConstants} from 'common/constants';
 import {Logger} from 'common/log';
 
 import type {CertificateModalData} from 'types/certificate';
@@ -45,7 +46,7 @@ export class CertificateManager {
         if (!mainWindow) {
             return;
         }
-        const modalPromise = modalManager.addModal<CertificateModalData, CertificateModalResult>(`certificate-${url}`, html, preload, {url, list}, mainWindow);
+        const modalPromise = modalManager.addModal<CertificateModalData, CertificateModalResult>(`${ModalConstants.CERTIFICATE_MODAL}-${url}`, html, preload, {url, list}, mainWindow);
         if (modalPromise) {
             modalPromise.then((data) => {
                 const {cert} = data;

--- a/src/main/menus/app.ts
+++ b/src/main/menus/app.ts
@@ -10,7 +10,7 @@ import log from 'electron-log';
 import ServerViewState from 'app/serverViewState';
 import {OPEN_SERVERS_DROPDOWN, SHOW_NEW_SERVER_MODAL} from 'common/communication';
 import type {Config} from 'common/config';
-import {DEFAULT_EE_REPORT_PROBLEM_LINK, DEFAULT_TE_REPORT_PROBLEM_LINK} from 'common/constants';
+import {DEFAULT_EE_REPORT_PROBLEM_LINK, DEFAULT_TE_REPORT_PROBLEM_LINK, ModalConstants} from 'common/constants';
 import ServerManager from 'common/servers/serverManager';
 import {t} from 'common/utils/util';
 import {getViewDisplayName} from 'common/views/View';
@@ -59,7 +59,7 @@ export function createTemplate(config: Config, updateManager: UpdateManager) {
             }
 
             ModalManager.addModal(
-                'settingsModal',
+                ModalConstants.SETTINGS_MODAL,
                 'mattermost-desktop://renderer/settings.html',
                 getLocalPreload('internalAPI.js'),
                 null,

--- a/src/main/menus/tray.ts
+++ b/src/main/menus/tray.ts
@@ -7,6 +7,7 @@ import type {MenuItem, MenuItemConstructorOptions} from 'electron';
 import {Menu} from 'electron';
 
 import ServerViewState from 'app/serverViewState';
+import {ModalConstants} from 'common/constants';
 import ServerManager from 'common/servers/serverManager';
 import {localizeMessage} from 'main/i18nManager';
 import {getLocalPreload} from 'main/utils';
@@ -34,7 +35,7 @@ export function createTemplate() {
                 }
 
                 ModalManager.addModal(
-                    'settingsModal',
+                    ModalConstants.SETTINGS_MODAL,
                     'mattermost-desktop://renderer/settings.html',
                     getLocalPreload('internalAPI.js'),
                     null,


### PR DESCRIPTION
#### Summary
Convert all the modal keys to use constants instead.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63265

```release-note
NONE
```
