### PR TITLE
[MM-66638] Fixed a crash when hovering over an external URL in a re-docked pop-out window

### DIFF
--- a/src/app/tabs/tabManager.test.js
+++ b/src/app/tabs/tabManager.test.js
@@ -26,6 +26,7 @@ import {
     VIEW_TYPE_REMOVED,
     VIEW_TYPE_ADDED,
     CLEAR_CACHE_AND_RELOAD,
+    UPDATE_TARGET_URL,
 } from 'common/communication';
 import ServerManager from 'common/servers/serverManager';
 import {ViewType} from 'common/views/MattermostView';
@@ -54,6 +55,7 @@ jest.mock('app/mainWindow/mainWindow', () => ({
         showLoadingScreen: jest.fn(),
         fadeLoadingScreen: jest.fn(),
         sendToRenderer: jest.fn(),
+        showURLView: jest.fn(),
     },
 }));
 
@@ -949,6 +951,78 @@ describe('TabManager', () => {
 
             // Verify switchToNextTabIfNecessary was called
             expect(switchToNextTabSpy).toHaveBeenCalledWith('test-tab-id', 'test-server-id');
+        });
+
+        it('should not call showURLView when UPDATE_TARGET_URL is emitted after view removal', () => {
+            const {EventEmitter} = jest.requireActual('events');
+            const tabManager = new TabManager();
+            const mockWebContentsView = Object.assign(new EventEmitter(), {
+                id: 'test-tab-id',
+                isErrored: jest.fn(() => false),
+                focus: jest.fn(),
+                needsLoadingScreen: jest.fn(() => false),
+                getWebContentsView: jest.fn(() => ({
+                    webContents: {
+                        focus: jest.fn(),
+                        on: jest.fn(),
+                        off: jest.fn(),
+                    },
+                    setBounds: jest.fn(),
+                })),
+            });
+
+            // Set up initial state - don't include test-tab-id in tabOrder yet
+            const tabIds = ['tab1', 'tab3'];
+            tabManager.tabOrder.set('test-server-id', tabIds);
+            tabManager.activeTabs.set('test-server-id', 'tab1');
+
+            // Clear the global mock and set up test-specific mock
+            ViewManager.getView.mockReset();
+            ViewManager.getView.mockImplementation((id) => {
+                if (id === null || id === undefined) {
+                    return null;
+                }
+                return {
+                    id,
+                    serverId: 'test-server-id',
+                    type: ViewType.TAB,
+                    isErrored: jest.fn(() => false),
+                    toUniqueView: jest.fn(() => ({
+                        id,
+                        serverId: 'test-server-id',
+                        type: ViewType.TAB,
+                    })),
+                };
+            });
+            WebContentsManager.getView.mockReturnValue(mockWebContentsView);
+            WebContentsManager.createView.mockReturnValue(mockWebContentsView);
+            MainWindow.get.mockReturnValue(mockMainWindow);
+            MainWindow.window = {
+                ...mockMainWindow,
+                showURLView: jest.fn(),
+            };
+
+            // Create the view to set up listeners
+            ViewManager.mockViewManager.emit(VIEW_CREATED, 'test-tab-id');
+
+            // Emit UPDATE_TARGET_URL - should call showURLView
+            // Note: The listener should be set up by setupTab when the view is created
+            mockWebContentsView.emit(UPDATE_TARGET_URL, 'https://example.com');
+
+            // Verify showURLView was called
+            expect(MainWindow.window.showURLView).toHaveBeenCalledWith('https://example.com');
+
+            // Remove the view
+            ViewManager.mockViewManager.emit(VIEW_TYPE_REMOVED, 'test-tab-id', ViewType.TAB);
+
+            // Clear the mock call history
+            MainWindow.window.showURLView.mockClear();
+
+            // Emit UPDATE_TARGET_URL after removal - should NOT call showURLView
+            mockWebContentsView.emit(UPDATE_TARGET_URL, 'https://example.com');
+
+            // Verify showURLView was NOT called
+            expect(MainWindow.window.showURLView).not.toHaveBeenCalled();
         });
     });
 

--- a/src/app/tabs/tabManager.ts
+++ b/src/app/tabs/tabManager.ts
@@ -37,6 +37,7 @@ import {
     CLOSE_SERVERS_DROPDOWN,
     CLOSE_DOWNLOADS_DROPDOWN,
     CLEAR_CACHE_AND_RELOAD,
+    UPDATE_TARGET_URL,
 } from 'common/communication';
 import {Logger} from 'common/log';
 import ServerManager from 'common/servers/serverManager';
