### PR TITLE
[MM-66775] Update camera/mic permission descriptions to remove Jitsi reference

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -110,8 +110,8 @@
     "entitlements": "./resources/mac/entitlements.mac.plist",
     "entitlementsInherit": "./resources/mac/entitlements.mac.inherit.plist",
     "extendInfo": {
-      "NSMicrophoneUsageDescription": "Microphone access may be used by Mattermost plugins, such as Jitsi video conferencing.",
-      "NSCameraUsageDescription": "Camera access may be used by Mattermost plugins, such as Jitsi video conferencing.",
+      "NSMicrophoneUsageDescription": "Microphone access is used to capture audio for voice communication and recordings.",
+      "NSCameraUsageDescription": "Camera access is used to capture video for video conferencing and recordings.",
       "NSFocusStatusUsageDescription": "Focus status is used by Mattermost to determine whether to send notifications or not.",
       "LSFileQuarantineEnabled": true
     }


### PR DESCRIPTION
#### Summary
Updated the microphone and camera permission descriptions in `electron-builder.json` to use more general wording. The previous descriptions specifically mentioned "Jitsi video conferencing" but these permissions are used for various voice and video features including Calls, not just Jitsi plugins.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66775

#### Checklist
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)

#### Device Information
MacOS, 15.7.2

#### Screenshots
Ignore the `Mattermost 3` -- that's just the way I named my binary to avoid replacing the main one:

<img width="586" height="542" alt="CleanShot 2025-11-27 at 10 30 43@2x" src="https://github.com/user-attachments/assets/dcbc3d54-38de-4bcb-96cd-8ab0ccf88717" />

#### Release Note

```release-note
Updated macOS permission dialogs to use general wording instead of specifically referencing Jitsi.
```