### PR TITLE
Add `Disable React/Redux Dev Tools` to Developer Mode, enable Developer Mode for the nightly build

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -95,6 +95,7 @@
   "main.menus.app.view.clearDataForServer": "Clear Data for Current Server",
   "main.menus.app.view.developerModeBrowserOnly": "Browser Only Mode",
   "main.menus.app.view.developerModeDisableContextMenu": "Disable Context Menu",
+  "main.menus.app.view.developerModeDisableDevTools": "Disable React/Redux Dev Tools",
   "main.menus.app.view.developerModeDisableNotificationStorage": "Disable Notification Storage",
   "main.menus.app.view.developerModeDisableUserActivityMonitor": "Disable User Activity Monitor",
   "main.menus.app.view.devToolsCurrentCallWidget": "Developer Tools for Call Widget",

--- a/src/app/menus/appMenu/view.ts
+++ b/src/app/menus/appMenu/view.ts
@@ -89,6 +89,14 @@ export default function createViewMenu() {
                     DeveloperMode.toggle('disableContextMenu');
                 },
             },
+            {
+                label: localizeMessage('main.menus.app.view.developerModeDisableDevTools', 'Disable React/Redux Dev Tools'),
+                type: 'checkbox' as const,
+                checked: DeveloperMode.get('disableDevTools'),
+                click() {
+                    DeveloperMode.toggle('disableDevTools');
+                },
+            },
         );
     }
 

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -424,7 +424,7 @@ async function initializeAfterAppReady() {
     // eslint-disable-next-line no-undef
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    if (global.isDev || __IS_NIGHTLY_BUILD__) {
+    if ((global.isDev || __IS_NIGHTLY_BUILD__) && !DeveloperMode.get('disableDevTools')) {
         installExtension([REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS], {
             loadExtensionOptions: {
                 allowFileAccess: true,

--- a/src/main/developerMode.ts
+++ b/src/main/developerMode.ts
@@ -21,7 +21,12 @@ export class DeveloperMode extends EventEmitter {
         ipcMain.handle(IS_DEVELOPER_MODE_ENABLED, this.enabled);
     }
 
-    enabled = () => process.env.MM_DESKTOP_DEVELOPER_MODE === 'true' || isDev;
+    enabled = () => {
+        // eslint-disable-next-line no-undef
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        return process.env.MM_DESKTOP_DEVELOPER_MODE === 'true' || isDev || __IS_NIGHTLY_BUILD__;
+    };
 
     toggle = (setting: keyof DeveloperSettings) => {
         if (!this.enabled()) {

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -15,6 +15,7 @@ export type DeveloperSettings = {
     disableNotificationStorage?: boolean;
     disableUserActivityMonitor?: boolean;
     disableContextMenu?: boolean;
+    disableDevTools?: boolean;
 };
 
 export type SettingsDefinition = Record<string, SettingCategory>;


### PR DESCRIPTION
#### Summary
React and Redux DevTools can cause memory leaks in the Desktop App when left running, especially in nightly builds where they are enabled by default.

This PR adds a `disableDevTools` developer setting to turn off React and Redux DevTools installation. The setting is available in the View menu under Developer Tools when Developer Mode is enabled, allowing users to disable the extensions to prevent memory issues. Additionally, Developer Mode is now enabled by default for nightly builds, making developer features available without requiring an environment variable.

```release-note
NONE
```
