### PR TITLE
[MM-68365] Block NTLM authentication for non-server configured domains

### DIFF
--- a/src/app/serverHub.test.js
+++ b/src/app/serverHub.test.js
@@ -21,6 +21,12 @@ jest.mock('electron', () => ({
         handle: jest.fn(),
         emit: jest.fn(),
     },
+    session: {
+        defaultSession: {
+            allowNTLMCredentialsForDomains: jest.fn(),
+            clearData: jest.fn(),
+        },
+    },
 }));
 
 jest.mock('common/servers/serverManager', () => ({
@@ -562,6 +568,42 @@ describe('app/serverViewState', () => {
             expect(result.status).toBe(URLValidationStatus.URLExists);
             expect(result.validatedURL).toBe('https://mainserver.com/');
             expect(result.existingServerName).toBe('Test Server 1');
+        });
+    });
+
+    describe('updateAuthServerAllowlist', () => {
+        const {session} = jest.requireMock('electron');
+
+        beforeEach(() => {
+            session.defaultSession.allowNTLMCredentialsForDomains.mockClear();
+        });
+
+        it('should set the allowlist to the configured server hostnames', () => {
+            ServerManager.getAllServers.mockReturnValue([
+                {url: new URL('https://server-1.com')},
+                {url: new URL('https://server-2.example.org:8443/subpath')},
+            ]);
+            const hub = new ServerHub();
+            hub.updateAuthServerAllowlist();
+            expect(session.defaultSession.allowNTLMCredentialsForDomains).
+                toHaveBeenCalledWith('server-1.com,server-2.example.org');
+        });
+
+        it('should set an empty allowlist when there are no configured servers', () => {
+            ServerManager.getAllServers.mockReturnValue([]);
+            const hub = new ServerHub();
+            hub.updateAuthServerAllowlist();
+            expect(session.defaultSession.allowNTLMCredentialsForDomains).toHaveBeenCalledWith('');
+        });
+
+        it('should clear server data and refresh the allowlist when a server is removed', () => {
+            ServerManager.getAllServers.mockReturnValue([
+                {url: new URL('https://server-1.com')},
+            ]);
+            const hub = new ServerHub();
+            hub.handleServerCleanup({id: 'server-2', url: new URL('https://server-2.com')});
+            expect(session.defaultSession.clearData).toHaveBeenCalledWith({origins: ['https://server-2.com']});
+            expect(session.defaultSession.allowNTLMCredentialsForDomains).toHaveBeenCalledWith('server-1.com');
         });
     });
 });

--- a/src/app/serverHub.ts
+++ b/src/app/serverHub.ts
@@ -22,7 +22,9 @@ import {
     GET_LAST_ACTIVE,
     SERVER_SWITCHED,
     GET_CURRENT_SERVER,
+    SERVER_ADDED,
     SERVER_REMOVED,
+    SERVER_URL_CHANGED,
 } from 'common/communication';
 import {ModalConstants} from 'common/constants';
 import {Logger} from 'common/log';
@@ -58,6 +60,8 @@ export class ServerHub {
 
         ServerManager.on(SERVER_SWITCHED, this.handleServerCurrentChanged);
         ServerManager.on(SERVER_REMOVED, this.handleServerCleanup);
+        ServerManager.on(SERVER_ADDED, this.updateAuthServerAllowlist);
+        ServerManager.on(SERVER_URL_CHANGED, this.updateAuthServerAllowlist);
     }
 
     // TODO: Move me somewhere else later
@@ -500,6 +504,14 @@ export class ServerHub {
         session.defaultSession.clearData({
             origins: [server.url.origin],
         });
+        this.updateAuthServerAllowlist();
+    };
+
+    private updateAuthServerAllowlist = () => {
+        const hostnames = ServerManager.getAllServers().
+            map((server) => server.url.hostname).
+            filter(Boolean);
+        session.defaultSession.allowNTLMCredentialsForDomains(hostnames.join(','));
     };
 
     private handleGetLastActive = () => {

--- a/src/main/app/initialize.test.js
+++ b/src/main/app/initialize.test.js
@@ -71,6 +71,7 @@ jest.mock('electron', () => ({
             setSpellCheckerDictionaryDownloadURL: jest.fn(),
             setPermissionRequestHandler: jest.fn(),
             on: jest.fn(),
+            allowNTLMCredentialsForDomains: jest.fn(),
         },
     },
     protocol: {

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -285,6 +285,9 @@ async function initializeAfterAppReady() {
         WebContentsManager,
     });
 
+    // Block all NTLM/Negotiate requests by default
+    session.defaultSession.allowNTLMCredentialsForDomains('');
+
     protocol.handle('mattermost-desktop', (request: Request) => {
         const url = parseURL(request.url);
         if (!url) {


### PR DESCRIPTION
#### Summary
This PR restricts Chromium's NTLM/Negotiate allowlist to the hostnames of configured Mattermost servers.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68365

#### Release Note
```release-note
Fixed an issue related to authentication on non-configured domains.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change modifies global Electron session authentication configuration to restrict NTLM/Negotiate to configured server hostnames. This touches authentication/session behavior (a critical path) and may regress environments that relied on NTLM for non-configured domains, or where hostname extraction fails (ports, subdomains, IPv6, credentialed URLs). Event-driven updates reduce risk but failures in SERVER_ADDED / SERVER_URL_CHANGED / SERVER_REMOVED handling or session.clearData timing could leave stale allowlists or session state.

**QA Recommendation:** Perform targeted manual QA focusing on: (1) NTLM auth succeeds only for configured server hostnames, (2) NTLM is blocked for non-configured domains, (3) allowlist updates correctly when adding/removing/changing server URLs (including ports, subdomains, and IPv6), and (4) session data cleared for removed servers and subsequent allowlist recalculation. Prioritize tests in Windows/domain-joined environments and mixed-origin setups despite existing unit tests.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->