### PR TITLE
Fix an issue where the incompatible server check defaults to show the screen when the server info is not present

### DIFF
--- a/src/main/views/MattermostWebContentsView.ts
+++ b/src/main/views/MattermostWebContentsView.ts
@@ -433,7 +433,7 @@ export class MattermostWebContentsView extends EventEmitter {
     private loadSuccess = (loadURL: string) => {
         return () => {
             const serverInfo = ServerManager.getRemoteInfo(this.view.server.id);
-            if (serverInfo?.serverVersion && semver.gte(serverInfo.serverVersion, '9.4.0')) {
+            if (!serverInfo?.serverVersion || semver.gte(serverInfo.serverVersion, '9.4.0')) {
                 this.log.verbose(`finished loading ${loadURL}`);
                 MainWindow.sendToRenderer(LOAD_SUCCESS, this.id);
                 this.maxRetries = MAX_SERVER_RETRIES;


### PR DESCRIPTION
#### Summary
The incompatible server version check assumed that compatible servers should be able to respond to the API request that checks for server version, however this is not always working.

As a short term fix, we will default to not show the screen if the server version is not present.

#### Ticket Link
Closes https://github.com/mattermost/desktop/issues/3363

```release-note
Fix an issue where the incompatible server screen shows by default when the server info is not present.
```
