### PR TITLE
Fix object has been destroyed error after closing the main window

### DIFF
--- a/src/app/mainWindow/mainWindow.ts
+++ b/src/app/mainWindow/mainWindow.ts
@@ -360,27 +360,27 @@ export class MainWindow extends EventEmitter {
      * Server Manager atomic event handlers
      */
     private handleServerAdded = (serverId: string, setAsCurrentServer: boolean) => {
-        this.win?.browserWindow.webContents.send(SERVER_ADDED, serverId, setAsCurrentServer);
+        this.sendToRenderer(SERVER_ADDED, serverId, setAsCurrentServer);
     };
 
     private handleServerRemoved = (server: MattermostServer) => {
-        this.win?.browserWindow.webContents.send(SERVER_REMOVED, server.id);
+        this.sendToRenderer(SERVER_REMOVED, server.id);
     };
 
     private handleServerUrlChanged = (serverId: string) => {
-        this.win?.browserWindow.webContents.send(SERVER_URL_CHANGED, serverId);
+        this.sendToRenderer(SERVER_URL_CHANGED, serverId);
     };
 
     private handleServerNameChanged = (serverId: string) => {
-        this.win?.browserWindow.webContents.send(SERVER_NAME_CHANGED, serverId);
+        this.sendToRenderer(SERVER_NAME_CHANGED, serverId);
     };
 
     private handleServerSwitched = (serverId: string) => {
-        this.win?.browserWindow.webContents.send(SERVER_SWITCHED, serverId);
+        this.sendToRenderer(SERVER_SWITCHED, serverId);
     };
 
     private handleServerLoggedInChanged = (serverId: string, loggedIn: boolean) => {
-        this.win?.browserWindow.webContents.send(SERVER_LOGGED_IN_CHANGED, serverId, loggedIn);
+        this.sendToRenderer(SERVER_LOGGED_IN_CHANGED, serverId, loggedIn);
     };
 
     /**
@@ -388,11 +388,11 @@ export class MainWindow extends EventEmitter {
      */
 
     private handleUpdateAppStateForViewId = (viewId: string, isExpired: boolean, newMentions: number, newUnreads: boolean) => {
-        this.win?.browserWindow.webContents.send(UPDATE_MENTIONS, viewId, newMentions, newUnreads, isExpired);
+        this.sendToRenderer(UPDATE_MENTIONS, viewId, newMentions, newUnreads, isExpired);
     };
 
     private handleUpdateAppStateForServerId = (serverId: string, expired: boolean, newMentions: number, newUnreads: boolean) => {
-        this.win?.browserWindow.webContents.send(UPDATE_MENTIONS_FOR_SERVER, serverId, expired, newMentions, newUnreads);
+        this.sendToRenderer(UPDATE_MENTIONS_FOR_SERVER, serverId, expired, newMentions, newUnreads);
     };
 
     private handleEmitConfiguration = () => {
@@ -400,7 +400,7 @@ export class MainWindow extends EventEmitter {
     };
 
     private sendViewLimitUpdated = () => {
-        this.win?.browserWindow.webContents.send(VIEW_LIMIT_UPDATED);
+        this.sendToRenderer(VIEW_LIMIT_UPDATED);
     };
 
     private handleGetIsViewLimitReached = () => {

--- a/src/app/mainWindow/serverDropdownView.ts
+++ b/src/app/mainWindow/serverDropdownView.ts
@@ -94,7 +94,11 @@ export class ServerDropdownView {
     private updateDropdown = () => {
         log.silly('updateDropdown');
 
-        this.view?.webContents.send(
+        if (!this.view || this.view.webContents.isDestroyed()) {
+            return;
+        }
+
+        this.view.webContents.send(
             UPDATE_SERVERS_DROPDOWN,
             this.servers,
             this.windowBounds,

--- a/src/app/windows/baseWindow.test.js
+++ b/src/app/windows/baseWindow.test.js
@@ -65,6 +65,7 @@ jest.mock('electron', () => {
             mockBrowserWindow.getContentBounds = jest.fn(() => ({x: 0, y: 0, width: 800, height: 600}));
             mockBrowserWindow.getSize = jest.fn(() => [800, 600]);
             mockBrowserWindow.restore = jest.fn();
+            mockBrowserWindow.isDestroyed = jest.fn(() => false);
             return mockBrowserWindow;
         }),
         dialog: {

--- a/src/app/windows/baseWindow.ts
+++ b/src/app/windows/baseWindow.ts
@@ -157,7 +157,10 @@ export default class BaseWindow {
     };
 
     private sendToRendererWithRetry = (maxRetries: number, channel: string, ...args: unknown[]) => {
-        if (!this.win || !this.ready) {
+        if (!this.win || this.win.isDestroyed()) {
+            return;
+        }
+        if (!this.ready) {
             if (maxRetries > 0) {
                 log.debug(`Can't send ${channel}, will retry`);
                 setTimeout(() => {


### PR DESCRIPTION
#### Summary
When the main window is destroyed during app quit, server views can still fire IPC events like `UNREADS_AND_MENTIONS` that flow through `AppState.emitStatusForServer`. The listeners in `MainWindow` and `ServerDropdownView` then call `webContents.send()` on the destroyed `BrowserWindow`/`WebContentsView`, causing the Sentry-reported `TypeError: Object has been destroyed`.

This PR adds an `isDestroyed()` early return in `BaseWindow.sendToRendererWithRetry`, switches `MainWindow` event handlers to use `sendToRenderer()` instead of directly accessing `browserWindow.webContents.send()`, and adds an `isDestroyed()` guard in `ServerDropdownView.updateDropdown`.

#### Ticket Link
N/A (Sentry report)

#### Release Note
```release-note
Fixed a crash that could occur when the main window was closed while server views were still sending status updates.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes introduce defensive checks to prevent calling methods on destroyed BrowserWindows/WebContentsViews, which reduces crash risk. However, there is moderate regression risk from centralizing 9 event handlers through `sendToRenderer()`, which now applies retry logic to more code paths than before. Additionally, `BaseWindow.sendToRendererWithRetry()` is a shared utility affecting multiple window types (MainWindow, PopoutWindows), creating broader impact. The early `isDestroyed()` check is straightforward, but the subtle behavior change of applying retries to previously non-retried handlers could introduce unexpected delays or duplicate message sends in edge cases.

**QA Recommendation:** Medium manual QA is recommended. Focus testing on: (1) Window closure scenarios, especially closing main window while server operations are in progress; (2) Server status update flows (UNREADS_AND_MENTIONS, server switching, login state changes) during window lifecycle transitions; (3) Popout window behavior to ensure BaseWindow changes don't affect popout functionality; (4) Message ordering/duplication issues from retry logic applying to more handlers. Automated test coverage should be enhanced for the `isDestroyed()` guard paths and the behavior changes in ServerDropdownView.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->