### PR TITLE
docs: make Cursor E2E agents run Mattermost + desktop together

### DIFF
--- a/.cursor/rules/e2e-agents.mdc
+++ b/.cursor/rules/e2e-agents.mdc
@@ -1,0 +1,25 @@
+---
+description: Mattermost + desktop must run together for E2E triage; use PR server URLs or Docker; always build-test before Playwright.
+globs:
+  - e2e/**
+  - AGENTS.md
+---
+
+# Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+# See LICENSE.txt for license information.
+
+# E2E fixes for Cursor agents
+
+When fixing E2E failures (including automations triggered from PR comments or CI):
+
+1. **Mattermost must be running and reachable** at `MM_TEST_SERVER_URL`. Playwright launches Electron, which loads that URL — there is no valid E2E fix without it.
+   - If the PR has an **E2E Test Servers Ready** (or similar) comment with per-platform URLs, use the **`linux`** URL on Cursor Cloud unless matching another OS is required. Use the admin username and password from that comment or from the workflow inputs.
+   - Otherwise run Mattermost via Docker as documented in the root `AGENTS.md` (Mattermost preview on port 8065, bootstrap user and team).
+
+2. **Before `npx playwright test`**, from repo root run **`npm run build-test`**. The suite expects the test-mode desktop build; skipping this produces misleading failures.
+
+3. On Linux cloud VMs set **`DISPLAY=:1`** and follow sandbox steps in root `AGENTS.md`.
+
+4. Many simultaneous failures usually mean **infrastructure** (server down, wrong env, missing build). Confirm `curl` to `/api/v4/system/ping` and a clean `build-test` before editing many specs. Use `e2e/AGENTS.md` to classify product vs test bugs.
+
+Do not post a fix or commit until the target spec has been re-run with the correct `MM_TEST_*` environment and passes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,6 +269,24 @@ Open Settings (`Ctrl/Cmd+,`) → switch logging to **Debug** → reproduce → *
 
 ## Cursor Cloud-specific instructions
 
+### Cursor automations and PR-assigned agents for E2E
+
+E2E failures are only actionable when **Mattermost and the desktop app run together** the same way CI does. An agent that edits tests without a reachable server, or runs Playwright without the **test** build, will look like it is “fixing” things while reproducing nothing.
+
+**Required stack (do all of these before changing code):**
+
+1. **Reachable Mattermost** — The Playwright harness drives a real Electron app that loads a real server URL from `MM_TEST_SERVER_URL`.
+   - **PR runs (Matterwick):** If the PR has a comment such as “E2E Test Servers Ready” with a table of URLs, use the URL for the platform you are validating (for Cursor Cloud VMs use the **`linux`** URL unless you have a reason to match another OS). Copy **`MM_TEST_USER_NAME`** and **`MM_TEST_PASSWORD`** from that same comment (or from the failing workflow’s configured secrets/inputs). Before running tests, confirm the server is up, for example: `curl -sf "$MM_TEST_SERVER_URL/api/v4/system/ping"`.
+   - **No PR server comment:** Start local Mattermost with Docker under [Starting a local Mattermost server with Docker](#starting-a-local-mattermost-server-with-docker), then set `MM_TEST_SERVER_URL=http://localhost:8065` (and the same admin bootstrap / team steps as in that section).
+
+2. **Built desktop test binary** — From the repository root, after `npm ci` (and `cd e2e && npm ci && cd ..` if needed), run **`npm run build-test`**. This is what wires `NODE_ENV=test` and produces the binary Playwright launches. Running `npx playwright test` without this step usually fails immediately or flakes in ways that are not product bugs.
+
+3. **Headless display (Linux agents)** — Set `DISPLAY=:1` (and sandbox steps under [Running on headless Linux (Cloud VM)](#running-on-headless-linux-cloud-vm)) before any Electron or Playwright command.
+
+**Mass failure on CI:** When many unrelated specs fail at once, still verify (a) `curl` ping to `MM_TEST_SERVER_URL` and (b) a clean `npm run build-test` locally. Only treat failures as narrow test bugs after the shared harness is confirmed good; see `e2e/AGENTS.md` (sections on app launch and readiness).
+
+**Product vs test bugs:** If the same assertion fails with a healthy server and a fresh `build-test`, decide using `e2e/AGENTS.md` (reproduce in browser, main-process vs renderer, fixture vs spec). Prefer fixes in `src/` when the desktop regresses; prefer test/helper changes when the spec was wrong or flaky.
+
 ### Node version
 
 The project requires Node.js v20.15.0 (specified in `.nvmrc`). Use `nvm` to switch:
@@ -347,11 +365,11 @@ If a run leaves Electron hanging: `killall Electron 2>/dev/null || true`
 
 When asked to fix E2E failures:
 
-1. **Start the Mattermost server** using the Docker instructions above.
+1. **Mattermost available** — Prefer URLs and credentials from the PR’s E2E server comment when present; otherwise start Docker Mattermost as in [Starting a local Mattermost server with Docker](#starting-a-local-mattermost-server-with-docker). Do not skip this step.
 2. **Read the CI logs** to identify which spec files failed. Use `gh run view --job <job-id> --log-failed`.
-3. **Build the test bundle**: `npm run build-test`
-4. **Reproduce** each failure locally before editing.
-5. **Fix the test** — see `e2e/AGENTS.md` for classification and design rules.
+3. **Build the test bundle**: `npm run build-test` (required for Playwright; see [Cursor automations and PR-assigned agents for E2E](#cursor-automations-and-pr-assigned-agents-for-e2e)).
+4. **Reproduce** each failure locally with the same `MM_TEST_*` values as CI before editing.
+5. **Fix the smallest useful layer** (spec, helper, fixture, or app) — see `e2e/AGENTS.md` for classification and design rules.
 6. **Re-run the spec** to confirm the fix, then commit.
 
 ### Login state propagation (common E2E flake)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the gap called out in [PR #3773 review discussion](https://github.com/mattermost/desktop/pull/3773#pullrequestreview-4207381103): Cursor automations were posting “mass failure / investigate CI” style outcomes without reliably reproducing E2E because agents were not consistently pairing a **reachable Mattermost** with a **test-mode desktop build** before changing code.

## Changes

- **`AGENTS.md`** — New subsection under Cursor Cloud instructions that spells out the required stack for PR-assigned agents: use Matterwick PR server comments when present (with `curl` ping), fall back to Docker otherwise, always run `npm run build-test` before Playwright, use `DISPLAY=:1` on Linux, how to interpret mass failures, and product vs test bug triage. The “Fixing E2E tests” checklist now defers to that section instead of implying Docker-only.
- **`.cursor/rules/e2e-agents.mdc`** — Project rule scoped to `e2e/**` and `AGENTS.md` so Cursor picks up the same mandatory workflow when working on E2E.

## Notes for automation authors

If a GitHub Action launches an agent with a prompt, include the **linux** `MM_TEST_SERVER_URL` and credentials from the “E2E Test Servers Ready” comment when available; repo docs alone cannot inject secrets into the agent — the dispatcher must pass them in the prompt or env.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de2e3596-c7ca-49a7-bfa3-c95d52fef18e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de2e3596-c7ca-49a7-bfa3-c95d52fef18e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

