### PR TITLE
[MM-63779] Remove Icon element from shortcuts, default to base EXE for icon in shortcuts

### DIFF
--- a/patches/app-builder-lib+26.4.1.patch
+++ b/patches/app-builder-lib+26.4.1.patch
@@ -1,3 +1,25 @@
+diff --git a/node_modules/app-builder-lib/out/targets/MsiTarget.js b/node_modules/app-builder-lib/out/targets/MsiTarget.js
+index 6fe63f1..85e3925 100644
+--- a/node_modules/app-builder-lib/out/targets/MsiTarget.js
++++ b/node_modules/app-builder-lib/out/targets/MsiTarget.js
+@@ -215,7 +215,7 @@ class MsiTarget extends core_1.Target {
+                 result += `>\n`;
+                 const shortcutName = commonOptions.shortcutName;
+                 if (isCreateDesktopShortcut) {
+-                    result += `${fileSpace}  <Shortcut Id="desktopShortcut" Directory="DesktopFolder" Name="${xmlAttr(shortcutName)}" WorkingDirectory="APPLICATIONFOLDER" Advertise="yes" Icon="${this.iconId}"/>\n`;
++                    result += `${fileSpace}  <Shortcut Id="desktopShortcut" Directory="DesktopFolder" Name="${xmlAttr(shortcutName)}" WorkingDirectory="APPLICATIONFOLDER" Advertise="yes"/>\n`;
+                 }
+                 const hasMenuCategory = commonOptions.menuCategory != null;
+                 const startMenuShortcutDirectoryId = hasMenuCategory ? "AppProgramMenuDir" : "ProgramMenuFolder";
+@@ -223,7 +223,7 @@ class MsiTarget extends core_1.Target {
+                     if (hasMenuCategory) {
+                         dirs.push(`<Directory Id="${startMenuShortcutDirectoryId}" Name="ProgramMenuFolder:\\${commonOptions.menuCategory}\\"/>`);
+                     }
+-                    result += `${fileSpace}  <Shortcut Id="startMenuShortcut" Directory="${startMenuShortcutDirectoryId}" Name="${xmlAttr(shortcutName)}" WorkingDirectory="APPLICATIONFOLDER" Advertise="yes" Icon="${this.iconId}">\n`;
++                    result += `${fileSpace}  <Shortcut Id="startMenuShortcut" Directory="${startMenuShortcutDirectoryId}" Name="${xmlAttr(shortcutName)}" WorkingDirectory="APPLICATIONFOLDER" Advertise="yes">\n`;
+                     result += `${fileSpace}    <ShortcutProperty Key="System.AppUserModel.ID" Value="${xmlAttr(this.packager.appInfo.id)}"/>\n`;
+                     result += `${fileSpace}  </Shortcut>\n`;
+                 }
 diff --git a/node_modules/app-builder-lib/templates/msi/template.xml b/node_modules/app-builder-lib/templates/msi/template.xml
 index 2d5cd3c..cf70b8b 100644
 --- a/node_modules/app-builder-lib/templates/msi/template.xml


### PR DESCRIPTION
#### Summary
Our MSI build process added an Icon element that specified a different potential icon for shortcuts from our actual executable. However, this caused weirdness with shortcuts when the app was replaced and thus the icon file was replaced too.

This PR just removes the Icon element which forces the installer to just use the EXE as the icon file, which is correct and should avoid this issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63779
Closes https://github.com/mattermost/desktop/issues/3428

```release-note
Fixed an issue where installing over top of an old Desktop App on Windows could break the shortcut.
NOTE: You may need to remake your shortcut in the taskbar once after this change.
```
