### PR TITLE
[codex] Add raw slash command shortcut setting

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -278,6 +278,8 @@
   "renderer.components.settingsPage.serverSetting.noServers": "No servers added",
   "renderer.components.settingsPage.serverSetting.noServers.description": "Add a server to connect to your team's communication hub",
   "renderer.components.settingsPage.serverSetting.title": "Servers",
+  "renderer.components.settingsPage.sendRawSlashCommandsWithCmdOrCtrlEnter": "Send slash commands as messages with Cmd/Ctrl+Enter",
+  "renderer.components.settingsPage.sendRawSlashCommandsWithCmdOrCtrlEnter.description": "When a message starts with '/', this shortcut sends the text as a normal message instead of running a slash command.",
   "renderer.components.settingsPage.showUnreadBadge.description.dock": "Regardless of this setting, mentions are always indicated with a red badge and item count on the Dock icon.",
   "renderer.components.settingsPage.showUnreadBadge.description.taskbar": "Regardless of this setting, mentions are always indicated with a red badge and item count on the taskbar icon.",
   "renderer.components.settingsPage.showUnreadBadge.dock": "Show red badge on Dock icon to indicate unread messages",

--- a/src/app/preload/externalAPI.ts
+++ b/src/app/preload/externalAPI.ts
@@ -52,9 +52,13 @@ import {
     POPOUT_CLOSED,
     WINDOW_CLOSE,
     UPDATE_POPOUT_TITLE_TEMPLATE,
+    GET_CONFIGURATION,
+    RELOAD_CONFIGURATION,
 } from 'common/communication';
 
 import type {ExternalAPI} from 'types/externalAPI';
+
+import {installRawSlashCommandShortcut, setRawSlashCommandShortcutEnabled} from './rawSlashCommandShortcut';
 
 const createListener: ExternalAPI['createListener'] = (channel: string, listener: (...args: never[]) => void) => {
     const listenerWithEvent = (_: IpcRendererEvent, ...args: unknown[]) =>
@@ -64,6 +68,27 @@ const createListener: ExternalAPI['createListener'] = (channel: string, listener
         ipcRenderer.off(channel, listenerWithEvent);
     };
 };
