### PR TITLE
[MM-66396] Reset and clear server theme when the app logs out

### DIFF
--- a/src/common/servers/serverManager.ts
+++ b/src/common/servers/serverManager.ts
@@ -101,9 +101,15 @@ export class ServerManager extends EventEmitter {
         if (!server) {
             return;
         }
+        if (!loggedIn) {
+            server.theme = undefined;
+        }
         server.isLoggedIn = loggedIn;
         this.servers.set(serverId, server);
         this.emit(SERVER_LOGGED_IN_CHANGED, serverId, loggedIn);
+        if (!loggedIn) {
+            this.emit(SERVER_THEME_CHANGED, serverId);
+        }
     };
 
     private createServer = (server: Server, isPredefined: boolean, initialLoadURL?: URL) => {
@@ -199,6 +205,9 @@ export class ServerManager extends EventEmitter {
         log.debug('updateTheme', {theme});
         const server = this.servers.get(serverId);
         if (!server) {
+            return;
+        }
+        if (!server.isLoggedIn) {
             return;
         }
         server.theme = {


### PR DESCRIPTION
#### Summary
When the application logs out and the user is using theme syncing, the theme will change to the default light theme that the web app uses, which for dark mode users can be a bit jarring.

This PR forces the theme to reset when the user logs out so that it will continue to respect dark mode for those using it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66396

```release-note
NONE
```
