### PR TITLE
Fix SBOM file name

### DIFF
--- a/.github/workflows/snyk-sbom.yml
+++ b/.github/workflows/snyk-sbom.yml
@@ -13,7 +13,7 @@ jobs:
   sbom:
     permissions:
       contents: write
-    uses: mattermost/actions-workflows/.github/workflows/snyk-sbom.yml@a7b0a0fbb4c962f12f34f70563997636e49ac4ac
+    uses: mattermost/actions-workflows/.github/workflows/snyk-sbom.yml@2174576d3c65eb4db691bf09fd72246b59f331c8
     secrets: inherit
     with:
       is_monorepo: false


### PR DESCRIPTION
#### Summary

- Fix SBOM filename (the name came out as `sbom-desktop-.RELEASE_TAG.json ` instead of `sbom-desktop-v5.11.2.json`)

#### Ticket Link

NA

#### Release Note

```release-note
NONE
```