### PR TITLE
Fix theme source not resetting when using system theme

### DIFF
--- a/src/main/themeManager.ts
+++ b/src/main/themeManager.ts
@@ -118,7 +118,10 @@ export class ThemeManager {
             });
             return;
         }
-        if (!server.theme.isUsingSystemTheme) {
+        if (server.theme.isUsingSystemTheme) {
+            // Ensure we reset the theme source in case the user is switching themes
+            this.resetThemeSource();
+        } else {
             const themeSource = isLightColor(server.theme.centerChannelBg) ? 'light' : 'dark';
             if (nativeTheme.themeSource !== themeSource) {
                 nativeTheme.themeSource = themeSource;


### PR DESCRIPTION
## Summary
- Fixed an inverted condition in `ThemeManager` where `isUsingSystemTheme` was negated, preventing `resetThemeSource()` from being called when the user switches to the system theme
- Now correctly resets the theme source when the system theme is active and applies the custom theme source only when the system theme is not in use

## Test plan
- [ ] Set a server theme, then switch to "Use system theme" — verify the desktop app follows the OS dark/light mode
- [ ] Switch from system theme to a custom theme — verify the desktop app applies the correct light/dark mode based on the center channel background color
- [ ] Toggle between system and custom themes multiple times to ensure no stale state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change corrects an inverted conditional in `updateMainViews()`, flipping when `resetThemeSource()` is called based on the `isUsingSystemTheme` flag. While the code modification is minimal and isolated to a single method, it addresses a logic bug that affects user-facing theme behavior. Potential risks include: (1) if existing workarounds or dependencies exist around the broken behavior, this fix could surface unexpected issues; (2) theme state transitions between system and custom themes need to work correctly across both main and popout views; (3) the fix changes the path through which `nativeTheme.themeSource` gets updated, which could have side effects with Electron's native theme handling if there are edge cases not covered by tests.

**QA Recommendation:** Manual QA is essential. Verify both code paths thoroughly following the test plan provided in the PR: confirm system theme correctly follows OS dark/light mode changes, verify custom theme application uses proper light/dark modes based on server colors, and stress-test repeated toggling between system and custom themes. A test file exists (`src/main/themeManager.test.js`), but coverage verification is recommended to ensure both conditional branches are tested. Pay particular attention to theme persistence and visual consistency when switching between themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->