### PR TITLE
Add a copy email address context menu item

### DIFF
--- a/src/app/views/MattermostWebContentsView.test.js
+++ b/src/app/views/MattermostWebContentsView.test.js
@@ -3,6 +3,8 @@
 
 'use strict';
 
+import {clipboard} from 'electron';
+
 import AppState from 'common/appState';
 import {LOAD_FAILED, UPDATE_TARGET_URL} from 'common/communication';
 import {MattermostServer} from 'common/servers/MattermostServer';
@@ -10,6 +12,7 @@ import ServerManager from 'common/servers/serverManager';
 import {MattermostView, ViewType} from 'common/views/MattermostView';
 import ViewManager from 'common/views/viewManager';
 import {updateServerInfos} from 'main/app/utils';
+import {localizeMessage} from 'main/i18nManager';
 import {getServerAPI} from 'main/server/serverAPI';
 
 import {MattermostWebContentsView} from './MattermostWebContentsView';
@@ -21,6 +24,9 @@ jest.mock('electron', () => ({
     app: {
         getVersion: () => '5.0.0',
         getPath: jest.fn(() => '/valid/downloads/path'),
+    },
+    clipboard: {
+        writeText: jest.fn(),
     },
     WebContentsView: jest.fn().mockImplementation(() => ({
         webContents: {
@@ -98,6 +104,7 @@ jest.mock('main/server/serverAPI', () => ({
     getServerAPI: jest.fn(),
 }));
 jest.mock('common/views/viewManager', () => ({
+    isViewLimitReached: jest.fn(),
     updateViewTitle: jest.fn(),
     getViewLog: jest.fn().mockReturnValue({
         info: jest.fn(),
@@ -331,6 +338,39 @@ describe('main/views/MattermostWebContentsView', () => {
             mattermostView.updateHistoryButton();
             expect(mattermostView.webContentsView.webContents.navigationHistory.clear).toHaveBeenCalled();
             expect(mattermostView.isAtRoot).toBe(true);
+        });
+    });
+
+    describe('generateContextMenu', () => {
+        const window = {on: jest.fn(), webContents: {send: jest.fn()}};
+        const mattermostView = new MattermostWebContentsView(view, {}, window);
+
+        beforeEach(() => {
+            ServerManager.getServer.mockReturnValue(server);
+            localizeMessage.mockImplementation((id, defaultMessage) => defaultMessage);
+            clipboard.writeText.mockClear();
+        });
+
+        it('should add copy email address item for mailto links', () => {
+            const contextMenuOptions = mattermostView.generateContextMenu();
+            const menuItems = contextMenuOptions.prepend(null, {
+                linkURL: 'mailto:first%40mattermost.com,second%40mattermost.com?subject=Hello',
+            });
+
+            expect(menuItems).toHaveLength(1);
+            expect(menuItems[0].label).toBe('Copy Email Address');
+
+            menuItems[0].click();
+            expect(clipboard.writeText).toHaveBeenCalledWith('first@mattermost.com,second@mattermost.com');
+        });
+
+        it('should not add copy email address item for non-mailto links', () => {
+            const contextMenuOptions = mattermostView.generateContextMenu();
+            const menuItems = contextMenuOptions.prepend(null, {
+                linkURL: 'https://mattermost.com',
+            });
+
+            expect(menuItems).toEqual([]);
         });
     });
 

--- a/src/app/views/MattermostWebContentsView.test.js
+++ b/src/app/views/MattermostWebContentsView.test.js
@@ -351,26 +351,33 @@ describe('main/views/MattermostWebContentsView', () => {
             clipboard.writeText.mockClear();
         });
 
-        it('should add copy email address item for mailto links', () => {
+        it('should place copy email address right after copy link for mailto links', () => {
             const contextMenuOptions = mattermostView.generateContextMenu();
-            const menuItems = contextMenuOptions.prepend(null, {
+            const defaultActions = {
+                copyLink: jest.fn().mockReturnValue({label: 'Copy Link'}),
+            };
+            const menuItems = contextMenuOptions.append(defaultActions, {
                 linkURL: 'mailto:first%40mattermost.com,second%40mattermost.com?subject=Hello',
             });
 
-            expect(menuItems).toHaveLength(1);
-            expect(menuItems[0].label).toBe('Copy Email Address');
+            expect(menuItems).toHaveLength(2);
+            expect(menuItems[0].label).toBe('Copy Link');
+            expect(menuItems[1].label).toBe('Copy Email Address');
 
-            menuItems[0].click();
+            menuItems[1].click();
             expect(clipboard.writeText).toHaveBeenCalledWith('first@mattermost.com,second@mattermost.com');
         });
 
-        it('should not add copy email address item for non-mailto links', () => {
+        it('should keep copy link without adding copy email address for non-mailto links', () => {
             const contextMenuOptions = mattermostView.generateContextMenu();
-            const menuItems = contextMenuOptions.prepend(null, {
+            const defaultActions = {
+                copyLink: jest.fn().mockReturnValue({label: 'Copy Link'}),
+            };
+            const menuItems = contextMenuOptions.append(defaultActions, {
                 linkURL: 'https://mattermost.com',
             });
 
-            expect(menuItems).toEqual([]);
+            expect(menuItems).toEqual([{label: 'Copy Link'}]);
         });
     });
 

--- a/src/app/views/MattermostWebContentsView.ts
+++ b/src/app/views/MattermostWebContentsView.ts
@@ -501,23 +501,23 @@ export class MattermostWebContentsView extends EventEmitter {
         }
 
         return {
-            prepend: (_, parameters) => {
+            showCopyLink: false,
+            append: (defaultActions, parameters) => {
+                const items = [defaultActions.copyLink({})];
+
                 const emailAddress = getEmailAddressFromMailtoLink(parameters.linkURL);
-                if (!emailAddress) {
-                    return [];
+                if (emailAddress) {
+                    items.push({
+                        label: localizeMessage('app.menus.contextMenu.copyEmailAddress', 'Copy Email Address'),
+                        click() {
+                            clipboard.writeText(emailAddress);
+                        },
+                    });
                 }
 
-                return [{
-                    label: localizeMessage('app.menus.contextMenu.copyEmailAddress', 'Copy Email Address'),
-                    click() {
-                        clipboard.writeText(emailAddress);
-                    },
-                }];
-            },
-            append: (_, parameters) => {
                 const parsedURL = parseURL(parameters.linkURL);
                 if (parsedURL && isInternalURL(parsedURL, server.url)) {
-                    return [
+                    items.push(
                         {
                             type: 'separator' as const,
                         },
@@ -535,9 +535,9 @@ export class MattermostWebContentsView extends EventEmitter {
                                 NavigationManager.openLinkInNewWindow(parsedURL.toString());
                             },
                         },
-                    ];
+                    );
                 }
-                return [];
+                return items;
             },
         };
     };

--- a/src/app/views/MattermostWebContentsView.ts
+++ b/src/app/views/MattermostWebContentsView.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {type BrowserWindow, WebContentsView, app, ipcMain} from 'electron';
+import {type BrowserWindow, WebContentsView, app, clipboard, ipcMain} from 'electron';
 import type {WebContentsViewConstructorOptions, Event} from 'electron/main';
 import type {Options} from 'electron-context-menu';
 import {EventEmitter} from 'events';
@@ -46,6 +46,16 @@ enum Status {
     WAITING_MM,
     ERROR = -1,
 }
+
+const getEmailAddressFromMailtoLink = (linkURL: string) => {
+    const parsedURL = parseURL(linkURL);
+    if (!parsedURL || parsedURL.protocol !== 'mailto:') {
+        return '';
+    }
+
+    return decodeURIComponent(parsedURL.pathname.replace(/^\/+/, ''));
+};
+
 export class MattermostWebContentsView extends EventEmitter {
     private view: MattermostView;
     private parentWindow: BrowserWindow;
@@ -491,6 +501,19 @@ export class MattermostWebContentsView extends EventEmitter {
         }
 
         return {
+            prepend: (_, parameters) => {
+                const emailAddress = getEmailAddressFromMailtoLink(parameters.linkURL);
+                if (!emailAddress) {
+                    return [];
+                }
+
+                return [{
+                    label: localizeMessage('app.menus.contextMenu.copyEmailAddress', 'Copy Email Address'),
+                    click() {
+                        clipboard.writeText(emailAddress);
+                    },
+                }];
+            },
             append: (_, parameters) => {
                 const parsedURL = parseURL(parameters.linkURL);
                 if (parsedURL && isInternalURL(parsedURL, server.url)) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
- add a `Copy Email Address` context menu item for `mailto:` links in server views
- place `Copy Email Address` immediately next to `Copy Link` in the desktop context menu
- keep the existing desktop-only behavior covered with focused unit tests

#### Ticket Link
- Fixes https://github.com/mattermost/desktop/issues/0

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] executed `npm run lint:js` for proper code formatting
- [ ] Run E2E tests by adding label `E2E/Run`

#### Screenshots

<img width="517" height="465" alt="image" src="https://github.com/user-attachments/assets/075ae10e-2bc7-439b-afb1-710336b72b89" />
<img width="431" height="231" alt="image" src="https://github.com/user-attachments/assets/fde483b4-5cc5-4fe1-bf4f-bd9a6d5081fe" />


#### Release Note
```release-note
Added a Copy Email Address context menu item for mailto links in the desktop app.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d605445c-bb6e-469a-9f9f-eb0968eeb174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d605445c-bb6e-469a-9f9f-eb0968eeb174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** 
- The context menu generation refactoring modifies the internal URL branch to use a shared `items` array rather than separate returns, which could introduce regressions if conditional logic flow isn't properly preserved for internal links
- New email parsing logic using `decodeURIComponent` on mailto: URLs could fail on edge cases with malformed or special character encodings not covered by the existing test cases
- The clipboard integration is new but limited to a single context menu action, minimizing side effects
- Changes are localized to context menu handling in a single view component, reducing blast radius

**QA Recommendation:** 
- Manual QA should focus on verifying context menu behavior works correctly across different link types (mailto with single/multiple recipients, standard https links, internal links)
- Test email address extraction and copying for various encodings (special characters, internationalized domains) to catch edge cases in `decodeURIComponent` parsing
- Verify internal link handling still works properly since the refactored array logic changed from separate return to appended items
- Basic cross-platform testing on at least macOS and Windows recommended given clipboard interactions
- Given E2E tests were not run per the PR checklist, consider manual end-to-end context menu interaction testing

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->