### PR TITLE
Fixed an issue where clicking the tray menu items would not raise the main window if occluded

### DIFF
--- a/src/app/menus/tray.test.js
+++ b/src/app/menus/tray.test.js
@@ -90,8 +90,6 @@ describe('main/menus/tray', () => {
 
         serverMenuItem.click();
 
-        expect(MainWindow.get).toHaveBeenCalled();
-        expect(mockWindow.isVisible).toHaveBeenCalled();
         expect(MainWindow.show).toHaveBeenCalled();
         expect(ServerManager.updateCurrentServer).toHaveBeenCalledWith('server-1');
     });
@@ -116,8 +114,6 @@ describe('main/menus/tray', () => {
 
         settingsMenuItem.click();
 
-        expect(MainWindow.get).toHaveBeenCalled();
-        expect(mockWindow.isVisible).toHaveBeenCalled();
         expect(mockWindow.show).toHaveBeenCalled();
         expect(ModalManager.addModal).toHaveBeenCalled();
     });

--- a/src/app/menus/tray.ts
+++ b/src/app/menus/tray.ts
@@ -19,9 +19,7 @@ export default function createTrayMenu() {
             return {
                 label: server.name.length > 50 ? `${server.name.slice(0, 50)}...` : server.name,
                 click: () => {
-                    if (!MainWindow.get()?.isVisible()) {
-                        MainWindow.show();
-                    }
+                    MainWindow.show();
                     ServerManager.updateCurrentServer(server.id);
                 },
             };
@@ -35,9 +33,7 @@ export default function createTrayMenu() {
                     return;
                 }
 
-                if (!mainWindow.isVisible()) {
-                    mainWindow.show();
-                }
+                mainWindow.show();
 
                 ModalManager.addModal(
                     ModalConstants.SETTINGS_MODAL,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
#3625 put in a fix for #3612 but there seems to be some faulty behavior in Electron's `BrowserWindow.isVisible()`. It should return `false` if the window is occluded, but it empirically doesn't on Linux and there are Eletron bugs that never seem to have been resolved on [MacOS](https://github.com/electron/electron/issues/16776) and [Windows](https://github.com/electron/electron/issues/17540). Calling `show()` unconditionally on tray item clicks fixes the issue and should be benign in the case that the window is already on top.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/desktop/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Closes #3612
(note: already closed, but this is relevant to that issue)

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [x] executed `npm run lint:js` for proper code formatting
- [ ] Run E2E tests by adding label `E2E/Run`

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->
Dell XPS-15, XUbuntu 24.04

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:
-->
```release-note
Fixed an issue where clicking the tray menu items would not open the main window if it's occluded
```
