### PR TITLE
[MM-63399] Add a changelog link for when the app auto updates

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -301,6 +301,7 @@
   "renderer.downloadsDropdown.Update.MattermostVersionX": "{appName} version {version}",
   "renderer.downloadsDropdown.Update.NewDesktopVersionAvailable": "New Desktop version available",
   "renderer.downloadsDropdown.Update.RestartAndUpdate": "Restart & update",
+  "renderer.downloadsDropdown.Update.ViewChangelog": "View Changelog",
   "renderer.downloadsDropdownMenu.CancelDownload": "Cancel Download",
   "renderer.downloadsDropdownMenu.Clear": "Clear",
   "renderer.downloadsDropdownMenu.Open": "Open",

--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -104,6 +104,7 @@ export const UPDATE_URL_VIEW_WIDTH = 'update-url-view-width';
 
 export const OPEN_SERVER_EXTERNALLY = 'open-server-externally';
 export const OPEN_SERVER_UPGRADE_LINK = 'open-server-upgrade-link';
+export const OPEN_CHANGELOG_LINK = 'open-changelog-link';
 
 export const PING_DOMAIN = 'ping-domain';
 

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -49,6 +49,7 @@ export const DEFAULT_ACADEMY_LINK = 'https://academy.mattermost.com/';
 export const DEFAULT_TE_REPORT_PROBLEM_LINK = 'https://mattermost.com/pl/report-a-bug';
 export const DEFAULT_EE_REPORT_PROBLEM_LINK = 'https://support.mattermost.com/hc/en-us/requests/new';
 export const DEFAULT_UPGRADE_LINK = 'https://forum.mattermost.com/t/mattermost-desktop-app-5-11-important-compatibility-notice/22599';
