### PR TITLE
Fix: application startup with error "Cannot read properties of null (reading 'id')"

### DIFF
--- a/src/main/authManager.ts
+++ b/src/main/authManager.ts
@@ -40,6 +40,11 @@ export class AuthManager {
         if (!parsedURL) {
             return;
         }
+        
+        if (!webContents) {
+            return;
+        }
+        
         const serverURL = ViewManager.getViewByWebContentsId(webContents.id)?.view.server.url;
         if (!serverURL) {
             return;


### PR DESCRIPTION
#### Summary
On every startup the application crashes with the following error message:

![mmerror](https://github.com/user-attachments/assets/7315797d-9a5e-4b4a-a100-228c04555304)

```
Application: Mattermost 5.11.2 [commit: 5.11.2]
Platform: Linux 5.10.236-1-MANJARO x64
TypeError: Cannot read properties of null (reading 'id')
    at App.<anonymous> (/usr/lib/mattermost-desktop/app.asar/index.js:2:109191)
    at App.emit (node:events:524:28)
```

This PR checks for the null value, and aborts operation.

#### Device Information
This PR was tested on: Arch Linux

#### Release Note

```release-note
Fix: application startup with error "Cannot read properties of null (reading 'id')"
```
