### PR TITLE
Don't require the update file to exist

### DIFF
--- a/scripts/patch_updater_yml.sh
+++ b/scripts/patch_updater_yml.sh
@@ -17,7 +17,7 @@ NEXT_MAJOR_VERSION="$(npx semver $STABLE_VERSION -i major)"
 NEWER_VERSION_EXISTS="$(git ls-remote --tags origin v${NEXT_MINOR_VERSION} v${NEXT_MAJOR_VERSION})"
 if [ -e .esr ] && [ ! -z "$NEWER_VERSION_EXISTS" ]; then
     echo "ESR branch, skipping auto-updater yml generation"
-    rm ./release/"${RELEASE_VERSION}"*.yml
+    rm ./release/"${RELEASE_VERSION}"*.yml || true
     exit 0
 fi
 


### PR DESCRIPTION
The ESR CI build fails on Linux if the update file doesn't exist.

```release-note
NONE
```
