### PR TITLE
[MM-67767] Add priority modal queueing so that some modals can show above others

### DIFF
--- a/src/app/mainWindow/modals/modalManager.test.js
+++ b/src/app/mainWindow/modals/modalManager.test.js
@@ -94,11 +94,52 @@ describe('main/views/modalManager', () => {
         });
     });
 
+    describe('addPriorityModal', () => {
+        const modalManager = new ModalManager();
+
+        beforeEach(() => {
+            modalManager.modalQueue = [];
+            modalManager.modalPromises = new Map();
+            modalManager.showModal = jest.fn();
+        });
+
+        it('should not add modal with the same key, should return the existing promise', () => {
+            modalManager.modalQueue.push({key: 'existing_key'});
+            const promise = Promise.resolve();
+            modalManager.modalPromises.set('existing_key', promise);
+            expect(modalManager.addPriorityModal('existing_key', 'some_html', 'preload', {}, {})).toBe(promise);
+        });
+
+        it('should insert modal at front of queue and always call showModal', () => {
+            const existingModal = {key: 'existing_key', suspend: jest.fn()};
+            modalManager.modalQueue.push(existingModal);
+            modalManager.addPriorityModal('priority_key', 'some_html', 'preload', {}, {});
+            expect(modalManager.modalPromises.has('priority_key')).toBe(true);
+            expect(modalManager.modalQueue.length).toBe(2);
+            expect(modalManager.modalQueue[1]).toBe(existingModal);
+            expect(modalManager.showModal).toBeCalled();
+        });
+
+        it('should suspend the current front modal before inserting', () => {
+            const existingModal = {key: 'existing_key', suspend: jest.fn()};
+            modalManager.modalQueue.push(existingModal);
+            modalManager.addPriorityModal('priority_key', 'some_html', 'preload', {}, {});
+            expect(existingModal.suspend).toBeCalled();
+        });
+
+        it('should work when queue is empty', () => {
+            modalManager.addPriorityModal('new_key', 'some_html', 'preload', {}, {});
+            expect(modalManager.modalPromises.has('new_key')).toBe(true);
+            expect(modalManager.modalQueue.length).toBe(1);
+            expect(modalManager.showModal).toBeCalled();
+        });
+    });
+
     describe('showModal', () => {
         const oldEnv = process.env;
         const modalManager = new ModalManager();
-        const modalView = {key: 'test', view: {webContents: {id: 1}}, show: jest.fn(), hide: jest.fn()};
-        const modalView2 = {key: 'test2', view: {webContents: {id: 2}}, show: jest.fn(), hide: jest.fn()};
+        const modalView = {key: 'test', view: {webContents: {id: 1}}, show: jest.fn(), suspend: jest.fn()};
+        const modalView2 = {key: 'test2', view: {webContents: {id: 2}}, show: jest.fn(), suspend: jest.fn()};
         const promise = Promise.resolve();
 
         beforeEach(() => {
@@ -112,10 +153,10 @@ describe('main/views/modalManager', () => {
             process.env = oldEnv;
         });
 
-        it('should show first modal and hide second one', () => {
+        it('should show first modal and suspend second one', () => {
             modalManager.showModal();
             expect(modalView.show).toBeCalled();
-            expect(modalView.hide).not.toBeCalled();
+            expect(modalView2.suspend).toBeCalled();
         });
 
         it('should include dev tools when env variable is enabled', () => {

--- a/src/app/mainWindow/modals/modalManager.ts
+++ b/src/app/mainWindow/modals/modalManager.ts
@@ -43,23 +43,39 @@ export class ModalManager {
         ipcMain.on(EMIT_CONFIGURATION, this.handleEmitConfiguration);
     }
 
-    // TODO: add a queue/add differentiation, in case we need to put a modal first in line
     addModal = <T, T2>(key: string, html: string, preload: string, data: T, win: BrowserWindow, uncloseable = false) => {
+        return this.enqueueModal<T, T2>(key, html, preload, data, win, uncloseable, false);
+    };
+
+    addPriorityModal = <T, T2>(key: string, html: string, preload: string, data: T, win: BrowserWindow, uncloseable = false) => {
+        return this.enqueueModal<T, T2>(key, html, preload, data, win, uncloseable, true);
+    };
+
+    private enqueueModal = <T, T2>(key: string, html: string, preload: string, data: T, win: BrowserWindow, uncloseable: boolean, priority: boolean) => {
         const foundModal = this.modalQueue.find((modal) => modal.key === key);
-        if (!foundModal) {
-            const modalPromise = new Promise((resolve: (value: T2) => void, reject) => {
-                const mv = new ModalView<T, T2>(key, html, preload, data, resolve, reject, win, uncloseable);
-                this.modalQueue.push(mv);
-            });
-
-            if (this.modalQueue.length === 1) {
-                this.showModal();
-            }
-
-            this.modalPromises.set(key, modalPromise);
-            return modalPromise;
+        if (foundModal) {
+            return this.modalPromises.get(key) as Promise<T2>;
         }
-        return this.modalPromises.get(key) as Promise<T2>;
+
+        const modalPromise = new Promise((resolve: (value: T2) => void, reject) => {
+            const mv = new ModalView<T, T2>(key, html, preload, data, resolve, reject, win, uncloseable);
+
+            if (priority) {
+                if (this.modalQueue.length > 0) {
+                    this.modalQueue[0].suspend();
+                }
+                this.modalQueue.unshift(mv);
+            } else {
+                this.modalQueue.push(mv);
+            }
+        });
+
+        if (priority || this.modalQueue.length === 1) {
+            this.showModal();
+        }
+
+        this.modalPromises.set(key, modalPromise);
+        return modalPromise;
     };
 
     removeModal = (key: string) => {
@@ -102,8 +118,7 @@ export class ModalManager {
                 modal.show(undefined, Boolean(withDevTools));
                 WebContentsEventManager.addWebContentsEventListeners(modal.view.webContents);
             } else {
-                MainWindow.sendToRenderer(MODAL_CLOSE);
-                modal.hide();
+                modal.suspend();
             }
         });
     };

--- a/src/app/mainWindow/modals/modalView.ts
+++ b/src/app/mainWindow/modals/modalView.ts
@@ -107,6 +107,14 @@ export class ModalView<T, T2> {
         }
     };
 
+    suspend = () => {
+        if (this.windowAttached) {
+            this.windowAttached.contentView.removeChildView(this.view);
+            delete this.windowAttached;
+            this.status = Status.ACTIVE;
+        }
+    };
+
     handleInfoRequest = () => {
         return this.data;
     };

--- a/src/main/app/intercom.test.js
+++ b/src/main/app/intercom.test.js
@@ -12,6 +12,7 @@ import {
     handleWelcomeScreenModal,
     handleMainWindowIsShown,
     handleToggleSecureInput,
+    handleShowSettingsModal,
 } from './intercom';
 
 jest.mock('electron', () => ({
@@ -47,6 +48,7 @@ jest.mock('main/utils', () => ({
 jest.mock('common/views/viewManager', () => ({}));
 jest.mock('app/mainWindow/modals/modalManager', () => ({
     addModal: jest.fn(),
+    addPriorityModal: jest.fn(),
 }));
 jest.mock('app/mainWindow/mainWindow', () => ({
     get: jest.fn(),
@@ -82,6 +84,24 @@ describe('main/app/intercom', () => {
 
             handleMainWindowIsShown();
             expect(ModalManager.addModal).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('handleShowSettingsModal', () => {
+        beforeEach(() => {
+            getLocalPreload.mockReturnValue('/some/preload.js');
+            MainWindow.get.mockReturnValue({});
+        });
+
+        it('should open settings modal using addPriorityModal', () => {
+            handleShowSettingsModal();
+            expect(ModalManager.addPriorityModal).toHaveBeenCalledWith('settingsModal', 'mattermost-desktop://renderer/settings.html', '/some/preload.js', null, {});
+        });
+
+        it('should not open settings modal if no main window', () => {
+            MainWindow.get.mockReturnValue(null);
+            handleShowSettingsModal();
+            expect(ModalManager.addPriorityModal).not.toHaveBeenCalled();
         });
     });
 

--- a/src/main/app/intercom.ts
+++ b/src/main/app/intercom.ts
@@ -191,7 +191,7 @@ export function handleShowSettingsModal() {
         return;
     }
 
-    ModalManager.addModal(
+    ModalManager.addPriorityModal(
         ModalConstants.SETTINGS_MODAL,
         'mattermost-desktop://renderer/settings.html',
         getLocalPreload('internalAPI.js'),


### PR DESCRIPTION
#### Summary
The modal queue is strictly sequential — only the front modal is shown. When no servers are configured, the Welcome screen sits at the front of the queue and is uncloseable. Opening Settings enqueues it behind Welcome, where it never gets displayed.

This PR adds priority modal support to `ModalManager` so that certain modals (like Settings) can be inserted at the front of the queue, suspending the current modal without destroying it. When the priority modal closes, the previously-showing modal resumes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67767

#### Release Note
```release-note
Fixed an issue where the Settings modal could not be opened when no servers were configured.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes introduce a new modal suspension/resumption mechanism that modifies the lifecycle of queued modals. Previously, modals beyond the first in the queue were fully hidden (closing devtools, unregistering from performance monitor, disposing context menu, closing web contents). Now, non-visible modals call the new `suspend()` method which only detaches the view without these cleanup operations. This lifecycle change could leak resources if modals remain suspended indefinitely or cause unexpected state if callers rely on the previous cleanup behavior. Additionally, `ModalView.suspend()` lacks unit test coverage despite being a critical new lifecycle method. The Settings modal is the only current consumer of `addPriorityModal()`, limiting immediate exposure, but the infrastructure is now in place for broader adoption.

**QA Recommendation:** Manual QA should verify modal state transitions, particularly: (1) opening Settings modal when no servers are configured; (2) queuing multiple modals sequentially to ensure suspension/resumption works correctly; (3) long-lived scenarios where modals may remain suspended to check for resource leaks; (4) closing suspended modals to confirm proper cleanup. E2E tests for welcome screen and other modal-driven flows should be executed. Consider adding unit tests for `ModalView.suspend()` before merge.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->