### PR TITLE
Fix theme resetting on the main window when a pop-out opens

### DIFF
--- a/src/app/views/webContentsManager.ts
+++ b/src/app/views/webContentsManager.ts
@@ -287,6 +287,9 @@ export class WebContentsManager {
         if (!view) {
             return;
         }
+        if (ViewManager.getView(view.id)?.type === ViewType.WINDOW) {
+            return;
+        }
         ServerManager.updateTheme(view.serverId, theme);
     };
 


### PR DESCRIPTION
#### Summary
When theme synchronization is enabled, if you opened a pop-out window when you have a theme applied that is only applied to one team, the theme on the main window is reset. This was caused by us still allowing pop-outs to update the server theme, which they're not supposed to do (the main view will do that for us). This PR fixes that.

```release-note
NONE
```
