### PR TITLE
[MM-64601] Suppress exception handling on force-exit when clearing all data

### DIFF
--- a/src/main/app/utils.ts
+++ b/src/main/app/utils.ts
@@ -240,6 +240,12 @@ export async function clearAllData() {
         await session.defaultSession.clearCodeCaches({});
         await session.defaultSession.clearHostResolverCache();
         await session.defaultSession.clearData();
+
+        // These are here to suppress an unnecessary exception thrown when the app is force exited
+        // The app will restart anyways so we don't need to handle the exception
+        process.removeAllListeners('uncaughtException');
+        process.removeAllListeners('unhandledRejection');
+
         app.relaunch();
         app.exit();
     }


### PR DESCRIPTION
#### Summary
A very annoying exception is thrown by `electron-context-menu` when the app is force exited. It is trying to remove the context menu after the object has been destroyed which throws an exception in Electron.

Patching it requires removing the built-in dispose that's supposed to happen, so this PR just removes the exception handlers so that we don't see the pop-up, since it's unnecessary. Added a comment to clarify the issue.

#### Ticket Link
Closes #3449
https://mattermost.atlassian.net/browse/MM-64601

```release-note
Fixed an unnecessary exception handler dialog box appearing when clicking Clear All Data
```
