### PR TITLE
Update view names when server name changes

### DIFF
--- a/src/common/views/viewManager.test.js
+++ b/src/common/views/viewManager.test.js
@@ -10,6 +10,7 @@ import {
     VIEW_REMOVED,
     SERVER_ADDED,
     SERVER_REMOVED,
+    SERVER_NAME_CHANGED,
 } from 'common/communication';
 import ServerManager from 'common/servers/serverManager';
 import {ViewType} from 'common/views/MattermostView';
@@ -250,6 +251,53 @@ describe('ViewManager', () => {
             ServerManager.mockServerManager.emit(SERVER_ADDED, mockServer.id, true);
 
             expect(createViewSpy).toHaveBeenCalledWith(mockServer, ViewType.TAB);
+        });
+    });
+
+    describe('handleServerNameChanged', () => {
+        it('should update serverName on all views for that server', () => {
+            const viewManager = new ViewManager();
+            const view1 = viewManager.createView(mockServer, ViewType.TAB);
+            const view2 = viewManager.createView(mockServer, ViewType.TAB);
+            viewManager.updateViewTitle(view1.id, 'Channel 1', 'Team 1');
+
+            ServerManager.getServer.mockReturnValue({...mockServer, name: 'Renamed Server'});
+            const emitSpy = jest.spyOn(viewManager, 'emit');
+
+            ServerManager.mockServerManager.emit(SERVER_NAME_CHANGED, mockServer.id);
+
+            expect(view1.title.serverName).toBe('Renamed Server');
+            expect(view1.title.channelName).toBe('Channel 1');
+            expect(view1.title.teamName).toBe('Team 1');
+            expect(view2.title.serverName).toBe('Renamed Server');
+            expect(emitSpy).toHaveBeenCalledWith(VIEW_TITLE_UPDATED, view1.id);
+            expect(emitSpy).toHaveBeenCalledWith(VIEW_TITLE_UPDATED, view2.id);
+
+            ServerManager.getServer.mockReturnValue(mockServer);
+        });
+
+        it('should not update views for other servers', () => {
+            const viewManager = new ViewManager();
+            const otherServer = {
+                id: 'other-server-id',
+                name: 'Other Server',
+                url: new URL('https://other.com'),
+                initialLoadURL: new URL('https://other.com'),
+            };
+            const view1 = viewManager.createView(mockServer, ViewType.TAB);
+            const view2 = viewManager.createView(otherServer, ViewType.TAB);
+
+            ServerManager.getServer.mockReturnValue({...mockServer, name: 'Renamed Server'});
+            const emitSpy = jest.spyOn(viewManager, 'emit');
+
+            ServerManager.mockServerManager.emit(SERVER_NAME_CHANGED, mockServer.id);
+
+            expect(view1.title.serverName).toBe('Renamed Server');
+            expect(view2.title.serverName).toBe('Other Server');
+            expect(emitSpy).toHaveBeenCalledWith(VIEW_TITLE_UPDATED, view1.id);
+            expect(emitSpy).not.toHaveBeenCalledWith(VIEW_TITLE_UPDATED, view2.id);
+
+            ServerManager.getServer.mockReturnValue(mockServer);
         });
     });
 

--- a/src/common/views/viewManager.ts
+++ b/src/common/views/viewManager.ts
@@ -12,6 +12,7 @@ import {
     VIEW_REMOVED,
     SERVER_ADDED,
     SERVER_REMOVED,
+    SERVER_NAME_CHANGED,
     VIEW_TYPE_REMOVED,
     VIEW_TYPE_ADDED,
 } from 'common/communication';
@@ -35,6 +36,7 @@ export class ViewManager extends EventEmitter {
 
         ServerManager.on(SERVER_REMOVED, this.handleServerWasRemoved);
         ServerManager.on(SERVER_ADDED, this.handleServerWasAdded);
+        ServerManager.on(SERVER_NAME_CHANGED, this.handleServerNameChanged);
     }
 
     getView = (id: string) => {
@@ -209,6 +211,25 @@ export class ViewManager extends EventEmitter {
             return new Logger(...additionalPrefixes, viewId);
         }
         return new Logger(...additionalPrefixes, server.id, viewId);
+    };
+
+    private handleServerNameChanged = (serverId: string) => {
+        log.debug('handleServerNameChanged', {serverId});
+
+        const server = ServerManager.getServer(serverId);
+        if (!server) {
+            return;
+        }
+
+        this.views.forEach((view) => {
+            if (view.serverId === serverId) {
+                view.title = {
+                    ...view.title,
+                    serverName: server.name,
+                };
+                this.emit(VIEW_TITLE_UPDATED, view.id);
+            }
+        });
     };
 
     private handleServerWasRemoved = (server: MattermostServer) => {


### PR DESCRIPTION
#### Summary
The server name stored on each view is only set when the view is created and never refreshed on rename. This PR has the `ViewManager` listen for server name changes and propagate the updated name to all views for that server.

#### Release Note
```release-note
Fixed an issue where renaming a server while not logged in did not update the tab title.
```