### PR TITLE
[MM-66805] Use registry to get tray icon theme on Windows

### DIFF
--- a/src/app/system/tray/tray.ts
+++ b/src/app/system/tray/tray.ts
@@ -3,11 +3,12 @@
 
 import path from 'path';
 
-import {app, nativeImage, Tray, systemPreferences, nativeTheme} from 'electron';
+import {app, nativeImage, Tray, systemPreferences} from 'electron';
 
 import MainWindow from 'app/mainWindow/mainWindow';
 import AppState from 'common/appState';
 import {UPDATE_APPSTATE_TOTALS} from 'common/communication';
+import Config from 'common/config';
 import {Logger} from 'common/log';
 import {localizeMessage} from 'main/i18nManager';
 
@@ -45,8 +46,10 @@ export class TrayIcon {
     };
 
     refreshImages = (trayIconTheme: string) => {
-        const systemTheme = nativeTheme.shouldUseDarkColors ? 'light' : 'dark';
-        const winTheme = trayIconTheme === 'use_system' ? systemTheme : trayIconTheme;
+        let winTheme = trayIconTheme;
+        if (trayIconTheme === 'use_system') {
+            winTheme = Config.getWindowsSystemDarkMode() ? 'light' : 'dark';
+        }
 
         switch (process.platform) {
         case 'win32':

--- a/src/common/config/RegistryConfig.ts
+++ b/src/common/config/RegistryConfig.ts
@@ -106,6 +106,27 @@ export default class RegistryConfig extends EventEmitter {
     }
 
     /**
+   * Retrieves the current Windows theme preference (AppsUseLightTheme)
+   * @returns true if light mode is enabled, false if dark mode is enabled
+   */
+    getAppsUseLightTheme(): boolean {
+        if (process.platform !== 'win32') {
+            return true;
+        }
+        try {
+            const value = this.getRegistryEntryValues(
+                HKEY.HKEY_CURRENT_USER,
+                'Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize',
+                'AppsUseLightTheme',
+            );
+            return value === undefined ? true : value === 1;
+        } catch (error) {
+            log.debug('Error reading AppsUseLightTheme from registry', error);
+            return true;
+        }
+    }
+
+    /**
    * Initiates retrieval of a specific key in the Windows registry
    *
    * @param {string} key Path to the registry key to return

--- a/src/common/config/index.ts
+++ b/src/common/config/index.ts
@@ -265,6 +265,10 @@ export class Config extends EventEmitter {
         return this.combinedData?.themeSyncing ?? true;
     }
 
+    getWindowsSystemDarkMode = () => {
+        return !this.registryConfig.getAppsUseLightTheme();
+    };
+
     /**
      * Gets the servers from registry into the config object and reload
      *


### PR DESCRIPTION
#### Summary
The changes to sync the Desktop App theme with the web app created a strange situation in which if you are using a light theme with the Desktop App, but dark theme in Windows, the tray icon will still appear dark. This causes the icon to be hard to see, and is caused by the dark mode in Electron being fully overridden in our app when using a dark theme.

Since this only affects Windows users, in that macOS relies on a template that it can adjust the colour for, and Linux requires that dark mode be set manually, this PR switches Windows to always rely on the system theme for the tray icon when selected in the Settings Modal, by reading the registry directly using our native node module. We still rely on Electron to tell us when the value has updated, but the value itself is read from the registry ad-hoc.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66805
Closes #3595

```release-note
Fixed an issue where the Windows tray icon theme would not respect the system theme
```
