### PR TITLE
[MM-65146] Force MSI to install per-machine by default

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -188,7 +188,8 @@
   },
   "msi": {
     "additionalWixArgs": ["-ext", "WixUtilExtension"],
-    "upgradeCode": "{8523DAF0-699D-4CC7-9A65-C5E696A9DE6D}"
+    "upgradeCode": "{8523DAF0-699D-4CC7-9A65-C5E696A9DE6D}",
+    "perMachine": true
   },
   "rpm": {
     "fpm": ["--rpm-rpmbuild-define", "_build_id_links none", "--rpm-digest=sha256"]

--- a/patches/app-builder-lib+26.4.1.patch
+++ b/patches/app-builder-lib+26.4.1.patch
@@ -21,7 +21,7 @@ index 6fe63f1..85e3925 100644
                      result += `${fileSpace}  </Shortcut>\n`;
                  }
 diff --git a/node_modules/app-builder-lib/templates/msi/template.xml b/node_modules/app-builder-lib/templates/msi/template.xml
-index 2d5cd3c..cf70b8b 100644
+index 2d5cd3c..b5d8d51 100644
 --- a/node_modules/app-builder-lib/templates/msi/template.xml
 +++ b/node_modules/app-builder-lib/templates/msi/template.xml
 @@ -1,5 +1,8 @@
@@ -71,8 +71,8 @@ index 2d5cd3c..cf70b8b 100644
 +    />
 +    <CustomAction
 +      Id="removeExeInstaller"
-+      Directory="APPLICATIONFOLDER"
-+      ExeCommand="[APPLICATIONFOLDER]Uninstall ${productName}.exe /S"
++      Property="EXEINSTALLEREXISTS"
++      ExeCommand="[EXEINSTALLEREXISTS] /S"
 +      Execute="immediate"
 +      Impersonate="yes"
 +      Return="ignore"


### PR DESCRIPTION
#### Summary
This PR address some compliance requires for MSI installers by making the MSI install per-machine by default. This means that the installer will always, by default:
- install to `C:\Program Files\Mattermost`
- create shortcuts in the Public folder
- add registry keys to HKLM instead of HKCU

This has been tested against our existing EXE and MSI installers, with a few caveats:
- When installing over top of the MSI installer for versions below v5.9, an extra shortcut may be left in the user's start menu. This can be safely deleted
- When installing over top of the MSI installer for versions from v5.9 to v6.0.4, if the installation was done per-user (as is the default), the new installer will not replace the old one. This is due to the fact that MSIs cannot modify across contexts, so as a one-time fix, users will have to manually uninstall the old one. We recommend doing this before installing the new one.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-65146

#### Device Information
This PR was tested on: Windows 11 25H2

```release-note
Force MSI to install per-machine by default. See Known Issues for more details.
```
