### PR TITLE
[MM-68285] Add a Copy Email Address menu item for mailto: links

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,4 +1,5 @@
 {
+  "app.menus.contextMenu.copyEmailAddress": "Copy Email Address",
   "app.menus.contextMenu.openInNewTab": "Open in new tab",
   "app.menus.contextMenu.openInNewWindow": "Open in new window",
   "app.navigationManager.invalidLinkDescription": "The link you clicked appears to be malformed and cannot be opened. Please check the URL for errors before trying again.",

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -18,6 +18,7 @@ export const UPDATE_DOWNLOAD_ITEM: Omit<DownloadedItem, 'filename' | 'state'> = 
     totalBytes: 0,
 };
 
+export const MAILTO_PREFIX = 'mailto:';
 export const MATTERMOST_PROTOCOL = 'mattermost';
 
 // Regular expressions

--- a/src/main/contextMenu.test.js
+++ b/src/main/contextMenu.test.js
@@ -2,11 +2,23 @@
 // See LICENSE.txt for license information.
 'use strict';
 
+import {clipboard} from 'electron';
+
 import ContextMenu from './contextMenu';
+
+jest.mock('electron', () => ({
+    clipboard: {
+        writeText: jest.fn(),
+    },
+}));
 
 jest.mock('electron-context-menu', () => {
     return () => jest.fn();
 });
+
+jest.mock('main/i18nManager', () => ({
+    localizeMessage: (key, defaultString) => defaultString,
+}));
 
 describe('main/contextMenu', () => {
     describe('shouldShowMenu', () => {
@@ -68,6 +80,41 @@ describe('main/contextMenu', () => {
                 selectionText: '',
                 isEditable: true,
             })).toBe(true);
+        });
+    });
+
+    describe('append', () => {
+        const mockDefaultActions = {};
+
+        beforeEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it('should return empty array for non-mailto links', () => {
+            const contextMenu = new ContextMenu({}, {webContents: {}});
+            const items = contextMenu.menuOptions.append(mockDefaultActions, {linkURL: 'https://example.com'});
+            expect(items).toHaveLength(0);
+        });
+
+        it('should include Copy Email Address for mailto links', () => {
+            const contextMenu = new ContextMenu({}, {webContents: {}});
+            const items = contextMenu.menuOptions.append(mockDefaultActions, {linkURL: 'mailto:user@example.com'});
+            expect(items).toHaveLength(1);
+            expect(items[0].label).toBe('Copy Email Address');
+
+            items[0].click();
+            expect(clipboard.writeText).toHaveBeenCalledWith('user@example.com');
+        });
+
+        it('should include items from provided append after the default items', () => {
+            const providedAppend = jest.fn().mockReturnValue([{label: 'Extra Item'}]);
+            const contextMenu = new ContextMenu({append: providedAppend}, {webContents: {}});
+
+            const items = contextMenu.menuOptions.append(mockDefaultActions, {linkURL: 'mailto:user@example.com'}, null, null);
+            expect(items).toHaveLength(2);
+            expect(items[0].label).toBe('Copy Email Address');
+            expect(items[1].label).toBe('Extra Item');
+            expect(providedAppend).toHaveBeenCalled();
         });
     });
 

--- a/src/main/contextMenu.ts
+++ b/src/main/contextMenu.ts
@@ -2,11 +2,14 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {BrowserWindow, BrowserView, WebviewTag, WebContents, ContextMenuParams, Event} from 'electron';
+import type {BrowserWindow, BrowserView, WebviewTag, WebContents, ContextMenuParams, Event, MenuItemConstructorOptions} from 'electron';
+import {clipboard} from 'electron';
 import type {Options} from 'electron-context-menu';
 import electronContextMenu from 'electron-context-menu';
 
 import {parseURL} from 'common/utils/url';
