### PR TITLE
Fix: Build Mac no dmg job failing due to MACOS_NOTIFICATION_STATE_NO_SDK_CHECK

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,6 +159,11 @@ jobs:
           brew install yq
           jq '.mac.target=["zip"]' electron-builder.json | jq '.mac.gatekeeperAssess=false' > /tmp/electron-builder.json && cp /tmp/electron-builder.json .
           sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+          export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+          echo "SDKROOT=$SDKROOT" >> $GITHUB_ENV
+          xcrun --sdk macosx --show-sdk-version
+          xcodebuild -version
+          ls -l /Applications/Xcode_16.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs
           npm ci
       - name: ci/test
         uses: ./.github/actions/test
@@ -168,6 +173,8 @@ jobs:
           npm run package:mac
           bash -x ./scripts/patch_updater_yml.sh
           bash -x ./scripts/cp_artifacts.sh release ./build/macos/
+        env:
+          SDKROOT: ${{ env.SDKROOT }}
       - name: ci/upload-test-results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,10 +160,6 @@ jobs:
           jq '.mac.target=["zip"]' electron-builder.json | jq '.mac.gatekeeperAssess=false' > /tmp/electron-builder.json && cp /tmp/electron-builder.json .
           sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
-          echo "SDKROOT=$SDKROOT" >> $GITHUB_ENV
-          xcrun --sdk macosx --show-sdk-version
-          xcodebuild -version
-          ls -l /Applications/Xcode_16.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs
           npm ci
       - name: ci/test
         uses: ./.github/actions/test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,6 +160,10 @@ jobs:
           jq '.mac.target=["zip"]' electron-builder.json | jq '.mac.gatekeeperAssess=false' > /tmp/electron-builder.json && cp /tmp/electron-builder.json .
           sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+          echo "SDKROOT=$SDKROOT" >> $GITHUB_ENV
+          xcrun --sdk macosx --show-sdk-version
+          xcodebuild -version
+          ls -l /Applications/Xcode_16.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs
           npm ci
       - name: ci/test
         uses: ./.github/actions/test


### PR DESCRIPTION
this PR https://github.com/mattermost/desktop/pull/3393 had the Macos build job failing. 
I had added a temprory Fix to skip check. 

The error we were seeing:

xcodebuild: error: SDK "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk" cannot be located.
This is because the active developer path is set to the Command Line Tools, which don’t include full SDKs like MacOSX.sdk.

With this fix the full SDK is used

```release-note
NONE
```
