### PR TITLE
Fix zoom-in shortcut to work with numpad +

### DIFF
--- a/src/main/menus/app.ts
+++ b/src/main/menus/app.ts
@@ -270,6 +270,10 @@ export function createTemplate(config: Config, updateManager: UpdateManager) {
         visible: false,
         accelerator: 'CmdOrCtrl+Shift+=',
     }, {
+        role: 'zoomIn',
+        visible: false,
+        accelerator: 'CmdOrCtrl+Plus',
+    }, {
         role: 'zoomOut',
         label: localizeMessage('main.menus.app.view.zoomOut', 'Zoom Out'),
         accelerator: 'CmdOrCtrl+-',


### PR DESCRIPTION
#### Summary
The zoom-in keyboard shortcut does not work with the numpad + button, since the accelerators were basing off the `=` button. This PR adds one for `+` specifically.

#### Ticket Link
Fixes #3359

```release-note
Fix an issue with the zoom-in keyboard shortcut
```
