### PR TITLE
Automated cherry pick of #3685

### DIFF
--- a/src/app/views/webContentEvents.ts
+++ b/src/app/views/webContentEvents.ts
@@ -25,6 +25,7 @@ import {
     isPublicFilesUrl,
     isTeamUrl,
     isValidURI,
+    normalizeUrlForValidation,
     parseURL,
 } from 'common/utils/url';
 import ViewManager from 'common/views/viewManager';
@@ -126,12 +127,15 @@ export class WebContentsEventManager {
 
             const parsedURL = parseURL(details.url);
             if (!parsedURL) {
-                this.log(webContentsId).warn('Ignoring non-url');
+                this.log(webContentsId).warn(`Ignoring non-url: ${details.url}`);
                 return {action: 'deny'};
             }
 
-            if (!isValidURI(details.url)) {
-                this.log(webContentsId).warn('Ignoring invalid URL');
+            // Normalize URL before validation to handle characters like backslashes and curly braces
+            // that are technically invalid per RFC 3986 but commonly used by apps like MS Teams,
+            // SharePoint, and OneNote
+            if (!isValidURI(normalizeUrlForValidation(details.url))) {
+                this.log(webContentsId).warn(`Ignoring invalid URL: ${details.url}`);
                 dialog.showErrorBox(
                     localizeMessage('main.webContentEvents.invalidLinkTitle', 'Invalid Link'),
                     localizeMessage(

--- a/src/common/utils/url.ts
+++ b/src/common/utils/url.ts
@@ -128,3 +128,16 @@ const equalUrlsIgnoringSubpath = (url1: URL, url2: URL, ignoreScheme?: boolean) 
 const escapeRegExp = (s: string) => {
     return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 };
+
+/**
+ * Normalizes a URL for RFC 3986 validation by encoding characters that are
+ * technically invalid but commonly used by applications like MS Teams, SharePoint, and OneNote.
+ * - Converts Windows-style backslashes to forward slashes
+ * - Encodes curly braces which are used in GUIDs and JSON-like query parameters
+ */
+export const normalizeUrlForValidation = (url: string): string => {
+    return url.
+        replace(/\\/g, '/').
+        replace(/\{/g, '%7B').
+        replace(/\}/g, '%7D');
+};


### PR DESCRIPTION
Cherry pick of #3685 on release-6.1.

/cc  @wiggin77

```release-note
Fixed an issue where Microsoft Teams, SharePoint, and OneNote links were incorrectly rejected as "Invalid Link" due to special characters in their URLs.
```