### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,3 +266,32 @@ Open Settings (`Ctrl/Cmd+,`) → switch logging to **Debug** → reproduce → *
 3. **Restart** app (and computer if needed).
 4. **Reset data** — **View → Clear All Data**, or delete the config directory.
 5. **Collect debug logs and heap snapshots**.
+
+## Cursor Cloud specific instructions
+
+### Environment
+
+- Node.js v20.15.0 and npm 10.7.0 are pre-installed (matching `.nvmrc`).
+- The update script runs `npm install` which handles `patch-package` and `electron-builder install-app-deps` via the postinstall hook.
+- Chrome-sandbox requires SUID permissions on Linux. Before running the app, execute:
+  ```
+  sudo chown root:root ./node_modules/electron/dist/chrome-sandbox
+  sudo chmod 4755 ./node_modules/electron/dist/chrome-sandbox
+  ```
+
+### Running the app
+
+- Use `./node_modules/.bin/electron dist/ --disable-dev-mode` after `npm run build` to launch.
+- `npm run watch` provides dev mode with auto-rebuild and restart; it also runs the linux-dev-setup script (requires sudo).
+- In headless environments (no dbus), expect harmless dbus errors in logs. These do not affect functionality.
+- Modal windows (e.g. "Add Server" dialog) may not render in environments without a compositor. Core app functionality still works.
+
+### Key commands reference
+
+See `package.json` scripts and the "Common commands" table above. Summary:
+- Lint: `npm run lint:js`
+- Type check: `npm run check-types`
+- Unit tests: `npm run test:unit`
+- All checks: `npm run check`
+- Dev build: `npm run build`
+- Dev mode with watch: `npm run watch`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to AGENTS.md with environment setup notes for cloud agents:

- Documents that Node.js v20.15.0 and npm are pre-installed
- Notes chrome-sandbox SUID permission requirement on Linux
- Documents how to run the app in headless environments
- Lists expected dbus warnings and modal rendering limitations
- References key commands from existing documentation

This helps future cloud agents quickly set up and run the Mattermost Desktop app without re-discovering these environment-specific details.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9efbbc97-4a07-438f-aaee-882c98697047"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9efbbc97-4a07-438f-aaee-882c98697047"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

