### PR TITLE
[MM-67940] Suppress annoying error when theme is missing

### DIFF
--- a/src/renderer/utils.ts
+++ b/src/renderer/utils.ts
@@ -98,6 +98,9 @@ const printVersion = () => {
 };
 
 const setTheme = (theme: Theme) => {
+    if (!theme) {
+        return;
+    }
     document.body.style.setProperty('--sidebar-bg', theme.sidebarBg);
     document.body.style.setProperty('--sidebar-bg-rgb', toRgbValues(theme.sidebarBg));
     document.body.style.setProperty('--sidebar-text', theme.sidebarText);


### PR DESCRIPTION
#### Summary
An annoying error would show up in the Developer Tools for Main Window, misdirecting users into thinking it's a cause for a problem, when it's just happening because the theme is missing. This was caused by not checking if the theme exists before setting it. This PR fixes that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67940

```release-note
Fix a misleading error message in the Developer Tools for Main Window
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** This is a minimal defensive guard clause addition to the `setTheme` utility function that prevents property access on a falsy theme object. The change is isolated to a single function with zero blast radius to other modules or systems.

**Regression Risk:** Negligible. The guard clause only adds an early return when the theme parameter is falsy, preventing subsequent property access errors. When theme is truthy, behavior remains identical to the original implementation. The function's interface and semantics are unchanged—it still performs theme application correctly.

**QA Recommendation:** Minimal manual QA required. Verify that (1) theme application continues to work normally when a valid theme is provided, and (2) no misleading error appears in Developer Tools when a theme is missing. Risk of skipping manual QA is very low given the straightforward nature of this defensive check.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->