### PR TITLE
Improve title bar control button visibility

### DIFF
--- a/src/app/windows/baseWindow.ts
+++ b/src/app/windows/baseWindow.ts
@@ -177,7 +177,7 @@ export default class BaseWindow {
     private getTitleBarOverlay = () => {
         return {
             color: Config.darkMode ? 'rgba(25, 27, 31, 0)' : 'rgba(255, 255, 255, 0)',
-            symbolColor: Config.darkMode ? 'rgba(227, 228, 232, 0.64)' : 'rgba(63, 67, 80, 0.64)',
+            symbolColor: Config.darkMode ? 'rgba(227, 228, 232, 0.9)' : 'rgba(63, 67, 80, 0.9)',
             height: TAB_BAR_HEIGHT,
         };
     };


### PR DESCRIPTION
## Summary

Improved the visibility of the title bar window control buttons by increasing the opacity of `symbolColor` in the title bar overlay configuration.

## Changes Made

* Updated `symbolColor` opacity from `0.64` to `0.9`
* Applied to both dark and light modes

## Issue

The minimize, maximize, and close buttons were difficult to see against certain default theme backgrounds due to low contrast/opacity.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Minimal. This is a purely visual change affecting window control button opacity in the title bar. The modification is isolated to a private method in a single file, involves only a constant value change (0.64 to 0.9), and has no behavioral or logical implications. No shared dependencies, core logic, or critical paths are affected.

**QA Recommendation:** Manual visual regression testing is recommended to verify that the window control buttons (minimize, maximize, close) are clearly visible and properly styled with the increased opacity in both dark and light theme modes. Automated testing coverage is low value given the trivial nature of the change.

*Generated by CodeRabbitAI*

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/desktop/pull/3819)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->