### PR TITLE
[MM-66831] Remove global shortcut override for Linux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "copy-webpack-plugin": "10.2.4",
         "cross-env": "7.0.3",
         "css-loader": "6.7.1",
-        "electron": "38.2.1",
+        "electron": "38.7.2",
         "electron-builder": "24.13.3",
         "eslint": "8.57.0",
         "eslint-import-resolver-webpack": "0.13.8",
@@ -7328,9 +7328,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "38.2.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-38.2.1.tgz",
-      "integrity": "sha512-P4pE2RpRg3kM8IeOK+heg6iAxR5wcXnNHrbVchn7M3GBnYAhjfJRkROusdOro5PlKzdtfKjesbbqaG4MqQXccg==",
+      "version": "38.7.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-38.7.2.tgz",
+      "integrity": "sha512-BcjR0IHqp3uv4ytVQwW2/9zAWo17Rjwrydn6RS+g+vqhpcPTzmBHDCHKaEcqheSl/7zzKPgFZdvT21BoSfrxRQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "copy-webpack-plugin": "10.2.4",
     "cross-env": "7.0.3",
     "css-loader": "6.7.1",
-    "electron": "38.2.1",
+    "electron": "38.7.2",
     "electron-builder": "24.13.3",
     "eslint": "8.57.0",
     "eslint-import-resolver-webpack": "0.13.8",

--- a/src/app/mainWindow/mainWindow.test.js
+++ b/src/app/mainWindow/mainWindow.test.js
@@ -4,7 +4,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import {BrowserWindow, screen, app, globalShortcut, dialog} from 'electron';
+import {BrowserWindow, screen, app, dialog} from 'electron';
 
 import {SELECT_NEXT_TAB, SELECT_PREVIOUS_TAB} from 'common/communication';
 import Config from 'common/config';
@@ -40,10 +40,6 @@ jest.mock('electron', () => ({
     screen: {
         getDisplayMatching: jest.fn(),
         getPrimaryDisplay: jest.fn(),
-    },
-    globalShortcut: {
-        register: jest.fn(),
-        registerAll: jest.fn(),
     },
 }));
 
@@ -543,61 +539,6 @@ describe('main/windows/mainWindow', () => {
             });
             expect(window.webContents.send).toHaveBeenCalledWith(SELECT_NEXT_TAB);
             expect(window.webContents.send).toHaveBeenCalledWith(SELECT_PREVIOUS_TAB);
-        });
-
-        it('should add override shortcuts for the top menu on Linux to stop it showing up', () => {
-            const {isKDE} = require('../../main/utils');
-            isKDE.mockReturnValue(false);
-
-            const originalPlatform = process.platform;
-            Object.defineProperty(process, 'platform', {
-                value: 'linux',
-            });
-            const window = {
-                ...baseWindow,
-                getSize: jest.fn().mockReturnValue([800, 600]),
-                getContentBounds: jest.fn().mockReturnValue({x: 0, y: 0, width: 800, height: 600}),
-                on: jest.fn().mockImplementation((event, cb) => {
-                    if (event === 'focus') {
-                        cb();
-                    }
-                }),
-            };
-            BrowserWindow.mockImplementation(() => window);
-            const mainWindow = new MainWindow();
-            mainWindow.init();
-            Object.defineProperty(process, 'platform', {
-                value: originalPlatform,
-            });
-            expect(globalShortcut.registerAll).toHaveBeenCalledWith(['Alt+F', 'Alt+E', 'Alt+V', 'Alt+H', 'Alt+W', 'Alt+P'], expect.any(Function));
-        });
-
-        it('should register global shortcuts even when window is minimized on KDE/KWin', () => {
-            const {isKDE} = require('../../main/utils');
-            isKDE.mockReturnValue(true);
-
-            const originalPlatform = process.platform;
-            Object.defineProperty(process, 'platform', {
-                value: 'linux',
-            });
-            const window = {
-                ...baseWindow,
-                isMinimized: jest.fn().mockReturnValue(true),
-                on: jest.fn().mockImplementation((event, cb) => {
-                    if (event === 'focus') {
-                        cb();
-                    }
-                }),
-            };
-            BrowserWindow.mockImplementation(() => window);
-            const mainWindow = new MainWindow();
-            mainWindow.getBounds = jest.fn();
-            mainWindow.init();
-
-            expect(globalShortcut.registerAll).toHaveBeenCalled();
-            Object.defineProperty(process, 'platform', {
-                value: originalPlatform,
-            });
         });
     });
 

--- a/src/app/windows/baseWindow.test.js
+++ b/src/app/windows/baseWindow.test.js
@@ -6,7 +6,7 @@
 import os from 'os';
 import path from 'path';
 
