### PR TITLE
F12 to open Developer Tools for Current Tab

### DIFF
--- a/src/app/menus/appMenu/view.ts
+++ b/src/app/menus/appMenu/view.ts
@@ -33,6 +33,7 @@ export default function createViewMenu() {
             click() {
                 TabManager.getCurrentActiveTabView()?.openDevTools();
             },
+            accelerator: 'f12',
         },
     ];
 


### PR DESCRIPTION
#### Summary
Press F12 to open Developer Tools for Current Tab, not sure why we didn't have this before.

```release-note
F12 to open Developer Tools for Current Tab
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Minimal. The change adds a keyboard accelerator binding (`f12`) to an existing menu item for Developer Tools. The underlying functionality already exists and works correctly through the menu click handler. The modification is purely additive, affecting only keyboard shortcut configuration with no impact to core logic, shared utilities, or existing application behavior.

**QA Recommendation:** Minimal manual QA needed. Verify that pressing F12 correctly opens Developer Tools for the current active tab across different platforms (Windows, macOS, Linux). Since the underlying functionality is pre-existing and only a keyboard binding is being added, focused smoke testing of the F12 shortcut should be sufficient. Ensure no conflicts with platform-specific F12 handlers or other application shortcuts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/desktop/pull/3832?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->