### PR TITLE
[MM-66819] Check for calls widget when opening popouts

### DIFF
--- a/src/app/windows/popoutManager.ts
+++ b/src/app/windows/popoutManager.ts
@@ -6,6 +6,7 @@ import {ipcMain} from 'electron';
 
 import type {PopoutViewProps} from '@mattermost/desktop-api';
 
+import CallsWidgetWindow from 'app/callsWidgetWindow';
 import MainWindow from 'app/mainWindow/mainWindow';
 import MenuManager from 'app/menus';
 import type {MattermostWebContentsView} from 'app/views/MattermostWebContentsView';
@@ -305,7 +306,8 @@ export class PopoutManager {
             return undefined;
         }
 
-        const view = WebContentsManager.getViewByWebContentsId(event.sender.id);
+        const callsViewId = CallsWidgetWindow.isCallsWidget(event.sender.id) && CallsWidgetWindow.mainViewId;
+        const view = callsViewId ? WebContentsManager.getView(callsViewId) : WebContentsManager.getViewByWebContentsId(event.sender.id);
         if (!view) {
             return undefined;
         }


### PR DESCRIPTION
#### Summary
The popout manager did not account for the calls widget when checking if it could open popouts. This PR checks for the widget window and allows popouts to bind to the parent view of the calls widget.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66819

```release-note
Fixed an issue where the Calls Widget would not allow popouts
```
