### PR TITLE
Cherry-pick of #3802 to `release-5.13`

### DIFF
--- a/src/app/serverViewState.test.js
+++ b/src/app/serverViewState.test.js
@@ -23,6 +23,11 @@ jest.mock('electron', () => ({
         handle: jest.fn(),
         emit: jest.fn(),
     },
+    session: {
+        defaultSession: {
+            allowNTLMCredentialsForDomains: jest.fn(),
+        },
+    },
 }));
 
 jest.mock('common/servers/serverManager', () => ({
@@ -38,6 +43,7 @@ jest.mock('common/servers/serverManager', () => ({
     getServerLog: jest.fn(),
     lookupViewByURL: jest.fn(),
     getOrderedServers: jest.fn(),
+    on: jest.fn(),
 }));
 jest.mock('common/servers/MattermostServer', () => ({
     MattermostServer: jest.fn(),
@@ -600,6 +606,32 @@ describe('app/serverViewState', () => {
         it('should open the specified view', () => {
             serverViewState.handleOpenView(null, 'view-1');
             expect(ViewManager.showById).toBeCalledWith('view-1');
+        });
+    });
+
+    describe('updateAuthServerAllowlist', () => {
+        const {session} = jest.requireMock('electron');
+
+        beforeEach(() => {
+            session.defaultSession.allowNTLMCredentialsForDomains.mockClear();
+        });
+
+        it('should set the allowlist to the configured server hostnames', () => {
+            ServerManager.getAllServers.mockReturnValue([
+                {url: new URL('https://server-1.com')},
+                {url: new URL('https://server-2.example.org:8443/subpath')},
+            ]);
+            const state = new ServerViewState();
+            state.updateAuthServerAllowlist();
+            expect(session.defaultSession.allowNTLMCredentialsForDomains).
+                toHaveBeenCalledWith('server-1.com,server-2.example.org');
+        });
+
+        it('should set an empty allowlist when there are no configured servers', () => {
+            ServerManager.getAllServers.mockReturnValue([]);
+            const state = new ServerViewState();
+            state.updateAuthServerAllowlist();
+            expect(session.defaultSession.allowNTLMCredentialsForDomains).toHaveBeenCalledWith('');
         });
     });
 });

--- a/src/app/serverViewState.ts
+++ b/src/app/serverViewState.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import type {IpcMainEvent, IpcMainInvokeEvent} from 'electron';
-import {ipcMain} from 'electron';
+import {ipcMain, session} from 'electron';
 
 import {
     CLOSE_VIEW,
@@ -10,6 +10,8 @@ import {
     GET_ORDERED_SERVERS,
     GET_ORDERED_TABS_FOR_SERVER,
     OPEN_VIEW,
+    SERVERS_UPDATE,
+    SERVERS_URL_MODIFIED,
     SHOW_EDIT_SERVER_MODAL,
     SHOW_NEW_SERVER_MODAL,
     SHOW_REMOVE_SERVER_MODAL,
@@ -66,7 +68,17 @@ export class ServerViewState {
         ipcMain.on(ADD_SERVER, this.handleAddServer);
         ipcMain.on(EDIT_SERVER, this.handleEditServer);
         ipcMain.on(REMOVE_SERVER, this.handleRemoveServer);
+
+        ServerManager.on(SERVERS_UPDATE, this.updateAuthServerAllowlist);
+        ServerManager.on(SERVERS_URL_MODIFIED, this.updateAuthServerAllowlist);
     }
+
+    private updateAuthServerAllowlist = () => {
+        const hostnames = ServerManager.getAllServers().
+            map((server) => server.url.hostname).
+            filter(Boolean);
+        session.defaultSession.allowNTLMCredentialsForDomains(hostnames.join(','));
+    };
 
     init = () => {
         // Don't need to init twice

--- a/src/main/app/initialize.test.js
+++ b/src/main/app/initialize.test.js
@@ -70,6 +70,7 @@ jest.mock('electron', () => ({
             setSpellCheckerDictionaryDownloadURL: jest.fn(),
             setPermissionRequestHandler: jest.fn(),
             on: jest.fn(),
+            allowNTLMCredentialsForDomains: jest.fn(),
         },
     },
     protocol: {

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -289,6 +289,9 @@ function initializeInterCommunicationEventListeners() {
 }
 
 async function initializeAfterAppReady() {
+    // Block all NTLM/Negotiate requests by default
+    session.defaultSession.allowNTLMCredentialsForDomains('');
+
     protocol.handle('mattermost-desktop', (request: Request) => {
         const url = parseURL(request.url);
         if (!url) {


### PR DESCRIPTION
#### Summary
Cherry-pick of #3802 to `release-5.13`

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes introduce new event listeners (`SERVERS_UPDATE`, `SERVERS_URL_MODIFIED`) in `ServerViewState` that trigger NTLM allowlist updates. While this is isolated to authentication/session management and includes dedicated test coverage, NTLM credential handling is security-sensitive infrastructure. The initialization of `allowNTLMCredentialsForDomains('')` establishes a secure-by-default baseline, but any misconfiguration in how servers are processed through `updateAuthServerAllowlist()` could affect credential negotiation across the application. The main regression vectors are: (1) server list parsing failures leaving stale allowlists, (2) event listener race conditions during server updates, and (3) untested edge cases in hostname extraction/formatting.

**QA Recommendation:** Manual QA should focus on: (1) server connection/reconnection workflows to verify NTLM credentials are properly negotiated after server updates, (2) rapid server config changes to test event listener stability, (3) edge cases like servers with non-standard ports, internationalized domain names, and empty server lists. Given full automated test coverage exists for the core logic (`updateAuthServerAllowlist()`), automated regression testing can be supplemented with targeted manual verification of end-to-end authentication flows, particularly on Windows environments where NTLM/Negotiate is actively used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->