### PR TITLE
Drop beta label from ARM64

### DIFF
--- a/scripts/generate_release_markdown.sh
+++ b/scripts/generate_release_markdown.sh
@@ -23,11 +23,11 @@ The download links can be found below.
 
 #### Windows - installer files
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win-x64.msi")
-$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win-arm64.msi") (beta)
+$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win-arm64.msi")
 
 #### Windows - zip files
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win-x64.zip")
-$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win-arm64.zip") (beta)
+$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-win-arm64.zip")
 
 #### Mac
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-mac-universal.dmg")
@@ -35,18 +35,18 @@ $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-mac-x64.dmg")
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-mac-m1.dmg")
 
 #### Linux
-$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-linux-arm64.tar.gz") (beta)
+$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-linux-arm64.tar.gz")
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-linux-x64.tar.gz")
 
 #### Linux (Unofficial) - deb files
-$(print_link "${BASE_URL}/mattermost-desktop_${VERSION}-1_arm64.deb") (beta)
+$(print_link "${BASE_URL}/mattermost-desktop_${VERSION}-1_arm64.deb")
 $(print_link "${BASE_URL}/mattermost-desktop_${VERSION}-1_amd64.deb")
 
 #### Linux (Unofficial) - rpm files (beta)
-$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-linux-aarch64.rpm") (beta)
+$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-linux-aarch64.rpm")
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-linux-x86_64.rpm")
 
 #### Linux (Unofficial) - AppImage files
-$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-linux-arm64.AppImage") (beta)
+$(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-linux-arm64.AppImage")
 $(print_link "${BASE_URL}/mattermost-desktop-${VERSION}-linux-x86_64.AppImage")
 MD


### PR DESCRIPTION
#### Summary
ARM64 has been released as part of the Desktop App for a while now, and has been stable since I've been using it. It's been a mainstay for macOS for about 3 years now, so I think it should be taken out of beta for Windows/Linux as well.

```release-note
NONE
```
