### PR TITLE
[MM-68490] Ensure Welcome Modal is closed when a server is added

### DIFF
--- a/src/app/serverHub.test.js
+++ b/src/app/serverHub.test.js
@@ -47,6 +47,7 @@ jest.mock('main/server/serverInfo', () => ({
 }));
 jest.mock('app/mainWindow/modals/modalManager', () => ({
     addModal: jest.fn(),
+    removeModal: jest.fn(),
 }));
 jest.mock('main/utils', () => ({
     getLocalPreload: jest.fn(),

--- a/src/app/serverHub.ts
+++ b/src/app/serverHub.ts
@@ -23,6 +23,7 @@ import {
     SERVER_SWITCHED,
     GET_CURRENT_SERVER,
     SERVER_REMOVED,
+    SERVER_ADDED,
 } from 'common/communication';
 import {ModalConstants} from 'common/constants';
 import {Logger} from 'common/log';
@@ -58,7 +59,12 @@ export class ServerHub {
 
         ServerManager.on(SERVER_SWITCHED, this.handleServerCurrentChanged);
         ServerManager.on(SERVER_REMOVED, this.handleServerCleanup);
+        ServerManager.on(SERVER_ADDED, this.handleServerAdded);
     }
+
+    private handleServerAdded = () => {
+        ModalManager.removeModal(ModalConstants.WELCOME_SCREEN_MODAL);
+    };
 
     // TODO: Move me somewhere else later
     handleServerCurrentChanged = () => {


### PR DESCRIPTION
#### Summary
When the Welcome Screen modal was open and a user added a server through another path (e.g., the Settings modal), the welcome modal would still reappear after the priority modal closed because nothing dismissed it.

This PR listens for the `SERVER_ADDED` event in `ServerHub` and removes the welcome screen modal from `ModalManager`, ensuring it's dismissed regardless of which path triggered the server addition.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68490

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Minimal risk of regressions. The change adds a single event listener to ServerHub that calls the existing `ModalManager.removeModal()` method when a server is added. The `removeModal` implementation safely handles cases where the target modal doesn't exist (returns early without error). The `SERVER_ADDED` event is already established in the codebase and actively listened to by other components (serverDropdownView, mainWindow) without issues, demonstrating a proven pattern. No existing behavior is modified—only a new side effect is introduced. The test infrastructure was already in place with proper mocking.

**QA Recommendation:** Minimal manual QA is recommended. Verify that the welcome modal is properly dismissed when servers are added through alternative paths (e.g., via the Settings modal) and confirm that normal server addition workflows continue to function correctly. Ensure the modal doesn't unexpectedly disappear in unrelated scenarios. The change is isolated and straightforward, with automated test coverage for the happy path already established through existing mocks.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->