### PR TITLE
[GH-3768] Pass raw URL directly to shell.openExternal after confirming protocol

### DIFF
--- a/src/app/views/pluginsPopUps.test.js
+++ b/src/app/views/pluginsPopUps.test.js
@@ -136,7 +136,7 @@ describe('PluginsPopUpsManager', () => {
 
         // Verify opening custom protocols is handled through allowProtocolDialog
         expect(handlers['window-open']({url: 'custom:somelink'})).toEqual({action: 'deny'});
-        expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(new URL('custom:somelink'));
+        expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith('custom:somelink');
         expect(shell.openExternal).not.toHaveBeenCalledWith('custom:somelink');
 
         // Verify opening external links is allowed through browser

--- a/src/app/views/pluginsPopUps.ts
+++ b/src/app/views/pluginsPopUps.ts
@@ -79,7 +79,7 @@ export class PluginsPopUpsManager {
 
             // Check for custom protocol
             if (isCustomProtocol(parsedURL)) {
-                allowProtocolDialog.handleDialogEvent(parsedURL);
+                allowProtocolDialog.handleDialogEvent(url);
                 return {action: 'deny'};
             }
 

--- a/src/app/views/webContentEvents.test.js
+++ b/src/app/views/webContentEvents.test.js
@@ -183,8 +183,9 @@ describe('main/views/webContentsEvents', () => {
         });
 
         it('should divert to allowProtocolDialog for custom protocols that are not mattermost or http', () => {
-            expect(newWindow({url: 'spotify:album:2OZbaW9tgO62ndm375lFZr'})).toStrictEqual({action: 'deny'});
-            expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(new URL('spotify:album:2OZbaW9tgO62ndm375lFZr'));
+            const url = 'spotify:album:2OZbaW9tgO62ndm375lFZr';
+            expect(newWindow({url})).toStrictEqual({action: 'deny'});
+            expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(url);
         });
 
         describe('should block malicious URLs', () => {
@@ -192,7 +193,7 @@ describe('main/views/webContentsEvents', () => {
                 const maliciousUrl = String.raw`customproto:///" --data-dir "\\deans-mbp\mattermost`;
                 expect(newWindow({url: maliciousUrl})).toStrictEqual({action: 'deny'});
                 expect(shell.openExternal).not.toBeCalled();
-                expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(new URL(maliciousUrl));
+                expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(maliciousUrl);
             });
 
             it('should reject UNC paths with no scheme and show dialog', () => {
@@ -204,9 +205,10 @@ describe('main/views/webContentsEvents', () => {
             });
 
             it('should route file: protocol through confirmation dialog', () => {
-                expect(newWindow({url: 'file:///etc/passwd'})).toStrictEqual({action: 'deny'});
+                const url = 'file:///etc/passwd';
+                expect(newWindow({url})).toStrictEqual({action: 'deny'});
                 expect(shell.openExternal).not.toBeCalled();
-                expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(new URL('file:///etc/passwd'));
+                expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(url);
             });
 
             it('should reject URLs with literal null bytes and show dialog', () => {
@@ -233,33 +235,38 @@ describe('main/views/webContentsEvents', () => {
 
         describe('should sanitize shell-relevant characters via serialization', () => {
             it('should percent-encode backticks', () => {
-                expect(newWindow({url: 'customproto:///path/`whoami`'})).toStrictEqual({action: 'deny'});
+                const url = 'customproto:///path/`whoami`';
+                expect(newWindow({url})).toStrictEqual({action: 'deny'});
                 expect(shell.openExternal).not.toBeCalled();
-                expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(new URL('customproto:///path/`whoami`'));
+                expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(url);
             });
 
             it('should encode spaces in $() shell expansion patterns', () => {
-                expect(newWindow({url: 'customproto:///$(curl evil.com)'})).toStrictEqual({action: 'deny'});
+                const url = 'customproto:///$(curl evil.com)';
+                expect(newWindow({url})).toStrictEqual({action: 'deny'});
                 expect(shell.openExternal).not.toBeCalled();
-                expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(new URL('customproto:///$(curl evil.com)'));
+                expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(url);
             });
 
             it('should preserve double-encoded values without double-decoding', () => {
-                expect(newWindow({url: 'customproto:///path%2520with%2520spaces'})).toStrictEqual({action: 'deny'});
+                const url = 'customproto:///path%2520with%2520spaces';
+                expect(newWindow({url})).toStrictEqual({action: 'deny'});
                 expect(shell.openExternal).not.toBeCalled();
-                expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(new URL('customproto:///path%2520with%2520spaces'));
+                expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(url);
             });
         });
 
         describe('should handle mixed-case schemes', () => {
             it('should lowercase the scheme for ONENOTE:', () => {
-                expect(newWindow({url: 'ONENOTE:///path'})).toStrictEqual({action: 'deny'});
-                expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(new URL('ONENOTE:///path'));
+                const url = 'ONENOTE:///path';
+                expect(newWindow({url})).toStrictEqual({action: 'deny'});
+                expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(url);
             });
 
             it('should lowercase the scheme for mixed case OneNote:', () => {
-                expect(newWindow({url: 'OneNote:///path'})).toStrictEqual({action: 'deny'});
-                expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(new URL('OneNote:///path'));
+                const url = 'OneNote:///path';
+                expect(newWindow({url})).toStrictEqual({action: 'deny'});
+                expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(url);
             });
         });
 
@@ -267,25 +274,25 @@ describe('main/views/webContentsEvents', () => {
             it('should allow OneNote URLs with curly braces', () => {
                 const onenoteUrl = 'onenote:///D:/OneNote/Apps/Test.one#Page&page-id={840EDD0C-B6FB-481E-A342-E39AEDA50EE6}';
                 expect(newWindow({url: onenoteUrl})).toStrictEqual({action: 'deny'});
-                expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(new URL(onenoteUrl));
+                expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(onenoteUrl);
             });
 
             it('should allow OneNote URLs with backslashes', () => {
                 const onenoteUrl = String.raw`onenote:///D:\OneNote\Apps\Mattermost.one#Sch%C3%B6ne%20neue%20Seite&page-id={840EDD0C-B6FB-481E-A342-E39AEDA50EE6}`;
                 expect(newWindow({url: onenoteUrl})).toStrictEqual({action: 'deny'});
-                expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(new URL(onenoteUrl));
+                expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(onenoteUrl);
             });
 
             it('should allow OneNote URLs with unicode and emoji', () => {
                 const onenoteUrl = 'onenote:///C:/notebook/section.one#Schöne%20Seite%20🌞';
                 expect(newWindow({url: onenoteUrl})).toStrictEqual({action: 'deny'});
-                expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(new URL(onenoteUrl));
+                expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(onenoteUrl);
             });
 
             it('should allow SharePoint URLs', () => {
                 const sharepointUrl = 'ms-word:ofe|u|https://company.sharepoint.com/sites/team/Documents/file.docx';
                 expect(newWindow({url: sharepointUrl})).toStrictEqual({action: 'deny'});
-                expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(new URL(sharepointUrl));
+                expect(allowProtocolDialog.handleDialogEvent).toBeCalledWith(sharepointUrl);
             });
         });
 

--- a/src/app/views/webContentEvents.ts
+++ b/src/app/views/webContentEvents.ts
@@ -116,7 +116,7 @@ export class WebContentsEventManager {
             }
 
             if (isCustomProtocol(parsedURL)) {
-                allowProtocolDialog.handleDialogEvent(parsedURL).catch((err) => {
+                allowProtocolDialog.handleDialogEvent(url).catch((err) => {
                     this.log(webContentsId).warn('Error handling custom protocol dialog', err);
                 });
                 event.preventDefault();
@@ -168,7 +168,7 @@ export class WebContentsEventManager {
 
             // Check for other custom protocols
             if (isCustomProtocol(parsedURL)) {
-                allowProtocolDialog.handleDialogEvent(parsedURL).catch((err) => {
+                allowProtocolDialog.handleDialogEvent(details.url).catch((err) => {
                     this.log(webContentsId).warn('Error handling custom protocol dialog', err);
                 });
                 return {action: 'deny'};

--- a/src/main/security/allowProtocolDialog.test.js
+++ b/src/main/security/allowProtocolDialog.test.js
@@ -134,13 +134,23 @@ describe('main/allowProtocolDialog', () => {
         });
 
         it('should open protocol that is already allowed', () => {
-            allowProtocolDialog.handleDialogEvent(new URL('spotify:album:3AQgdwMNCiN7awXch5fAaG'));
+            allowProtocolDialog.handleDialogEvent('spotify:album:3AQgdwMNCiN7awXch5fAaG');
             expect(shell.openExternal).toBeCalledWith('spotify:album:3AQgdwMNCiN7awXch5fAaG');
+        });
+
+        it('should preserve the original URL with embedded scheme colons', async () => {
+            const promise = Promise.resolve({response: 0});
+            MainWindow.get.mockImplementation(() => ({}));
+            dialog.showMessageBox.mockImplementation(() => promise);
+            allowProtocolDialog.handleDialogEvent('myapp://https://myapp.com/v/13123123123');
+            await promise;
+
+            expect(shell.openExternal).toBeCalledWith('myapp://https://myapp.com/v/13123123123');
         });
 
         it('should not open message box if main window is missing', () => {
             MainWindow.get.mockImplementation(() => null);
-            allowProtocolDialog.handleDialogEvent(new URL('mattermost://community.mattermost.com'));
+            allowProtocolDialog.handleDialogEvent('mattermost://community.mattermost.com');
             expect(shell.openExternal).not.toBeCalled();
             expect(dialog.showMessageBox).not.toBeCalled();
         });
@@ -153,7 +163,7 @@ describe('main/allowProtocolDialog', () => {
             it('should open the window but not save when clicking Yes', async () => {
                 const promise = Promise.resolve({response: 0});
                 dialog.showMessageBox.mockImplementation(() => promise);
-                allowProtocolDialog.handleDialogEvent(new URL('mattermost://community.mattermost.com'));
+                allowProtocolDialog.handleDialogEvent('mattermost://community.mattermost.com');
                 await promise;
 
                 expect(shell.openExternal).toBeCalledWith('mattermost://community.mattermost.com');
@@ -164,7 +174,7 @@ describe('main/allowProtocolDialog', () => {
             it('should open the window and save when clicking Yes and Save', async () => {
                 const promise = Promise.resolve({response: 1});
                 dialog.showMessageBox.mockImplementation(() => promise);
-                allowProtocolDialog.handleDialogEvent(new URL('mattermost://community.mattermost.com'));
+                allowProtocolDialog.handleDialogEvent('mattermost://community.mattermost.com');
                 await promise;
 
                 expect(shell.openExternal).toBeCalledWith('mattermost://community.mattermost.com');
@@ -175,7 +185,7 @@ describe('main/allowProtocolDialog', () => {
             it('should do nothing when clicking No', async () => {
                 const promise = Promise.resolve({response: 2});
                 dialog.showMessageBox.mockImplementation(() => promise);
-                allowProtocolDialog.handleDialogEvent(new URL('mattermost://community.mattermost.com'));
+                allowProtocolDialog.handleDialogEvent('mattermost://community.mattermost.com');
                 await promise;
 
                 expect(shell.openExternal).not.toBeCalled();
@@ -187,7 +197,7 @@ describe('main/allowProtocolDialog', () => {
                 const promise = Promise.resolve({response: 0});
                 dialog.showMessageBox.mockImplementation(() => promise);
                 shell.openExternal.mockReturnValue(Promise.reject(new Error('bad protocol')));
-                allowProtocolDialog.handleDialogEvent(new URL('bad-protocol://community.mattermost.com'));
+                allowProtocolDialog.handleDialogEvent('bad-protocol://community.mattermost.com');
                 await promise;
 
                 expect(shell.openExternal).toBeCalledWith('bad-protocol://community.mattermost.com');
@@ -213,7 +223,7 @@ describe('main/allowProtocolDialog', () => {
             ['ms-appinstaller://example.com/package.appinstaller'],
             ['ms-officecmd://example.com/open?url=file.docx'],
         ])('should silently block %s without opening dialog or shell', async (urlStr) => {
-            await allowProtocolDialog.handleDialogEvent(new URL(urlStr));
+            await allowProtocolDialog.handleDialogEvent(urlStr);
 
             expect(dialog.showMessageBox).not.toBeCalled();
             expect(shell.openExternal).not.toBeCalled();

--- a/src/main/security/allowProtocolDialog.ts
+++ b/src/main/security/allowProtocolDialog.ts
@@ -8,6 +8,7 @@ import {dialog, shell} from 'electron';
 
 import buildConfig from 'common/config/buildConfig';
 import {Logger} from 'common/log';
+import {parseURL} from 'common/utils/url';
 import * as Validator from 'common/Validator';
 import {localizeMessage} from 'main/i18nManager';
 
@@ -60,9 +61,12 @@ export class AllowProtocolDialog {
         }
     };
 
-    handleDialogEvent = async (url: URL) => {
-        const protocol = url.protocol;
-        const serializedURL = url.toString();
+    handleDialogEvent = async (url: string) => {
+        const parsedURL = parseURL(url);
+        if (!parsedURL) {
+            return;
+        }
+        const protocol = parsedURL.protocol;
 
         if (BLOCKED_PROTOCOLS.has(protocol)) {
             log.warn(`Blocked attempt to open dangerous protocol: ${protocol}`);
@@ -71,7 +75,7 @@ export class AllowProtocolDialog {
 
         try {
             if (this.allowedProtocols.indexOf(protocol) !== -1) {
-                await shell.openExternal(serializedURL);
+                await shell.openExternal(url);
                 return;
             }
             const mainWindow = MainWindow.get();
@@ -81,7 +85,7 @@ export class AllowProtocolDialog {
             const {response} = await dialog.showMessageBox(mainWindow, {
                 title: localizeMessage('main.allowProtocolDialog.title', 'Non http(s) protocol'),
                 message: localizeMessage('main.allowProtocolDialog.message', '{protocol} link requires an external application.', {protocol}),
-                detail: localizeMessage('main.allowProtocolDialog.detail', 'The requested link is {URL}. Do you want to continue?', {URL: serializedURL}),
+                detail: localizeMessage('main.allowProtocolDialog.detail', 'The requested link is {URL}. Do you want to continue?', {URL: url}),
                 defaultId: 2,
                 type: 'warning',
                 buttons: [
@@ -102,11 +106,11 @@ export class AllowProtocolDialog {
                     }
                 }
                 fs.writeFile(allowedProtocolFile, JSON.stringify(this.allowedProtocols), handleError);
-                await shell.openExternal(serializedURL);
+                await shell.openExternal(url);
                 break;
             }
             case 0:
-                await shell.openExternal(serializedURL);
+                await shell.openExternal(url);
                 break;
             }
         } catch (error) {


### PR DESCRIPTION
#### Summary
A change in #3716 switched `AllowProtocolDialog.handleDialogEvent` from accepting the original URL string to accepting a parsed WHATWG `URL` object, then calling `.toString()` before passing it to `shell.openExternal`. For non-standard protocol schemes, WHATWG URL serialization can alter the URL in ways that break the target application's ability to interpret it.

This PR changes `handleDialogEvent` back to accepting the raw URL string and only parses it internally to extract the protocol for security checks (blocked protocol list, allowlist). The unmodified string is passed to `shell.openExternal` and shown in the confirmation dialog.

#### Ticket Link
Fixes https://github.com/mattermost/desktop/issues/3768

#### Release Note
```release-note
Fixed an issue where clicking custom protocol links could open the target application with a malformed URL.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟠 Medium

**Regression Risk:** 
The changes modify a security-sensitive code path (custom protocol handling) by altering how the `handleDialogEvent` method processes URLs. While the revert is straightforward and tests have been comprehensively updated across all affected modules (allowProtocolDialog, webContentEvents, pluginsPopUps—820 lines of test coverage total), there is inherent risk when modifying protocol security validation logic. The public API signature changed (`URL` → `string`), and the security checks (BLOCKED_PROTOCOLS list, allowlist validation) remain in place but operate on parsed URLs internally rather than receiving pre-parsed objects. Any gaps in test scenarios for non-standard protocol formats could allow malformed URLs to bypass checks or fail at the `shell.openExternal` layer.

**QA Recommendation:**
Manual QA should focus on: (1) Custom/non-standard protocol link handling across various formats (e.g., `myapp://https://...`, `custom:path`, complex parameter strings); (2) Verification that target applications receive the correct unmodified URL string; (3) Blocked protocol enforcement (file://, javascript:, etc.) still functions correctly; (4) Mixed-case protocol schemes and edge-case URL formats. Given that comprehensive tests cover these scenarios and the fix is a controlled revert of a known problematic change, manual QA can be focused rather than exhaustive, with emphasis on real-world custom protocol links used in the Mattermost ecosystem.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->