### PR TITLE
[MM-68690] Null check on missing headers when loading resources

### DIFF
--- a/src/main/downloadsManager.test.js
+++ b/src/main/downloadsManager.test.js
@@ -192,6 +192,20 @@ describe('main/downloadsManager', () => {
         expect(dl.fileSizes.get('file.txt')).toBe('4242');
     });
 
+    it('MM-68690 - should not throw when content-disposition header is missing', () => {
+        const dl = new DownloadsManager({});
+        const details = {
+            responseHeaders: {
+                'content-encoding': ['gzip'],
+                'x-uncompressed-content-length': ['4242'],
+            },
+        };
+        const cb = jest.fn();
+        expect(() => dl.webRequestOnHeadersReceivedHandler(details, cb)).not.toThrow();
+        expect(cb).toHaveBeenCalledWith({});
+        expect(dl.fileSizes.size).toBe(0);
+    });
+
     it('should clear the downloads list', () => {
         const dl = new DownloadsManager(JSON.stringify(downloadsJson));
         dl.clearDownloadsDropDown();

--- a/src/main/downloadsManager.ts
+++ b/src/main/downloadsManager.ts
@@ -143,7 +143,7 @@ export class DownloadsManager extends JsonFileManager<DownloadedItems> {
     webRequestOnHeadersReceivedHandler = (details: Electron.OnHeadersReceivedListenerDetails, cb: (headersReceivedResponse: Electron.HeadersReceivedResponse) => void) => {
         const headers = details.responseHeaders ?? {};
 
-        if (headers?.['content-encoding']?.includes('gzip') && headers?.['x-uncompressed-content-length'] && headers?.['content-disposition'].join(';')?.includes('filename=')) {
+        if (headers?.['content-encoding']?.includes('gzip') && headers?.['x-uncompressed-content-length'] && headers?.['content-disposition']?.join?.(';')?.includes('filename=')) {
             const filename = readFilenameFromContentDispositionHeader(headers['content-disposition']);
             const fileSize = headers['x-uncompressed-content-length']?.[0] || '0';
             if (filename && (!this.fileSizes.has(filename) || this.fileSizes.get(filename)?.toString() !== fileSize)) {


### PR DESCRIPTION
#### Summary
Certain network responses can be missing headers that the downloads manager assumed were always present, leading to an unhandled error.

This PR adds defensive null checks when reading response headers in the downloads handler.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68690

#### Release Note
```release-note
Improved robustness of the downloads handler when handling unexpected network responses.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Minimal. The changes are purely defensive—adding optional chaining operators (`?.`) and optional method calls (`?.join?.()`) to guard against missing `content-disposition` headers in network responses. The logic flow remains unchanged when headers are present, and the new null checks only prevent crashes in edge cases. The fix is scoped to a single, isolated method (`webRequestOnHeadersReceivedHandler`) within the downloads feature. No shared utilities, base classes, or widely-imported modules are affected.

**QA Recommendation:** Minimal manual QA required. The fix addresses a specific edge case (missing headers) that is already covered by an added unit test. Basic smoke testing of the downloads feature is recommended to verify that normal download flows (with complete headers) remain unaffected, but comprehensive testing can rely on the unit test coverage.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->