### PR TITLE
[MM-68794] Calls expanded view's close PopOut not working on desktop

### DIFF
--- a/src/app/callsWidgetWindow.test.js
+++ b/src/app/callsWidgetWindow.test.js
@@ -14,6 +14,7 @@ import {
     UPDATE_SHORTCUT_MENU,
     CALLS_WIDGET_OPEN_THREAD,
     CALLS_WIDGET_OPEN_STOP_RECORDING_MODAL,
+    WINDOW_CLOSE,
 } from 'common/communication';
 import ServerManager from 'common/servers/serverManager';
 import {
@@ -427,6 +428,51 @@ describe('main/windows/callsWidgetWindow', () => {
             callsWidgetWindow.handlePopOutFocus();
             expect(callsWidgetWindow.popOut.restore).toBeCalled();
             expect(callsWidgetWindow.popOut.focus).toBeCalled();
+        });
+    });
+
+    describe('handlePopOutClose (WINDOW_CLOSE)', () => {
+        const callsWidgetWindow = new CallsWidgetWindow();
+        callsWidgetWindow.popOut = {
+            isDestroyed: jest.fn().mockReturnValue(false),
+            close: jest.fn(),
+            webContents: {id: 42},
+        };
+
+        afterEach(() => {
+            jest.clearAllMocks();
+            callsWidgetWindow.popOut.isDestroyed.mockReturnValue(false);
+        });
+
+        it('should register a WINDOW_CLOSE listener on construction', () => {
+            ipcMain.on.mockClear();
+            // eslint-disable-next-line no-new
+            new CallsWidgetWindow();
+            const calls = ipcMain.on.mock.calls.filter((c) => c[0] === WINDOW_CLOSE);
+            expect(calls).toHaveLength(1);
+        });
+
+        it('should close the popout when sender id matches', () => {
+            callsWidgetWindow.handlePopOutClose({sender: {id: 42}});
+            expect(callsWidgetWindow.popOut.close).toBeCalled();
+        });
+
+        // Coexists with PopoutManager's WINDOW_CLOSE handler — a non-Calls renderer
+        // sending WINDOW_CLOSE must not affect our popout.
+        it('should not close when sender id does not match (e.g. another popout)', () => {
+            callsWidgetWindow.handlePopOutClose({sender: {id: 7}});
+            expect(callsWidgetWindow.popOut.close).not.toBeCalled();
+        });
+
+        it('should not close when popout is destroyed', () => {
+            callsWidgetWindow.popOut.isDestroyed.mockReturnValue(true);
+            callsWidgetWindow.handlePopOutClose({sender: {id: 42}});
+            expect(callsWidgetWindow.popOut.close).not.toBeCalled();
+        });
+
+        it('should not throw when popout is undefined', () => {
+            const widget = new CallsWidgetWindow();
+            expect(() => widget.handlePopOutClose({sender: {id: 42}})).not.toThrow();
         });
     });
 

--- a/src/app/callsWidgetWindow.ts
+++ b/src/app/callsWidgetWindow.ts
@@ -28,6 +28,7 @@ import {
     GET_DESKTOP_SOURCES,
     UPDATE_SHORTCUT_MENU,
     VIEW_REMOVED,
+    WINDOW_CLOSE,
 } from 'common/communication';
 import {Logger} from 'common/log';
 import ServerManager from 'common/servers/serverManager';
@@ -72,6 +73,7 @@ export class CallsWidgetWindow {
         ipcMain.on(CALLS_WIDGET_RESIZE, this.handleResize);
         ipcMain.on(CALLS_WIDGET_SHARE_SCREEN, this.handleShareScreen);
         ipcMain.on(CALLS_POPOUT_FOCUS, this.handlePopOutFocus);
+        ipcMain.on(WINDOW_CLOSE, this.handlePopOutClose);
         ipcMain.handle(GET_DESKTOP_SOURCES, this.handleGetDesktopSources);
         ipcMain.handle(CALLS_JOIN_CALL, this.handleCreateCallsWidgetWindow);
         ipcMain.on(CALLS_LEAVE_CALL, this.handleCallsLeave);
@@ -424,6 +426,18 @@ export class CallsWidgetWindow {
             this.popOut.restore();
         }
         this.popOut.focus();
+    };
+
+    private handlePopOutClose = (event: IpcMainEvent) => {
+        if (!this.popOut || this.popOut.isDestroyed()) {
+            return;
+        }
+
+        if (event.sender.id !== this.popOut.webContents.id) {
+            return;
+        }
+
+        this.popOut.close();
     };
 
     private handleGetDesktopSources = async (event: IpcMainInvokeEvent, opts: Electron.SourcesOptions) => {


### PR DESCRIPTION
#### Summary
* Registered a new IPC event listener for `WINDOW_CLOSE` in the `CallsWidgetWindow` constructor to handle close requests from the popout's renderer process 


#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-68794


#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [x] executed `npm run lint:js` for proper code formatting
- [x] Run E2E tests by adding label `E2E/Run`

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/desktop/pull/3824?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->