### PR TITLE
fix(e2e): require matterwick instance_details for policy tests, remove hardcoded mobile server fallback

### DIFF
--- a/.github/workflows/e2e-functional.yml
+++ b/.github/workflows/e2e-functional.yml
@@ -282,12 +282,17 @@ jobs:
         env:
           INSTANCE_DETAILS: ${{ inputs.instance_details }}
         run: |
-          RUNNER_OS=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')
-          URL=""
-          if [ -n "${INSTANCE_DETAILS}" ]; then
-            URL=$(echo "${INSTANCE_DETAILS}" | jq -r --arg os "$RUNNER_OS" '.[] | select(.runner | ascii_downcase | contains($os)) | .url // empty' | head -1)
+          if [ -z "${INSTANCE_DETAILS}" ]; then
+            echo "Error: instance_details input is required but was not provided" >&2
+            exit 1
           fi
-          echo "MM_TEST_SERVER_URL=${URL:-https://mobile-e2e-site-2.test.mattermost.cloud/}" >> $GITHUB_ENV
+          RUNNER_OS=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')
+          URL=$(echo "${INSTANCE_DETAILS}" | jq -r --arg os "$RUNNER_OS" '.[] | select(.runner | ascii_downcase | contains($os)) | .url // empty' | head -1)
+          if [ -z "${URL}" ]; then
+            echo "Error: No server URL found in instance_details for runner OS: ${RUNNER_OS}" >&2
+            exit 1
+          fi
+          echo "MM_TEST_SERVER_URL=${URL}" >> $GITHUB_ENV
 
       - name: e2e/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/e2e-nightly-trigger.yml
+++ b/.github/workflows/e2e-nightly-trigger.yml
@@ -5,6 +5,10 @@ name: E2E Nightly Trigger
 # instances (linux/macos/windows), and dispatches e2e-functional.yml with instance details.
 # When e2e-functional.yml completes, Matterwick destroys the provisioned instances.
 on:
+  push:
+    branches:
+      - master
+      - 'release-*'
   schedule:
     - cron: "0 0 * * 4,5" # Thursday and Friday midnight UTC
 


### PR DESCRIPTION
## Summary
- Removes the hardcoded fallback URL `https://mobile-e2e-site-2.test.mattermost.cloud/` from the `e2e-policy-tests` job in `e2e-functional.yml`
- Policy tests now fail fast with a clear error if `instance_details` is not provided or contains no URL for the current runner OS
- Prevents policy tests from silently running against a stale/wrong mobile test server when matterwick doesn't dispatch correctly


#### Release Note

```release-note
NONE
```