### PR TITLE
[MM-64732] Enable hardened runtime on MAS build

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -117,7 +117,6 @@
     }
   },
   "mas": {
-    "hardenedRuntime": false,
     "entitlements": "./resources/mac/entitlements.mas.plist",
     "entitlementsInherit": "./resources/mac/entitlements.mas.inherit.plist",
     "entitlementsLoginHelper": "./resources/mac/entitlements.mas.inherit.plist",

--- a/resources/mac/entitlements.mas.inherit.plist
+++ b/resources/mac/entitlements.mas.inherit.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
 	<key>com.apple.security.inherit</key>
     <true/>
 </dict>


### PR DESCRIPTION
#### Summary
Our MAS build was missing the hardened runtime, which is needed to avoid certain exploits. This PR turns that runtime on and fixes an entitlement issue causing the app to not work.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64732

```release-note
macOS: Enable hardened runtime on MAS build
```

