### PR TITLE
[MM-64399] Fix crash in electron-context-menu

### DIFF
--- a/patches/electron-context-menu+4.0.4.patch
+++ b/patches/electron-context-menu+4.0.4.patch
@@ -47,7 +47,7 @@ index 468e48b..e182878 100644
  		event: ElectronEvent
  	) => MenuItemConstructorOptions[];
 diff --git a/node_modules/electron-context-menu/index.js b/node_modules/electron-context-menu/index.js
-index b10daea..d7d26f3 100644
+index b10daea..4514ef1 100644
 --- a/node_modules/electron-context-menu/index.js
 +++ b/node_modules/electron-context-menu/index.js
 @@ -1,7 +1,6 @@
@@ -63,7 +63,7 @@ index b10daea..d7d26f3 100644
  				click(menuItem) {
  					properties.srcURL = menuItem.transform ? menuItem.transform(properties.srcURL) : properties.srcURL;
 -					download(win, properties.srcURL);
-+					win.webContents.downloadURL(properties.srcURL);
++					webContents(win).downloadURL(properties.srcURL);
  				},
  			}),
  			saveImageAs: decorateMenuItem({
@@ -72,7 +72,7 @@ index b10daea..d7d26f3 100644
  				click(menuItem) {
  					properties.srcURL = menuItem.transform ? menuItem.transform(properties.srcURL) : properties.srcURL;
 -					download(win, properties.srcURL, {saveAs: true});
-+					win.webContents.downloadURL(properties.srcURL, {saveAs: true});
++					webContents(win).downloadURL(properties.srcURL, {saveAs: true});
  				},
  			}),
  			saveVideo: decorateMenuItem({
@@ -81,7 +81,7 @@ index b10daea..d7d26f3 100644
  				click(menuItem) {
  					properties.srcURL = menuItem.transform ? menuItem.transform(properties.srcURL) : properties.srcURL;
 -					download(win, properties.srcURL);
-+					win.webContents.downloadURL(properties.srcURL);
++					webContents(win).downloadURL(properties.srcURL);
  				},
  			}),
  			saveVideoAs: decorateMenuItem({
@@ -90,7 +90,7 @@ index b10daea..d7d26f3 100644
  				click(menuItem) {
  					properties.srcURL = menuItem.transform ? menuItem.transform(properties.srcURL) : properties.srcURL;
 -					download(win, properties.srcURL, {saveAs: true});
-+					win.webContents.downloadURL(properties.srcURL, {saveAs: true});
++					webContents(win).downloadURL(properties.srcURL, {saveAs: true});
  				},
  			}),
  			copyLink: decorateMenuItem({
@@ -99,7 +99,7 @@ index b10daea..d7d26f3 100644
  				click(menuItem) {
  					properties.linkURL = menuItem.transform ? menuItem.transform(properties.linkURL) : properties.linkURL;
 -					download(win, properties.linkURL, {saveAs: true});
-+					win.webContents.downloadURL(properties.linkURL, {saveAs: true});
++					webContents(win).downloadURL(properties.linkURL, {saveAs: true});
  				},
  			}),
  			copyImage: decorateMenuItem({


### PR DESCRIPTION
#### Summary
A conflict in how we were passing window context to the `electron-context-menu` caused crashes in our app, since some pass the `webContents` and others pass the window object. There is a handler in `electron-context-menu` for this, but we weren't using it.

This PR switches to use that handle so that either windows or `webContents` will work fine.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64399
Fixes #3440 

```release-note
NONE
```
