### PR TITLE
[MM-67761] Ensure loading screen doesn't attempt to re-add itself if already fading or removing

### DIFF
--- a/src/app/views/loadingScreen.test.js
+++ b/src/app/views/loadingScreen.test.js
@@ -75,5 +75,19 @@ describe('main/views/loadingScreen', () => {
             expect(loadingScreen.view.webContents.send).toHaveBeenCalledWith(TOGGLE_LOADING_SCREEN_VISIBILITY, true);
             expect(mainWindow.contentView.addChildView).toHaveBeenCalledWith(loadingScreen.view);
         });
+
+        it('should not show the loading screen if fade() is called before did-finish-load fires', () => {
+            loadingScreen.view.webContents.send.mockClear();
+            mainWindow.contentView.addChildView.mockClear();
+
+            loadingScreen.view.webContents.isLoading.mockReturnValue(true);
+            loadingScreen.show();
+            loadingScreen.fade();
+
+            loadingScreen.view.webContents.emit('did-finish-load');
+
+            expect(loadingScreen.view.webContents.send).not.toHaveBeenCalledWith(TOGGLE_LOADING_SCREEN_VISIBILITY, true);
+            expect(mainWindow.contentView.addChildView).not.toHaveBeenCalled();
+        });
     });
 });

--- a/src/app/views/loadingScreen.ts
+++ b/src/app/views/loadingScreen.ts
@@ -51,7 +51,13 @@ export class LoadingScreen {
 
         if (this.view.webContents.isLoading()) {
             this.view.webContents.once('did-finish-load', () => {
+                if (this.state !== LoadingScreenState.VISIBLE) {
+                    return;
+                }
+
                 this.view.webContents.send(TOGGLE_LOADING_SCREEN_VISIBILITY, true);
+
+                log.debug('show: did-finish-load fired, adding loading screen view');
 
                 // Electron does a weird thing where even if the index is undefined, it will not add the view on top properly
                 if (condition?.()) {
@@ -62,6 +68,7 @@ export class LoadingScreen {
             });
         } else {
             this.view.webContents.send(TOGGLE_LOADING_SCREEN_VISIBILITY, true);
+            log.debug('show: not loading, adding loading screen view');
             if (condition?.()) {
                 this.parent.contentView.addChildView(this.view, 1);
             } else {
@@ -74,6 +81,7 @@ export class LoadingScreen {
 
     fade = () => {
         if (this.state === LoadingScreenState.VISIBLE) {
+            log.debug('fade: fading loading screen');
             this.state = LoadingScreenState.FADING;
             this.view.webContents.send(TOGGLE_LOADING_SCREEN_VISIBILITY, false);
         }


### PR DESCRIPTION
#### Summary
The loading screen can intermittently get stuck on first launch due to a race condition between `show()` and `fade()` in `LoadingScreen`. When `show()` is called while the loading screen HTML is still loading, it defers adding the view until `did-finish-load`. If the server view finishes loading and `fade()` fires before that callback, the deferred `did-finish-load` handler re-adds the loading screen view after it has already started fading, leaving it visible until the user switches servers or tabs.

This PR adds a state guard in the `did-finish-load` callback that skips showing the loading screen if the state is no longer `VISIBLE` (i.e., `fade()` has already been called).

I wasn't able to directly reproduce this issue since it's very intermittent, so I've added debug logging to the `show()` and `fade()` methods to help diagnose any other loading screen dismissal issues that may surface.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67761
https://github.com/mattermost/desktop/issues/3712

```release-note
Fix an issue where the loading screen might get stuck over top of the app
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** The changes are isolated to the LoadingScreen component (a single UI module) and implement a defensive state guard to prevent a specific race condition. A new test directly validates this fix, with no modifications to public APIs, shared dependencies, or critical business logic paths.

**Regression Risk:** Minimal. The change adds a state check (`if (this.state !== LoadingScreenState.VISIBLE) { return; }`) in the did-finish-load callback that only exits early if the state is no longer VISIBLE—preventing the problematic re-add scenario. This guard does not alter the normal loading screen flow and purely prevents an edge case. Debug logging additions have no functional impact. Existing happy-path behavior is completely unaffected.

**QA Recommendation:** Light manual QA recommended. Focus on first-launch scenarios and rapid server/tab switching to verify the loading screen appears and dismisses properly under normal conditions. Given the addition of dedicated test coverage for the race condition and the isolated, defensive nature of the changes, skipping manual QA carries acceptable risk if standard first-launch verification is performed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->