### PR TITLE
[MM-66102] Upgrade Electron to v37.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "mattermost-desktop",
-      "version": "5.13.0-develop.1",
+      "version": "5.13.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -54,7 +54,7 @@
         "copy-webpack-plugin": "10.2.4",
         "cross-env": "7.0.3",
         "css-loader": "6.7.1",
-        "electron": "37.4.0",
+        "electron": "37.6.1",
         "electron-builder": "24.13.3",
         "eslint": "8.57.0",
         "eslint-import-resolver-webpack": "0.13.8",
@@ -7215,9 +7215,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "37.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-37.4.0.tgz",
-      "integrity": "sha512-HhsSdWowE5ODOeWNc/323Ug2C52mq/TqNBG+4uMeOA3G2dMXNc/nfyi0RYu1rJEgiaJLEjtHveeZZaYRYFsFCQ==",
+      "version": "37.6.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.6.1.tgz",
+      "integrity": "sha512-aHtJVNjqf0lk7dlPoc1X+fMBpZtLn+XGvP6IYc3gooTwsD1D/Ic2SBRC9SnIk6LkWTsDaSF9jgH1d9Q7eABy/Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "copy-webpack-plugin": "10.2.4",
     "cross-env": "7.0.3",
     "css-loader": "6.7.1",
-    "electron": "37.4.0",
+    "electron": "37.6.1",
     "electron-builder": "24.13.3",
     "eslint": "8.57.0",
     "eslint-import-resolver-webpack": "0.13.8",


### PR DESCRIPTION
#### Summary
Backporting MM-66102 to `release-5.13` by upgrading Electron to v37.6.1.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66102
Fixes #3526 

```release-note
Upgrade Electron to v37.6.1
```
