### PR TITLE
Fix Linux cross-compiler scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "package:linux:arch-arm64": "cross-env CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ electron-builder --linux",
     "package:linux-tar": "npm run build-prod && npm run package:linux:arch-x64 -- tar.gz --x64 --publish=never && npm run package:linux:arch-arm64 -- tar.gz --arm64 --publish=never",
     "package:linux-pkg": "npm run build-prod && npm run package:linux:arch-x64 -- deb rpm flatpak --x64 --publish=never && npm run package:linux:arch-arm64 -- deb rpm flatpak --arm64 --publish=never",
-    "package:linux-appImage": "npm run build-prod && npm run package:linux-arch-x64 -- tar.gz appimage --x64 --publish=never && npm run package:linux-arch-arm64 -- tar.gz appimage --arm64 --publish=never"
+    "package:linux-appImage": "npm run build-prod && npm run package:linux:arch-x64 -- tar.gz appimage --x64 --publish=never && npm run package:linux:arch-arm64 -- tar.gz appimage --arm64 --publish=never"
   },
   "jest": {
     "clearMocks": true,


### PR DESCRIPTION
#### Summary
Our Linux build scripts are set up to run cross-compile for ARM64, but not on x64. If you're like me and run Linux in a VM on an Apple Silicon Mac, this means you have to go edit the package.json to get the compiler to work properly.

However, since the flags are ignored if you're on the same arch, this PR just forces them on regardless of the arch so that it works without editing.

```release-note
NONE
```
