### PR TITLE
[MM-66807] Ensure URL bounds update every time the URL view is shown

### DIFF
--- a/src/renderer/components/UrlView/UrlView.tsx
+++ b/src/renderer/components/UrlView/UrlView.tsx
@@ -13,14 +13,9 @@ export default function UrlView() {
     useEffect(() => {
         window.desktop.onSetURLForURLView((newUrl) => {
             setUrl(newUrl);
+            window.desktop.updateURLViewWidth(urlRef.current?.scrollWidth);
         });
     }, []);
-
-    useEffect(() => {
-        if (url) {
-            window.desktop.updateURLViewWidth(urlRef.current?.scrollWidth);
-        }
-    }, [url]);
 
     if (url) {
         return (


### PR DESCRIPTION
#### Summary
The URLView component was only updating the bounds when the url changed, which means if a user resizes the window and hovers the same external URL, the URL view wouldn't move to the correct spot.

This PR forces the bounds update to happen in the same cycle, so that we're always guaranteed to update the bounds

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66807

```release-note
Fixed an issue where the URL view could end up in the middle of the screen
```
