### PR TITLE
[MM-67695] Fix getLoadingURL to account for query parameters, subpaths

### DIFF
--- a/src/common/views/MattermostView.test.js
+++ b/src/common/views/MattermostView.test.js
@@ -80,7 +80,7 @@ describe('MattermostView', () => {
             expect(view.getLoadingURL().toString()).toBe('https://test.com/channels/town-square?teid=test-team-id');
         });
 
-        it('should preserve query string in initial path for root pathname with a subpath', () => {
+        it('should preserve query string in initial path for server URL with a subpath', () => {
             mockServer.url = new URL('https://test.com/subpath');
             const view = new MattermostView(mockServer, ViewType.TAB, '/channels/town-square?teid=test-team-id&channel_id=test-channel-id');
 
@@ -124,6 +124,25 @@ describe('MattermostView', () => {
             mockServer.url = new URL('https://test.com/');
             const view = new MattermostView(mockServer, ViewType.TAB, '/channels/town-square');
             expect(view.getLoadingURL().toString()).toBe('https://test.com/channels/town-square');
+        });
+
+        it('should call isInternalURL with the constructed URL and server URL', () => {
+            mockServer.url = new URL('https://test.com/');
+            const view = new MattermostView(mockServer, ViewType.TAB, '/channels/town-square');
+            view.getLoadingURL();
+
+            expect(isInternalURL).toHaveBeenCalledWith(
+                new URL('https://test.com/channels/town-square'),
+                mockServer.url,
+            );
+        });
+
+        it('should fall back to server URL when isInternalURL returns false', () => {
+            mockServer.url = new URL('https://test.com/subpath');
+            isInternalURL.mockReturnValue(false);
+            const view = new MattermostView(mockServer, ViewType.TAB, '/some/external/path');
+
+            expect(view.getLoadingURL()).toEqual(mockServer.url);
         });
     });
 });

--- a/src/common/views/MattermostView.ts
+++ b/src/common/views/MattermostView.ts
@@ -66,7 +66,7 @@ export class MattermostView {
         }
 
         // Fall back to the server URL if the URL is not internal
-        if (!isInternalURL(server.url, url)) {
+        if (!isInternalURL(url, server.url)) {
             return server.url;
         }
         return url;


### PR DESCRIPTION
#### Summary
When opening a pop-out window, or new tab, if the URL that was used to open that view contains query parameters (ie. ?), it will not work and the ? gets URL encoded. This likely doesn't affect anything currently, but it limits our ability to work with pop-out windows.

This PR fixes the URL encode issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67695

```release-note
Fixed an issue where new views would not load if the URL to open contains query parameters
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**Bug Fixes**
- Fixes getLoadingURL so query parameters and subpaths in the initial path are preserved when constructing the loading URL (prevents URL-encoding the question mark and dropping query strings).
- Updates internal URL validation to call isInternalURL with the constructed URL and the server URL and fall back to server.url when the constructed URL is not internal.

**Tests**
- Adds unit tests covering:
  - Preservation of query strings for root and subpath server URLs.
  - Handling of leading/trailing slashes in initialPath.
  - Validation behavior when parseURL returns null.
  - isInternalURL being called with the constructed URL and fallback to server.url when it returns false.

## Change Impact: 🟢 Low

**Reasoning:** The change is a focused fix to URL construction and validation in MattermostView.getLoadingURL with comprehensive unit tests added.  
**Regression Risk:** Low — logic is localized to a single view helper, well-covered by tests, and behavior falls back to server.url on validation failure.  
**Blast Radius:** narrow — affects view-loading for pop-outs/new tabs only.  
**High-Risk Flows Affected:** None  
**QA Recommendation:** Minimal manual QA: verify opening pop-outs and new tabs with URLs containing query parameters and subpaths (smoke test). Automated tests suffice to skip broad manual regression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->