### PR TITLE
[MM-67550] Revert to Electron v40.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "copy-webpack-plugin": "10.2.4",
         "cross-env": "7.0.3",
         "css-loader": "6.7.1",
-        "electron": "40.1.0",
+        "electron": "40.0.0",
         "electron-builder": "26.6.0",
         "eslint": "8.57.0",
         "eslint-import-resolver-webpack": "0.13.8",
@@ -8413,9 +8413,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "40.1.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-40.1.0.tgz",
-      "integrity": "sha512-2j/kvw7uF0H1PnzYBzw2k2Q6q16J8ToKrtQzZfsAoXbbMY0l5gQi2DLOauIZLzwp4O01n8Wt/74JhSRwG0yj9A==",
+      "version": "40.0.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-40.0.0.tgz",
+      "integrity": "sha512-UyBy5yJ0/wm4gNugCtNPjvddjAknMTuXR2aCHioXicH7aKRKGDBPp4xqTEi/doVcB3R+MN3wfU9o8d/9pwgK2A==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "copy-webpack-plugin": "10.2.4",
     "cross-env": "7.0.3",
     "css-loader": "6.7.1",
-    "electron": "40.1.0",
+    "electron": "40.0.0",
     "electron-builder": "26.6.0",
     "eslint": "8.57.0",
     "eslint-import-resolver-webpack": "0.13.8",


### PR DESCRIPTION
#### Summary
An upstream issue is causing problems with our app on the Mac App Store: https://github.com/electron/electron/issues/49770

For the time being, we'll revert to Electron v40.0.0 until this is solved.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67550

```release-note
Upgrade to Electron v40.0.0
```
