### PR TITLE
workflow: adjust permissions

### DIFF
--- a/.github/workflows/nightly-main.yml
+++ b/.github/workflows/nightly-main.yml
@@ -201,6 +201,9 @@ jobs:
       - build-mac-installer
       - build-msi-installer
       - build-linux
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: nightly/checkout-repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -174,6 +174,9 @@ jobs:
       - build-mac-installer
       - build-msi-installer
       - build-linux
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: release/setup-aws-credentials
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1


### PR DESCRIPTION
#### Summary
- Fix `It looks like you might be trying to authenticate with OIDC. Did you mean to set the `id-token` permission? If you are not trying to authenticate with OIDC and the action is working successfully, you can ignore this message.`

#### Ticket Link
- Fixes https://github.com/mattermost/desktop/actions/runs/21274493353/job/61232653730

#### Release Note
```release-note
NONE
```

