### PR TITLE
[MM-66255] Focus main window when opening a link from a pop-out window when the pop-out has a parent

### DIFF
--- a/src/app/navigationManager.test.js
+++ b/src/app/navigationManager.test.js
@@ -59,6 +59,10 @@ jest.mock('common/servers/serverManager', () => ({
     getServer: jest.fn(),
 }));
 
+jest.mock('app/mainWindow/mainWindow', () => ({
+    get: jest.fn(),
+}));
+
 jest.mock('common/utils/url', () => ({
     parseURL: (url) => {
         try {

--- a/src/app/navigationManager.ts
+++ b/src/app/navigationManager.ts
@@ -4,6 +4,7 @@
 import type {IpcMainEvent, IpcMainInvokeEvent} from 'electron';
 import {dialog, ipcMain} from 'electron';
 
+import MainWindow from 'app/mainWindow/mainWindow';
 import ModalManager from 'app/mainWindow/modals/modalManager';
 import ServerHub from 'app/serverHub';
 import TabManager from 'app/tabs/tabManager';
@@ -152,6 +153,9 @@ export class NavigationManager {
         }
 
         if (currentView.parentViewId) {
+            if (!MainWindow.get()?.isFocused()) {
+                MainWindow.get()?.focus();
+            }
             TabManager.switchToTab(currentView.parentViewId);
             currentView = WebContentsManager.getView(currentView.parentViewId);
         }


### PR DESCRIPTION
#### Summary
When a user would click a link in one of the thread pop-outs, it opens the link, but doesn't focus the main window again. This PR ensures the main window gets focused when we're switching to it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66255

```release-note
NONE
```
