### PR TITLE
[MM-66676] Only scroll the settings section instead of the whole settings modal

### DIFF
--- a/src/renderer/components/SettingsModal/SettingsModal.scss
+++ b/src/renderer/components/SettingsModal/SettingsModal.scss
@@ -15,11 +15,13 @@
             display: flex;
             flex-direction: column;
             flex: 1;
+            overflow: hidden;
+            min-height: 0;
     
             > .Modal__body {
                 display: flex;
                 flex: 1;
-                min-height: 475px;
+                min-height: 0;
         
                 .SettingsModal__sidebar {
                     flex: 0 0 auto;
@@ -76,6 +78,9 @@
                     width: 100%;
                     display: flex;
                     flex-direction: column;
+                    flex: 1;
+                    min-height: 0;
+                    overflow-y: auto;
         
                     > div + div {
                         margin-top: 24px;


### PR DESCRIPTION
#### Summary
Our settings modal was scrolling the whole body, causing some visual issues with the sidebar.

This PR fixes this by switching the scrolling to just scroll the actually settings area.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66676

#### Screenshots
| before | after |
|---|---|
| <img width="835" height="419" alt="image" src="https://github.com/user-attachments/assets/4427fbe6-703a-4444-8944-3e9f587b4760" /> | <img width="839" height="422" alt="image" src="https://github.com/user-attachments/assets/58f91803-dae6-4aaa-9545-e4a65b834935" />|

```release-note
Fixed a visual issue with the Settings Modal while scrolling
```
