### PR TITLE
[MM-67757] Suppress Electron error

### DIFF
--- a/src/main/CriticalErrorHandler.ts
+++ b/src/main/CriticalErrorHandler.ts
@@ -24,6 +24,15 @@ export class CriticalErrorHandler {
             return;
         }
 
+        // Suppress a very specific known Electron bug that won't be fixed in the current version
+        // See https://github.com/electron/electron/issues/50059
+        if (err.name === 'TypeError' &&
+            err.message === 'Invalid URL' &&
+            err.stack?.includes('electron/js2c/browser_init')) {
+            log.warn('Suppressing Electron internal popup error', err.message);
+            return;
+        }
+
         if (app.isReady()) {
             this.showExceptionDialog(err);
         } else {


### PR DESCRIPTION
#### Summary
https://github.com/electron/electron/pull/50062 won't be fixed for Electron 37, so for v5.13 we will just suppress the error to allow the app to run normally.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67757

```release-note
Fix an issue where the app throws an error on a malformed URL
```
