### PR TITLE
Separate update latest version script from the normal release script

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -196,17 +196,8 @@ jobs:
         run: |
           mkdir -p ./aws-s3-dist
           cp -r --backup=numbered ./build/{macos-release,win-release,linux}/* ./aws-s3-dist
-      - name: release/generate-latest-version
-        id: generate-latest
-        run: |
-          bash -x ./scripts/generate_latest_version.sh
       - name: release/upload-to-s3
         run: aws s3 cp ./aws-s3-dist/ s3://${{ secrets.MM_DESKTOP_RELEASE_BUCKET }} --cache-control "no-cache" --recursive
-      - name: release/upload-latest-version
-        env:
-          FILENAME: ${{ steps.generate-latest.outputs.FILENAME }}
-          BUCKET: ${{ secrets.MM_DESKTOP_RELEASE_BUCKET }}
-        run: aws s3 cp ./"$FILENAME" "s3://${BUCKET}${FILENAME}" --cache-control "no-cache"
 
   github-release:
     runs-on: ubuntu-22.04

--- a/.github/workflows/update-latest-version.yml
+++ b/.github/workflows/update-latest-version.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Branch to read the version from (e.g. release-6.3)'
+        description: 'Branch to read the version from: master or release-X.Y'
         required: true
         type: string
 
@@ -21,7 +21,18 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      REF: ${{ inputs.ref }}
     steps:
+      # This is a lightweight guard to ensure the input ref is valid.
+      - name: Verify input ref
+        run: |
+          if ! [[ "$REF" == "master" || "$REF" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Input ref must be master or release-X.Y (got '${REF}')"
+            exit 1
+          fi
+          echo "OK: Input ref is valid ($REF)"
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/update-latest-version.yml
+++ b/.github/workflows/update-latest-version.yml
@@ -1,0 +1,44 @@
+name: Update Latest Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch to read the version from (e.g. release-6.3)'
+        required: true
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  TERM: xterm
+
+jobs:
+  update-latest-version:
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup AWS credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.MM_DESKTOP_RELEASE_AWS_ROLE_TO_ASSUME }}
+
+      - name: Generate latest version file
+        id: generate-latest
+        run: bash -x ./scripts/generate_latest_version.sh
+
+      - name: Upload latest version to S3
+        env:
+          FILENAME: ${{ steps.generate-latest.outputs.FILENAME }}
+          BUCKET: ${{ secrets.MM_DESKTOP_RELEASE_BUCKET }}
+        run: aws s3 cp ./"$FILENAME" "s3://${BUCKET}${FILENAME}" --cache-control "no-cache"


### PR DESCRIPTION
#### Summary
Separate update latest version script from the normal release script

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change isolates the "update latest version" flow into a new manual `workflow_dispatch` workflow and removes the automated generation/upload step from the release workflow. Code regression risk is low because production code is untouched and the generate script is unchanged; however, process/regression risk is moderate since failing to manually trigger the new workflow after releases can leave S3-hosted version file(s) stale and affect consumers relying on latest-version endpoints.

**QA Recommendation:** Light manual QA recommended: verify the new workflow input validation, manually trigger `Update Latest Version` with representative refs (master and a release-X.Y) to confirm the script generates the expected filename and uploads to the correct S3 path, and validate AWS role assumption and bucket permissions. Also update release runbooks/checklists to ensure the manual step is executed post-release.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->