### PR TITLE
[MM-66655][MM-66657] Catch errors from the server API when unexpected status codes are returned

### DIFF
--- a/src/main/app/utils.test.js
+++ b/src/main/app/utils.test.js
@@ -7,9 +7,12 @@ import {dialog, screen} from 'electron';
 
 import MainWindow from 'app/mainWindow/mainWindow';
 import JsonFileManager from 'common/JsonFileManager';
+import {MattermostServer} from 'common/servers/MattermostServer';
+import ServerManager from 'common/servers/serverManager';
 import {updatePaths} from 'main/constants';
+import {ServerInfo} from 'main/server/serverInfo';
 
-import {getDeeplinkingURL, resizeScreen, migrateMacAppStore} from './utils';
+import {getDeeplinkingURL, resizeScreen, migrateMacAppStore, updateServerInfos} from './utils';
 
 jest.mock('fs', () => ({
     readFileSync: jest.fn(),
@@ -72,6 +75,22 @@ jest.mock('app/navigationManager', () => ({
 
 jest.mock('./initialize', () => ({
     mainProtocol: 'mattermost',
+}));
+
+jest.mock('common/servers/MattermostServer', () => ({
+    MattermostServer: jest.fn().mockImplementation((config) => ({
+        id: config.id || 'server-1',
+        name: config.name || 'Test Server',
+        url: config.url || 'http://localhost:8065',
+    })),
+}));
+
+jest.mock('common/servers/serverManager', () => ({
+    updateRemoteInfo: jest.fn(),
+}));
+
+jest.mock('main/server/serverInfo', () => ({
+    ServerInfo: jest.fn(),
 }));
 
 describe('main/app/utils', () => {
@@ -258,5 +277,25 @@ describe('main/app/utils', () => {
                 expect(migrationPrefs.setValue).toHaveBeenCalledWith('masConfigs', true);
             });
         }
+    });
+
+    describe('updateServerInfos', () => {
+        beforeEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it('should catch error when ServerInfo.fetchRemoteInfo throws', async () => {
+            const mockServer = new MattermostServer({id: 'server-1', name: 'Test Server', url: 'http://localhost:8065'});
+            const mockError = new Error('Network error');
+            const mockServerInfoInstance = {
+                fetchRemoteInfo: jest.fn().mockRejectedValue(mockError),
+            };
+            ServerInfo.mockImplementation(() => mockServerInfoInstance);
+
+            await updateServerInfos([mockServer]);
+
+            expect(mockServerInfoInstance.fetchRemoteInfo).toHaveBeenCalled();
+            expect(ServerManager.updateRemoteInfo).not.toHaveBeenCalled();
+        });
     });
 });


### PR DESCRIPTION
#### Summary
A change we made to allow error handling based on status code in the server API causes a crash when an errored server is configured. This was caused by not handling the error from the call to `getRemoteInfo` after the server is loading.

This PR adds a try/catch wrapper around that call, and logs it and ignores it such that the error does not crash the application.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66655
https://mattermost.atlassian.net/browse/MM-66657
Closes #3560

```release-note
Fixed an issue where the app would crash on errored servers
```
