### PR TITLE
[MM-67654] Remove untrusted URL check for client certs

### DIFF
--- a/src/main/security/preAuthManager.test.js
+++ b/src/main/security/preAuthManager.test.js
@@ -145,20 +145,13 @@ describe('main/preAuthManager', () => {
             preAuthManager.handleClientCert({preventDefault: jest.fn()}, null, 'trustedurl.com:8080', [{}, {}], callback);
             expect(ModalManager.addModal).toBeCalled();
         });
-
-        it('should not pop modal for untrusted domain:port format URLs', () => {
-            ServerManager.lookupServerByURL.mockReturnValue(undefined);
-            const callback = jest.fn();
-            preAuthManager.handleClientCert({preventDefault: jest.fn()}, null, 'untrusted.com:8080', [{}, {}], callback);
-            expect(ModalManager.addModal).not.toBeCalled();
-            expect(callback).not.toBeCalled();
-        });
     });
 
     describe('handlePreAuthSecret', () => {
         const preAuthManager = new PreAuthManager();
 
         it('should not pop modal on untrusted URL', () => {
+            ServerManager.lookupServerByURL.mockReturnValue(undefined);
             const callback = jest.fn();
             preAuthManager.handlePreAuthSecret('http://untrustedurl.com/', callback);
             expect(ModalManager.addModal).not.toBeCalled();

--- a/src/main/security/preAuthManager.ts
+++ b/src/main/security/preAuthManager.ts
@@ -134,24 +134,6 @@ export class PreAuthManager {
 
         event.preventDefault(); // prevent the app from getting the first certificate available
 
-        // The URL provided is in the format <domain>:<port>, so we need to convert it to a proper URL for trust checking
-        let urlToCheck = url;
-        if (url.includes(':') && !url.includes('://')) {
-            const [domain, port] = url.split(':');
-            if (port === '443') {
-                urlToCheck = `https://${domain}`;
-            } else if (port === '80') {
-                urlToCheck = `http://${domain}`;
-            } else {
-                urlToCheck = `https://${url}`;
-            }
-        }
-
-        if (!this.isTrustedURL(urlToCheck)) {
-            log.info('URL is not trusted. Skipping certificate selection');
-            return;
-        }
-
         const mainWindow = MainWindow.get();
         if (!mainWindow) {
             log.info('No main window found. Skipping certificate selection');


### PR DESCRIPTION
#### Summary
The client certificate check had an untrusted URL check added to be in line with the other pre-auth checks. However, this is unnecessary since it requires another user step before the certificate is passed up. In the case of a single certificate, it would also pick that one anyways, so this PR removes the untrusted URL check, since it was breaking certain plugins. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67654

```release-note
Fixed an issue where the Desktop App wouldn't load content from the JIRA plugin in certain cases
```
