### PR TITLE
ci: fix security issues and improve Cursor E2E automation workflows

### DIFF
--- a/.github/workflows/e2e-cursor-commands.yml
+++ b/.github/workflows/e2e-cursor-commands.yml
@@ -105,11 +105,12 @@ jobs:
             core.setOutput('head_branch', headBranch);
 
             // ── Find the latest E2E run for this PR branch ───────────────────
-            // Look for the most recent completed "Electron Playwright Tests"
-            // workflow_dispatch run whose head_sha matches the PR.
             let latestRunUrl = '';
-            let failingSummary = '';
-            let serverBlock = '(not available)';
+            let latestRunId  = '';
+            let failingSummary = '(no failing test data found — check CI logs manually)';
+            const serverUrls   = { linux: '', macos: '', windows: '' };
+            let adminUsername  = '';
+            let serverTableBlock = '(server URLs not found)';
 
             try {
               const workflows = await github.rest.actions.listRepoWorkflows({ owner, repo });
@@ -128,28 +129,79 @@ jobs:
                 );
                 if (matchingRun) {
                   latestRunUrl = matchingRun.html_url;
+                  latestRunId  = String(matchingRun.id);
 
                   if (isFix) {
-                    // Collect per-platform job conclusions
-                    const jobs = await github.rest.actions.listJobsForWorkflowRun({
-                      owner, repo, run_id: matchingRun.id, per_page: 100,
-                    });
-                    const lines = [];
-                    for (const job of jobs.data.jobs) {
-                      if (job.conclusion === 'failure') {
-                        const n = job.name.toLowerCase();
-                        const plat = n.includes('linux') || n.includes('ubuntu') ? 'linux'
-                          : n.includes('macos') || n.includes('darwin')          ? 'macos'
-                          : n.includes('windows')                                ? 'windows'
-                          : null;
-                        if (plat) {
-                          lines.push(`- ${plat}: failed`);
+                    // ── Download JUnit artifacts for exact test names ─────────
+                    const failingTests = { linux: [], macos: [], windows: [] };
+
+                    try {
+                      const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                        owner, repo, run_id: matchingRun.id, per_page: 50,
+                      });
+
+                      for (const artifact of artifacts.data.artifacts) {
+                        const aName = artifact.name.toLowerCase();
+                        let platform = null;
+                        if (aName.startsWith('test-results-linux') || aName.startsWith('test-results-ubuntu')) {
+                          platform = 'linux';
+                        } else if (aName.startsWith('test-results-macos') || aName.startsWith('test-results-darwin')) {
+                          platform = 'macos';
+                        } else if (aName.startsWith('test-results-windows')) {
+                          platform = 'windows';
+                        }
+                        if (!platform) { continue; }
+
+                        try {
+                          const dl = await github.rest.actions.downloadArtifact({
+                            owner, repo, artifact_id: artifact.id, archive_format: 'zip',
+                          });
+                          const resp = await fetch(dl.url);
+                          const buf  = Buffer.from(await resp.arrayBuffer());
+                          const AdmZip = require('adm-zip');
+                          const zip = new AdmZip(buf);
+                          const xmlEntry = zip.getEntries().find(
+                            (e) => e.entryName.endsWith('e2e-junit.xml'),
+                          );
+                          if (!xmlEntry) { continue; }
+                          const xml = xmlEntry.getData().toString('utf8');
+                          const suiteMatches = xml.matchAll(/<testcase[^>]+name="([^"]+)"[^>]*>[\s\S]*?<(?:failure|error)[^/]/g);
+                          for (const m of suiteMatches) {
+                            failingTests[platform].push(m[1]);
+                          }
+                        } catch (err) {
+                          core.warning(`Could not parse JUnit for ${platform}: ${err.message}`);
                         }
                       }
+                    } catch (err) {
+                      core.warning(`Could not fetch artifacts: ${err.message}`);
                     }
-                    failingSummary = lines.length > 0
-                      ? lines.join('\n')
-                      : 'All platforms may have failed — treating as mass-failure scenario.';
+
+                    const failingTestsBlock = Object.entries(failingTests)
+                      .filter(([, names]) => names.length > 0)
+                      .map(([plat, names]) => `${plat}:\n${names.map((n) => `  - ${n}`).join('\n')}`)
+                      .join('\n\n');
+
+                    if (failingTestsBlock) {
+                      failingSummary = failingTestsBlock;
+                    } else {
+                      // Fall back to job-level conclusion if JUnit is unavailable
+                      const jobs = await github.rest.actions.listJobsForWorkflowRun({
+                        owner, repo, run_id: matchingRun.id, per_page: 100,
+                      });
+                      const lines = [];
+                      for (const job of jobs.data.jobs) {
+                        if (job.conclusion === 'failure') {
+                          const n = job.name.toLowerCase();
+                          const plat = n.includes('linux') || n.includes('ubuntu') ? 'linux'
+                            : n.includes('macos') || n.includes('darwin')          ? 'macos'
+                            : n.includes('windows')                                ? 'windows'
+                            : null;
+                          if (plat) { lines.push(`- ${plat}: failed (JUnit unavailable — check CI logs)`); }
+                        }
+                      }
+                      if (lines.length > 0) { failingSummary = lines.join('\n'); }
+                    }
                   }
                 }
               }
@@ -158,9 +210,10 @@ jobs:
             }
 
             core.setOutput('latest_run_url', latestRunUrl);
+            core.setOutput('latest_run_id',  latestRunId);
             core.setOutput('failing_summary', failingSummary);
 
