### PR TITLE
[MM-67406] Wait for Sentry queue to flush before exiting the app

### DIFF
--- a/src/main/CriticalErrorHandler.ts
+++ b/src/main/CriticalErrorHandler.ts
@@ -25,8 +25,6 @@ export class CriticalErrorHandler {
             return;
         }
 
-        sentryHandler.captureException(err);
-
         if (app.isReady()) {
             this.showExceptionDialog(err);
         } else {
@@ -90,6 +88,8 @@ export class CriticalErrorHandler {
                 app.relaunch();
                 break;
             }
+            return sentryHandler.flush();
+        }).then(() => {
             app.exit(-1);
         });
     };

--- a/src/main/app/app.test.js
+++ b/src/main/app/app.test.js
@@ -25,6 +25,9 @@ jest.mock('main/app/utils', () => ({
     getDeeplinkingURL: jest.fn(),
     openDeepLink: jest.fn(),
 }));
+jest.mock('main/sentryHandler', () => ({
+    flush: jest.fn(),
+}));
 jest.mock('main/updateNotifier', () => ({}));
 
 jest.mock('main/security/certificateStore', () => ({

--- a/src/main/app/app.ts
+++ b/src/main/app/app.ts
@@ -12,6 +12,7 @@ import ServerManager from 'common/servers/serverManager';
 import {parseURL} from 'common/utils/url';
 import {localizeMessage} from 'main/i18nManager';
 import CertificateStore from 'main/security/certificateStore';
+import sentryHandler from 'main/sentryHandler';
 
 import {getDeeplinkingURL, openDeepLink, resizeScreen} from './utils';
 
@@ -78,6 +79,7 @@ export function handleAppBeforeQuit() {
     log.debug('handleAppBeforeQuit');
 
     // Make sure tray icon gets removed if the user exits via CTRL-Q
+    sentryHandler.flush();
     Tray.destroy();
     global.willAppQuit = true;
 }

--- a/src/main/sentryHandler.test.js
+++ b/src/main/sentryHandler.test.js
@@ -123,47 +123,6 @@ describe('main/sentryHandler', () => {
         });
     });
 
-    describe('captureException', () => {
-        beforeEach(() => {
-            process.env = {NODE_ENV: 'production'};
-            sentryHandler.init();
-        });
-
-        it('should capture exception when initialized and enabled', () => {
-            const error = new Error('Test error');
-            sentryHandler.captureException(error);
-            expect(Sentry.captureException).toHaveBeenCalledWith(error);
-        });
-
-        it('should not capture exception if not initialized', () => {
-            const uninitializedHandler = new SentryHandler();
-            const error = new Error('Test error');
-            uninitializedHandler.captureException(error);
-            expect(Sentry.captureException).not.toHaveBeenCalled();
-        });
-
-        it('should not capture exception if NODE_ENV is not production', () => {
-            process.env = {NODE_ENV: 'development'};
-            const error = new Error('Test error');
-            sentryHandler.captureException(error);
-            expect(Sentry.captureException).not.toHaveBeenCalled();
-        });
-
-        it('should not capture exception if enableSentry is false', () => {
-            Config.enableSentry = false;
-            const error = new Error('Test error');
-            sentryHandler.captureException(error);
-            expect(Sentry.captureException).not.toHaveBeenCalled();
-            Config.enableSentry = true;
-        });
-
-        it('should handle missing error argument', () => {
-            sentryHandler.captureException(null);
-
-            expect(Sentry.captureException).not.toHaveBeenCalled();
-        });
-    });
-
     describe('isPrereleaseBuild', () => {
         beforeEach(() => {
             process.env = {NODE_ENV: 'production'};

--- a/src/main/sentryHandler.ts
+++ b/src/main/sentryHandler.ts
@@ -41,17 +41,8 @@ export class SentryHandler {
         log.info('Sentry initialized for error tracking', {isPrerelease});
     };
 
-    captureException = (error: Error) => {
-        if (!this.shouldSendToSentry() || !this.sentryInitialized) {
-            return;
-        }
-
-        if (!error) {
-            log.warn('captureException called with missing arguments', error);
-            return;
-        }
-
-        Sentry.captureException(error);
+    flush = () => {
+        return Sentry.flush(3000);
     };
 
     private addSentryContext = () => {


### PR DESCRIPTION
#### Summary
When the uncaught exception handler is running, the JS execution appears to be paused such that Sentry cannot finish sending its events up. Once the dialog finishes, by the time that Sentry can finish the app has exited.

This PR fixes the exception handler such that it will wait for Sentry to finish its queue before exiting the app, so that events appear more reliably.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67406

```release-note
NONE
```