+import {localizeMessage} from 'main/i18nManager';
+import {getEmailAddressFromMailtoLink} from 'main/utils';
 
 const defaultMenuOptions = {
     shouldShowMenu: (e: Event, p: ContextMenuParams) => {
@@ -35,8 +38,29 @@ export default class ContextMenu {
 
     constructor(options: Options, view: BrowserWindow | WebContents) {
         const providedOptions: Options = options || {};
+        const providedAppend = providedOptions.append;
 
-        this.menuOptions = Object.assign({}, defaultMenuOptions, providedOptions);
+        const append: Options['append'] = (defaultActions, parameters, ...rest) => {
+            const items: MenuItemConstructorOptions[] = [];
+
+            const emailAddress = getEmailAddressFromMailtoLink(parameters.linkURL);
+            if (emailAddress) {
+                items.push({
+                    label: localizeMessage('app.menus.contextMenu.copyEmailAddress', 'Copy Email Address'),
+                    click() {
+                        clipboard.writeText(emailAddress);
+                    },
+                });
+            }
+
+            if (providedAppend) {
+                items.push(...providedAppend(defaultActions, parameters, ...rest));
+            }
+
+            return items;
+        };
+
+        this.menuOptions = {...defaultMenuOptions, ...providedOptions, append};
         this.view = view;
 
         this.reload();

--- a/src/main/utils.test.js
+++ b/src/main/utils.test.js
@@ -138,6 +138,12 @@ describe('main/utils', () => {
         it('should return undefined for empty string', () => {
             expect(Utils.getEmailAddressFromMailtoLink('')).toBeUndefined();
         });
+
+        it('should strip control characters from the email address', () => {
+            expect(Utils.getEmailAddressFromMailtoLink('mailto:user@example.com\r\ninjection')).toBe('user@example.cominjection');
+            expect(Utils.getEmailAddressFromMailtoLink('mailto:user\t@example.com')).toBe('user@example.com');
+            expect(Utils.getEmailAddressFromMailtoLink('mailto:user\0@example.com')).toBe('user@example.com');
+        });
     });
 
     describe('isInsideRectangle', () => {

--- a/src/main/utils.test.js
+++ b/src/main/utils.test.js
@@ -118,6 +118,28 @@ describe('main/utils', () => {
         });
     });
 
+    describe('getEmailAddressFromMailtoLink', () => {
+        it('should extract email from mailto link', () => {
+            expect(Utils.getEmailAddressFromMailtoLink('mailto:user@example.com')).toBe('user@example.com');
+        });
+
+        it('should strip query parameters', () => {
+            expect(Utils.getEmailAddressFromMailtoLink('mailto:user@example.com?subject=Hello&body=Hi')).toBe('user@example.com');
+        });
+
+        it('should handle case-insensitive mailto prefix', () => {
+            expect(Utils.getEmailAddressFromMailtoLink('MAILTO:user@example.com')).toBe('user@example.com');
+        });
+
+        it('should return undefined for non-mailto links', () => {
+            expect(Utils.getEmailAddressFromMailtoLink('https://example.com')).toBeUndefined();
+        });
+
+        it('should return undefined for empty string', () => {
+            expect(Utils.getEmailAddressFromMailtoLink('')).toBeUndefined();
+        });
+    });
+
     describe('isInsideRectangle', () => {
         it.each([
             [{x: 0, y: 0, width: 1920, height: 1080}, {x: 100, y: 100, width: 1280, height: 720}, true],

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -20,7 +20,8 @@ export function getEmailAddressFromMailtoLink(link: string): string | undefined 
     if (!link.toLowerCase().startsWith(MAILTO_PREFIX)) {
         return undefined;
     }
-    return link.slice(MAILTO_PREFIX.length).split('?')[0];
+    const email = link.slice(MAILTO_PREFIX.length).split('?')[0];
+    return email.replace(/[\r\n\t\0]/g, '');
 }
 
 export function isInsideRectangle(container: Electron.Rectangle, rect: Electron.Rectangle) {

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -11,9 +11,17 @@ const exec = promisify(execOriginal);
 import type {BrowserWindow} from 'electron';
 import {app} from 'electron';
 
+import {MAILTO_PREFIX} from 'common/constants';
 import {TAB_BAR_HEIGHT} from 'common/utils/constants';
 
 import type {Args} from 'types/args';
+
+export function getEmailAddressFromMailtoLink(link: string): string | undefined {
+    if (!link.toLowerCase().startsWith(MAILTO_PREFIX)) {
+        return undefined;
+    }
+    return link.slice(MAILTO_PREFIX.length).split('?')[0];
+}
 
 export function isInsideRectangle(container: Electron.Rectangle, rect: Electron.Rectangle) {
     if (container.x > rect.x) {


### PR DESCRIPTION
#### Summary
Right-clicking a `mailto:` link in the desktop app only offered "Copy Link", which copied the full `mailto:user@example.com` URL rather than just the email address. This is inconvenient when handling multiple email addresses.

This PR adds a "Copy Email Address" item to the context menu that appears when right-clicking a `mailto:` link, copying just the email address without the `mailto:` prefix or query parameters.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68285

#### Screenshots
<img width="378" height="270" alt="image" src="https://github.com/user-attachments/assets/fca4feab-1319-4664-be53-4e2c6dd0534d" />

#### Release Note
```release-note
Added a "Copy Email Address" option to the right-click context menu for mailto links.
```