-            // ── Read server URLs from the PR comment ─────────────────────────
+            // ── Read per-platform server info from the PR comment ─────────────
             try {
               const comments = await github.rest.issues.listComments({
                 owner, repo, issue_number: prNumber, per_page: 100,
@@ -169,20 +222,30 @@ jobs:
                 (c) => c.body && c.body.includes('<!-- e2e-server-info -->')
               );
               if (infoComment) {
-                const tableLines = infoComment.body.
-                  split('\n').
-                  filter((l) => l.startsWith('|') && !l.startsWith('| Platform')).
-                  slice(0, 4);
-                serverBlock = tableLines.join('\n');
+                const body = infoComment.body;
+                const rowRe = /^\|\s*`(linux|macos|windows)`\s*\|\s*(\S+)\s*\|/im;
+                for (const line of body.split('\n')) {
+                  const m = line.match(rowRe);
+                  if (m) { serverUrls[m[1].toLowerCase()] = m[2]; }
+                }
+                const userMatch = body.match(/\*\*Admin username:\*\*\s*`([^`]+)`/);
+                if (userMatch) { adminUsername = userMatch[1]; }
+                const tableLines = body.split('\n').filter(
+                  (l) => l.startsWith('|') && !l.startsWith('| Platform'),
+                ).slice(0, 5);
+                serverTableBlock = tableLines.join('\n');
               }
             } catch (err) {
               core.warning(`Could not read PR comments: ${err.message}`);
             }
 
-            core.setOutput('server_block', serverBlock);
+            core.setOutput('server_url_linux',   serverUrls.linux);
+            core.setOutput('server_url_macos',   serverUrls.macos);
+            core.setOutput('server_url_windows', serverUrls.windows);
+            core.setOutput('admin_username',     adminUsername);
+            core.setOutput('server_table_block', serverTableBlock);
 
             // ── Collect the PR diff summary for "add tests" command ──────────
-            // List only the changed file paths — cheap and keeps the prompt small.
             let changedFiles = '';
             if (isAdd) {
               try {
@@ -204,68 +267,140 @@ jobs:
         if: steps.context.outputs.command == 'fix'
         id: fix_prompt
         env:
-          PR_URL: ${{ steps.context.outputs.pr_url }}
           FAILING_SUMMARY: ${{ steps.context.outputs.failing_summary }}
-          SERVER_BLOCK: ${{ steps.context.outputs.server_block }}
+          SERVER_TABLE_BLOCK: ${{ steps.context.outputs.server_table_block }}
+          SERVER_URL_LINUX: ${{ steps.context.outputs.server_url_linux }}
+          SERVER_URL_MACOS: ${{ steps.context.outputs.server_url_macos }}
+          SERVER_URL_WINDOWS: ${{ steps.context.outputs.server_url_windows }}
+          ADMIN_USERNAME: ${{ steps.context.outputs.admin_username }}
           LATEST_RUN_URL: ${{ steps.context.outputs.latest_run_url }}
+          LATEST_RUN_ID: ${{ steps.context.outputs.latest_run_id }}
           REQUESTER: ${{ github.event.comment.user.login }}
         run: |
           cat > /tmp/prompt.txt << 'PROMPT_EOF'
-          A developer (@${REQUESTER}) has asked you to fix ALL failing E2E tests on
-          this PR, including mass failures that the automatic trigger skipped.
+          @${REQUESTER} asked you to fix ALL failing E2E tests on this PR,
+          including mass failures that the automatic trigger skipped.
+          You are running on a Linux agent with an X server on DISPLAY=:1.
 
-          This was likely caused by a large change to the codebase. Treat widespread
-          failures as potentially having a shared root cause (e.g. a renamed selector,
-          a changed IPC channel, a modified config shape) before fixing each test
-          individually.
-
-          FAILING PLATFORMS
-          -----------------
+          ══════════════════════════════════════════════════
+          FAILING TESTS (from CI JUnit XML)
+          ══════════════════════════════════════════════════
           ${FAILING_SUMMARY}
 
-          SERVER URLS (provisioned by Matterwick — still live)
-          -----------------------------------------------------
-          ${SERVER_BLOCK}
+          ══════════════════════════════════════════════════
+          PROVISIONED TEST SERVERS (still live)
+          ══════════════════════════════════════════════════
+          ${SERVER_TABLE_BLOCK}
 
-          LATEST E2E WORKFLOW RUN (for full logs and JUnit artifacts)
-          ------------------------------------------------------------
-          ${LATEST_RUN_URL}
+          Individual URLs for use in run commands:
+            Linux   server: ${SERVER_URL_LINUX}
+            macOS   server: ${SERVER_URL_MACOS}
+            Windows server: ${SERVER_URL_WINDOWS}
+            Admin username: ${ADMIN_USERNAME}
+            Admin password: read the MM_TEST_PASSWORD environment variable
+                            (injected as a Cursor secret — do NOT hardcode it)
 
-          INSTRUCTIONS
-          ------------
-          1. Read the CI workflow run logs to identify ALL failing test names and
-             their error messages.
+          CI run (for full logs and trace artifacts): ${LATEST_RUN_URL}
 
-          2. Look for a SHARED ROOT CAUSE first:
-             - Same selector missing across many tests → likely a renamed component
-             - Same IPC channel / API call failing → likely a changed interface
-             - Same timeout pattern → likely a new async flow or loading state
-             If you find a shared cause, fix it at the shared layer (helper,
-             fixture, or app-side test hook) rather than patching every spec.
+          ══════════════════════════════════════════════════
+          STEP-BY-STEP INSTRUCTIONS
+          ══════════════════════════════════════════════════
 
-          3. For each remaining failure, classify as TEST BUG or PRODUCT BUG:
-             TEST BUG  → Fix in e2e/specs/, e2e/helpers/, e2e/fixtures/ only.
-                         Run the spec against the live server to confirm it passes.
-             PRODUCT BUG → Do NOT modify the test. Post a PR comment:
-                           "Product Bug: <test name> — expected X, got Y, likely in <src/ file>"
+          ## Step 1 — Build the app
 
-          4. HARD LIMITS to keep token usage reasonable:
-             - Fix at most 10 distinct test files per run.
-             - If more than 10 files need fixing, fix the most common pattern,
-               post a comment listing the rest, and stop.
-             - Never touch src/ files. Only e2e/.
+          Run this once at the start:
 
-          5. After all fixes and reports, post a single summary comment on the PR.
+            source ~/.nvm/nvm.sh && nvm use 20.15.0
+            npm ci
+            cd e2e && npm ci && cd ..
+            npm run build-test
+
+          If the build fails, stop and post a PR comment with the error.
+
+          ## Step 2 — Identify exact failing spec files
+
+          The failing test names are listed above. Map each name to a file in
+          e2e/specs/. If the JUnit block is empty, download the artifacts:
+
+            gh run download ${LATEST_RUN_ID} \
+              --name test-results-linux \
+              --dir /tmp/results-linux
+            cat /tmp/results-linux/test-results/e2e-junit.xml | grep 'testcase name'
+
+          Repeat for test-results-macos / test-results-windows.
+
+          ## Step 3 — Look for a SHARED ROOT CAUSE first
+
+          Widespread failures often share one root cause:
+            - Same selector missing across tests → renamed UI component
+            - Same IPC channel failing           → changed interface
+            - Same timeout pattern               → new async loading state
+
+          If you find a shared cause, fix it at the shared layer (helper or
+          fixture) rather than patching every spec individually.
+
+          ## Step 4 — Reproduce BEFORE editing
+
+          Run the failing spec against the Linux server:
+
+            cd e2e
+            export DISPLAY=:1
+            export MM_TEST_SERVER_URL="${SERVER_URL_LINUX}"
+            export MM_TEST_USER_NAME="${ADMIN_USERNAME}"
+            export MM_TEST_PASSWORD="${MM_TEST_PASSWORD}"
+            xvfb-run --auto-servernum --server-args='-screen 0 1280x960x24' \
+              npx playwright test <spec-file-relative-to-e2e/> \
+              --reporter=list --workers=1
+            cd ..
+
+          You MUST see the failure before touching code.
+          If you cannot reproduce, classify as "flake" and post a PR comment.
+
+          ## Step 5 — Fix and re-run
+
+          After each edit, run the same command from Step 4. Confirm the test
+          passes before committing that file.
+
+          DO NOT COMMIT a fix unless the re-run shows "X passed".
+
+          For macOS/Windows-only failures:
+            Run the spec against the Linux server to validate the logic.
+            If it passes on Linux, commit with a note about the platform gap.
+            CI will confirm on the real platform after push.
+
+          ## Step 6 — Classify failures you cannot fix locally
+
+          PRODUCT BUG → Post a PR comment:
+            "Product Bug: <test name> — expected X, got Y, likely in <src/ file>"
+
+          ## Step 7 — Hard limits
+
+          - Fix at most 10 distinct spec files per run.
+          - Never touch src/ files.
+          - Scope: e2e/specs/, e2e/helpers/, e2e/fixtures/, e2e/utils/ only.
+          - Never add long sleeps (> 2 s) as a fix.
+
+          ## Step 8 — Summary comment
+
+          After committing all fixes, post a single PR comment:
+            - Each fix: spec file path + root-cause description +
+              exact run command + "PASSED" result
+            - Each product bug: test name + symptom + suspected src/ file
+            - Any flakes: test name + reason
           PROMPT_EOF
 
           PROMPT=$(sed \
             -e "s|\${REQUESTER}|${REQUESTER}|g" \
             -e "s|\${FAILING_SUMMARY}|${FAILING_SUMMARY}|g" \
-            -e "s|\${SERVER_BLOCK}|${SERVER_BLOCK}|g" \
+            -e "s|\${SERVER_TABLE_BLOCK}|${SERVER_TABLE_BLOCK}|g" \
+            -e "s|\${SERVER_URL_LINUX}|${SERVER_URL_LINUX}|g" \
+            -e "s|\${SERVER_URL_MACOS}|${SERVER_URL_MACOS}|g" \
+            -e "s|\${SERVER_URL_WINDOWS}|${SERVER_URL_WINDOWS}|g" \
+            -e "s|\${ADMIN_USERNAME}|${ADMIN_USERNAME}|g" \
             -e "s|\${LATEST_RUN_URL}|${LATEST_RUN_URL}|g" \
+            -e "s|\${LATEST_RUN_ID}|${LATEST_RUN_ID}|g" \
             /tmp/prompt.txt)
 
-          # Write to file for the launch step to read
           echo "${PROMPT}" > /tmp/final-prompt.txt
           echo "prompt_file=/tmp/final-prompt.txt" >> "$GITHUB_OUTPUT"
 
@@ -274,57 +409,83 @@ jobs:
         if: steps.context.outputs.command == 'add'
         id: add_prompt
         env:
-          PR_URL: ${{ steps.context.outputs.pr_url }}
           CHANGED_FILES: ${{ steps.context.outputs.changed_files }}
-          SERVER_BLOCK: ${{ steps.context.outputs.server_block }}
+          SERVER_TABLE_BLOCK: ${{ steps.context.outputs.server_table_block }}
+          SERVER_URL_LINUX: ${{ steps.context.outputs.server_url_linux }}
+          ADMIN_USERNAME: ${{ steps.context.outputs.admin_username }}
           REQUESTER: ${{ github.event.comment.user.login }}
         run: |
           cat > /tmp/prompt.txt << 'PROMPT_EOF'
-          A developer (@${REQUESTER}) has asked you to add E2E test cases that cover
-          the changes introduced by this PR.
+          @${REQUESTER} asked you to add E2E test cases that cover the changes
+          introduced by this PR. You are running on a Linux agent (DISPLAY=:1).
 
           CHANGED FILES IN THIS PR (non-e2e only)
           ----------------------------------------
           ${CHANGED_FILES}
 
-          SERVER URLS (to run and validate your new tests against)
-          ---------------------------------------------------------
-          ${SERVER_BLOCK}
+          PROVISIONED TEST SERVERS
+          -------------------------
+          ${SERVER_TABLE_BLOCK}
+
+          Linux server for local verification:
+            MM_TEST_SERVER_URL: ${SERVER_URL_LINUX}
+            MM_TEST_USER_NAME:  ${ADMIN_USERNAME}
+            MM_TEST_PASSWORD:   read MM_TEST_PASSWORD env var (Cursor secret)
 
           INSTRUCTIONS
           ------------
-          1. Read each changed file to understand what behavior was added or modified.
 
-          2. For each meaningful behavioral change, write a new Playwright E2E test
-             (or extend an existing spec if one already covers that area).
+          ## Step 1 — Build
+            source ~/.nvm/nvm.sh && nvm use 20.15.0
+            npm ci && cd e2e && npm ci && cd .. && npm run build-test
 
-          3. Test placement rules:
-             - New specs go in e2e/specs/ under the most relevant subdirectory.
-             - Tests that require a live Mattermost server must use demoMattermostConfig
-               and be tagged @all so they run in CI.
-             - Use the fixture layer (e2e/fixtures/index.ts) — do not re-implement
-               launch / login logic.
-             - Follow patterns in existing e2e/specs/ files for style and structure.
-             - Tag each new test with @P2 @all or the appropriate priority.
+          ## Step 2 — Understand the changes
+          Read each changed file to understand what behavior was added or modified.
 
-          4. After writing tests, run each new spec against the live server URL to
-             confirm it passes before committing.
+          ## Step 3 — Write tests
+          For each meaningful behavioral change, write a new Playwright E2E spec
+          (or extend an existing spec if one already covers that area).
 
-          5. HARD LIMITS:
-             - Add at most 3 new spec files per run.
-             - Do not modify src/ files.
-             - If you cannot determine a clear, testable behavior from the diff,
-               post a comment explaining what is ambiguous rather than writing
-               a low-quality test.
+          Placement rules:
+            - New specs go in e2e/specs/ under the most relevant subdirectory.
+            - Use the fixture layer (e2e/fixtures/index.ts) — do not re-implement
+              launch or login logic.
+            - Follow patterns in existing e2e/specs/ files.
+            - Tag each new test with @P2 @all or the appropriate priority.
 
-          6. After committing, post a PR comment listing each new test file with a
-             one-line description of what it covers.
+          ## Step 4 — Run each new spec before committing
+
+            cd e2e
+            export DISPLAY=:1
+            export MM_TEST_SERVER_URL="${SERVER_URL_LINUX}"
+            export MM_TEST_USER_NAME="${ADMIN_USERNAME}"
+            export MM_TEST_PASSWORD="${MM_TEST_PASSWORD}"
+            xvfb-run --auto-servernum --server-args='-screen 0 1280x960x24' \
+              npx playwright test <new-spec-file> --reporter=list --workers=1
+            cd ..
+
+          A new test MUST pass before you commit it.
+          If it cannot be made to pass locally, explain why in a PR comment.
+
+          ## Step 5 — Hard limits
+            - Add at most 3 new spec files per run.
+            - Do not modify src/ files.
+            - If you cannot determine a clear, testable behavior, post a PR
+              comment explaining the ambiguity instead of writing a weak test.
+
+          ## Step 6 — Summary comment
+          After committing, post a PR comment listing each new file with:
+            - File path
+            - What behavior it covers
+            - Exact run command used + "PASSED" confirmation
           PROMPT_EOF
 
           PROMPT=$(sed \
             -e "s|\${REQUESTER}|${REQUESTER}|g" \
             -e "s|\${CHANGED_FILES}|${CHANGED_FILES}|g" \
-            -e "s|\${SERVER_BLOCK}|${SERVER_BLOCK}|g" \
+            -e "s|\${SERVER_TABLE_BLOCK}|${SERVER_TABLE_BLOCK}|g" \
+            -e "s|\${SERVER_URL_LINUX}|${SERVER_URL_LINUX}|g" \
+            -e "s|\${ADMIN_USERNAME}|${ADMIN_USERNAME}|g" \
             /tmp/prompt.txt)
 
           echo "${PROMPT}" > /tmp/final-prompt.txt
@@ -394,7 +555,7 @@ jobs:
                 '',
                 `Task: **${action}**`,
                 '',
-                'The agent will push results directly to this branch.',
+                'The agent will reproduce each failure before editing, confirm the fix passes, then push to this branch.',
                 agentUrl ? `\n**Agent:** ${agentUrl}` : '',
               ].filter(Boolean).join('\n'),
             });

--- a/.github/workflows/e2e-cursor-commands.yml
+++ b/.github/workflows/e2e-cursor-commands.yml
@@ -296,8 +296,9 @@ jobs:
             Linux   server: ${SERVER_URL_LINUX}
             macOS   server: ${SERVER_URL_MACOS}
             Windows server: ${SERVER_URL_WINDOWS}
-            Admin username: ${ADMIN_USERNAME}
-            Admin password: read the MM_TEST_PASSWORD environment variable
+            Admin username: read the MM_DESKTOP_E2E_USER_NAME environment variable
+                            (injected as a Cursor secret — do NOT hardcode it)
+            Admin password: read the MM_DESKTOP_E2E_USER_CREDENTIALS environment variable
                             (injected as a Cursor secret — do NOT hardcode it)
 
           CI run (for full logs and trace artifacts): ${LATEST_RUN_URL}
@@ -346,8 +347,8 @@ jobs:
             cd e2e
             export DISPLAY=:1
             export MM_TEST_SERVER_URL="${SERVER_URL_LINUX}"
-            export MM_TEST_USER_NAME="${ADMIN_USERNAME}"
-            export MM_TEST_PASSWORD="${MM_TEST_PASSWORD}"
+            export MM_TEST_USER_NAME="${MM_DESKTOP_E2E_USER_NAME}"
+            export MM_TEST_PASSWORD="${MM_DESKTOP_E2E_USER_CREDENTIALS}"
             xvfb-run --auto-servernum --server-args='-screen 0 1280x960x24' \
               npx playwright test <spec-file-relative-to-e2e/> \
               --reporter=list --workers=1
@@ -429,8 +430,8 @@ jobs:
 
           Linux server for local verification:
             MM_TEST_SERVER_URL: ${SERVER_URL_LINUX}
-            MM_TEST_USER_NAME:  ${ADMIN_USERNAME}
-            MM_TEST_PASSWORD:   read MM_TEST_PASSWORD env var (Cursor secret)
+            MM_TEST_USER_NAME:  read MM_DESKTOP_E2E_USER_NAME env var (Cursor secret)
+            MM_TEST_PASSWORD:   read MM_DESKTOP_E2E_USER_CREDENTIALS env var (Cursor secret)
 
           INSTRUCTIONS
           ------------
@@ -458,8 +459,8 @@ jobs:
             cd e2e
             export DISPLAY=:1
             export MM_TEST_SERVER_URL="${SERVER_URL_LINUX}"
-            export MM_TEST_USER_NAME="${ADMIN_USERNAME}"
-            export MM_TEST_PASSWORD="${MM_TEST_PASSWORD}"
+            export MM_TEST_USER_NAME="${MM_DESKTOP_E2E_USER_NAME}"
+            export MM_TEST_PASSWORD="${MM_DESKTOP_E2E_USER_CREDENTIALS}"
             xvfb-run --auto-servernum --server-args='-screen 0 1280x960x24' \
               npx playwright test <new-spec-file> --reporter=list --workers=1
             cd ..

--- a/.github/workflows/e2e-cursor-commands.yml
+++ b/.github/workflows/e2e-cursor-commands.yml
@@ -25,10 +25,9 @@ on:
   issue_comment:
     types: [created]
 
+# Write permissions are scoped to the job that posts comments / reactions.
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
   actions: read
 
 jobs:
@@ -43,31 +42,53 @@ jobs:
         contains(github.event.comment.body, '@cursor fix e2e') ||
         contains(github.event.comment.body, '@cursor add e2e')
       )
+    permissions:
+      contents: read
+      actions: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: React to comment so the user knows it was received
+        continue-on-error: true
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          COMMENT_ID: ${{ github.event.comment.id }}
         with:
           github-token: ${{ github.token }}
           script: |
             await github.rest.reactions.createForIssueComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              comment_id: ${{ github.event.comment.id }},
+              comment_id: Number(process.env.COMMENT_ID),
               content: 'eyes',
             });
 
       - name: Parse command and gather context
         id: context
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          # Pass user-controlled comment body via env to prevent script injection.
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         with:
           github-token: ${{ github.token }}
           script: |
             const { owner, repo } = context.repo;
-            const commentBody = `${{ github.event.comment.body }}`.toLowerCase();
-            const prNumber    = ${{ github.event.issue.number }};
+            const commentBody = (process.env.COMMENT_BODY || '').toLowerCase();
+
+            const trimmed = String(process.env.PR_NUMBER ?? '').trim();
+            if (!(/^\d+$/).test(trimmed)) {
+              core.setFailed('Invalid PR number');
+              return;
+            }
+            const prNumber = Number(trimmed);
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.setFailed('Invalid PR number');
+              return;
+            }
 
             // Determine which command was invoked
             const isFix = commentBody.includes('@cursor fix e2e');
@@ -346,14 +367,19 @@ jobs:
 
       - name: Reply to comment with agent link
         if: always() && steps.launch.outcome == 'success'
+        continue-on-error: true
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           AGENT_URL: ${{ steps.launch.outputs.agent_url }}
           COMMAND: ${{ steps.context.outputs.command }}
+          PR_NUMBER: ${{ steps.context.outputs.pr_number }}
         with:
           github-token: ${{ github.token }}
           script: |
-            const prNumber  = ${{ github.event.issue.number }};
+            const trimmed = String(process.env.PR_NUMBER ?? '').trim();
+            if (!(/^\d+$/).test(trimmed)) { return; }
+            const prNumber = Number(trimmed);
+            if (!Number.isInteger(prNumber) || prNumber <= 0) { return; }
             const agentUrl  = process.env.AGENT_URL || '(pending)';
             const command   = process.env.COMMAND;
             const action    = command === 'fix'
@@ -375,14 +401,21 @@ jobs:
 
       - name: Reply to comment on failure
         if: always() && steps.launch.outcome == 'failure'
+        continue-on-error: true
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          PR_NUMBER: ${{ steps.context.outputs.pr_number }}
         with:
           github-token: ${{ github.token }}
           script: |
+            const trimmed = String(process.env.PR_NUMBER ?? '').trim();
+            if (!(/^\d+$/).test(trimmed)) { return; }
+            const prNumber = Number(trimmed);
+            if (!Number.isInteger(prNumber) || prNumber <= 0) { return; }
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: ${{ github.event.issue.number }},
+              issue_number: prNumber,
               body: [
                 '### :x: Cursor Agent Launch Failed',
                 '',

--- a/.github/workflows/e2e-fix-trigger.yml
+++ b/.github/workflows/e2e-fix-trigger.yml
@@ -346,8 +346,9 @@ jobs:
             Linux   server: ${SERVER_URL_LINUX}
             macOS   server: ${SERVER_URL_MACOS}
             Windows server: ${SERVER_URL_WINDOWS}
-            Admin username: ${ADMIN_USERNAME}
-            Admin password: read the MM_TEST_PASSWORD environment variable
+            Admin username: read the MM_DESKTOP_E2E_USER_NAME environment variable
+                            (injected as a Cursor secret — do NOT hardcode it)
+            Admin password: read the MM_DESKTOP_E2E_USER_CREDENTIALS environment variable
                             (injected as a Cursor secret — do NOT hardcode it)
 
           CI run (for full logs and trace artifacts): ${WORKFLOW_RUN_URL}
@@ -391,8 +392,8 @@ jobs:
             cd e2e
             export DISPLAY=:1
             export MM_TEST_SERVER_URL="${SERVER_URL_LINUX}"
-            export MM_TEST_USER_NAME="${ADMIN_USERNAME}"
-            export MM_TEST_PASSWORD="${MM_TEST_PASSWORD}"
+            export MM_TEST_USER_NAME="${MM_DESKTOP_E2E_USER_NAME}"
+            export MM_TEST_PASSWORD="${MM_DESKTOP_E2E_USER_CREDENTIALS}"
             xvfb-run --auto-servernum --server-args='-screen 0 1280x960x24' \
               npx playwright test <spec-file-relative-to-e2e/> \
               --reporter=list --workers=1

--- a/.github/workflows/e2e-fix-trigger.yml
+++ b/.github/workflows/e2e-fix-trigger.yml
@@ -37,10 +37,9 @@ on:
 
 # workflow_run always runs from the default branch — no PR secrets available
 # here. CURSOR_API_KEY must be a repository secret, not a PR/environment secret.
+# Write permissions are scoped to the single job that posts PR comments.
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
   actions: read
 
 env:
@@ -60,6 +59,11 @@ jobs:
     if: |
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.event == 'workflow_dispatch'
+    permissions:
+      contents: read
+      actions: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -69,11 +73,12 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           MASS_FAILURE_THRESHOLD: ${{ env.MASS_FAILURE_THRESHOLD }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
         with:
           github-token: ${{ github.token }}
           script: |
             const { owner, repo } = context.repo;
-            const runId = ${{ github.event.workflow_run.id }};
+            const runId = Number(process.env.WORKFLOW_RUN_ID);
             const threshold = parseInt(process.env.MASS_FAILURE_THRESHOLD, 10);
 
             // ── 1. Resolve the PR ────────────────────────────────────────────
@@ -203,14 +208,21 @@ jobs:
 
       - name: Post skip notice for mass failures
         if: steps.triage.outputs.skip == 'true' && steps.triage.outputs.skip_reason == 'mass_failure'
+        continue-on-error: true
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          PR_NUMBER: ${{ steps.triage.outputs.pr_number }}
+          TOTAL_FAILURES: ${{ steps.triage.outputs.total_failures }}
+          WORKFLOW_RUN_URL: ${{ steps.triage.outputs.workflow_run_url }}
         with:
           github-token: ${{ github.token }}
           script: |
-            const prNumber = parseInt('${{ steps.triage.outputs.pr_number }}', 10);
-            if (!prNumber) { return; }
-            const total = '${{ steps.triage.outputs.total_failures }}';
-            const runUrl = '${{ steps.triage.outputs.workflow_run_url }}';
+            const trimmed = String(process.env.PR_NUMBER ?? '').trim();
+            if (!(/^\d+$/).test(trimmed)) { return; }
+            const prNumber = Number(trimmed);
+            if (!Number.isInteger(prNumber) || prNumber <= 0) { return; }
+            const total = process.env.TOTAL_FAILURES;
+            const runUrl = process.env.WORKFLOW_RUN_URL;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -231,6 +243,7 @@ jobs:
 
       - name: Launch Cursor agent to fix E2E failures
         if: steps.triage.outputs.skip == 'false' && steps.triage.outputs.pr_url != ''
+        id: launch
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           PR_URL: ${{ steps.triage.outputs.pr_url }}
@@ -330,21 +343,25 @@ jobs:
           AGENT_URL=$(echo "${RESPONSE}" | jq -r '.target.url // empty')
           echo "Cursor agent launched: ${AGENT_ID}"
           echo "Agent URL: ${AGENT_URL}"
-          echo "AGENT_ID=${AGENT_ID}" >> "$GITHUB_OUTPUT"
-          echo "AGENT_URL=${AGENT_URL}" >> "$GITHUB_OUTPUT"
+          echo "agent_id=${AGENT_ID}" >> "$GITHUB_OUTPUT"
+          echo "agent_url=${AGENT_URL}" >> "$GITHUB_OUTPUT"
 
       - name: Post agent launch notice on PR
         if: steps.triage.outputs.skip == 'false' && steps.triage.outputs.pr_url != ''
+        continue-on-error: true
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
-          AGENT_URL: ${{ env.AGENT_URL }}
+          AGENT_URL: ${{ steps.launch.outputs.agent_url }}
           FAILING_SUMMARY: ${{ steps.triage.outputs.failing_summary }}
           WORKFLOW_RUN_URL: ${{ steps.triage.outputs.workflow_run_url }}
+          PR_NUMBER: ${{ steps.triage.outputs.pr_number }}
         with:
           github-token: ${{ github.token }}
           script: |
-            const prNumber = parseInt('${{ steps.triage.outputs.pr_number }}', 10);
-            if (!prNumber) { return; }
+            const trimmed = String(process.env.PR_NUMBER ?? '').trim();
+            if (!(/^\d+$/).test(trimmed)) { return; }
+            const prNumber = Number(trimmed);
+            if (!Number.isInteger(prNumber) || prNumber <= 0) { return; }
             const agentUrl   = process.env.AGENT_URL    || '(pending)';
             const runUrl     = process.env.WORKFLOW_RUN_URL;
             const summary    = process.env.FAILING_SUMMARY;

--- a/.github/workflows/e2e-fix-trigger.yml
+++ b/.github/workflows/e2e-fix-trigger.yml
@@ -16,18 +16,23 @@ name: E2E Fix Trigger
 #
 # 2. SKIP nightly runs — they have no PR to fix.
 #
-# 3. The prompt passed to the Cursor API contains only:
-#    - The failing test names grouped by platform (not full logs)
-#    - The server URLs from the existing PR comment (already posted by
-#      post-server-info) so the agent can reproduce failures
-#    - Clear triage instructions so the agent classifies each failure as a
-#      test bug (fix it) or a product bug (post a comment, do not retry)
+# 3. The triage step downloads the JUnit XML artifact so the prompt contains
+#    the exact failing test names, not just platform-level counts. This
+#    prevents the agent from guessing which tests failed.
 #
-# 4. source.prUrl is used (not source.repository + ref) so the agent works
+# 4. Per-platform server URLs and admin credentials are extracted from the
+#    server-info PR comment and passed individually so the agent can run the
+#    exact failing spec against the exact server where it failed.
+#
+# 5. The agent prompt has a hard "MUST RUN BEFORE COMMIT" rule: the agent
+#    must execute the failing spec against the live server and see it pass
+#    before staging the fix. Platform-specific run commands are provided.
+#
+# 6. source.prUrl is used (not source.repository + ref) so the agent works
 #    directly on the PR's head branch and pushes fixes there, triggering
 #    another CI run automatically.
 #
-# 5. target.autoBranch: false — push to the PR's existing head branch rather
+# 7. target.autoBranch: false — push to the PR's existing head branch rather
 #    than creating a new branch.
 
 on:
@@ -83,7 +88,7 @@ jobs:
 
             // ── 1. Resolve the PR ────────────────────────────────────────────
             const run = await github.rest.actions.getWorkflowRun({ owner, repo, run_id: runId });
-            const headSha  = run.data.head_sha;
+            const headSha    = run.data.head_sha;
             const headBranch = run.data.head_branch;
             const headOwner  = run.data.head_repository?.owner?.login || owner;
 
@@ -113,17 +118,12 @@ jobs:
             core.setOutput('pr_number', String(prNumber));
             core.setOutput('pr_url', prUrl);
 
-            // ── 2. Collect per-platform failure counts from run outputs ──────
-            // The e2e-tests matrix job exposes NEW_FAILURES_{LINUX,MACOS,WINDOWS}
-            // as workflow outputs via the reusable template.
+            // ── 2. Collect per-platform failure counts ───────────────────────
             const jobs = await github.rest.actions.listJobsForWorkflowRun({
               owner, repo, run_id: runId, per_page: 100,
             });
 
-            // Extract NEW_FAILURES from step outputs if available, otherwise
-            // use job conclusion to estimate.
             const platformFailures = { linux: 0, macos: 0, windows: 0 };
-            const platformJobIds   = { linux: null, macos: null, windows: null };
 
             for (const job of jobs.data.jobs) {
               const nameLower = job.name.toLowerCase();
@@ -135,14 +135,8 @@ jobs:
               } else if (nameLower.includes('windows') || nameLower.includes('win32')) {
                 platform = 'windows';
               }
-              if (!platform) {
-                continue;
-              }
-              platformJobIds[platform] = job.id;
+              if (!platform) { continue; }
               if (job.conclusion === 'failure') {
-                // We don't have direct access to the NEW_FAILURES output here;
-                // mark as at least 1. The actual count is in the JUnit artifact
-                // but downloading it here would be expensive.
                 platformFailures[platform] = platformFailures[platform] || 1;
               }
             }
@@ -150,13 +144,8 @@ jobs:
             const totalFailures = Object.values(platformFailures).reduce((a, b) => a + b, 0);
             core.info(`Failure counts — linux:${platformFailures.linux} macos:${platformFailures.macos} windows:${platformFailures.windows} total:${totalFailures}`);
             core.setOutput('total_failures', String(totalFailures));
-            core.setOutput('failures_linux', String(platformFailures.linux));
-            core.setOutput('failures_macos', String(platformFailures.macos));
-            core.setOutput('failures_windows', String(platformFailures.windows));
 
             // ── 3. Mass-failure check ────────────────────────────────────────
-            // If every platform failed we almost certainly have an infra issue,
-            // not individual test bugs. Skip the agent to avoid wasting tokens.
             const allPlatformsFailed =
               platformFailures.linux > 0 &&
               platformFailures.macos > 0 &&
@@ -171,12 +160,82 @@ jobs:
 
             core.setOutput('skip', 'false');
 
-            // ── 4. Collect server URLs from the PR comment ───────────────────
-            // post-server-info already posted the server URLs; read them back
-            // so we can include them in the agent prompt without fetching
-            // anything extra.
+            // ── 4. Download JUnit artifacts to get exact failing test names ──
+            // Each platform uploads a test-results-{os} artifact containing
+            // e2e/test-results/e2e-junit.xml. Download and parse them here so
+            // the agent prompt contains exact test names, not just counts.
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner, repo, run_id: runId, per_page: 50,
+            });
+
+            const failingTests = { linux: [], macos: [], windows: [] };
+
+            for (const artifact of artifacts.data.artifacts) {
+              const nameLower = artifact.name.toLowerCase();
+              let platform = null;
+              if (nameLower.startsWith('test-results-linux') || nameLower.startsWith('test-results-ubuntu')) {
+                platform = 'linux';
+              } else if (nameLower.startsWith('test-results-macos') || nameLower.startsWith('test-results-darwin')) {
+                platform = 'macos';
+              } else if (nameLower.startsWith('test-results-windows')) {
+                platform = 'windows';
+              }
+              if (!platform || platformFailures[platform] === 0) { continue; }
+
+              try {
+                // Download the artifact zip (streams as redirect URL)
+                const dl = await github.rest.actions.downloadArtifact({
+                  owner, repo, artifact_id: artifact.id, archive_format: 'zip',
+                });
+                // dl.url is the redirect; use fetch to get the zip bytes
+                const resp = await fetch(dl.url);
+                const buf  = Buffer.from(await resp.arrayBuffer());
+
+                // Unzip in memory — find the JUnit XML
+                const AdmZip = require('adm-zip');
+                const zip = new AdmZip(buf);
+                const xmlEntry = zip.getEntries().find(
+                  (e) => e.entryName.endsWith('e2e-junit.xml'),
+                );
+                if (!xmlEntry) { continue; }
+
+                const xml = xmlEntry.getData().toString('utf8');
+                // Parse out <failure> test names via simple regex — no full XML parse needed
+                const suiteMatches = xml.matchAll(/<testcase[^>]+name="([^"]+)"[^>]*>[\s\S]*?<(?:failure|error)[^/]/g);
+                for (const m of suiteMatches) {
+                  failingTests[platform].push(m[1]);
+                }
+              } catch (err) {
+                core.warning(`Could not parse JUnit for ${platform}: ${err.message}`);
+              }
+            }
+
+            const failingTestsBlock = Object.entries(failingTests)
+              .filter(([, names]) => names.length > 0)
+              .map(([platform, names]) => {
+                const list = names.map((n) => `  - ${n}`).join('\n');
+                return `${platform}:\n${list}`;
+              })
+              .join('\n\n');
+
+            // Falling back to platform count summary if we could not parse XML
+            const failingSummary = failingTestsBlock ||
+              Object.entries(platformFailures)
+                .filter(([, count]) => count > 0)
+                .map(([p, c]) => `- ${p}: ${c} failure(s) (JUnit not available — check CI logs)`)
+                .join('\n');
+
+            core.setOutput('failing_tests_block', failingTestsBlock);
+            core.setOutput('failing_summary', failingSummary);
+
+            // ── 5. Extract per-platform server info from the PR comment ──────
+            // post-server-info posted a Markdown table; parse out individual
+            // rows so we can expose each URL and the admin username separately.
             const MARKER = '<!-- e2e-server-info -->';
-            let serverBlock = '(server URLs not found in PR comment)';
+            const serverUrls    = { linux: '', macos: '', windows: '' };
+            let adminUsername   = '';
+            let serverTableBlock = '(server URLs not found in PR comment)';
+
             try {
               const comments = await github.rest.issues.listComments({
                 owner, repo, issue_number: prNumber, per_page: 100,
@@ -185,26 +244,38 @@ jobs:
                 (c) => c.body && c.body.includes(MARKER),
               );
               if (infoComment) {
-                // Extract just the table lines — skip the header and trailing lines
-                const tableLines = infoComment.body.
-                  split('\n').
-                  filter((l) => l.startsWith('|') && !l.startsWith('| Platform')).
-                  slice(0, 4); // at most 3 platform rows + divider
-                serverBlock = tableLines.join('\n');
+                const body = infoComment.body;
+
+                // Extract table rows (lines starting with |`linux`|, |`macos`|, |`windows`|)
+                const rowRe = /^\|\s*`(linux|macos|windows)`\s*\|\s*(\S+)\s*\|/im;
+                for (const line of body.split('\n')) {
+                  const m = line.match(rowRe);
+                  if (m) {
+                    serverUrls[m[1].toLowerCase()] = m[2];
+                  }
+                }
+
+                // Extract admin username from "**Admin username:** `...`"
+                const userMatch = body.match(/\*\*Admin username:\*\*\s*`([^`]+)`/);
+                if (userMatch) { adminUsername = userMatch[1]; }
+
+                // Keep the raw table for the prompt as well
+                const tableLines = body.split('\n').filter(
+                  (l) => l.startsWith('|') && !l.startsWith('| Platform'),
+                ).slice(0, 5);
+                serverTableBlock = tableLines.join('\n');
               }
             } catch (err) {
               core.warning(`Could not read PR comments: ${err.message}`);
             }
 
-            // ── 5. Build the failing-platform summary (short, no full logs) ──
-            const failingSummary = Object.entries(platformFailures).
-              filter(([, count]) => count > 0).
-              map(([platform, count]) => `- ${platform}: ${count} failure(s)`).
-              join('\n');
-
-            core.setOutput('failing_summary', failingSummary);
-            core.setOutput('server_block', serverBlock);
+            core.setOutput('server_url_linux',   serverUrls.linux);
+            core.setOutput('server_url_macos',   serverUrls.macos);
+            core.setOutput('server_url_windows', serverUrls.windows);
+            core.setOutput('admin_username',     adminUsername);
+            core.setOutput('server_table_block', serverTableBlock);
             core.setOutput('workflow_run_url', `https://github.com/${owner}/${repo}/actions/runs/${runId}`);
+            core.setOutput('workflow_run_id', String(runId));
 
       - name: Post skip notice for mass failures
         if: steps.triage.outputs.skip == 'true' && steps.triage.outputs.skip_reason == 'mass_failure'
@@ -238,6 +309,7 @@ jobs:
                 '1. Check the [workflow run](' + runUrl + ') for build errors or server provisioning failures.',
                 '2. If it was a transient CI issue, push an empty commit to re-trigger E2E.',
                 '3. If it is a real product regression, investigate the failing tests manually.',
+                '4. To override and force-launch the agent anyway, comment `@cursor fix e2e` on this PR.',
               ].join('\n'),
             });
 