-import {BrowserWindow, app, globalShortcut, ipcMain, dialog} from 'electron';
+import {BrowserWindow, app, ipcMain, dialog} from 'electron';
 
 import {
     EMIT_CONFIGURATION,
@@ -69,10 +69,6 @@ jest.mock('electron', () => {
         }),
         dialog: {
             showMessageBox: jest.fn(),
-        },
-        globalShortcut: {
-            registerAll: jest.fn(),
-            unregisterAll: jest.fn(),
         },
         ipcMain: mockIpcMain,
         mockIpcMain,
@@ -273,7 +269,6 @@ describe('BaseWindow', () => {
             expect(baseWindow).toBeDefined();
             expect(baseWindow.browserWindow.once).toHaveBeenCalledWith('restore', expect.any(Function));
             expect(baseWindow.browserWindow.on).toHaveBeenCalledWith('closed', expect.any(Function));
-            expect(baseWindow.browserWindow.on).toHaveBeenCalledWith('focus', expect.any(Function));
             expect(baseWindow.browserWindow.on).toHaveBeenCalledWith('blur', expect.any(Function));
             expect(baseWindow.browserWindow.on).toHaveBeenCalledWith('unresponsive', expect.any(Function));
             expect(baseWindow.browserWindow.on).toHaveBeenCalledWith('enter-full-screen', expect.any(Function));
@@ -467,28 +462,11 @@ describe('BaseWindow', () => {
     });
 
     describe('event handlers', () => {
-        it('should register global shortcuts on focus for Linux', () => {
-            const originalPlatform = process.platform;
-            Object.defineProperty(process, 'platform', {value: 'linux'});
-
-            const baseWindow = new BaseWindow({});
-
-            baseWindow.browserWindow.emit('focus');
-
-            expect(globalShortcut.registerAll).toHaveBeenCalledWith(
-                ['Alt+F', 'Alt+E', 'Alt+V', 'Alt+H', 'Alt+W', 'Alt+P'],
-                expect.any(Function),
-            );
-
-            Object.defineProperty(process, 'platform', {value: originalPlatform});
-        });
-
-        it('should unregister global shortcuts on blur', () => {
+        it('should remove secure input on blur', () => {
             const baseWindow = new BaseWindow({});
 
             baseWindow.browserWindow.emit('blur');
 
-            expect(globalShortcut.unregisterAll).toHaveBeenCalled();
             expect(ipcMain.emit).toHaveBeenCalledWith(TOGGLE_SECURE_INPUT, null, false);
         });
 

--- a/src/app/windows/baseWindow.ts
+++ b/src/app/windows/baseWindow.ts
@@ -5,7 +5,7 @@ import os from 'os';
 import path from 'path';
 
 import type {BrowserWindowConstructorOptions, Input, WebContents} from 'electron';
-import {app, BrowserWindow, dialog, globalShortcut, ipcMain} from 'electron';
+import {app, BrowserWindow, dialog, ipcMain} from 'electron';
 
 import {LoadingScreen} from 'app/views/loadingScreen';
 import {URLView} from 'app/views/urlView';
@@ -25,7 +25,6 @@ import ContextMenu from '../../main/contextMenu';
 import {getLocalPreload} from '../../main/utils';
 
 const log = new Logger('BaseWindow');
-const ALT_MENU_KEYS = ['Alt+F', 'Alt+E', 'Alt+V', 'Alt+H', 'Alt+W', 'Alt+P'];
 
 export default class BaseWindow {
     private win: BrowserWindow;
@@ -80,7 +79,6 @@ export default class BaseWindow {
             this.win?.restore();
         });
         this.win.on('closed', this.onClosed);
-        this.win.on('focus', this.onFocus);
         this.win.on('blur', this.onBlur);
         this.win.on('unresponsive', this.onUnresponsive);
         this.win.on('enter-full-screen', this.onEnterFullScreen);
@@ -197,17 +195,7 @@ export default class BaseWindow {
         };
     };
 
-    private onFocus = () => {
-        // Only add shortcuts when window is in focus
-        if (process.platform === 'linux') {
-            globalShortcut.registerAll(ALT_MENU_KEYS, () => {
-                // do nothing because we want to supress the menu popping up
-            });
-        }
-    };
-
     private onBlur = () => {
-        globalShortcut.unregisterAll();
         ipcMain.emit(TOGGLE_SECURE_INPUT, null, false);
     };
 


### PR DESCRIPTION
#### Summary
When you open the app on newer Linux desktops, you get an annoying global shortcuts popup asking for permission to set these shortcuts. This was caused by a workaround we had implemented to suppress a menu popup when pressing the Alt key.

This no longer seems to be needed, so this PR removes that override.
It also upgrades the application to Electron 38.7.0, which is what was causing the pop-up unnecessarily, so it should not show up regardless of global shortcuts in the future.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66831
Closes https://github.com/mattermost/desktop/issues/3574

```release-note
Fixed an issue where a global shortcuts window would pop up on every start of the app on Linux
```
