### PR TITLE
[MM-64617] Add enter key press handler to each of the modals

### DIFF
--- a/src/renderer/components/DestructiveConfirmModal.tsx
+++ b/src/renderer/components/DestructiveConfirmModal.tsx
@@ -36,6 +36,7 @@ export default function DestructiveConfirmationModal(props: Props) {
             modalHeaderText={title}
             handleCancel={onCancel}
             handleConfirm={onAccept}
+            handleEnterKeyPress={onAccept}
             confirmButtonText={acceptLabel}
             cancelButtonText={cancelLabel}
             confirmButtonClassName='btn-danger'

--- a/src/renderer/components/Modal.tsx
+++ b/src/renderer/components/Modal.tsx
@@ -124,7 +124,7 @@ export const Modal: React.FC<Props> = ({
 
     const handleConfirmClick = async (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
         event.preventDefault();
-        if (autoCloseOnConfirmButton) {
+        if (autoCloseOnConfirmButton && !isConfirmDisabled) {
             await onHide();
         }
         handleConfirm?.();
@@ -135,7 +135,7 @@ export const Modal: React.FC<Props> = ({
             if (event.nativeEvent.isComposing) {
                 return;
             }
-            if (autoCloseOnConfirmButton) {
+            if (autoCloseOnConfirmButton && !isConfirmDisabled) {
                 await onHide();
             }
             if (handleEnterKeyPress) {

--- a/src/renderer/components/NewServerModal.tsx
+++ b/src/renderer/components/NewServerModal.tsx
@@ -361,6 +361,7 @@ class NewServerModal extends React.PureComponent<Props, State> {
                 onExited={this.props.unremoveable ? () => {} : this.props.onClose}
                 modalHeaderText={this.getModalTitle()}
                 confirmButtonText={this.getSaveButtonLabel()}
+                handleEnterKeyPress={this.save}
                 handleConfirm={this.save}
                 isConfirmDisabled={!this.state.serverName.length || !this.state.validationResult || this.isServerURLErrored()}
                 handleCancel={this.props.onClose}

--- a/src/renderer/components/SettingsModal/index.tsx
+++ b/src/renderer/components/SettingsModal/index.tsx
@@ -156,6 +156,7 @@ export default function SettingsModal({
                         defaultMessage='Desktop App Settings'
                     />
                 }
+                autoCloseOnConfirmButton={false}
                 headerContent={savingText}
                 bodyDivider={true}
                 bodyPadding={false}

--- a/src/renderer/components/showCertificateModal.tsx
+++ b/src/renderer/components/showCertificateModal.tsx
@@ -79,6 +79,7 @@ export default class ShowCertificateModal extends React.PureComponent<Props, Sta
                         />
                     }
                     handleConfirm={this.handleOk}
+                    handleEnterKeyPress={this.handleOk}
                 >
                     <dl>
                         {certificateSection(

--- a/src/renderer/modals/login/loginModal.tsx
+++ b/src/renderer/modals/login/loginModal.tsx
@@ -110,6 +110,7 @@ class LoginModal extends React.PureComponent<Props, State> {
                     />
                 }
                 handleConfirm={this.handleSubmit}
+                handleEnterKeyPress={this.handleSubmit}
                 confirmButtonText={
                     <FormattedMessage
                         id='label.login'

--- a/src/renderer/modals/permission/permissionModal.tsx
+++ b/src/renderer/modals/permission/permissionModal.tsx
@@ -104,6 +104,7 @@ class PermissionModal extends React.PureComponent<Props, State> {
                 onExited={() => {}}
                 modalHeaderText={this.getModalTitle()}
                 handleConfirm={this.props.handleGrant}
+                handleEnterKeyPress={this.props.handleGrant}
                 confirmButtonText={
                     <FormattedMessage
                         id='label.accept'


### PR DESCRIPTION
#### Summary
When we added the new modals, we neglected to account for how Enter key presses work with the new Modal component. For most of them, it would just hide the modal and not actually close it.

This PR adds the handlers to bind most of them to just their confirm button options, and also makes a change in the component itself to not hide unless the confirm button is enabled.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64617

```release-note
Fixed an issue where the Enter key would not confirm most modals
```