@@ -248,74 +320,142 @@ jobs:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           PR_URL: ${{ steps.triage.outputs.pr_url }}
           FAILING_SUMMARY: ${{ steps.triage.outputs.failing_summary }}
-          SERVER_BLOCK: ${{ steps.triage.outputs.server_block }}
+          SERVER_TABLE_BLOCK: ${{ steps.triage.outputs.server_table_block }}
+          SERVER_URL_LINUX: ${{ steps.triage.outputs.server_url_linux }}
+          SERVER_URL_MACOS: ${{ steps.triage.outputs.server_url_macos }}
+          SERVER_URL_WINDOWS: ${{ steps.triage.outputs.server_url_windows }}
+          ADMIN_USERNAME: ${{ steps.triage.outputs.admin_username }}
           WORKFLOW_RUN_URL: ${{ steps.triage.outputs.workflow_run_url }}
+          WORKFLOW_RUN_ID: ${{ steps.triage.outputs.workflow_run_id }}
         run: |
-          # Build the prompt as a file to avoid shell quoting issues with
-          # multi-line strings and special characters.
           cat > /tmp/agent-prompt.txt << 'PROMPT_EOF'
-          E2E tests failed on this PR. Your job is to investigate each failure,
-          classify it, and act accordingly.
+          E2E tests failed on this PR. Your job is to fix every test bug you find.
+          You are running on a Linux agent with an X server on DISPLAY=:1.
 
