### PR TITLE
Cherrypick of #3797 to `release-5.13`

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -36,6 +36,7 @@ export const MASK_PATH = 'PATH';
 export const MASK_URL = 'URL';
 
 export const LOGS_MAX_STRING_LENGTH = 63;
+export const MAX_URL_LENGTH = 8192;
 
 // We use this URL inside the Diagnostics to check if the computer has internet connectivity
 export const IS_ONLINE_ENDPOINT = 'https://community.mattermost.com/api/v4/system/ping';

--- a/src/common/utils/url.test.js
+++ b/src/common/utils/url.test.js
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 'use strict';
 
+import {MAX_URL_LENGTH} from 'common/constants';
 import {
     getFormattedPathName,
     isUrlType,
@@ -45,6 +46,19 @@ describe('common/utils/url', () => {
             const parsedURL = parseURL(urlWithExtraSlashes);
 
             expect(parsedURL.toString()).toBe('https://mattermost.com/sub/path/example');
+        });
+
+        it('should reject URLs longer than the maximum allowed length', () => {
+            const oversizedURL = `http://example.com/${'A'.repeat(MAX_URL_LENGTH)}`;
+            expect(parseURL(oversizedURL)).toBeUndefined();
+        });
+
+        it('should accept URLs at exactly the maximum allowed length', () => {
+            const prefix = 'http://example.com/';
+            const padding = 'A'.repeat(MAX_URL_LENGTH - prefix.length);
+            const maxLengthURL = `${prefix}${padding}`;
+            expect(maxLengthURL.length).toBe(MAX_URL_LENGTH);
+            expect(parseURL(maxLengthURL)).toBeDefined();
         });
     });
 

--- a/src/common/utils/url.ts
+++ b/src/common/utils/url.ts
@@ -4,12 +4,17 @@
 import {isHttpsUri, isHttpUri, isUri} from 'valid-url';
 
 import buildConfig from 'common/config/buildConfig';
+import {MAX_URL_LENGTH} from 'common/constants';
 import {nonTeamUrlPaths, CALLS_PLUGIN_ID} from 'common/utils/constants';
 
 export const getFormattedPathName = (pn: string) => (pn.endsWith('/') ? pn : `${pn}/`);
 export const parseURL = (inputURL: string | URL) => {
     if (inputURL instanceof URL) {
         return inputURL;
+    }
+    const inputURLBytes = new TextEncoder().encode(inputURL).length;
+    if (inputURLBytes > MAX_URL_LENGTH) {
+        return undefined;
     }
     try {
         return new URL(inputURL.replace(/([^:]\/)\/+/g, '$1')); // Regex here to remove extra slashes


### PR DESCRIPTION
Cherrypick of #3797 to `release-5.13`

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes introduce a size limit check to the widely-used `parseURL()` utility function, which is imported by 20+ files across the codebase (server info, diagnostics, plugins, views, windows, auth, and menus). While the 8KB limit is generous for standard URLs, the new validation creates a behavioral change: URLs exceeding this size now return `undefined` instead of attempting parsing. Callers already handle `undefined` returns, but any code assuming `parseURL` processes all valid URL strings without size restrictions could break. The check occurs before the existing try-catch block, so oversized URLs skip the normalization logic entirely. Risk is mitigated by the high threshold (8KB), which far exceeds typical URL lengths.

**QA Recommendation:** Light manual testing recommended. Focus on edge cases: (1) verify legitimate server URLs and navigation flows work normally, (2) test plugin URLs and custom endpoints to confirm none exceed 8KB, (3) validate that oversized URLs are properly rejected in permission dialogs and link handling. Automated test coverage is present (boundary condition tests added), but given the wide blast radius (20+ dependent modules) and critical nature of URL validation in navigation/security, manual verification of common navigation and authentication flows is prudent before release.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->