### PR TITLE
In-App Links in Channel's Bookmarks

### DIFF
--- a/src/main/views/webContentEvents.ts
+++ b/src/main/views/webContentEvents.ts
@@ -136,7 +136,7 @@ export class WebContentsEventManager {
                 ViewManager.handleDeepLink(parsedURL);
                 return {action: 'deny'};
             }
-            
+
             // Check for other custom protocols
             if (isCustomProtocol(parsedURL)) {
                 allowProtocolDialog.handleDialogEvent(parsedURL.protocol, details.url);

--- a/src/main/views/webContentEvents.ts
+++ b/src/main/views/webContentEvents.ts
@@ -28,7 +28,7 @@ import ViewManager from 'main/views/viewManager';
 import CallsWidgetWindow from 'main/windows/callsWidgetWindow';
 import MainWindow from 'main/windows/mainWindow';
 
-import {generateHandleConsoleMessage, isCustomProtocol} from './webContentEventsCommon';
+import {generateHandleConsoleMessage, isCustomProtocol, isMattermostProtocol} from './webContentEventsCommon';
 
 import allowProtocolDialog from '../allowProtocolDialog';
 import {composeUserAgent} from '../utils';
@@ -131,7 +131,13 @@ export class WebContentsEventManager {
                 return PluginsPopUpsManager.handleNewWindow(webContentsId, details);
             }
 
-            // Check for custom protocol
+            // Check for mattermost protocol - handle internally
+            if (isMattermostProtocol(parsedURL)) {
+                ViewManager.handleDeepLink(parsedURL);
+                return {action: 'deny'};
+            }
+            
+            // Check for other custom protocols
             if (isCustomProtocol(parsedURL)) {
                 allowProtocolDialog.handleDialogEvent(parsedURL.protocol, details.url);
                 return {action: 'deny'};

--- a/src/main/views/webContentEventsCommon.ts
+++ b/src/main/views/webContentEventsCommon.ts
@@ -34,3 +34,8 @@ export function isCustomProtocol(url: URL) {
     const scheme = protocols && protocols[0] && protocols[0].schemes && protocols[0].schemes[0];
     return url.protocol !== 'http:' && url.protocol !== 'https:' && url.protocol !== `${scheme}:`;
 }
+
+export function isMattermostProtocol(url: URL) {
+    const scheme = protocols && protocols[0] && protocols[0].schemes && protocols[0].schemes[0];
+    return url.protocol === `${scheme}:`;
+}


### PR DESCRIPTION
## Summary

Enhances mattermost:// protocol handling for in-app links in channel bookmarks. When users click bookmarks with mattermost:// URLs, they now open within the desktop app using internal deep linking instead of triggering external protocol dialogs.

- Add isMattermostProtocol() helper function to identify mattermost:// URLs
- Update webContentEvents to handle mattermost:// links through internal deep linking
- Ensure mattermost:// links in bookmarks open within the app instead of external dialog
- Maintain existing custom protocol dialog for other non-http/https protocols

This improves the user experience by allowing mattermost:// bookmarks to navigate directly within the desktop app without prompting external application dialogs.

## Ticket Link
Related to [server-side implementation](https://github.com/mattermost/mattermost/pull/30956) for in-app links feature in channel bookmarks.
Fixes [29145](https://github.com/mattermost/mattermost/issues/29145)

## Checklist

- [x] Added or updated unit tests (required for all new features)
- [ ]  Has UI changes
- [x]  read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x]  completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [x]  executed npm run lint:js for proper code formatting
- [ ]  Run E2E tests by adding label Run Desktop E2E Tests

## Release Note

```release-note
Enhanced mattermost:// protocol handling to open in-app links within the desktop application instead of external protocol dialogs.
```