### PR TITLE
Desktop: Quick fixes for docs label automation

### DIFF
--- a/.github/workflows/docs-impact-review.yml
+++ b/.github/workflows/docs-impact-review.yml
@@ -3,6 +3,8 @@ name: Documentation Impact Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - master
 
 concurrency:
   group: ${{ format('docs-impact-{0}', github.event.pull_request.number) }}
@@ -16,7 +18,7 @@ permissions:
 
 jobs:
   docs-impact-review:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && !startsWith(github.event.pull_request.user.login, 'unified-ci-app')
     runs-on: ubuntu-24.04
     env:
       HAS_ANTHROPIC_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}


### PR DESCRIPTION
Applying same fixes from https://github.com/mattermost/mattermost/pull/36185 to desktop.

Fixes the following issues:
 - Don't run the ci check on release branches. Only run it on master/main branch.
 - Skip analyzing docs impact for PRs opened by ``unified-ci-app`` bot.

```release-note
NONE
```