-          FAILING PLATFORMS
-          -----------------
+          ══════════════════════════════════════════════════
+          FAILING TESTS (from CI JUnit XML)
+          ══════════════════════════════════════════════════
           ${FAILING_SUMMARY}
 
-          SERVER URLS (provisioned by Matterwick — still live)
-          -----------------------------------------------------
-          ${SERVER_BLOCK}
+          ══════════════════════════════════════════════════
+          PROVISIONED TEST SERVERS (still live)
+          ══════════════════════════════════════════════════
+          ${SERVER_TABLE_BLOCK}
 
-          WORKFLOW RUN (for full logs and JUnit artifacts)
-          -------------------------------------------------
-          ${WORKFLOW_RUN_URL}
+          Individual URLs for use in run commands:
+            Linux   server: ${SERVER_URL_LINUX}
+            macOS   server: ${SERVER_URL_MACOS}
+            Windows server: ${SERVER_URL_WINDOWS}
+            Admin username: ${ADMIN_USERNAME}
+            Admin password: read the MM_TEST_PASSWORD environment variable
+                            (injected as a Cursor secret — do NOT hardcode it)
 
-          INSTRUCTIONS
-          ------------
-          1. Read the CI workflow run logs to find the exact failing test names
-             and error messages. Download the JUnit XML artifact if available.
+          CI run (for full logs and trace artifacts): ${WORKFLOW_RUN_URL}
 
