### PR TITLE
[MM-68368] Limit URL size to 8K

### DIFF
--- a/src/app/views/webContentEvents.test.js
+++ b/src/app/views/webContentEvents.test.js
@@ -56,6 +56,7 @@ jest.mock('main/app/utils', () => ({
 
 jest.mock('common/constants', () => ({
     MATTERMOST_PROTOCOL: 'mattermost',
+    MAX_URL_LENGTH: 8192,
 }));
 
 jest.mock('main/security/allowProtocolDialog', () => ({
@@ -227,6 +228,14 @@ describe('main/views/webContentsEvents', () => {
 
             it('should reject completely malformed URIs with no scheme and show dialog', () => {
                 expect(newWindow({url: 'not-a-url-at-all'})).toStrictEqual({action: 'deny'});
+                expect(dialog.showErrorBox).toHaveBeenCalled();
+                expect(shell.openExternal).not.toBeCalled();
+                expect(allowProtocolDialog.handleDialogEvent).not.toBeCalled();
+            });
+
+            it('should reject oversized URLs from window.open and show dialog', () => {
+                const oversizedURL = `http://example.com/${'A'.repeat(1000000)}`;
+                expect(newWindow({url: oversizedURL})).toStrictEqual({action: 'deny'});
                 expect(dialog.showErrorBox).toHaveBeenCalled();
                 expect(shell.openExternal).not.toBeCalled();
                 expect(allowProtocolDialog.handleDialogEvent).not.toBeCalled();

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -40,6 +40,7 @@ export const MASK_URL = 'URL';
 
 export const LOGS_MAX_STRING_LENGTH = 63;
 export const POPOUT_RATE_LIMIT = 1000;
+export const MAX_URL_LENGTH = 8192;
 
 // We use this URL inside the Diagnostics to check if the computer has internet connectivity
 export const IS_ONLINE_ENDPOINT = 'https://community.mattermost.com/api/v4/system/ping';

--- a/src/common/utils/url.test.js
+++ b/src/common/utils/url.test.js
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 'use strict';
 
+import {MAX_URL_LENGTH} from 'common/constants';
 import {
     getFormattedPathName,
     isUrlType,
@@ -62,6 +63,19 @@ describe('common/utils/url', () => {
 
         it('should reject URLs with percent-encoded null bytes', () => {
             expect(parseURL('customproto:///path%00malicious')).toBeUndefined();
+        });
+
+        it('should reject URLs longer than the maximum allowed length', () => {
+            const oversizedURL = `http://example.com/${'A'.repeat(MAX_URL_LENGTH)}`;
+            expect(parseURL(oversizedURL)).toBeUndefined();
+        });
+
+        it('should accept URLs at exactly the maximum allowed length', () => {
+            const prefix = 'http://example.com/';
+            const padding = 'A'.repeat(MAX_URL_LENGTH - prefix.length);
+            const maxLengthURL = `${prefix}${padding}`;
+            expect(maxLengthURL.length).toBe(MAX_URL_LENGTH);
+            expect(parseURL(maxLengthURL)).toBeDefined();
         });
     });
 

--- a/src/common/utils/url.ts
+++ b/src/common/utils/url.ts
@@ -4,12 +4,16 @@
 import {isHttpsUri, isHttpUri, isUri} from 'valid-url';
 
 import buildConfig from 'common/config/buildConfig';
+import {MAX_URL_LENGTH} from 'common/constants';
 import {nonTeamUrlPaths, CALLS_PLUGIN_ID} from 'common/utils/constants';
 
 export const getFormattedPathName = (pn: string) => (pn.endsWith('/') ? pn : `${pn}/`);
 export const parseURL = (inputURL: string | URL) => {
     if (inputURL instanceof URL) {
         return inputURL;
+    }
+    if (inputURL.length > MAX_URL_LENGTH) {
+        return undefined;
     }
     if (inputURL.includes('\0') || inputURL.toLowerCase().includes('%00')) {
         return undefined;

--- a/src/common/utils/url.ts
+++ b/src/common/utils/url.ts
@@ -12,7 +12,12 @@ export const parseURL = (inputURL: string | URL) => {
     if (inputURL instanceof URL) {
         return inputURL;
     }
-    if (inputURL.length > MAX_URL_LENGTH) {
+export const parseURL = (inputURL: string | URL) => {
+    if (inputURL instanceof URL) {
+        return inputURL;
+    }
+    const inputURLBytes = new TextEncoder().encode(inputURL).length;
+    if (inputURLBytes > MAX_URL_LENGTH) {
         return undefined;
     }
     if (inputURL.includes('\0') || inputURL.toLowerCase().includes('%00')) {

--- a/src/common/utils/url.ts
+++ b/src/common/utils/url.ts
@@ -12,10 +12,6 @@ export const parseURL = (inputURL: string | URL) => {
     if (inputURL instanceof URL) {
         return inputURL;
     }
-export const parseURL = (inputURL: string | URL) => {
-    if (inputURL instanceof URL) {
-        return inputURL;
-    }
     const inputURLBytes = new TextEncoder().encode(inputURL).length;
     if (inputURLBytes > MAX_URL_LENGTH) {
         return undefined;


### PR DESCRIPTION
#### Summary
Adds an upper bound (8 KB) on the length of URL strings accepted by `parseURL`, with the limit centralized as `MAX_URL_LENGTH` in `common/constants`. Inputs above the limit are rejected the same way other malformed values are today (returning `undefined`), so all existing callers fall through to their normal "invalid URL" handling.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68368

#### Release Note
```release-note
Fixed an issue where overly long URLs were not handled correctly
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** 
The change introduces an 8KB length check to parseURL, a shared utility used across renderer and navigation paths. Oversized inputs are now treated as malformed and cause parseURL to return undefined, preserving the existing malformed-input contract; this minimizes surprises for callers that already handle undefined. However, this touches a widely-used utility and could affect rare workflows that relied on processing very long (≥8KB) URLs. Unit tests covering the new boundary behavior were added, lowering but not eliminating regression risk.

**QA Recommendation:** 
Perform targeted manual QA on URL-dependent flows: new-window handling, external navigation, protocol dialogs, deep links/magic links, and any integrations that may pass very long URLs. Test normal URLs and boundary cases (exactly 8KB and >8KB). Given added tests, a focused spot-check across these areas is sufficient.

*Generated by CodeRabbitAI*

---

## Release Notes
Fixed an issue where overly long URLs were not handled correctly
<!-- end of auto-generated comment: release notes by coderabbit.ai -->