### PR TITLE
[MM-66562] Only change the server URL when the site URL is reachable

### DIFF
--- a/src/common/servers/serverManager.test.js
+++ b/src/common/servers/serverManager.test.js
@@ -46,15 +46,27 @@ describe('common/servers/serverManager', () => {
             expect(serverManager.persistServers).not.toHaveBeenCalled();
         });
 
-        it('should update server URL using site URL', async () => {
+        it('should update server URL using site URL when validated', async () => {
             serverManager.updateRemoteInfo('server-1', {
                 siteURL: 'http://server-2.com',
                 serverVersion: '6.0.0',
                 hasPlaybooks: true,
                 hasFocalboard: true,
-            });
+            }, true);
 
             expect(serverManager.servers.get('server-1').url.toString()).toBe('http://server-2.com/');
+        });
+
+        it('should not update server URL when site URL is not validated', async () => {
+            serverManager.updateRemoteInfo('server-1', {
+                siteURL: 'http://server-2.com',
+                serverVersion: '6.0.0',
+                hasPlaybooks: true,
+                hasFocalboard: true,
+            }, false);
+
+            expect(serverManager.servers.get('server-1').url.toString()).toBe('http://server-1.com/');
+            expect(serverManager.persistServers).not.toHaveBeenCalled();
         });
     });
 

--- a/src/common/servers/serverManager.ts
+++ b/src/common/servers/serverManager.ts
@@ -172,7 +172,7 @@ export class ServerManager extends EventEmitter {
         return existingServer;
     };
 
-    updateRemoteInfo = (serverId: string, remoteInfo: RemoteInfo) => {
+    updateRemoteInfo = (serverId: string, remoteInfo: RemoteInfo, isSiteURLValidated?: boolean) => {
         log.debug('updateRemoteInfo', {serverId});
 
         const server = this.servers.get(serverId);
@@ -182,7 +182,7 @@ export class ServerManager extends EventEmitter {
 
         this.remoteInfo.set(serverId, remoteInfo);
 
-        if (remoteInfo.siteURL && server.url.toString() !== new URL(remoteInfo.siteURL).toString()) {
+        if (remoteInfo.siteURL && server.url.toString() !== new URL(remoteInfo.siteURL).toString() && isSiteURLValidated) {
             server.updateURL(remoteInfo.siteURL);
             this.servers.set(serverId, server);
             this.emit(SERVER_URL_CHANGED, serverId);


### PR DESCRIPTION
#### Summary
Changes to the `ServerManager` reintroduced a bug in which when we retrieve server info, we will update the server URL with the configured `SiteURL`, even if the `SiteURL` isn't reachable. For some users, this will cause their server not to work at all.

This PR adds a check to first do a ping to the `SiteURL` to ensure that the client can reach it before we update the server info.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66562

```release-note
NONE
```
