### PR TITLE
Move version info to `mac` section to workaround `electron-builder` bug

### DIFF
--- a/electron-builder.ts
+++ b/electron-builder.ts
@@ -10,7 +10,7 @@ function getMacVersions() {
     if (process.env.GITHUB_RUN_ID) {
         buildVersion = `${process.env.GITHUB_RUN_ID}${process.env.GITHUB_RUN_ATTEMPT || ''}`;
     } else {
-        const match = pkg.version.match(/-\d+\.(\d+)$/);
+        const match = pkg.version.match(/-[^.]+\.(\d+)$/);
         if (match) {
             buildVersion = match[1];
         }
@@ -135,6 +135,7 @@ const config = {
             NSFocusStatusUsageDescription: 'Focus status is used by Mattermost to determine whether to send notifications or not.',
             LSFileQuarantineEnabled: true,
         },
+        ...getMacVersions(),
     },
     mas: {
         entitlements: './resources/mac/entitlements.mas.plist',
@@ -146,7 +147,6 @@ const config = {
             NSUserActivityTypes: ['INSendMessageIntent'],
         },
         singleArchFiles: '*',
-        ...getMacVersions(),
     },
     masDev: {
         provisioningProfile: './dev.provisionprofile',


### PR DESCRIPTION
#### Summary
Move version info to `mac` section to workaround `electron-builder` bug

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** This is an isolated build configuration change targeting a specific electron-builder bug affecting Mac/MAS builds. The modification redistributes version metadata from the `mas` configuration to the `mac` configuration to work around how electron-builder handles version properties. No runtime behavior or cross-platform functionality is affected.

**Regression Risk:** Minimal. The regex pattern change in `getMacVersions()` from `/-\d+\.(\d+)$/` to `/-[^.]+\.(\d+)$/` is more permissive and reduces the chance of version parsing failures on non-CI environments. The move of version fields from `mas` to `mac` configuration is a targeted fix for electron-builder's handling of version properties. Changes are confined to Mac and MAS build targets only, with no impact on Windows or Linux builds. The function returns the same structure regardless of changes.

**QA Recommendation:** Manual QA testing should focus on Mac and MAS builds to verify that version metadata is correctly applied during packaging. Specifically, test that both `bundleShortVersion` and `bundleVersion` are correctly set in the `mac` build output, and that the MAS build succeeds without version configuration errors. Since this is a build configuration fix rather than runtime code change, QA can be scoped to build verification and Mac App Store submission testing. Skipping Mac/MAS build validation would be high-risk and should not be done.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->