### PR TITLE
[MM-65009] Force windows to run install-deps regardless of cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,6 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
       - name: ci/install-dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
         run: |
@@ -115,7 +114,6 @@ jobs:
           node-gyp install --devdir="C:\Users\runneradmin\.electron-gyp" --target=$(jq -r .devDependencies.electron package.json) --dist-url="https://electronjs.org/headers"
           node-gyp install --devdir="C:\Users\runneradmin\.electron-gyp" --target=$(jq -r .devDependencies.electron package.json) --dist-url="https://electronjs.org/headers" --arch arm64
       - name: ci/install-dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
         run: |

--- a/test.txt
+++ b/test.txt
@@ -1,2 +1,0 @@
-test file for PR
-test2


### PR DESCRIPTION
#### Summary
With the addition of `registry-js`, we need to now run `npm i` regardless of caching on Windows.

```release-note
NONE
```