-          2. For each failing test, open the test source file in e2e/specs/ and
-             classify the failure:
+          ══════════════════════════════════════════════════
+          STEP-BY-STEP INSTRUCTIONS
+          ══════════════════════════════════════════════════
 
-             TEST BUG — the test itself is wrong:
-             Examples: stale selector, wrong timeout, missing wait, wrong
-             assertion value, race condition in setup/teardown.
-             Action: Fix the test code and push a commit to this branch.
+          ## Step 1 — Build the app
 
-             PRODUCT BUG — the app behavior does not match what the test expects:
-             Examples: UI element removed/renamed, IPC channel changed, feature
-             regression in src/.
-             Action: Do NOT modify the test. Instead post a PR comment describing:
-             - Which test failed
-             - What the test expected vs what actually happened
-             - Which src/ file is likely responsible
-             Label the comment "Product Bug: <test name>".
+          Run this once at the start (required before any spec can run):
 
-          3. IMPORTANT RULES to avoid wasting tokens:
-             - Fix at most 8 test files per run. If more than 8 distinct test
-               files are failing, fix the 8 most-common failure patterns and
-               post a comment listing the remaining ones as product bugs or
-               deferred test bugs.
-             - Do NOT rewrite tests from scratch. Make the smallest change that
-               fixes the failure.
-             - Do NOT touch any file in src/ (app source). Your scope is
-               e2e/specs/, e2e/helpers/, e2e/fixtures/, and e2e/utils/.
-             - If a selector is missing from the live server (checked via
-               MM_TEST_SERVER_URL), that is a product bug — report it.
-             - Run each fixed spec against the live server to confirm it passes
-               before committing.
+            source ~/.nvm/nvm.sh && nvm use 20.15.0
+            npm ci
+            cd e2e && npm ci && cd ..
+            npm run build-test
 
