### PR TITLE
Don't specify the mac provisioning profile in the electron-builder configuration

### DIFF
--- a/electron-builder.ts
+++ b/electron-builder.ts
@@ -127,7 +127,6 @@ const config = {
         ],
         hardenedRuntime: true,
         gatekeeperAssess: true,
-        provisioningProfile: process.env.MAC_PROVISIONING_PROFILE || './mac.provisionprofile',
         entitlements: './resources/mac/entitlements.mac.plist',
         entitlementsInherit: './resources/mac/entitlements.mac.inherit.plist',
         extendInfo: {


### PR DESCRIPTION
#### Summary
An issue was introduced in the MAS build when we migrated the electron-builder configuration. Apparently electron-builder doesn't like when we use the mac profile with the MAS one, which is why it's manually specified. This PR restores that behaviour.

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** This is a minimal, isolated configuration change that restores previously working behavior by removing a conflicting provisioning profile setting introduced during a recent TypeScript migration. The change does not affect core application logic, shared dependencies, or critical user-facing paths.

**Regression Risk:** Very low. The change resolves a documented electron-builder incompatibility where specifying both `mac.provisioningProfile` and `mas.provisioningProfile` causes MAS builds to fail. By removing the conflicting mac provisioning profile while retaining appropriate profiles in the `mas` and `masDev` configurations, this restores known-good build behavior. The standard macOS direct distribution builds (non-MAS) will proceed without explicit provisioning profile configuration, and MAS builds will use their designated profiles.

**QA Recommendation:** Minimal manual QA required. Primary focus should be on verifying macOS App Store (MAS) builds complete successfully and produce valid app bundles. Standard regression testing for non-macOS platforms (Windows, Linux) can be skipped as they are unaffected. Automated CI/CD build verification is the primary validation mechanism; no extensive manual testing is necessary given the nature of this localized configuration fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->