### PR TITLE
Fix title bar overlay

### DIFF
--- a/src/app/windows/baseWindow.test.js
+++ b/src/app/windows/baseWindow.test.js
@@ -51,6 +51,7 @@ jest.mock('electron', () => {
             mockBrowserWindow.on = jest.fn(mockBrowserWindow.on);
             mockBrowserWindow.once = jest.fn(mockBrowserWindow.once);
             mockBrowserWindow.setMenuBarVisibility = jest.fn();
+            mockBrowserWindow.setTitleBarOverlay = jest.fn();
             const mockWebContents = new EventEmitter();
             mockWebContents.zoomLevel = 0;
             mockWebContents.setWindowOpenHandler = jest.fn();
@@ -241,8 +242,8 @@ describe('BaseWindow', () => {
             expect(baseWindow).toBeDefined();
             expect(BrowserWindow).toHaveBeenCalledWith(expect.objectContaining({
                 titleBarOverlay: {
-                    color: '#efefef',
-                    symbolColor: '#474747',
+                    color: 'rgba(255, 255, 255, 0)',
+                    symbolColor: 'rgba(63, 67, 80, 0.64)',
                     height: TAB_BAR_HEIGHT,
                 },
             }));
@@ -256,8 +257,8 @@ describe('BaseWindow', () => {
             expect(baseWindow).toBeDefined();
             expect(BrowserWindow).toHaveBeenCalledWith(expect.objectContaining({
                 titleBarOverlay: {
-                    color: '#2e2e2e',
-                    symbolColor: '#c1c1c1',
+                    color: 'rgba(25, 27, 31, 0)',
+                    symbolColor: 'rgba(227, 228, 232, 0.64)',
                     height: TAB_BAR_HEIGHT,
                 },
             }));

--- a/src/app/windows/baseWindow.ts
+++ b/src/app/windows/baseWindow.ts
@@ -187,7 +187,7 @@ export default class BaseWindow {
     private getTitleBarOverlay = () => {
         return {
             color: Config.darkMode ? 'rgba(25, 27, 31, 0)' : 'rgba(255, 255, 255, 0)',
-            symbolColor: Config.darkMode ? 'rgba(227, 228, 232, 0.75)' : 'rgba(63, 67, 80, 0.75)',
+            symbolColor: Config.darkMode ? 'rgba(227, 228, 232, 0.64)' : 'rgba(63, 67, 80, 0.64)',
             height: TAB_BAR_HEIGHT,
         };
     };


### PR DESCRIPTION
#### Summary
The CSS changes caused a couple issue that needed to be fixed:
- Updating dark mode wasn't updating the title bar
- The colours on the title bar overlay on Windows/Linux were wrong

```release-note
NONE
```