-          4. After all fixes are committed (or all bugs reported), post a single
-             summary comment on the PR with:
-             - List of test bugs fixed (file name + one-line description)
-             - List of product bugs reported (test name + symptom)
+          If the build fails, stop and post a PR comment with the error.
+
+          ## Step 2 — Identify the exact failing spec files
+
+          The failing test names are listed above. Map each name to a file in
+          e2e/specs/. If the JUnit block is empty, download the test-results
+          artifact from the CI run URL above and extract e2e-junit.xml manually
+          using the GitHub CLI:
+
+            gh run download ${WORKFLOW_RUN_ID} \
+              --name test-results-linux \
+              --dir /tmp/results-linux
+            cat /tmp/results-linux/test-results/e2e-junit.xml | grep 'testcase name'
+
+          Repeat for test-results-macos / test-results-windows as needed.
+
+          ## Step 3 — Reproduce the failure BEFORE editing anything
+
+          Run the failing spec file. Use the Linux server URL for Linux-tagged
+          tests; any URL works for platform-neutral tests.
+
+          Linux run command (use this for linux-tagged tests or neutral tests):
+
+            cd e2e
+            export DISPLAY=:1
+            export MM_TEST_SERVER_URL="${SERVER_URL_LINUX}"
+            export MM_TEST_USER_NAME="${ADMIN_USERNAME}"
+            export MM_TEST_PASSWORD="${MM_TEST_PASSWORD}"
+            xvfb-run --auto-servernum --server-args='-screen 0 1280x960x24' \
+              npx playwright test <spec-file-relative-to-e2e/> \
+              --reporter=list --workers=1
+            cd ..
+
+          You MUST confirm the test fails on HEAD before touching any code.
+          If you cannot reproduce the failure, classify it as "flake" and post
+          a PR comment — do NOT edit the test.
+
+          ## Step 4 — Classify each failure
+
+          TEST BUG — the test code is wrong:
+            Examples: stale selector, wrong assertion value, missing wait,
+            race condition in setup/teardown, obsolete helper.
+            Action: fix the test code; then proceed to Step 5.
+
+          PRODUCT BUG — the app does not match what the test expects:
+            Examples: renamed UI element, changed IPC channel, missing feature.
+            Action: do NOT modify the test. Post a PR comment:
+              "Product Bug: <test name> — expected X, got Y, likely in <src/ file>"
+
+          ## Step 5 — Fix and re-run
+
+          After editing the spec (or its helper/fixture), run the exact same
+          command from Step 3 and confirm the test now passes.
+
+          DO NOT COMMIT a fix until the re-run shows the test passing.
+          If the re-run still fails, debug further before committing.
+
+          For macOS/Windows-only failures:
+            - The macOS/Windows platforms use the same spec source on GitHub.
+            - Run the spec against the Linux server first to confirm the test
+              logic is correct. If it passes on Linux but the failure was only
+              on macOS/Windows, note it in your commit message. Commit, then
+              push so CI re-runs on the real platform to confirm.
+
+          ## Step 6 — Hard limits
+
+          - Fix at most 8 distinct spec files per run.
+          - Never touch src/ files.
+          - Scope: e2e/specs/, e2e/helpers/, e2e/fixtures/, e2e/utils/ only.
+          - Never add long sleeps (> 2 s) as a fix.
+          - If you exceed the file limit, post a comment listing remaining failures.
+
+          ## Step 7 — Summary comment
+
+          After committing all fixes, post a single PR comment:
+            - Each fix: spec file path + one-line root-cause description +
+              exact run command used + "PASSED" result
+            - Each product bug: test name + symptom + suspected src/ file
+            - Any flakes: test name + why you concluded it is a flake
           PROMPT_EOF
 
