### PR TITLE
[MM-67369] Restore new window handler

### DIFF
--- a/src/main/views/MattermostWebContentsView.ts
+++ b/src/main/views/MattermostWebContentsView.ts
@@ -91,6 +91,8 @@ export class MattermostWebContentsView extends EventEmitter {
             }
         });
 
+        WebContentsEventManager.addWebContentsEventListeners(this.webContentsView.webContents);
+
         if (!DeveloperMode.get('disableContextMenu')) {
             this.contextMenu = new ContextMenu({}, this.webContentsView.webContents);
         }


### PR DESCRIPTION
#### Summary
The new window handler was accidentally removed here: https://github.com/mattermost/desktop/pull/3649/changes#diff-e350e4b11da73ab1db026d8b686ad81e05e3f8f5684b78307e5b1c156fb3cd74L94, causing external links to open in the Desktop App.

This PR restores it. To prevent this in the future, I will follow up with a PR on master with an E2E test.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67369

```release-note
Fixed an issue where external links were opening in the Desktop App
```