@@ -241,6 +242,7 @@ export class TabManager extends EventEmitter {
         webContentsView.on(LOADSCREEN_END, this.finishLoading);
         webContentsView.on(LOAD_FAILED, this.failLoading);
         webContentsView.on(RELOAD_VIEW, this.onReloadView);
+        webContentsView.on(UPDATE_TARGET_URL, this.onUpdateTargetURL);
         if (process.platform !== 'darwin') {
             // @ts-expect-error: The type is wrong on Electrons side
             webContentsView.getWebContentsView().webContents.on('before-input-event', mainWindow.handleAltKeyPressed);
@@ -250,6 +252,7 @@ export class TabManager extends EventEmitter {
             webContentsView.off(LOADSCREEN_END, this.finishLoading);
             webContentsView.off(LOAD_FAILED, this.failLoading);
             webContentsView.off(RELOAD_VIEW, this.onReloadView);
+            webContentsView.off(UPDATE_TARGET_URL, this.onUpdateTargetURL);
 
             // @ts-expect-error: The type is wrong on Electrons side
             webContentsView.getWebContentsView().webContents.off('before-input-event', mainWindow.handleAltKeyPressed);
@@ -484,6 +487,10 @@ export class TabManager extends EventEmitter {
         }
 
         MainWindow.window?.showLoadingScreen(() => ModalManager.isModalDisplayed());
+    };
+
+    private onUpdateTargetURL = (url: string) => {
+        MainWindow.window?.showURLView(url);
     };
 
     private handleClearCacheAndReload = () => {

--- a/src/app/views/webContentsManager.ts
+++ b/src/app/views/webContentsManager.ts
@@ -12,7 +12,6 @@ import WebContentsEventManager from 'app/views/webContentEvents';
 import type BaseWindow from 'app/windows/baseWindow';
 import AppState from 'common/appState';
 import {
-    UPDATE_TARGET_URL,
     REACT_APP_INITIALIZED,
     OPEN_SERVER_UPGRADE_LINK,
     OPEN_CHANGELOG_LINK,
@@ -104,7 +103,6 @@ export class WebContentsManager {
 
     createView = (view: MattermostView, parentWindow: BaseWindow): MattermostWebContentsView => {
         const webContentsView = new MattermostWebContentsView(view, {webPreferences: {spellcheck: Config.useSpellChecker}}, parentWindow.browserWindow);
-        webContentsView.on(UPDATE_TARGET_URL, (url) => parentWindow.showURLView(url));
         webContentsView.getWebContentsView().webContents.on('focus', () => {
             this.focusedWebContentsView = view.id;
         });

--- a/src/app/windows/popoutManager.test.js
+++ b/src/app/windows/popoutManager.test.js
@@ -11,6 +11,7 @@ import {
     LOADSCREEN_END,
     RELOAD_VIEW,
     UPDATE_POPOUT_TITLE,
+    UPDATE_TARGET_URL,
     VIEW_CREATED,
     VIEW_TITLE_UPDATED,
     VIEW_REMOVED,
@@ -58,8 +59,10 @@ jest.mock('app/windows/baseWindow', () => {
             addChildView: jest.fn(),
             removeChildView: jest.fn(),
             on: jest.fn(),
+            off: jest.fn(),
         },
         on: jest.fn(),
+        off: jest.fn(),
         once: jest.fn(),
         show: jest.fn(),
         close: jest.fn(),
@@ -137,8 +140,10 @@ describe('PopoutManager', () => {
                 addChildView: jest.fn(),
                 removeChildView: jest.fn(),
                 on: jest.fn(),
+                off: jest.fn(),
             },
             on: jest.fn(),
+            off: jest.fn(),
             once: jest.fn(),
             show: jest.fn(),
             close: jest.fn(),
@@ -148,6 +153,7 @@ describe('PopoutManager', () => {
         showLoadingScreen: jest.fn(),
         fadeLoadingScreen: jest.fn(),
         registerThemeManager: jest.fn(),
+        showURLView: jest.fn(),
     };
 
     const mockWebContentsView = {
@@ -566,6 +572,55 @@ describe('PopoutManager', () => {
 
             // Verify the window was removed from popoutWindows
             expect(popoutManager.popoutWindows.has('test-window-id')).toBe(false);
+        });
+
+        it('should not call showURLView when UPDATE_TARGET_URL is emitted after view removal', () => {
+            const {EventEmitter} = jest.requireActual('events');
+            const mockWindowView = {
+                id: 'test-window-id',
+                serverId: 'test-server-id',
+                type: ViewType.WINDOW,
+            };
+            const mockWebContentsView = Object.assign(new EventEmitter(), {
+                id: 'test-window-id',
+                getWebContentsView: jest.fn(() => ({
+                    webContents: {
+                        focus: jest.fn(),
+                        on: jest.fn(),
+                        off: jest.fn(),
+                    },
+                    setBounds: jest.fn(),
+                })),
+                needsLoadingScreen: jest.fn(() => false),
+            });
+
+            // Set up initial state
+            popoutManager.popoutWindows.set('test-window-id', mockBaseWindow);
+
+            ViewManager.getView.mockReturnValue(mockWindowView);
+            WebContentsManager.createView.mockReturnValue(mockWebContentsView);
+
+            // Create the view to set up listeners
+            ViewManager.mockViewManager.emit(VIEW_CREATED, 'test-window-id');
+            mockBaseWindow.browserWindow.webContents.emit('did-finish-load');
+
+            // Emit UPDATE_TARGET_URL - should call showURLView
+            mockWebContentsView.emit(UPDATE_TARGET_URL, 'https://example.com');
+
+            // Verify showURLView was called
+            expect(mockBaseWindow.showURLView).toHaveBeenCalledWith('https://example.com');
+
+            // Remove the view
+            ViewManager.mockViewManager.emit(VIEW_TYPE_REMOVED, 'test-window-id', ViewType.WINDOW);
+
+            // Clear the mock call history
+            mockBaseWindow.showURLView.mockClear();
+
+            // Emit UPDATE_TARGET_URL after removal - should NOT call showURLView
+            mockWebContentsView.emit(UPDATE_TARGET_URL, 'https://example.com');
+
+            // Verify showURLView was NOT called
+            expect(mockBaseWindow.showURLView).not.toHaveBeenCalled();
         });
     });
 

--- a/src/app/windows/popoutManager.ts
+++ b/src/app/windows/popoutManager.ts
@@ -32,6 +32,7 @@ import {
     SEND_TO_POPOUT,
     MESSAGE_FROM_POPOUT,
     POPOUT_CLOSED,
+    UPDATE_TARGET_URL,
 } from 'common/communication';
 import {POPOUT_RATE_LIMIT} from 'common/constants';
 import {Logger} from 'common/log';
@@ -151,12 +152,14 @@ export class PopoutManager {
             // TODO: Would be better encapsulated in the MenuManager
             MenuManager.refreshMenu();
         };
+        const updateTargetURL = (url: string) => window.showURLView(url);
         const setBounds = this.setBounds(window, webContentsView);
         const close = this.onClosePopout(viewId);
 
         mattermostWebContentsView.on(LOADSCREEN_END, loadScreenEnd);
         mattermostWebContentsView.on(LOAD_FAILED, loadFailed);
         mattermostWebContentsView.on(RELOAD_VIEW, reloadView);
+        mattermostWebContentsView.on(UPDATE_TARGET_URL, updateTargetURL);
         window.browserWindow.on('focus', focus);
         window.browserWindow.contentView.on('bounds-changed', setBounds);
         window.browserWindow.once('show', setBounds);
@@ -171,6 +174,7 @@ export class PopoutManager {
             mattermostWebContentsView.off(LOADSCREEN_END, loadScreenEnd);
             mattermostWebContentsView.off(LOAD_FAILED, loadFailed);
             mattermostWebContentsView.off(RELOAD_VIEW, reloadView);
+            mattermostWebContentsView.off(UPDATE_TARGET_URL, updateTargetURL);
             window.browserWindow.off('focus', focus);
             window.browserWindow.contentView.off('bounds-changed', setBounds);
             window.browserWindow.off('show', setBounds);


### PR DESCRIPTION
#### Summary
When a pop-out window is moved back into a main window, if you hover over an external link in that view, the application will crash. This crash is caused by improperly registering the URLView listener in the `WebContentsManager` and not accounting for the changeover to allow tabs/windows to be converted, which left the original listener in place when the view was created that called a destroyed view.

This PR removes the registry from the general view creation logic in `WebContentsManager` and adds it separately for `TabManager` and `PopoutManager` such that the views can be converted properly by allowing each manager to register/unregister the listener as needed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66638

```release-note
Fixed a crash when hovering over an external URL in a re-docked pop-out window
```