-          # Substitute the env vars into the prompt
+          # Substitute env vars into the prompt
           PROMPT=$(sed \
             -e "s|\${FAILING_SUMMARY}|${FAILING_SUMMARY}|g" \
-            -e "s|\${SERVER_BLOCK}|${SERVER_BLOCK}|g" \
+            -e "s|\${SERVER_TABLE_BLOCK}|${SERVER_TABLE_BLOCK}|g" \
+            -e "s|\${SERVER_URL_LINUX}|${SERVER_URL_LINUX}|g" \
+            -e "s|\${SERVER_URL_MACOS}|${SERVER_URL_MACOS}|g" \
+            -e "s|\${SERVER_URL_WINDOWS}|${SERVER_URL_WINDOWS}|g" \
+            -e "s|\${ADMIN_USERNAME}|${ADMIN_USERNAME}|g" \
             -e "s|\${WORKFLOW_RUN_URL}|${WORKFLOW_RUN_URL}|g" \
+            -e "s|\${WORKFLOW_RUN_ID}|${WORKFLOW_RUN_ID}|g" \
             /tmp/agent-prompt.txt)
 
           # Launch the Cursor agent
@@ -362,9 +502,9 @@ jobs:
             if (!(/^\d+$/).test(trimmed)) { return; }
             const prNumber = Number(trimmed);
             if (!Number.isInteger(prNumber) || prNumber <= 0) { return; }
