### PR TITLE
[MM-62005] Use `ready-to-show` event for focus workaround for URL view

### DIFF
--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -382,8 +382,7 @@ export class ViewManager {
 
             // This is a workaround for an issue where the URL view would steal focus from the main window
             // See: https://github.com/electron/electron/issues/42339
-            // Using an undocumented event that fires last when the URL view pops up
-            // @ts-ignore
+            // @ts-expect-error Using an undocumented event that fires last when the URL view pops up
             urlView.webContents.once('ready-to-show', () => {
                 log.debug('URL view focus prevented');
                 this.getCurrentView()?.focus();

--- a/src/main/views/viewManager.ts
+++ b/src/main/views/viewManager.ts
@@ -382,7 +382,9 @@ export class ViewManager {
 
             // This is a workaround for an issue where the URL view would steal focus from the main window
             // See: https://github.com/electron/electron/issues/42339
-            urlView.webContents.on('focus', () => {
+            // Using an undocumented event that fires last when the URL view pops up
+            // @ts-ignore
+            urlView.webContents.once('ready-to-show', () => {
                 log.debug('URL view focus prevented');
                 this.getCurrentView()?.focus();
             });


### PR DESCRIPTION
#### Summary
Our fix for focus trapping on the URL view on Desktop App wasn't sufficient, it wouldn't work on Windows/Linux due to the timing of the actual focusing. This PR switches to an undocumented `ready-to-show` event that fires before the web contents are shown, long after focus is taken. However this all happens very quickly, so now the event always fires after focus is taken but before the window shows, so focus won't be disrupted for long.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62005

```release-note
Fix focus loss when tabbing to an external URL for Windows/Linux
```