+
+contextBridge.executeInMainWorld({
+    func: installRawSlashCommandShortcut,
+    args: [process.platform],
+});
+const updateRawSlashCommandShortcutSetting = () => {
+    ipcRenderer.invoke(GET_CONFIGURATION).then((config) => {
+        const rawSlashCommandShortcutEnabled = Boolean(config?.sendRawSlashCommandsWithCmdOrCtrlEnter);
+        contextBridge.executeInMainWorld({
+            func: setRawSlashCommandShortcutEnabled,
+            args: [rawSlashCommandShortcutEnabled],
+        });
+    }).catch(() => {
+        contextBridge.executeInMainWorld({
+            func: setRawSlashCommandShortcutEnabled,
+            args: [false],
+        });
+    });
+};
+updateRawSlashCommandShortcutSetting();
+ipcRenderer.on(RELOAD_CONFIGURATION, updateRawSlashCommandShortcutSetting);
 
 const desktopAPI: DesktopAPI = {
 

--- a/src/app/preload/rawSlashCommandShortcut.test.ts
+++ b/src/app/preload/rawSlashCommandShortcut.test.ts
@@ -1,0 +1,199 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {
+    installRawSlashCommandShortcut,
+    setRawSlashCommandShortcutEnabled,
+} from './rawSlashCommandShortcut';
+
+type FetchResponse = {
+    ok: boolean;
+    status?: number;
+};
+
+describe('rawSlashCommandShortcut', () => {
+    const globalWithWindow = global as unknown as {window?: Window};
+    const originalWindow = globalWithWindow.window;
+    let keydownListener: ((event: KeyboardEvent) => void) | undefined;
+
+    const makeTextbox = (props: Partial<HTMLTextAreaElement> = {}) => ({
+        id: 'post_textbox',
+        value: '',
+        disabled: false,
+        readOnly: false,
+        dispatchEvent: jest.fn(),
+        ...props,
+    }) as unknown as HTMLTextAreaElement;
+
+    const addReactFiber = (textbox: HTMLTextAreaElement, memoizedProps: Record<string, string>, returnFiber?: Record<string, unknown>) => {
+        Object.defineProperty(textbox, '__reactFiber$test', {
+            value: {
+                memoizedProps,
+                return: returnFiber,
+            },
+        });
+    };
+
+    const installShortcut = (platform: NodeJS.Platform = 'darwin', response: FetchResponse = {ok: true}) => {
+        keydownListener = undefined;
+        const fetch = jest.fn().mockResolvedValue(response);
+        globalWithWindow.window = {
+            addEventListener: jest.fn((eventName: string, listener: (event: KeyboardEvent) => void) => {
+                if (eventName === 'keydown') {
+                    keydownListener = listener;
+                }
+            }),
+            fetch,
+        } as unknown as Window;
+
+        installRawSlashCommandShortcut(platform);
+
+        return fetch;
+    };
+
+    const dispatchShortcut = async (textbox: HTMLTextAreaElement, eventOverrides: Partial<KeyboardEvent> = {}) => {
+        const event = {
+            key: 'Enter',
+            metaKey: true,
+            preventDefault: jest.fn(),
+            stopImmediatePropagation: jest.fn(),
+            target: textbox,
+            ...eventOverrides,
+        } as unknown as KeyboardEvent;
+
+        expect(keydownListener).toBeDefined();
+        keydownListener?.(event);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        return event;
+    };
+
+    afterEach(() => {
+        if (originalWindow) {
+            globalWithWindow.window = originalWindow;
+        } else {
+            delete globalWithWindow.window;
+        }
+    });
+
+    it('should send an enabled slash message through the posts API', async () => {
+        const fetch = installShortcut();
+        setRawSlashCommandShortcutEnabled(true);
+
+        const textbox = makeTextbox({value: '/openclaw status'});
+        addReactFiber(textbox, {
+            channelId: 'channel-id',
+            rootId: '',
+        });
+
+        const event = await dispatchShortcut(textbox);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(event.stopImmediatePropagation).toHaveBeenCalled();
+        expect(fetch).toHaveBeenCalledWith('/api/v4/posts', {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({
+                channel_id: 'channel-id',
+                message: '/openclaw status',
+            }),
+        });
+        expect(textbox.value).toBe('');
+        expect(textbox.dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({type: 'input'}));
+    });
+
+    it('should only handle enabled modifier-enter events on slash messages', async () => {
+        const fetch = installShortcut();
+        const textbox = makeTextbox({value: '/openclaw status'});
+        addReactFiber(textbox, {
+            channelId: 'channel-id',
+            rootId: '',
+        });
+
+        await dispatchShortcut(textbox);
+        expect(fetch).not.toHaveBeenCalled();
+
+        setRawSlashCommandShortcutEnabled(true);
+        textbox.value = 'hello';
+        await dispatchShortcut(textbox);
+        expect(fetch).not.toHaveBeenCalled();
+
+        textbox.value = '/openclaw status';
+        await dispatchShortcut(textbox, {metaKey: false});
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('should support Ctrl+Enter on non-macOS and preserve thread root IDs', async () => {
+        const fetch = installShortcut('win32');
+        setRawSlashCommandShortcutEnabled(true);
+
+        const textbox = makeTextbox({
+            id: 'reply_textbox',
+            value: '/hermes summarize',
+        });
+        addReactFiber(textbox, {}, {
+            memoizedProps: {
+                channelId: 'channel-id',
+                rootId: 'root-id',
+            },
+        });
+
+        await dispatchShortcut(textbox, {
+            ctrlKey: true,
+            metaKey: false,
+        });
+
+        expect(fetch).toHaveBeenCalledWith('/api/v4/posts', expect.objectContaining({
+            body: JSON.stringify({
+                channel_id: 'channel-id',
+                message: '/hermes summarize',
+                root_id: 'root-id',
+            }),
+        }));
+    });
+
+    it('should not bypass webapp handling when a draft has unsupported state', async () => {
+        const fetch = installShortcut();
+        setRawSlashCommandShortcutEnabled(true);
+
+        const form = {
+            querySelector: jest.fn().mockReturnValue({}),
+        };
+        const textbox = makeTextbox({
+            value: '/openclaw status',
+            closest: jest.fn().mockReturnValue(form),
+        });
+        addReactFiber(textbox, {
+            channelId: 'channel-id',
+            rootId: '',
+        });
+
+        const event = await dispatchShortcut(textbox);
+
+        expect(form.querySelector).toHaveBeenCalledWith('.file-preview__container, .AdvancedTextEditor__labels');
+        expect(event.preventDefault).not.toHaveBeenCalled();
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('should keep the textbox contents when the posts API fails', async () => {
+        const fetch = installShortcut('darwin', {ok: false, status: 403});
+        const warn = jest.spyOn(console, 'warn').mockImplementation();
+        setRawSlashCommandShortcutEnabled(true);
+
+        const textbox = makeTextbox({value: '/hermes summarize'});
+        addReactFiber(textbox, {
+            channelId: 'channel-id',
+            rootId: '',
+        });
+
+        await dispatchShortcut(textbox);
+
+        expect(fetch).toHaveBeenCalled();
+        expect(textbox.value).toBe('/hermes summarize');
+        expect(warn).toHaveBeenCalledWith('Failed to send raw slash command message', expect.any(Error));
+
+        warn.mockRestore();
+    });
+});

--- a/src/app/preload/rawSlashCommandShortcut.ts
+++ b/src/app/preload/rawSlashCommandShortcut.ts
@@ -1,0 +1,131 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+type Platform = NodeJS.Platform;
+
+export function setRawSlashCommandShortcutEnabled(enabled: boolean) {
+    const enabledKey = '__mattermostDesktopRawSlashCommandShortcutEnabled';
+    (window as unknown as Record<string, boolean>)[enabledKey] = enabled;
+}
+
+export function installRawSlashCommandShortcut(platform: Platform) {
+    const enabledKey = '__mattermostDesktopRawSlashCommandShortcutEnabled';
+    const installedKey = '__mattermostDesktopRawSlashCommandShortcutInstalled';
+    const postTextboxId = 'post_textbox';
+    const replyTextboxId = 'reply_textbox';
+    const reactFiberKeyPrefix = '__reactFiber$';
+    const state = window as unknown as Record<string, boolean>;
+
+    if (state[installedKey]) {
+        return;
+    }
+    state[installedKey] = true;
+    state[enabledKey] = false;
+
+    type MainWorldReactFiber = {
+        memoizedProps?: {
+            channelId?: string;
+            rootId?: string;
+        };
+        return?: MainWorldReactFiber | null;
+    };
+
+    const isTextbox = (element: unknown): element is HTMLTextAreaElement => Boolean(
+        element &&
+        typeof element === 'object' &&
+        'id' in element &&
+        'value' in element,
+    );
+
+    const hasUnsupportedDraftState = (textbox: HTMLTextAreaElement) => {
+        const form = textbox.closest?.('form');
+        return Boolean(form?.querySelector('.file-preview__container, .AdvancedTextEditor__labels'));
+    };
+
+    const isMattermostComposeTextbox = (textbox: HTMLTextAreaElement) => (
+        (textbox.id === postTextboxId || textbox.id === replyTextboxId) &&
+        !textbox.disabled &&
+        !textbox.readOnly &&
+        !hasUnsupportedDraftState(textbox)
+    );
+
+    const isCmdOrCtrlEnter = (event: KeyboardEvent) => {
+        if (event.key !== 'Enter') {
+            return false;
+        }
+
+        return platform === 'darwin' ? event.metaKey : event.ctrlKey;
+    };
+
+    const getReactFiber = (element: HTMLTextAreaElement): MainWorldReactFiber | undefined => {
+        const fiberKey = Object.getOwnPropertyNames(element).find((key) => key.startsWith(reactFiberKeyPrefix));
+        if (!fiberKey) {
+            return undefined;
+        }
+
+        return (element as unknown as Record<string, MainWorldReactFiber | undefined>)[fiberKey];
+    };
+
+    const getPostContextFromTextbox = (textbox: HTMLTextAreaElement) => {
+        let fiber = getReactFiber(textbox);
+        while (fiber) {
+            const {channelId, rootId = ''} = fiber.memoizedProps ?? {};
+            if (channelId) {
+                return {channelId, rootId};
+            }
+            fiber = fiber.return ?? undefined;
+        }
+
+        return null;
+    };
+
+    const clearTextbox = (textbox: HTMLTextAreaElement) => {
+        textbox.value = '';
+        textbox.dispatchEvent(new Event('input', {bubbles: true}));
+    };
+
+    const submitRawSlashCommandFromTextbox = async (textbox: HTMLTextAreaElement, context: {channelId: string; rootId: string}) => {
+        const post: Record<string, string> = {
+            channel_id: context.channelId,
+            message: textbox.value,
+        };
+        if (context.rootId) {
+            post.root_id = context.rootId;
+        }
+
+        const response = await window.fetch('/api/v4/posts', {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(post),
+        });
+
+        if (!response.ok) {
+            throw new Error(`Unable to send raw slash command message: ${response.status ?? 'unknown'}`);
+        }
+
+        clearTextbox(textbox);
+    };
+
+    window.addEventListener('keydown', (event) => {
+        const textbox = isTextbox(event.target) ? event.target : null;
+        if (!state[enabledKey] ||
+            !textbox ||
+            !isMattermostComposeTextbox(textbox) ||
+            !textbox.value.startsWith('/') ||
+            !isCmdOrCtrlEnter(event)) {
+            return;
+        }
+
+        const context = getPostContextFromTextbox(textbox);
+        if (!context) {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        submitRawSlashCommandFromTextbox(textbox, context).catch((error) => {
+            console.warn('Failed to send raw slash command message', error);
+        });
+    }, true);
+}

--- a/src/app/views/webContentsManager.test.js
+++ b/src/app/views/webContentsManager.test.js
@@ -3,6 +3,7 @@
 
 import {session} from 'electron';
 
+import {EMIT_CONFIGURATION, RELOAD_CONFIGURATION} from 'common/communication';
 import ServerManager from 'common/servers/serverManager';
 import ViewManager from 'common/views/viewManager';
 import {flushCookiesStore} from 'main/app/utils';
@@ -43,6 +44,13 @@ jest.mock('app/serverHub', () => ({
 
 jest.mock('common/servers/MattermostServer', () => ({
     MattermostServer: jest.fn(),
+}));
+
+jest.mock('common/config', () => ({
+    __esModule: true,
+    default: {
+        useSpellChecker: true,
+    },
 }));
 
 jest.mock('common/utils/url', () => ({
@@ -271,6 +279,33 @@ describe('app/views/webContentsManager', () => {
             expect(mockView1.sendToRenderer).toHaveBeenCalledWith('test-channel', 'arg1', 'arg2');
             expect(mockView2.sendToRenderer).toHaveBeenCalledWith('test-channel', 'arg1', 'arg2');
             expect(mockView3.sendToRenderer).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('EMIT_CONFIGURATION handler', () => {
+        const webContentsManager = new WebContentsManager();
+        const mockView = {
+            id: 'view1',
+            isDestroyed: jest.fn().mockReturnValue(false),
+            sendToRenderer: jest.fn(),
+        };
+
+        beforeEach(() => {
+            webContentsManager.webContentsViews = new Map([
+                ['view1', mockView],
+            ]);
+        });
+
+        afterEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it('should send RELOAD_CONFIGURATION to server views', () => {
+            const ipcMain = require('electron').ipcMain;
+
+            ipcMain.emit(EMIT_CONFIGURATION);
+
+            expect(mockView.sendToRenderer).toHaveBeenCalledWith(RELOAD_CONFIGURATION);
         });
     });
 

--- a/src/app/views/webContentsManager.ts
+++ b/src/app/views/webContentsManager.ts
@@ -26,6 +26,8 @@ import {
     UPDATE_SERVER_THEME,
     DARK_MODE_CHANGE,
     UPDATE_THEME,
+    EMIT_CONFIGURATION,
+    RELOAD_CONFIGURATION,
 } from 'common/communication';
 import Config from 'common/config';
 import {DEFAULT_CHANGELOG_LINK} from 'common/constants';
@@ -63,6 +65,7 @@ export class WebContentsManager {
         ipcMain.on(OPEN_POPOUT_MENU, this.handleOpenPopoutMenu);
         ipcMain.on(UPDATE_SERVER_THEME, this.handleUpdateServerTheme);
         ipcMain.on(UPDATE_THEME, this.handleUpdateTheme);
+        ipcMain.on(EMIT_CONFIGURATION, this.handleEmitConfiguration);
 
         if (process.platform !== 'linux') {
             nativeTheme.on('updated', this.handleDarkModeChanged);
@@ -99,6 +102,10 @@ export class WebContentsManager {
                 view.sendToRenderer(channel, ...args);
             }
         });
+    };
+
+    private handleEmitConfiguration = () => {
+        this.sendToAllViews(RELOAD_CONFIGURATION);
     };
 
     createView = (view: MattermostView, parentWindow: BaseWindow): MattermostWebContentsView => {

--- a/src/common/Validator.test.js
+++ b/src/common/Validator.test.js
@@ -218,6 +218,7 @@ describe('common/Validator', () => {
             enableMetrics: true,
             enableSentry: true,
             useNativeTitleBar: false,
+            sendRawSlashCommandsWithCmdOrCtrlEnter: false,
         };
 
         it('should validate v4 config data', () => {
@@ -230,6 +231,13 @@ describe('common/Validator', () => {
                 spellCheckerURL: 'a-bad>url',
             };
             expect(Validator.validateV4ConfigData(modifiedConfig)).not.toHaveProperty('spellCheckerURL');
+        });
+
+        it('should default raw slash command shortcut to disabled', () => {
+            const modifiedConfig = {...config};
+            delete modifiedConfig.sendRawSlashCommandsWithCmdOrCtrlEnter;
+
+            expect(Validator.validateV4ConfigData(modifiedConfig)).toHaveProperty('sendRawSlashCommandsWithCmdOrCtrlEnter', false);
         });
     });
 

--- a/src/common/Validator.ts
+++ b/src/common/Validator.ts
@@ -189,6 +189,7 @@ const configDataSchemaV4 = Joi.object<ConfigV4>({
     themeSyncing: Joi.boolean().default(true),
     skippedVersions: Joi.array().items(Joi.string()).default([]),
     useNativeTitleBar: Joi.boolean().default(false),
+    sendRawSlashCommandsWithCmdOrCtrlEnter: Joi.boolean().default(false),
 });
 
 // eg. data['community.mattermost.com'] = { data: 'certificate data', issuerName: 'COMODO RSA Domain Validation Secure Server CA'};

--- a/src/common/config/defaultPreferences.ts
+++ b/src/common/config/defaultPreferences.ts
@@ -56,6 +56,7 @@ const defaultPreferences: ConfigV4 = {
     viewLimit: 15,
     themeSyncing: true,
     useNativeTitleBar: false,
+    sendRawSlashCommandsWithCmdOrCtrlEnter: false,
 };
 
 export default defaultPreferences;

--- a/src/common/config/index.ts
+++ b/src/common/config/index.ts
@@ -253,6 +253,10 @@ export class Config extends EventEmitter {
         return this.combinedData?.useNativeTitleBar ?? false;
     }
 
+    get sendRawSlashCommandsWithCmdOrCtrlEnter() {
+        return this.combinedData?.sendRawSlashCommandsWithCmdOrCtrlEnter ?? false;
+    }
+
     getWindowsSystemDarkMode = () => {
         return !policyConfigLoader.getAppsUseLightTheme();
     };

--- a/src/renderer/components/SettingsModal/definition.tsx
+++ b/src/renderer/components/SettingsModal/definition.tsx
@@ -163,6 +163,24 @@ const definition: (intl: IntlShape) => Promise<SettingsDefinition> = async (intl
                     },
                 },
                 {
+                    id: 'sendRawSlashCommandsWithCmdOrCtrlEnter',
+                    component: CheckSetting,
+                    props: {
+                        label: (
+                            <FormattedMessage
+                                id='renderer.components.settingsPage.sendRawSlashCommandsWithCmdOrCtrlEnter'
+                                defaultMessage='Send slash commands as messages with Cmd/Ctrl+Enter'
+                            />
+                        ),
+                        subLabel: (
+                            <FormattedMessage
+                                id='renderer.components.settingsPage.sendRawSlashCommandsWithCmdOrCtrlEnter.description'
+                                defaultMessage="When a message starts with '/', this shortcut sends the text as a normal message instead of running a slash command."
+                            />
+                        ),
+                    },
+                },
+                {
                     id: 'minimizeToTray',
                     component: CheckSetting,
                     condition: window.process.platform === 'linux' || window.process.platform === 'win32',

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -61,6 +61,7 @@ export type ConfigV4 = {
     themeSyncing?: boolean;
     skippedVersions?: string[];
     useNativeTitleBar?: boolean;
+    sendRawSlashCommandsWithCmdOrCtrlEnter?: boolean;
 }
 
 export type ConfigV3 = Omit<ConfigV4,


### PR DESCRIPTION
## Summary
- Adds a General settings checkbox for using Cmd+Enter on macOS, or Ctrl+Enter elsewhere, to send slash-prefixed messages as normal post text.
- Installs the shortcut in external Mattermost server views and refreshes the setting live when desktop configuration changes.
- Posts directly to `/api/v4/posts` only for plain compose/reply drafts, leaving attachment or advanced-label drafts on the normal webapp path.

## Validation
- `npm run check` (74 suites, 1156 tests)
- `npm run build:preload` (passes with the existing DefinePlugin NODE_ENV warning)