-            const agentUrl   = process.env.AGENT_URL    || '(pending)';
-            const runUrl     = process.env.WORKFLOW_RUN_URL;
-            const summary    = process.env.FAILING_SUMMARY;
+            const agentUrl = process.env.AGENT_URL || '(pending)';
+            const runUrl   = process.env.WORKFLOW_RUN_URL;
+            const summary  = process.env.FAILING_SUMMARY;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -372,11 +512,17 @@ jobs:
               body: [
                 '### :robot: Cursor Agent Launched to Fix E2E Failures',
                 '',
-                '**Failing platforms:**',
+                '**Failing tests:**',
+                '```',
                 summary,
+                '```',
                 '',
-                'The agent will investigate each failure, fix test bugs, and report product bugs.',
-                'It will push fixes directly to this branch (which will trigger a new E2E run).',
+                'The agent will:',
+                '1. Reproduce each failure locally before editing',
+                '2. Fix test bugs and confirm the fix passes before committing',
+                '3. Report product bugs as PR comments without modifying tests',
+                '',
+                'It will push fixes directly to this branch (triggering a new E2E run).',
                 '',
                 agentUrl ? `**Agent:** ${agentUrl}` : '',
                 `**CI run:** ${runUrl}`,

--- a/.github/workflows/e2e-functional.yml
+++ b/.github/workflows/e2e-functional.yml
@@ -118,11 +118,13 @@ jobs:
 
       - name: Update initial status for all platforms
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PLATFORMS: ${{ needs.prepare-matrix.outputs.platforms }}
         with:
           github-token: ${{ github.token }}
           script: |
             const { updateInitialStatus } = require('./e2e/utils/github-actions.js');
-            const platforms = ${{ needs.prepare-matrix.outputs.platforms }};
+            const platforms = JSON.parse(process.env.PLATFORMS);
             await updateInitialStatus({ github, context, platforms });
 
   e2e-tests:
@@ -237,13 +239,17 @@ jobs:
 
       - name: Update final status for all platforms
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PLATFORMS: ${{ needs.prepare-matrix.outputs.platforms }}
+          E2E_OUTPUTS: ${{ toJSON(needs.e2e-tests.outputs) }}
+          MERGED_REPORT_URL: ${{ needs.merge-e2e-report.outputs.merged-report-url }}
         with:
           github-token: ${{ github.token }}
           script: |
             const { updateFinalStatus } = require('./e2e/utils/github-actions.js');
-            const platforms = ${{ needs.prepare-matrix.outputs.platforms }};
-            const outputs = ${{ toJSON(needs.e2e-tests.outputs) }};
-            const mergedReportUrl = '${{ needs.merge-e2e-report.outputs.merged-report-url }}' || undefined;
+            const platforms = JSON.parse(process.env.PLATFORMS);
+            const outputs = JSON.parse(process.env.E2E_OUTPUTS);
+            const mergedReportUrl = process.env.MERGED_REPORT_URL || undefined;
             await updateFinalStatus({ github, context, platforms, outputs, mergedReportUrl });
 
   # remove-e2e-label is intentionally omitted: see e2e-label-cleanup.yml for context.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,9 +43,10 @@ When a Cursor cloud agent is launched by `e2e-fix-trigger.yml` or `e2e-cursor-co
 
 | Secret name | Value |
 |---|---|
-| `MM_TEST_PASSWORD` | The admin password for the Matterwick-provisioned E2E servers (same value as the `MM_DESKTOP_E2E_USER_CREDENTIALS` GitHub repo secret) |
+| `MM_DESKTOP_E2E_USER_NAME` | The admin username for the Matterwick-provisioned E2E servers (same value as the `MM_DESKTOP_E2E_USER_NAME` GitHub repo secret) |
+| `MM_DESKTOP_E2E_USER_CREDENTIALS` | The admin password for the Matterwick-provisioned E2E servers (same value as the `MM_DESKTOP_E2E_USER_CREDENTIALS` GitHub repo secret) |
 
-The `MM_TEST_SERVER_URL` and `MM_TEST_USER_NAME` values are injected into the agent prompt directly by the workflow (read from the server-info PR comment). Only `MM_TEST_PASSWORD` must be a Cursor secret because it cannot be safely embedded in a PR comment.
+These are exposed to the agent directly as environment variables. The agent uses them verbatim as `MM_TEST_USER_NAME` and `MM_TEST_PASSWORD` when running specs. `MM_TEST_SERVER_URL` is still injected into the agent prompt from the server-info PR comment (it is not secret).
 
 ### Running E2E tests locally on this Linux VM
 
@@ -59,8 +60,8 @@ npm run build-test
 cd e2e
 export DISPLAY=:1
 export MM_TEST_SERVER_URL=<server-url>
-export MM_TEST_USER_NAME=<admin-username>
-export MM_TEST_PASSWORD=<admin-password>
+export MM_TEST_USER_NAME="${MM_DESKTOP_E2E_USER_NAME}"
+export MM_TEST_PASSWORD="${MM_DESKTOP_E2E_USER_CREDENTIALS}"
 xvfb-run --auto-servernum --server-args='-screen 0 1280x960x24' \
   npx playwright test <spec-file-relative-to-e2e/> --reporter=list --workers=1
 cd ..

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,37 @@ All standard commands are documented in `CLAUDE.md` and `package.json`. Quick re
 
 E2E tests live in `e2e/` with a separate `package.json`. See `e2e/AGENTS.md` for detailed guidance. Server-backed E2E tests require a running Mattermost server and env vars `MM_TEST_SERVER_URL`, `MM_TEST_USER_NAME`, `MM_TEST_PASSWORD`. Startup/UI-only E2E tests can run without a server.
 
+### Cursor secrets required for E2E fix agents
+
+When a Cursor cloud agent is launched by `e2e-fix-trigger.yml` or `e2e-cursor-commands.yml` to fix failing E2E tests, it needs credentials to connect to the provisioned Mattermost test servers. Add the following secrets in the Cursor Dashboard (Cloud Agents → Secrets):
+
+| Secret name | Value |
+|---|---|
+| `MM_TEST_PASSWORD` | The admin password for the Matterwick-provisioned E2E servers (same value as the `MM_DESKTOP_E2E_USER_CREDENTIALS` GitHub repo secret) |
+
+The `MM_TEST_SERVER_URL` and `MM_TEST_USER_NAME` values are injected into the agent prompt directly by the workflow (read from the server-info PR comment). Only `MM_TEST_PASSWORD` must be a Cursor secret because it cannot be safely embedded in a PR comment.
+
+### Running E2E tests locally on this Linux VM
+
+To run a single spec file against a live server:
+
+```bash
+source ~/.nvm/nvm.sh && nvm use 20.15.0
+npm ci && cd e2e && npm ci && cd ..
+npm run build-test
+
+cd e2e
+export DISPLAY=:1
+export MM_TEST_SERVER_URL=<server-url>
+export MM_TEST_USER_NAME=<admin-username>
+export MM_TEST_PASSWORD=<admin-password>
+xvfb-run --auto-servernum --server-args='-screen 0 1280x960x24' \
+  npx playwright test <spec-file-relative-to-e2e/> --reporter=list --workers=1
+cd ..
+```
+
+If a run leaves Electron hanging: `killall Electron 2>/dev/null || true`
+
 ### Native modules
 
 The `postinstall` script runs `electron-builder install-app-deps` to rebuild native modules (registry-js, cf-prefs, etc.) for the current Electron version. If you see native module errors after `npm install`, ensure postinstall completed successfully.

--- a/e2e/utils/github-actions.js
+++ b/e2e/utils/github-actions.js
@@ -204,17 +204,31 @@ async function postServerInfoComment({github, context, platforms, adminUsername,
     const body = lines.join('\n');
     const {owner, repo} = context.repo;
 
+    // Search all pages of comments so the marker is never missed on busy PRs.
+    // Without full pagination a PR with > 100 comments would fail to find the
+    // existing comment and create a duplicate on every subsequent E2E run.
     let existingCommentId = null;
     try {
-        const {data: comments} = await github.rest.issues.listComments({
-            owner,
-            repo,
-            issue_number: prNumber,
-            per_page: 100,
-        });
-        const existing = comments.find((c) => c.body && c.body.includes(MARKER));
-        if (existing) {
-            existingCommentId = existing.id;
+        let page = 1;
+        while (!existingCommentId) {
+            const {data: comments} = await github.rest.issues.listComments({
+                owner,
+                repo,
+                issue_number: prNumber,
+                per_page: 100,
+                page,
+            });
+            if (comments.length === 0) {
+                break;
+            }
+            const found = comments.find((c) => c.body && c.body.includes(MARKER));
+            if (found) {
+                existingCommentId = found.id;
+            } else if (comments.length < 100) {
+                // Reached the last page without finding the marker.
+                break;
+            }
+            page++;
         }
     } catch (err) {
         console.log(`Could not list PR comments: ${err.message}`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Two rounds of changes to the three GitHub Actions workflows powering Cursor-driven automatic E2E test fixing.

---

### Round 1 — Security, permissions, reliability (original commit)

**`e2e-fix-trigger.yml`**
- `issues: write` / `pull-requests: write` moved from workflow-level to job-level (least-privilege).
- `github.event.workflow_run.id` passed via `env:` / `process.env` to avoid direct interpolation inside `script:`.
- PR number reads hardened with strict positive-integer validation.
- **Bug fix**: `AGENT_URL` was read from `${{ env.AGENT_URL }}` (never set at workflow level). Added `id: launch` to the curl step and changed reference to `${{ steps.launch.outputs.agent_url }}`. Agent link in PR comments now works.
- `continue-on-error: true` on both auxiliary comment steps.

**`e2e-cursor-commands.yml`**
- `issues: write` / `pull-requests: write` moved to job-level.
- **Critical injection fix**: `github.event.comment.body` (raw user input) was interpolated directly into a JS string literal. A single quote in a comment body could break out of the string and execute arbitrary JS on the runner. Now passed via `COMMENT_BODY` env var.
- Strict positive-integer validation applied to all PR number reads.
- `continue-on-error: true` on react and reply steps.

**`e2e-functional.yml`**
- `${{ needs.prepare-matrix.outputs.platforms }}` (JSON array) replaced with `env:` + `JSON.parse()` in both `github-script` blocks.

---

### Round 2 — Operational prompts: run before you commit

The agent prompts previously did not give exact build commands, server credentials, or a prohibition on guessing fixes. This round makes the agent actually run the failing test and see it pass before committing.

**Triage/context step (both fix workflows)**
- Downloads JUnit XML artifacts (`test-results-{linux,macos,windows}`) in-memory and parses exact failing test names with `adm-zip`. The prompt now contains the actual test name(s) instead of "linux: 1 failure(s)".
- Extracts per-platform server URLs (`SERVER_URL_LINUX`, `SERVER_URL_MACOS`, `SERVER_URL_WINDOWS`) individually from the server-info PR comment, plus the admin username.
- Exposes the workflow run ID so the agent can fall back to `gh run download` if the in-workflow parse fails.

**Agent prompts (fix flow)**
- Step 1: exact build commands (`nvm use 20.15.0`, `npm ci` ×2, `npm run build-test`).
- Step 2: how to find the spec file path from the JUnit test name; `gh run download` fallback.
- Step 3: shared-root-cause analysis before per-spec fixes.
- Step 4: hard **reproduce BEFORE editing** rule with the complete `xvfb-run` command, all env vars pre-filled. "You MUST see the failure before touching code."
- Step 5: hard **DO NOT COMMIT until the re-run shows passing** rule.
- Platform strategy: run against the Linux server to validate test logic; macOS/Windows is confirmed by CI re-run after push (cannot run natively on a Linux agent).
- Summary comment must include the exact run command used and a "PASSED" result.

**`AGENTS.md`**
- New section: **Cursor secrets required for E2E fix agents** — documents that `MM_TEST_PASSWORD` must be added as a Cursor Dashboard secret so the agent can authenticate against Matterwick-provisioned servers.
- New section: **Running E2E tests locally on this Linux VM** — the exact `xvfb-run` command with all env var exports.

#### Ticket Link

N/A

#### Checklist
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] executed `npm run lint:js` for proper code formatting

#### Release Note

```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06067875-1266-4f3e-a200-3b0e9ce489a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06067875-1266-4f3e-a200-3b0e9ce489a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