+export const DEFAULT_CHANGELOG_URL = 'https://docs.mattermost.com/help/apps/desktop-changelog.html';
 
 export const ModalConstants = {
     SETTINGS_MODAL: 'settingsModal',

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -49,7 +49,7 @@ export const DEFAULT_ACADEMY_LINK = 'https://academy.mattermost.com/';
 export const DEFAULT_TE_REPORT_PROBLEM_LINK = 'https://mattermost.com/pl/report-a-bug';
 export const DEFAULT_EE_REPORT_PROBLEM_LINK = 'https://support.mattermost.com/hc/en-us/requests/new';
 export const DEFAULT_UPGRADE_LINK = 'https://forum.mattermost.com/t/mattermost-desktop-app-5-11-important-compatibility-notice/22599';
-export const DEFAULT_CHANGELOG_URL = 'https://docs.mattermost.com/help/apps/desktop-changelog.html';
+export const DEFAULT_CHANGELOG_LINK = 'https://docs.mattermost.com/help/apps/desktop-changelog.html';
 
 export const ModalConstants = {
     SETTINGS_MODAL: 'settingsModal',

--- a/src/main/preload/internalAPI.js
+++ b/src/main/preload/internalAPI.js
@@ -99,6 +99,7 @@ import {
     GET_UNIQUE_SERVERS_WITH_PERMISSIONS,
     LOAD_INCOMPATIBLE_SERVER,
     OPEN_SERVER_UPGRADE_LINK,
+    OPEN_CHANGELOG_LINK,
 } from 'common/communication';
 
 console.log('Preload initialized');
@@ -127,6 +128,7 @@ contextBridge.exposeInMainWorld('desktop', {
     focusCurrentView: () => ipcRenderer.send(FOCUS_BROWSERVIEW),
     openServerExternally: () => ipcRenderer.send(OPEN_SERVER_EXTERNALLY),
     openServerUpgradeLink: () => ipcRenderer.send(OPEN_SERVER_UPGRADE_LINK),
+    openChangelogLink: () => ipcRenderer.send(OPEN_CHANGELOG_LINK),
     closeDownloadsDropdown: () => ipcRenderer.send(CLOSE_DOWNLOADS_DROPDOWN),
     closeDownloadsDropdownMenu: () => ipcRenderer.send(CLOSE_DOWNLOADS_DROPDOWN_MENU),
     openDownloadsDropdown: () => ipcRenderer.send(OPEN_DOWNLOADS_DROPDOWN),

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -35,7 +35,7 @@ import {
     DEVELOPER_MODE_UPDATED,
 } from 'common/communication';
 import Config from 'common/config';
-import {DEFAULT_CHANGELOG_URL} from 'common/constants';
+import {DEFAULT_CHANGELOG_LINK} from 'common/constants';
 import {Logger} from 'common/log';
 import type {MattermostServer} from 'common/servers/MattermostServer';
 import ServerManager from 'common/servers/serverManager';
@@ -591,7 +591,7 @@ export class ViewManager {
     };
 
     private handleOpenChangelogLink = () => {
-        shell.openExternal(DEFAULT_CHANGELOG_URL);
+        shell.openExternal(DEFAULT_CHANGELOG_LINK);
     };
 
     private handleUnreadsAndMentionsChanged = (e: IpcMainEvent, isUnread: boolean, mentionCount: number) => {

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -19,6 +19,8 @@ import {
     SERVERS_UPDATE,
     REACT_APP_INITIALIZED,
     OPEN_SERVER_EXTERNALLY,
+    OPEN_SERVER_UPGRADE_LINK,
+    OPEN_CHANGELOG_LINK,
     HISTORY,
     GET_VIEW_INFO_FOR_TEST,
     SESSION_EXPIRED,
@@ -31,9 +33,9 @@ import {
     UNREADS_AND_MENTIONS,
     TAB_LOGIN_CHANGED,
     DEVELOPER_MODE_UPDATED,
-    OPEN_SERVER_UPGRADE_LINK,
 } from 'common/communication';
 import Config from 'common/config';
+import {DEFAULT_CHANGELOG_URL} from 'common/constants';
 import {Logger} from 'common/log';
 import type {MattermostServer} from 'common/servers/MattermostServer';
 import ServerManager from 'common/servers/serverManager';
@@ -84,6 +86,7 @@ export class ViewManager {
         ipcMain.on(TAB_LOGIN_CHANGED, this.handleTabLoginChanged);
         ipcMain.on(OPEN_SERVER_EXTERNALLY, this.handleOpenServerExternally);
         ipcMain.on(OPEN_SERVER_UPGRADE_LINK, this.handleOpenServerUpgradeLink);
+        ipcMain.on(OPEN_CHANGELOG_LINK, this.handleOpenChangelogLink);
         ipcMain.on(UNREADS_AND_MENTIONS, this.handleUnreadsAndMentionsChanged);
         ipcMain.on(SESSION_EXPIRED, this.handleSessionExpired);
 
@@ -585,6 +588,10 @@ export class ViewManager {
         if (Config.upgradeLink) {
             shell.openExternal(Config.upgradeLink);
         }
+    };
+
+    private handleOpenChangelogLink = () => {
+        shell.openExternal(DEFAULT_CHANGELOG_URL);
     };
 
     private handleUnreadsAndMentionsChanged = (e: IpcMainEvent, isUnread: boolean, mentionCount: number) => {

--- a/src/renderer/components/DownloadsDropdown/Update/UpdateAvailable.tsx
+++ b/src/renderer/components/DownloadsDropdown/Update/UpdateAvailable.tsx
@@ -67,6 +67,16 @@ const UpdateAvailable = ({item, appName}: OwnProps) => {
                         />
                     </LoadingWrapper>
                 </button>
+                <a
+                    className='DownloadsDropdown__Update__Details__Changelog'
+                    onClick={() => window.desktop.openChangelogLink()}
+                    href='#'
+                >
+                    <FormattedMessage
+                        id='renderer.downloadsDropdown.Update.ViewChangelog'
+                        defaultMessage='View Changelog'
+                    />
+                </a>
             </div>
         </div>
     );

--- a/src/renderer/css/downloadsDropdown.scss
+++ b/src/renderer/css/downloadsDropdown.scss
@@ -350,13 +350,25 @@ body {
                         }
 
                         .DownloadsDropdown__Update__Details__Description {
-                            color: rgba(63, 67, 80, 0.64);
+                            color: rgba(var(--center-channel-color-rgb), 0.64);
                             font-size: 10px;
                             font-style: normal;
                             font-weight: 400;
                             letter-spacing: 0.02em;
                             line-height: 16px;
                             max-width: 200px;
+                        }
+
+                        .DownloadsDropdown__Update__Details__Changelog {
+                            color: var(--link-color);
+                            text-decoration: none;
+                            font-size: 12px;
+                            margin-top: 6px;
+                            display: inline-block;
+
+                            &:hover, &:focus {
+                                filter: brightness(90%);
+                            }
                         }
 
                         button#downloadUpdateButton {

--- a/src/renderer/css/downloadsDropdown.scss
+++ b/src/renderer/css/downloadsDropdown.scss
@@ -363,6 +363,7 @@ body {
                             color: var(--link-color);
                             text-decoration: none;
                             font-size: 12px;
+                            font-weight: 600;
                             margin-top: 6px;
                             display: inline-block;
 

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -40,6 +40,7 @@ declare global {
             focusCurrentView: () => void;
             openServerExternally: () => void;
             openServerUpgradeLink: () => void;
+            openChangelogLink: () => void;
             closeDownloadsDropdown: () => void;
             closeDownloadsDropdownMenu: () => void;
             openDownloadsDropdown: () => void;


### PR DESCRIPTION
#### Summary
This PR adds a link to the changelog when the user is prompted for an auto-update.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63399

#### Screenshots
NOTE: The screenshots says Electron in dev mode, they will say Mattermost in production
![Screenshot 2025-03-11 at 3 00 37 PM](https://github.com/user-attachments/assets/de9ef70b-86fb-4f46-957b-6c3c984db115)
![Screenshot 2025-03-11 at 3 00 18 PM](https://github.com/user-attachments/assets/c5a7b275-55f7-45c2-98fa-b39c7c7b6219)

```release-note
Add a changelog link for when the app auto updates
```
