### PR TITLE
Fix server removal bug

### DIFF
--- a/src/app/mainWindow/mainWindow.ts
+++ b/src/app/mainWindow/mainWindow.ts
@@ -35,6 +35,7 @@ import {
 } from 'common/communication';
 import Config from 'common/config';
 import {Logger} from 'common/log';
+import type {MattermostServer} from 'common/servers/MattermostServer';
 import ServerManager from 'common/servers/serverManager';
 import {DEFAULT_WINDOW_HEIGHT, DEFAULT_WINDOW_WIDTH, TAB_BAR_HEIGHT} from 'common/utils/constants';
 import * as Validator from 'common/Validator';
@@ -368,8 +369,8 @@ export class MainWindow extends EventEmitter {
         this.win?.browserWindow.webContents.send(SERVER_ADDED, serverId, setAsCurrentServer);
     };
 
-    private handleServerRemoved = (serverId: string) => {
-        this.win?.browserWindow.webContents.send(SERVER_REMOVED, serverId);
+    private handleServerRemoved = (server: MattermostServer) => {
+        this.win?.browserWindow.webContents.send(SERVER_REMOVED, server.id);
     };
 
     private handleServerUrlChanged = (serverId: string) => {

--- a/src/app/serverHub.ts
+++ b/src/app/serverHub.ts
@@ -406,13 +406,8 @@ export class ServerHub {
         }
     };
 
-    private handleServerCleanup = (serverId: string) => {
-        log.debug('handleServerCleanup', {serverId});
-
-        const server = ServerManager.getServer(serverId);
-        if (!server) {
-            return;
-        }
+    private handleServerCleanup = (server: MattermostServer) => {
+        log.debug('handleServerCleanup', {serverId: server.id});
 
         session.defaultSession.clearData({
             origins: [server.url.origin],

--- a/src/common/servers/serverManager.ts
+++ b/src/common/servers/serverManager.ts
@@ -217,7 +217,10 @@ export class ServerManager extends EventEmitter {
     removeServer = (serverId: string) => {
         log.debug('removeServer', {serverId});
 
-        this.emit(SERVER_REMOVED, serverId);
+        const server = this.servers.get(serverId);
+        if (!server) {
+            return;
+        }
 
         const index = this.serverOrder.findIndex((id) => id === serverId);
         this.serverOrder.splice(index, 1);
@@ -230,6 +233,7 @@ export class ServerManager extends EventEmitter {
             this.updateCurrentServer(nextServer);
         }
 
+        this.emit(SERVER_REMOVED, server);
         this.persistServers();
     };
 

--- a/src/common/views/viewManager.test.js
+++ b/src/common/views/viewManager.test.js
@@ -216,7 +216,7 @@ describe('ViewManager', () => {
             const view2 = viewManager.createView(mockServer, ViewType.TAB);
             const removeViewSpy = jest.spyOn(viewManager, 'removeView');
 
-            ServerManager.mockServerManager.emit(SERVER_REMOVED, mockServer.id);
+            ServerManager.mockServerManager.emit(SERVER_REMOVED, mockServer);
 
             expect(removeViewSpy).toHaveBeenCalledWith(view1.id);
             expect(removeViewSpy).toHaveBeenCalledWith(view2.id);
@@ -234,7 +234,7 @@ describe('ViewManager', () => {
             const view2 = viewManager.createView(otherServer, ViewType.TAB);
             const removeViewSpy = jest.spyOn(viewManager, 'removeView');
 
-            ServerManager.mockServerManager.emit(SERVER_REMOVED, mockServer.id);
+            ServerManager.mockServerManager.emit(SERVER_REMOVED, mockServer);
 
             expect(removeViewSpy).toHaveBeenCalledWith(view1.id);
             expect(removeViewSpy).not.toHaveBeenCalledWith(view2.id);

--- a/src/common/views/viewManager.ts
+++ b/src/common/views/viewManager.ts
@@ -174,11 +174,11 @@ export class ViewManager extends EventEmitter {
         return new Logger(...additionalPrefixes, server.id, viewId);
     };
 
-    private handleServerWasRemoved = (serverId: string) => {
-        log.debug('handleServerWasRemoved', {serverId});
+    private handleServerWasRemoved = (server: MattermostServer) => {
+        log.debug('handleServerWasRemoved', {serverId: server.id});
 
         this.views.forEach((view) => {
-            if (view.serverId === serverId) {
+            if (view.serverId === server.id) {
                 this.removeView(view.id);
             }
         });


### PR DESCRIPTION
I introduced a bug in #3509 that causes an issue on server removal. I made a change that required the server to still exist when the event was emitted, but I didn't take into account that other listeners assume the server would not exist.

To fix this, I just emit the entire server object on removal so that any data one of the listeners needs is still there when the listener is called.

```release-note
NONE
```
