### PR TITLE
[MM-66139] Move config module to use JsonFileManager

### DIFF
--- a/src/common/config/index.ts
+++ b/src/common/config/index.ts
@@ -292,7 +292,7 @@ export class Config extends EventEmitter {
      * @emits {synchronize} emitted once all data has been saved; used to notify other config instances of changes
      * @emits {error} emitted if saving local config data to file fails
      */
-    private saveLocalConfigData = (): void => {
+    private saveLocalConfigData = (isRetry = false): void => {
         if (!(this.json && this.localConfigData)) {
             return;
         }
@@ -312,8 +312,8 @@ export class Config extends EventEmitter {
         this.json.writeToFile().then(() => {
             this.emit('update', this.combinedData);
         }).catch((error: NodeJS.ErrnoException) => {
-            if (error.code === 'EBUSY') {
-                this.saveLocalConfigData();
+            if (error.code === 'EBUSY' && !isRetry) {
+                this.saveLocalConfigData(true);
             } else {
                 this.emit('error', error);
             }


### PR DESCRIPTION
#### Summary
Some users are experiencing corrupted `config.json` files after upgrading their Desktop Apps. I haven't been able to reproduce this myself, but this likely occurs when multiple config updates happen quickly, causing concurrent `fs.writeFile()` calls that interleave and corrupt the JSON. This likely was not an issue with the older architecture, but has been exposed in the newer version.

This PR refactors the `Config` class to use `JsonFileManager` instead of direct `fs.writeFile()` calls. `JsonFileManager` already includes a write queuing mechanism that serializes writes using a `Promise` chain, ensuring writes execute sequentially even when multiple config updates happen rapidly. This should prevent concurrent writes from interleaving and corrupting the JSON file for the affected users.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66139

```release-note
Fixed an issue where configuration files could be corrupted by interleaving writes
```
