### PR TITLE
[MM-67952] Fix ability for other plugins to ask for screen share sources

### DIFF
--- a/src/app/callsWidgetWindow.test.js
+++ b/src/app/callsWidgetWindow.test.js
@@ -844,6 +844,43 @@ describe('main/windows/callsWidgetWindow', () => {
             expect(views.get('server-1_view-1').sendToRenderer).not.toHaveBeenCalled();
         });
 
+        it('should return sources for a non-Calls view when no call is active', async () => {
+            callsWidgetWindow.mainView = undefined;
+            callsWidgetWindow.options = undefined;
+            callsWidgetWindow.getViewURL = jest.fn().mockReturnValue(undefined);
+            WebContentsManager.getServerURLByViewId.mockReturnValue('http://server-1.com');
+
+            jest.spyOn(desktopCapturer, 'getSources').mockResolvedValue([
+                {
+                    id: 'screen0',
+                    thumbnail: {
+                        toDataURL: jest.fn(),
+                    },
+                },
+            ]);
+
+            const sources = await callsWidgetWindow.handleGetDesktopSources({sender: {id: 3}}, null);
+            expect(sources).toEqual([
+                {
+                    id: 'screen0',
+                },
+            ]);
+            expect(PermissionsManager.doPermissionRequest).toHaveBeenCalledWith(
+                3,
+                'screenShare',
+                {requestingUrl: 'http://server-1.com', isMainFrame: false},
+            );
+        });
+
+        it('should throw when no call is active and view has no server URL', async () => {
+            callsWidgetWindow.mainView = undefined;
+            callsWidgetWindow.options = undefined;
+            callsWidgetWindow.getViewURL = jest.fn().mockReturnValue(undefined);
+            WebContentsManager.getServerURLByViewId.mockReturnValue(undefined);
+
+            await expect(callsWidgetWindow.handleGetDesktopSources({sender: {id: 3}}, null)).rejects.toThrow('serverURL not found');
+        });
+
         it('macos - no permissions', async () => {
             const originalPlatform = process.platform;
             Object.defineProperty(process, 'platform', {

--- a/src/app/callsWidgetWindow.ts
+++ b/src/app/callsWidgetWindow.ts
@@ -454,7 +454,7 @@ export class CallsWidgetWindow {
             }
         }
 
-        const serverURL = this.getViewURL();
+        const serverURL = this.getViewURL() ?? WebContentsManager.getServerURLByViewId(view.id);
         if (!serverURL) {
             throw new Error('handleGetDesktopSources: serverURL not found');
         }


### PR DESCRIPTION
#### Summary

[PR #3135](https://github.com/mattermost/desktop/pull/3135) added support for non-Calls plugins to request desktop screen sharing sources. The multi-view architecture refactor inadvertently broke this by depending on an active Call, meaning non-Calls plugins would always fail with a "serverURL not found" error when no call is in progress.

This PR restores the original behavior by falling back to the requesting view's own server URL when no Calls call is active. When a call is active the existing resolution path is used unchanged, so Calls behavior is unaffected.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67952

#### Release Note

```release-note
Fixed an issue where plugins other than Calls could not request desktop screen sharing sources.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** This is a minimal, defensive fallback fix for a previously broken code path. The change is isolated to a single method with a one-line modification using a nullish coalescing operator, ensuring backward compatibility. Comprehensive test coverage has been added for both success and error cases of the fallback logic.

**Regression Risk:** Very low. The fallback mechanism (`??`) only activates when `getViewURL()` returns undefined, preserving existing Calls behavior completely unchanged. The fix restores previously working functionality rather than introducing new logic. All existing validation checks remain in place. The change has been tested against both scenarios: when the fallback view URL exists and when it doesn't.

**QA Recommendation:** Minimal manual QA required. Test screen sharing requests from both Calls plugins (to ensure no regression) and non-Calls plugins (to verify the fix works). The isolated scope and defensive nature of the change make it very low-risk to deploy. Automated test coverage is already in place for both paths.

## Release Notes

Fixed an issue where plugins other than Calls could not request desktop screen sharing sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->