### PR TITLE
[MM-68250] Fix stuck mention badge when removing a server with unreads

### DIFF
--- a/src/common/appState.ts
+++ b/src/common/appState.ts
@@ -8,9 +8,11 @@ import {
     UPDATE_APPSTATE_TOTALS,
     UPDATE_APPSTATE_FOR_VIEW_ID,
     SERVER_LOGGED_IN_CHANGED,
+    SERVER_REMOVED,
     UPDATE_APPSTATE_FOR_SERVER_ID,
 } from 'common/communication';
 import {Logger} from 'common/log';
+import type {MattermostServer} from 'common/servers/MattermostServer';
 import ServerManager from 'common/servers/serverManager';
 import ViewManager from 'common/views/viewManager';
 
@@ -35,12 +37,20 @@ export class AppState extends EventEmitter {
         this.unreadsPerServer = new Map();
 
         ServerManager.on(SERVER_LOGGED_IN_CHANGED, this.handleServerLoggedInChanged);
+        ServerManager.on(SERVER_REMOVED, this.handleServerRemoved);
     }
 
     private handleServerLoggedInChanged = (serverId: string, loggedIn: boolean) => {
         if (!loggedIn) {
             this.clearServer(serverId);
         }
+    };
+
+    private handleServerRemoved = (server: MattermostServer) => {
+        this.expired.delete(server.id);
+        this.mentionsPerServer.delete(server.id);
+        this.unreadsPerServer.delete(server.id);
+        this.emitStatusForServer(server.id);
     };
 
     getExpired = () => {

--- a/src/renderer/components/MainPage.tsx
+++ b/src/renderer/components/MainPage.tsx
@@ -280,10 +280,18 @@ class MainPage extends React.PureComponent<Props, State> {
             const {mentionsPerServer, unreadsPerServer} = this.state;
 
             const newMentionsPerServer = {...mentionsPerServer};
-            newMentionsPerServer[serverId] = mentions || 0;
+            if (mentions) {
+                newMentionsPerServer[serverId] = mentions;
+            } else {
+                delete newMentionsPerServer[serverId];
+            }
 
             const newUnreadsPerServer = {...unreadsPerServer};
-            newUnreadsPerServer[serverId] = unreads || false;
+            if (unreads) {
+                newUnreadsPerServer[serverId] = unreads;
+            } else {
+                delete newUnreadsPerServer[serverId];
+            }
 
             this.setState({mentionsPerServer: newMentionsPerServer, unreadsPerServer: newUnreadsPerServer});
         });

--- a/src/renderer/components/MainPage.tsx
+++ b/src/renderer/components/MainPage.tsx
@@ -513,8 +513,8 @@ class MainPage extends React.PureComponent<Props, State> {
                             isDisabled={this.state.modalOpen}
                             activeServerName={activeServer.name}
                             totalMentionCount={totalMentionCount}
-                            currentMentions={this.state.mentionsPerServer[this.state.activeServerId!]}
-                            currentUnread={this.state.unreadsPerServer[this.state.activeServerId!]}
+                            currentMentions={this.state.mentionsPerServer[this.state.activeServerId!] ?? 0}
+                            currentUnread={this.state.unreadsPerServer[this.state.activeServerId!] ?? false}
                             hasUnreads={hasAnyUnreads}
                             isMenuOpen={this.state.isMenuOpen}
                         />


### PR DESCRIPTION
#### Summary
When a server with unreads or mentions was removed, the badge got stuck because `AppState` never cleaned up its per-server maps on removal, and the renderer kept stale entries in its local state indefinitely.

This PR adds a `SERVER_REMOVED` listener in `AppState` that clears the removed server's state and emits zeroed values via `emitStatusForServer`, flowing through the existing `onUpdateMentionsForServer` path in the renderer. The renderer now deletes entries at 0/false instead of preserving them.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68250

#### Release Note
```release-note
Fixed an issue where removing a server with unreads or mentions caused the badge indicator to become stuck until the app was restarted.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes introduce deletion of state entries (`delete newMentionsPerServer[serverId]`) when values are falsy in the renderer, which is a semantic shift from the previous behavior of preserving entries with default values. While this is a defensive change that only affects the server removal flow, there is potential for regression if other components depend on these keys always being present in the state objects. The AppState deletion logic is straightforward (deleting from Maps and re-emitting), but the state flow spans multiple layers (AppState → MainWindow → Renderer) with limited test coverage specifically for the cleanup scenario after server removal. The nullish coalescing operators (`??`) in ServerDropdownButton provide fallbacks, but edge cases around concurrent state updates during server removal are not explicitly tested.

**QA Recommendation:** Manual QA should focus on: (1) adding and removing a server with active mentions/unreads while monitoring badge state for stale indicators, (2) removing servers while unreads are being received, (3) switching between servers before/after removal, and (4) verifying badge counts return to 0/empty state immediately after server removal. Automated test coverage should be added for the complete cleanup flow (server removal → badge state zeroing → badge UI update) to prevent regression.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->