### PR TITLE
[MM-63849] Account for minor versions >= 10

### DIFF
--- a/scripts/generate_release_post.sh
+++ b/scripts/generate_release_post.sh
@@ -4,7 +4,7 @@ set -eu
 VERSION="$1" # such as 5.3.0-rc.1, 5.0.0
 
 TEMP_VERSION_FILE="$(mktemp -t temp_version_file.XXXX)"
-git for-each-ref --sort=creatordate --format '%(refname)' refs/tags | grep "v[0-9]\.[0-9]\.[0-9]" | grep -v mas | grep -v "v$VERSION" | sed "s/refs\/tags\/v//" > $TEMP_VERSION_FILE
+git for-each-ref --sort=creatordate --format '%(refname)' refs/tags | grep "v[0-9]\+\.[0-9]\+\.[0-9]\+" | grep -v mas | grep -v "v$VERSION" | sed "s/refs\/tags\/v//" > $TEMP_VERSION_FILE
 LAST_VERSION="$(cat $TEMP_VERSION_FILE | tail -1)"
 
 TEMP_CHANGES_FILE="$(mktemp -t temp_changes_file.XXXX)"


### PR DESCRIPTION
#### Summary
When building v5.12.0-rc.1, we ran into an issue where the text was too long. This was caused by the notification script going too far back in history, due to the script only checking for versions of the form `vx.x.x`, which didn't account for multiple digits.

This PR accounts for multiple digits.

This should be backported to v5.11 as well in case we need to release from there.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63849

```release-note
NONE
```
