### PR TITLE
[MM-66686] Restore Cmd+W functionality when the main window is on one or less tabs

### DIFF
--- a/src/app/menus/appMenu/file.test.js
+++ b/src/app/menus/appMenu/file.test.js
@@ -356,7 +356,6 @@ describe('app/menus/appMenu/file', () => {
             });
             const menu = createFileMenu();
             const hiddenCloseItem = menu.submenu.find((item) =>
-                item.role === 'close' &&
                 item.visible === false &&
                 item.accelerator === 'CmdOrCtrl+W',
             );

--- a/src/app/menus/appMenu/file.ts
+++ b/src/app/menus/appMenu/file.ts
@@ -121,9 +121,12 @@ function getBaseFileMenu(): MenuItemConstructorOptions[] {
             });
         } else {
             baseFileMenu.push({
-                role: 'close',
+                label: localizeMessage('main.menus.app.window.closeWindow', 'Close Window'),
                 visible: false,
                 accelerator: 'CmdOrCtrl+W',
+                click() {
+                    MainWindow.get()?.close();
+                },
             });
         }
     }


### PR DESCRIPTION
#### Summary
We made the decision to attempt to simplify keyboard shortcuts in the app with v6, in that we forced closing the main window to be `Cmd/Ctrl+Shift+W` at all times regardless of app state. However, a lot of users mentioned how this is not how other apps work and that it disrupted their workflow.

This PR adds a hidden accelerator to enable `Cmd/Ctrl+W` to close the windows there are 1 or less tabs available on the screen, similar to how web browsers work.

#### Ticket Link
Closes https://github.com/mattermost/desktop/issues/3558
https://mattermost.atlassian.net/browse/MM-66686

```release-note
Fixed the missing Cmd/Ctrl+W shortcut for closing windows
```
