### PR TITLE
workflows: upload artifacts to a new bucket

### DIFF
--- a/.github/workflows/nightly-main.yml
+++ b/.github/workflows/nightly-main.yml
@@ -244,6 +244,15 @@ jobs:
           echo "$LINKLIST" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
+      # Upload artifacts new bucket
+      - name: nightly/setup-aws-credentials-new-bucket
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.MM_DESKTOP_RELEASE_AWS_ROLE_TO_ASSUME }}
+      - name: nightly/upload-to-s3-new-bucket
+        run: aws s3 cp ./aws-s3-dist/ s3://${{ secrets.MM_DESKTOP_RELEASE_BUCKET }} --cache-control "no-cache" --recursive
+
   share-links-to-channel:
     runs-on: ubuntu-22.04
     needs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -197,6 +197,16 @@ jobs:
       - name: release/upload-to-s3
         run: aws s3 cp ./aws-s3-dist/ s3://releases.mattermost.com/desktop/ --acl public-read --cache-control "no-cache" --recursive
 
+      # Upload artifacts new bucket
+      - name: release/setup-aws-credentials-new-bucket
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.MM_DESKTOP_RELEASE_AWS_ROLE_TO_ASSUME }}
+
+      - name: release/upload-to-s3-new-bucket
+        run: aws s3 cp ./aws-s3-dist/ s3://${{ secrets.MM_DESKTOP_RELEASE_BUCKET }} --cache-control "no-cache" --recursive
+
   github-release:
     runs-on: ubuntu-22.04
     needs:


### PR DESCRIPTION
#### Summary
- Upload artifacts to a new bucket
- Doing this in a different step to ensure that we validate it first and to don't disrupt the regular workflow. After validation only this step will persist.

#### Ticket Link
- https://mattermost.atlassian.net/browse/SEC-9225

#### Release Note
```release-note
NONE
```
