### PR TITLE
[MM-66902] Dispose the context menu when the window closes

### DIFF
--- a/src/app/mainWindow/modals/modalView.test.js
+++ b/src/app/mainWindow/modals/modalView.test.js
@@ -23,7 +23,10 @@ jest.mock('electron', () => ({
     })),
 }));
 
-jest.mock('main/contextMenu', () => jest.fn());
+const mockContextMenu = {
+    dispose: jest.fn(),
+};
+jest.mock('main/contextMenu', () => jest.fn().mockImplementation(() => mockContextMenu));
 
 jest.mock('main/utils', () => ({
     getWindowBoundaries: jest.fn(),
@@ -132,6 +135,12 @@ describe('main/views/modalView', () => {
             modalView.view.webContents.isDevToolsOpened = jest.fn().mockReturnValue(true);
             modalView.hide();
             expect(modalView.view.webContents.closeDevTools).toBeCalled();
+        });
+
+        it('should dispose context menu on hide', () => {
+            mockContextMenu.dispose.mockClear();
+            modalView.hide();
+            expect(mockContextMenu.dispose).toHaveBeenCalled();
         });
     });
 });

--- a/src/app/mainWindow/modals/modalView.ts
+++ b/src/app/mainWindow/modals/modalView.ts
@@ -99,6 +99,7 @@ export class ModalView<T, T2> {
             }
             performanceMonitor.unregisterView(this.view.webContents.id);
             this.windowAttached.contentView.removeChildView(this.view);
+            this.contextMenu.dispose();
             this.view.webContents.close();
 
             delete this.windowAttached;

--- a/src/app/views/MattermostWebContentsView.test.js
+++ b/src/app/views/MattermostWebContentsView.test.js
@@ -359,6 +359,13 @@ describe('main/views/MattermostWebContentsView', () => {
             expect(AppState.clear).toBeCalledWith(mattermostView.id);
         });
 
+        it('should dispose context menu when context menu exists', () => {
+            const mattermostView = new MattermostWebContentsView(view, {}, window);
+            mattermostView.webContentsView.webContents.close = jest.fn();
+            mattermostView.destroy();
+            expect(contextMenu.dispose).toHaveBeenCalled();
+        });
+
         it('should clear outstanding timeouts', () => {
             const mattermostView = new MattermostWebContentsView(view, {}, window);
             mattermostView.webContentsView.webContents.close = jest.fn();

--- a/src/app/views/MattermostWebContentsView.ts
+++ b/src/app/views/MattermostWebContentsView.ts
@@ -227,6 +227,9 @@ export class MattermostWebContentsView extends EventEmitter {
         if (this.parentWindow) {
             this.parentWindow.contentView.removeChildView(this.webContentsView);
         }
+        if (this.contextMenu) {
+            this.contextMenu.dispose();
+        }
         this.webContentsView.webContents.close();
 
         if (this.retryLoad) {

--- a/src/app/views/webContentEvents.ts
+++ b/src/app/views/webContentEvents.ts
@@ -40,7 +40,7 @@ const log = new Logger('WebContentsEventManager');
 
 export class WebContentsEventManager {
     listeners: Record<number, () => void>;
-    popupWindow?: {win: BrowserWindow; serverURL?: URL};
+    popupWindow?: {win: BrowserWindow; serverURL?: URL; contextMenu?: ContextMenu};
 
     constructor() {
         this.listeners = {};
@@ -242,11 +242,14 @@ export class WebContentsEventManager {
                     popup.webContents.on('will-navigate', this.generateWillNavigate(popup.webContents.id));
                     popup.webContents.setWindowOpenHandler(this.denyNewWindow);
                     popup.once('closed', () => {
+                        if (this.popupWindow?.contextMenu) {
+                            this.popupWindow.contextMenu.dispose();
+                        }
                         this.popupWindow = undefined;
                     });
 
-                    const contextMenu = new ContextMenu({}, popup);
-                    contextMenu.reload();
+                    this.popupWindow.contextMenu = new ContextMenu({}, popup);
+                    this.popupWindow.contextMenu.reload();
                 }
 
                 popup.once('ready-to-show', () => popup.show());

--- a/src/app/windows/baseWindow.test.js
+++ b/src/app/windows/baseWindow.test.js
@@ -8,6 +8,8 @@ import path from 'path';
 
 import {BrowserWindow, app, ipcMain, dialog} from 'electron';
 
+import {LoadingScreen} from 'app/views/loadingScreen';
+import {URLView} from 'app/views/urlView';
 import {
     EMIT_CONFIGURATION,
     FOCUS_THREE_DOT_MENU,
@@ -112,6 +114,7 @@ jest.mock('app/views/urlView', () => ({
 describe('BaseWindow', () => {
     const mockContextMenu = {
         reload: jest.fn(),
+        dispose: jest.fn(),
     };
 
     beforeEach(() => {
@@ -310,9 +313,6 @@ describe('BaseWindow', () => {
         });
 
         it('should create LoadingScreen and URLView', () => {
-            const {LoadingScreen} = require('app/views/loadingScreen');
-            const {URLView} = require('app/views/urlView');
-
             const baseWindow = new BaseWindow({});
 
             expect(baseWindow).toBeDefined();
@@ -504,6 +504,18 @@ describe('BaseWindow', () => {
             baseWindow.browserWindow.emit('leave-full-screen');
 
             expect(baseWindow.browserWindow.webContents.send).toHaveBeenCalledWith('leave-full-screen');
+        });
+
+        it('should dispose context menu when window is closed', () => {
+            const baseWindow = new BaseWindow({});
+            const loadingScreen = LoadingScreen.mock.results[LoadingScreen.mock.results.length - 1].value;
+            const urlView = URLView.mock.results[URLView.mock.results.length - 1].value;
+
+            baseWindow.browserWindow.emit('closed');
+
+            expect(mockContextMenu.dispose).toHaveBeenCalled();
+            expect(loadingScreen.destroy).toHaveBeenCalled();
+            expect(urlView.destroy).toHaveBeenCalled();
         });
     });
 

--- a/src/app/windows/baseWindow.ts
+++ b/src/app/windows/baseWindow.ts
@@ -31,6 +31,7 @@ export default class BaseWindow {
     private loadingScreen: LoadingScreen;
     private urlView: URLView;
     private ready: boolean;
+    private contextMenu: ContextMenu;
 
     private altPressStatus: boolean;
 
@@ -90,8 +91,8 @@ export default class BaseWindow {
             this.win.webContents.openDevTools({mode: 'detach'});
         }
 
-        const contextMenu = new ContextMenu({}, this.win);
-        contextMenu.reload();
+        this.contextMenu = new ContextMenu({}, this.win);
+        this.contextMenu.reload();
 
         this.loadingScreen = new LoadingScreen(this.win);
         this.urlView = new URLView(this.win);
@@ -203,6 +204,7 @@ export default class BaseWindow {
         log.info('window closed');
         this.ready = false;
         ipcMain.off(EMIT_CONFIGURATION, this.onEmitConfiguration);
+        this.contextMenu.dispose();
         this.loadingScreen.destroy();
         this.urlView.destroy();
     };


### PR DESCRIPTION
#### Summary
The crash `Object has been destroyed" occurred because some `ContextMenu` instances weren't disposed when their attached windows/views were destroyed. The context menu's event handlers remained registered and tried to access destroyed `WebContents` objects, causing the crash.

This PR fixes the crash by ensuring `contextMenu.dispose()` is called in all cleanup paths before windows/views are destroyed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66902

```release-note
Fixed a potential crash in the context menu
```
