### PR TITLE
Fix calling setTitleBarOverlay on macOS

### DIFF
--- a/src/app/mainWindow/mainWindow.test.js
+++ b/src/app/mainWindow/mainWindow.test.js
@@ -656,4 +656,47 @@ describe('main/windows/mainWindow', () => {
             expect(mainWindow.init).toHaveBeenCalled();
         });
     });
+
+    describe('handleEmitConfiguration', () => {
+        let mainWindow;
+        const mockBrowserWindow = {
+            setTitleBarOverlay: jest.fn(),
+            webContents: {
+                send: jest.fn(),
+            },
+        };
+
+        beforeEach(() => {
+            mainWindow = new MainWindow();
+            mainWindow.win = {
+                browserWindow: mockBrowserWindow,
+            };
+            mainWindow.getTitleBarOverlay = jest.fn().mockReturnValue({
+                color: 'rgba(255, 255, 255, 0)',
+                symbolColor: 'rgba(63, 67, 80, 0.64)',
+                height: 40,
+            });
+            mainWindow.sendViewLimitUpdated = jest.fn();
+        });
+
+        afterEach(() => {
+            jest.resetAllMocks();
+        });
+
+        it('should not call setTitleBarOverlay when platform is darwin', () => {
+            const originalPlatform = process.platform;
+            Object.defineProperty(process, 'platform', {
+                value: 'darwin',
+            });
+
+            mainWindow.handleEmitConfiguration();
+
+            expect(mainWindow.sendViewLimitUpdated).toHaveBeenCalled();
+            expect(mockBrowserWindow.setTitleBarOverlay).not.toHaveBeenCalled();
+
+            Object.defineProperty(process, 'platform', {
+                value: originalPlatform,
+            });
+        });
+    });
 });

--- a/src/app/mainWindow/mainWindow.ts
+++ b/src/app/mainWindow/mainWindow.ts
@@ -403,7 +403,7 @@ export class MainWindow extends EventEmitter {
 
     private handleEmitConfiguration = () => {
         this.sendViewLimitUpdated();
-        if (process.platform === 'linux') {
+        if (process.platform !== 'darwin') {
             this.win?.browserWindow.setTitleBarOverlay?.(this.getTitleBarOverlay());
         }
     };

--- a/src/app/windows/baseWindow.test.js
+++ b/src/app/windows/baseWindow.test.js
@@ -9,6 +9,7 @@ import path from 'path';
 import {BrowserWindow, app, globalShortcut, ipcMain, dialog} from 'electron';
 
 import {
+    DARK_MODE_CHANGE,
     EMIT_CONFIGURATION,
     FOCUS_THREE_DOT_MENU,
     RELOAD_CONFIGURATION,
@@ -536,6 +537,30 @@ describe('BaseWindow', () => {
             ipcMain.emit(EMIT_CONFIGURATION);
 
             expect(baseWindow.browserWindow.webContents.send).toHaveBeenCalledWith(RELOAD_CONFIGURATION);
+        });
+
+        it('should not call setTitleBarOverlay when platform is darwin', () => {
+            const originalPlatform = process.platform;
+            Object.defineProperty(process, 'platform', {
+                value: 'darwin',
+            });
+
+            const baseWindow = new BaseWindow({});
+            baseWindow.getTitleBarOverlay = jest.fn().mockReturnValue({
+                color: 'rgba(255, 255, 255, 0)',
+                symbolColor: 'rgba(63, 67, 80, 0.64)',
+                height: 40,
+            });
+
+            ipcMain.emit(EMIT_CONFIGURATION);
+
+            expect(baseWindow.browserWindow.webContents.send).toHaveBeenCalledWith(RELOAD_CONFIGURATION);
+            expect(baseWindow.browserWindow.webContents.send).toHaveBeenCalledWith(DARK_MODE_CHANGE, Config.darkMode);
+            expect(baseWindow.browserWindow.setTitleBarOverlay).not.toHaveBeenCalled();
+
+            Object.defineProperty(process, 'platform', {
+                value: originalPlatform,
+            });
         });
     });
 });

--- a/src/app/windows/baseWindow.ts
+++ b/src/app/windows/baseWindow.ts
@@ -246,6 +246,8 @@ export default class BaseWindow {
     private onEmitConfiguration = () => {
         this.win.webContents.send(RELOAD_CONFIGURATION);
         this.win.webContents.send(DARK_MODE_CHANGE, Config.darkMode);
-        this.win.setTitleBarOverlay(this.getTitleBarOverlay());
+        if (process.platform !== 'darwin') {
+            this.win.setTitleBarOverlay(this.getTitleBarOverlay());
+        }
     };
 }


### PR DESCRIPTION
#### Summary
You can't call `setTitleBarOverlay` on macOS, it will crash the app as it is not defined. I've made this mistake before, so I'm fixing the problem and adding a test to make sure it doesn't break again.

```release-note
NONE
```
