### PR TITLE
[MM-64355] Disable server management in the Settings Modal when disabled via group policy

### DIFF
--- a/src/renderer/components/SettingsModal/components/ServerSetting.tsx
+++ b/src/renderer/components/SettingsModal/components/ServerSetting.tsx
@@ -121,16 +121,18 @@ export default function ServerSetting() {
                             defaultMessage='Servers'
                         />
                     </h3>
-                    {enableServerManagement && <button
-                        onClick={showAddServerModal}
-                        className='ServerSetting__addServer btn btn-sm btn-tertiary'
-                    >
-                        <i className='icon icon-plus'/>
-                        <FormattedMessage
-                            id='renderer.components.settingsPage.serverSetting.addAServer'
-                            defaultMessage='Add a server'
-                        />
-                    </button>}
+                    {enableServerManagement &&
+                        <button
+                            onClick={showAddServerModal}
+                            className='ServerSetting__addServer btn btn-sm btn-tertiary'
+                        >
+                            <i className='icon icon-plus'/>
+                            <FormattedMessage
+                                id='renderer.components.settingsPage.serverSetting.addAServer'
+                                defaultMessage='Add a server'
+                            />
+                        </button>
+                    }
                 </div>
                 {servers.length === 0 && (
                     <div className='ServerSetting__noServers'>
@@ -168,12 +170,14 @@ export default function ServerSetting() {
                             >
                                 <i className='icon icon-pencil-outline'/>
                             </button>
-                            {enableServerManagement && !server.server.isPredefined && <button
-                                onClick={showRemoveServerModal(server)}
-                                className='ServerSetting__removeServer btn btn-icon btn-sm btn-tertiary btn-transparent btn-danger'
-                            >
-                                <i className='icon icon-trash-can-outline'/>
-                            </button>}
+                            {enableServerManagement && !server.server.isPredefined &&
+                                <button
+                                    onClick={showRemoveServerModal(server)}
+                                    className='ServerSetting__removeServer btn btn-icon btn-sm btn-tertiary btn-transparent btn-danger'
+                                >
+                                    <i className='icon icon-trash-can-outline'/>
+                                </button>
+                            }
                         </div>
                     )))}
                 </div>


### PR DESCRIPTION
#### Summary
I missed when re-designing the modals that server management should be disabled when disabled in group policy. This PR accounts for group policy in server management.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64355
Fixes #3423 

```release-note
Disable server management in the Settings Modal when disabled via group policy
```
