### PR TITLE
[MM-67338] Enable Sentry and anonymous server metrics by default

### DIFF
--- a/src/common/Validator.test.js
+++ b/src/common/Validator.test.js
@@ -214,6 +214,8 @@ describe('common/Validator', () => {
             version: 4,
             viewLimit: 15,
             themeSyncing: true,
+            enableMetrics: true,
+            enableSentry: true,
         };
 
         it('should validate v4 config data', () => {

--- a/src/common/Validator.ts
+++ b/src/common/Validator.ts
@@ -182,8 +182,8 @@ const configDataSchemaV4 = Joi.object<ConfigV4>({
     alwaysClose: Joi.boolean(),
     logLevel: Joi.string().default('info'),
     appLanguage: Joi.string().allow(''),
-    enableMetrics: Joi.boolean(),
-    enableSentry: Joi.boolean(),
+    enableMetrics: Joi.boolean().default(true),
+    enableSentry: Joi.boolean().default(true),
     viewLimit: Joi.number().integer().min(1),
     themeSyncing: Joi.boolean().default(true),
 });


### PR DESCRIPTION
#### Summary
We intended to enable Sentry and anonymous server metrics by default, however, for users that upgraded their configuration, those values were not turned on. This PR fixes that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67338

```release-note
Enable Sentry and anonymous server metrics by default
```
