### PR TITLE
[MM-67416] Only call AppState once when unreads/mentions are updated

### DIFF
--- a/src/app/views/webContentsManager.ts
+++ b/src/app/views/webContentsManager.ts
@@ -240,8 +240,7 @@ export class WebContentsManager {
             return;
         }
 
-        AppState.updateUnreadsPerServer(view.serverId, isUnread);
-        AppState.updateMentionsPerServer(view.serverId, mentionCount);
+        AppState.updateUnreadsAndMentionsPerServer(view.serverId, mentionCount, isUnread);
     };
 
     private handleSessionExpired = (event: IpcMainEvent, isExpired: boolean) => {

--- a/src/common/appState.ts
+++ b/src/common/appState.ts
@@ -78,14 +78,9 @@ export class AppState extends EventEmitter {
         this.emitStatusForView(viewId);
     };
 
-    updateMentionsPerServer = (serverId: string, mentions: number) => {
-        ViewManager.getViewLog(serverId, 'AppState').silly('updateMentionsPerServer', mentions);
+    updateUnreadsAndMentionsPerServer = (serverId: string, mentions: number, unreads: boolean) => {
+        ViewManager.getViewLog(serverId, 'AppState').silly('updateUnreadsAndMentionsPerServer', mentions, unreads);
         this.mentionsPerServer.set(serverId, mentions);
-        this.emitStatusForServer(serverId);
-    };
-
-    updateUnreadsPerServer = (serverId: string, unreads: boolean) => {
-        ViewManager.getViewLog(serverId, 'AppState').silly('updateUnreadsPerServer', unreads);
         this.unreadsPerServer.set(serverId, unreads);
         this.emitStatusForServer(serverId);
     };


### PR DESCRIPTION
#### Summary
Changes made to `AppState` in which we have discrete actions for unreads and mentions updates caused a race condition on Windows, in which the taskbar badge would update twice really quickly, and end up ignoring the second update. This would cause the badge to briefly display the wrong information.

This PR consolidates the actions into one single action such that we only call the badge once, since it's not needed to do them separately at this time.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67416
Closes https://github.com/mattermost/desktop/issues/3676

```release-note
Fix an issue where the notification badge on Windows could get out of sync
```
