### PR TITLE
[MM-68874] Add validation on IPC endpoints where data is coming from the front-end

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,22 @@ export function handleDoSomething(e: IpcMainEvent, arg: string) {
 }
 ```
 
+#### Validating renderer-supplied arguments
+
+If the handler reads any arguments that originate from the renderer (i.e. anything reachable through `externalAPI.ts`, or any internal API call carrying renderer-controlled data), wrap the registration with `ipcValidate` from `common/Validator`. The wrapper validates each positional argument against a Joi schema, drops the call and logs on failure, and only invokes the handler when every argument is well-typed.
+
+```typescript
+import Joi from 'joi';
+import {ipcValidate} from 'common/Validator';
+
+ipcMain.on(DO_SOMETHING, ipcValidate(
+    handleDoSomething,
+    [Joi.string().required()],
+));
+```
+
+Reuse the shared schema exports (`themeSchema`, `joinCallOptsSchema`, etc.) from `common/Validator` for complex payloads; add new exports there rather than declaring schemas in the handler module. Handlers whose arguments are entirely main-process-internal don't need a wrapper.
+
 ### Event-driven communication
 
 Modules extending `EventEmitter` broadcast state changes. Define event constants in `communication.ts`, emit from the source, listen from consumers. Prefer events over direct calls when multiple modules react to the same change.

--- a/src/app/callsWidgetWindow.test.js
+++ b/src/app/callsWidgetWindow.test.js
@@ -593,7 +593,7 @@ describe('main/windows/callsWidgetWindow', () => {
                 func = callback;
             });
             browserWindow.loadURL.mockImplementation(() => {
-                func({sender: {id: 1}}, 'test');
+                func({sender: {id: 1}}, 'test', 'session-1');
                 return Promise.resolve();
             });
             BrowserWindow.mockReturnValue(browserWindow);
@@ -670,7 +670,7 @@ describe('main/windows/callsWidgetWindow', () => {
                 func = callback;
             });
             browserWindow.loadURL.mockImplementation(() => {
-                func({sender: {id: 1}}, 'test2');
+                func({sender: {id: 1}}, 'test2', 'session-2');
                 return Promise.resolve();
             });
             BrowserWindow.mockReturnValue(browserWindow);
@@ -689,7 +689,7 @@ describe('main/windows/callsWidgetWindow', () => {
                 func = callback;
             });
             browserWindow.loadURL.mockImplementation(() => {
-                func({sender: {id: 1}}, 'test2');
+                func({sender: {id: 1}}, 'test2', 'session-2');
                 return Promise.resolve();
             });
             BrowserWindow.mockReturnValue(browserWindow);

--- a/src/app/callsWidgetWindow.ts
+++ b/src/app/callsWidgetWindow.ts
@@ -3,6 +3,7 @@
 
 import type {IpcMainEvent, Rectangle, Event, IpcMainInvokeEvent} from 'electron';
 import {BrowserWindow, desktopCapturer, dialog, ipcMain, systemPreferences} from 'electron';
+import Joi from 'joi';
 
 import MainWindow from 'app/mainWindow/mainWindow';
 import NavigationManager from 'app/navigationManager';
@@ -35,6 +36,7 @@ import ServerManager from 'common/servers/serverManager';
 import {CALLS_PLUGIN_ID, MINIMUM_CALLS_WIDGET_HEIGHT, MINIMUM_CALLS_WIDGET_WIDTH} from 'common/utils/constants';
 import {getFormattedPathName, isCallsPopOutURL, parseURL} from 'common/utils/url';
 import Utils from 'common/utils/util';
+import {desktopSourcesOptsSchema, ipcValidate, joinCallOptsSchema} from 'common/Validator';
 import ViewManager from 'common/views/viewManager';
 import ContextMenu from 'main/contextMenu';
 import {localizeMessage} from 'main/i18nManager';
@@ -70,21 +72,42 @@ export class CallsWidgetWindow {
     };
 
     constructor() {
-        ipcMain.on(CALLS_WIDGET_RESIZE, this.handleResize);
-        ipcMain.on(CALLS_WIDGET_SHARE_SCREEN, this.handleShareScreen);
+        ipcMain.on(CALLS_WIDGET_RESIZE, ipcValidate(
+            this.handleResize,
+            [Joi.number().required(), Joi.number().required()],
+        ));
+        ipcMain.on(CALLS_WIDGET_SHARE_SCREEN, ipcValidate(
+            this.handleShareScreen,
+            [Joi.string().required(), Joi.boolean().required()],
+        ));
         ipcMain.on(CALLS_POPOUT_FOCUS, this.handlePopOutFocus);
         ipcMain.on(WINDOW_CLOSE, this.handlePopOutClose);
-        ipcMain.handle(GET_DESKTOP_SOURCES, this.handleGetDesktopSources);
-        ipcMain.handle(CALLS_JOIN_CALL, this.handleCreateCallsWidgetWindow);
+        ipcMain.handle(GET_DESKTOP_SOURCES, ipcValidate(
+            this.handleGetDesktopSources,
+            [desktopSourcesOptsSchema.required()],
+        ));
+        ipcMain.handle(CALLS_JOIN_CALL, ipcValidate(
+            this.handleCreateCallsWidgetWindow,
+            [joinCallOptsSchema.required()],
+        ));
         ipcMain.on(CALLS_LEAVE_CALL, this.handleCallsLeave);
 
         // forwards to the main app
         ipcMain.on(DESKTOP_SOURCES_MODAL_REQUEST, this.forwardToMainApp(DESKTOP_SOURCES_MODAL_REQUEST));
-        ipcMain.on(CALLS_ERROR, this.forwardToMainApp(CALLS_ERROR));
-        ipcMain.on(CALLS_LINK_CLICK, this.handleCallsLinkClick);
-        ipcMain.on(CALLS_JOIN_REQUEST, this.forwardToMainApp(CALLS_JOIN_REQUEST));
-        ipcMain.on(CALLS_WIDGET_OPEN_THREAD, this.handleCallsOpenThread);
-        ipcMain.on(CALLS_WIDGET_OPEN_STOP_RECORDING_MODAL, this.handleCallsOpenStopRecordingModal);
+        ipcMain.on(CALLS_ERROR, ipcValidate(
+            this.forwardToMainApp(CALLS_ERROR),
+            [Joi.string().required(), Joi.string(), Joi.string()],
+        ));
+        ipcMain.on(CALLS_LINK_CLICK, ipcValidate(this.handleCallsLinkClick, [Joi.string().required()]));
+        ipcMain.on(CALLS_JOIN_REQUEST, ipcValidate(
+            this.forwardToMainApp(CALLS_JOIN_REQUEST),
+            [Joi.string().required()],
+        ));
+        ipcMain.on(CALLS_WIDGET_OPEN_THREAD, ipcValidate(this.handleCallsOpenThread, [Joi.string().required()]));
+        ipcMain.on(CALLS_WIDGET_OPEN_STOP_RECORDING_MODAL, ipcValidate(
+            this.handleCallsOpenStopRecordingModal,
+            [Joi.string().required()],
+        ));
         ipcMain.on(CALLS_WIDGET_OPEN_USER_SETTINGS, this.forwardToMainApp(CALLS_WIDGET_OPEN_USER_SETTINGS));
 
         ViewManager.on(VIEW_REMOVED, this.handleViewRemoved);
@@ -560,22 +583,25 @@ export class CallsWidgetWindow {
         }
 
         const promise = new Promise((resolve) => {
-            const connected = (ev: IpcMainEvent, incomingCallId: string, incomingSessionId: string) => {
-                log.debug('onJoinedCall', {incomingCallId});
+            const connected = ipcValidate(
+                (ev: IpcMainEvent, incomingCallId: string, incomingSessionId: string) => {
+                    log.debug('onJoinedCall', {incomingCallId});
 
-                if (!this.isCallsWidget(ev.sender.id)) {
-                    log.debug('onJoinedCall', 'blocked on wrong webContentsId');
-                    return;
-                }
+                    if (!this.isCallsWidget(ev.sender.id)) {
+                        log.debug('onJoinedCall', 'blocked on wrong webContentsId');
+                        return;
+                    }
 
-                if (msg.callID !== incomingCallId) {
-                    log.debug('onJoinedCall', 'blocked on wrong callId');
-                    return;
-                }
+                    if (msg.callID !== incomingCallId) {
+                        log.debug('onJoinedCall', 'blocked on wrong callId');
+                        return;
+                    }
 
-                ipcMain.off(CALLS_JOINED_CALL, connected);
-                resolve({callID: msg.callID, sessionID: incomingSessionId});
-            };
+                    ipcMain.off(CALLS_JOINED_CALL, connected);
+                    resolve({callID: msg.callID, sessionID: incomingSessionId});
+                },
+                [Joi.string().required(), Joi.string().required()],
+            );
             ipcMain.on(CALLS_JOINED_CALL, connected);
         });
 

--- a/src/app/navigationManager.ts
+++ b/src/app/navigationManager.ts
@@ -3,6 +3,7 @@
 
 import type {IpcMainEvent, IpcMainInvokeEvent} from 'electron';
 import {dialog, ipcMain} from 'electron';
+import Joi from 'joi';
 
 import MainWindow from 'app/mainWindow/mainWindow';
 import ModalManager from 'app/mainWindow/modals/modalManager';
@@ -15,6 +16,7 @@ import type {MattermostServer} from 'common/servers/MattermostServer';
 import ServerManager from 'common/servers/serverManager';
 import {getFormattedPathName, isMagicLinkUrl, parseURL} from 'common/utils/url';
 import Utils from 'common/utils/util';
+import {ipcValidate} from 'common/Validator';
 import type {MattermostView} from 'common/views/MattermostView';
 import {ViewType} from 'common/views/MattermostView';
 import ViewManager from 'common/views/viewManager';
@@ -35,7 +37,7 @@ export class NavigationManager {
 
         ipcMain.handle(REQUEST_BROWSER_HISTORY_STATUS, this.handleRequestBrowserHistoryStatus);
         ipcMain.on(HISTORY, this.handleHistory);
-        ipcMain.on(BROWSER_HISTORY_PUSH, this.handleBrowserHistoryPush);
+        ipcMain.on(BROWSER_HISTORY_PUSH, ipcValidate(this.handleBrowserHistoryPush, [Joi.string().required()]));
     }
 
     private openLinkInTab = (url: string | URL, getView: (server: MattermostServer) => MattermostView | undefined) => {

--- a/src/app/views/webContentsManager.ts
+++ b/src/app/views/webContentsManager.ts
@@ -4,6 +4,7 @@
 import type {IpcMainEvent, IpcMainInvokeEvent} from 'electron';
 import {ipcMain, nativeTheme, session, shell} from 'electron';
 import isDev from 'electron-is-dev';
+import Joi from 'joi';
 
 import type {Theme} from '@mattermost/desktop-api';
 
@@ -31,6 +32,7 @@ import Config from 'common/config';
 import {DEFAULT_CHANGELOG_LINK} from 'common/constants';
 import {Logger} from 'common/log';
 import ServerManager from 'common/servers/serverManager';
+import {ipcValidate, themeSchema} from 'common/Validator';
 import {ViewType, type MattermostView} from 'common/views/MattermostView';
 import ViewManager from 'common/views/viewManager';
 import {flushCookiesStore} from 'main/app/utils';
@@ -58,11 +60,14 @@ export class WebContentsManager {
         ipcMain.on(OPEN_SERVER_EXTERNALLY, this.handleOpenServerExternally);
         ipcMain.on(OPEN_SERVER_UPGRADE_LINK, this.handleOpenServerUpgradeLink);
         ipcMain.on(OPEN_CHANGELOG_LINK, this.handleOpenChangelogLink);
-        ipcMain.on(UNREADS_AND_MENTIONS, this.handleUnreadsAndMentionsChanged);
-        ipcMain.on(SESSION_EXPIRED, this.handleSessionExpired);
+        ipcMain.on(UNREADS_AND_MENTIONS, ipcValidate(
+            this.handleUnreadsAndMentionsChanged,
+            [Joi.boolean().required(), Joi.number().integer().min(0).required()],
+        ));
+        ipcMain.on(SESSION_EXPIRED, ipcValidate(this.handleSessionExpired, [Joi.boolean().required()]));
         ipcMain.on(OPEN_POPOUT_MENU, this.handleOpenPopoutMenu);
         ipcMain.on(UPDATE_SERVER_THEME, this.handleUpdateServerTheme);
-        ipcMain.on(UPDATE_THEME, this.handleUpdateTheme);
+        ipcMain.on(UPDATE_THEME, ipcValidate(this.handleUpdateTheme, [themeSchema.required()]));
 
         if (process.platform !== 'linux') {
             nativeTheme.on('updated', this.handleDarkModeChanged);

--- a/src/app/views/webContentsManager.ts
+++ b/src/app/views/webContentsManager.ts
@@ -66,7 +66,7 @@ export class WebContentsManager {
         ));
         ipcMain.on(SESSION_EXPIRED, ipcValidate(this.handleSessionExpired, [Joi.boolean().required()]));
         ipcMain.on(OPEN_POPOUT_MENU, this.handleOpenPopoutMenu);
-        ipcMain.on(UPDATE_SERVER_THEME, this.handleUpdateServerTheme);
+        ipcMain.on(UPDATE_SERVER_THEME, ipcValidate(this.handleUpdateServerTheme, [themeSchema.required()]));
         ipcMain.on(UPDATE_THEME, ipcValidate(this.handleUpdateTheme, [themeSchema.required()]));
 
         if (process.platform !== 'linux') {

--- a/src/app/windows/popoutManager.ts
+++ b/src/app/windows/popoutManager.ts
@@ -3,6 +3,7 @@
 
 import type {IpcMainEvent, IpcMainInvokeEvent, WebContentsView} from 'electron';
 import {ipcMain} from 'electron';
+import Joi from 'joi';
 
 import type {PopoutViewProps} from '@mattermost/desktop-api';
 
@@ -43,6 +44,7 @@ import {POPOUT_RATE_LIMIT} from 'common/constants';
 import {Logger} from 'common/log';
 import ServerManager from 'common/servers/serverManager';
 import {DEFAULT_RHS_WINDOW_WIDTH, TAB_BAR_HEIGHT} from 'common/utils/constants';
+import {ipcValidate, popoutViewPropsSchema} from 'common/Validator';
 import type {MattermostView} from 'common/views/MattermostView';
 import {ViewType} from 'common/views/MattermostView';
 import ViewManager from 'common/views/viewManager';
@@ -65,13 +67,22 @@ export class PopoutManager {
 
         ipcMain.handle(CREATE_NEW_WINDOW, (event, serverId) => this.handleCreateNewWindow(serverId));
         ipcMain.handle(CAN_POPOUT, this.handleCanPopout);
-        ipcMain.handle(OPEN_POPOUT, this.handleOpenPopout);
-        ipcMain.handle(CAN_USE_POPOUT_OPTION, this.handleCanUsePopoutOption);
+        ipcMain.handle(OPEN_POPOUT, ipcValidate(
+            this.handleOpenPopout,
+            [Joi.string().required(), popoutViewPropsSchema.required()],
+        ));
+        ipcMain.handle(CAN_USE_POPOUT_OPTION, ipcValidate(this.handleCanUsePopoutOption, [Joi.string().required()]));
         ipcMain.on(WINDOW_CLOSE, this.handleWindowClose);
-        ipcMain.on(SEND_TO_PARENT, this.handleSendToParent);
-        ipcMain.on(SEND_TO_POPOUT, this.handleSendToPopout);
+        ipcMain.on(SEND_TO_PARENT, ipcValidate(this.handleSendToParent, [Joi.string().required()]));
+        ipcMain.on(SEND_TO_POPOUT, ipcValidate(
+            this.handleSendToPopout,
+            [Joi.string().required(), Joi.string().required()],
+        ));
         ipcMain.on(CLEAR_CACHE_AND_RELOAD, this.handleClearCacheAndReload);
-        ipcMain.on(UPDATE_POPOUT_TITLE_TEMPLATE, this.handleUpdatePopoutTitleTemplate);
+        ipcMain.on(UPDATE_POPOUT_TITLE_TEMPLATE, ipcValidate(
+            this.handleUpdatePopoutTitleTemplate,
+            [Joi.string().required()],
+        ));
 
         ViewManager.on(VIEW_CREATED, this.handleViewCreated);
         ViewManager.on(VIEW_REMOVED, this.handleViewRemoved);

--- a/src/common/AGENTS.md
+++ b/src/common/AGENTS.md
@@ -24,6 +24,8 @@ All IPC channel names as exported constants. Define new channels here first, the
 
 Joi-based validation schemas for all persisted data: config (V0–V4), servers, args, certificates, downloads, window state, and app state. Every module that reads user-editable JSON calls through `Validator` before trusting the data.
 
+Also exports `ipcValidate(handler, schemas)` — a wrapper used at every `ipcMain.on`/`ipcMain.handle` registration whose handler reads renderer-supplied arguments. It validates each positional argument against the provided Joi schemas, drops the call and logs on failure, and only invokes the handler when every argument is well-typed. Shared schemas for renderer payloads (`themeSchema`, `popoutViewPropsSchema`, `joinCallOptsSchema`, `desktopSourcesOptsSchema`) are exported alongside it; add new shared schemas here instead of declaring them in the consumer module.
+
 ### JsonFileManager (`JsonFileManager.ts`)
 
 Generic base class for reading/writing typed JSON files with atomic serialization. Used by `Config`, `AppVersionManager`, `CertificateStore`, and others that persist state to disk.

--- a/src/common/Validator.test.js
+++ b/src/common/Validator.test.js
@@ -3,6 +3,8 @@
 
 'use strict';
 
+import Joi from 'joi';
+
 import * as Validator from './Validator';
 
 describe('common/Validator', () => {
@@ -246,6 +248,78 @@ describe('common/Validator', () => {
 
         it('should reject invalid protocols', () => {
             expect(Validator.validateAllowedProtocols([...allowedProtocols, 'not-a-protocol'])).toStrictEqual(null);
+        });
+    });
+
+    describe('ipcValidate', () => {
+        const event = {sender: {id: 1}};
+
+        it('calls the underlying handler when every arg matches its schema', () => {
+            const handler = jest.fn().mockReturnValue('result');
+            const wrapped = Validator.ipcValidate(
+                handler,
+                [Joi.string().required(), Joi.number().required()],
+            );
+
+            expect(wrapped(event, 'hello', 42)).toBe('result');
+            expect(handler).toHaveBeenCalledWith(event, 'hello', 42);
+        });
+
+        it('drops the call and does not invoke the handler when an arg has the wrong type', () => {
+            const handler = jest.fn();
+            const wrapped = Validator.ipcValidate(
+                handler,
+                [Joi.string().required(), Joi.number().required()],
+            );
+
+            wrapped(event, 'hello', 1n);
+            expect(handler).not.toHaveBeenCalled();
+        });
+
+        it('drops the call when a required arg is missing', () => {
+            const handler = jest.fn();
+            const wrapped = Validator.ipcValidate(
+                handler,
+                [Joi.string().required(), Joi.number().required()],
+            );
+
+            wrapped(event, 'hello');
+            expect(handler).not.toHaveBeenCalled();
+        });
+
+        it('drops the call when a required object arg is null', () => {
+            const handler = jest.fn();
+            const wrapped = Validator.ipcValidate(handler, [Joi.object().required()]);
+
+            wrapped(event, null);
+            expect(handler).not.toHaveBeenCalled();
+        });
+
+        it('allows optional trailing args to be omitted', () => {
+            const handler = jest.fn().mockReturnValue('ok');
+            const wrapped = Validator.ipcValidate(
+                handler,
+                [Joi.string().required(), Joi.string(), Joi.string()],
+            );
+
+            expect(wrapped(event, 'hello')).toBe('ok');
+            expect(handler).toHaveBeenCalledWith(event, 'hello');
+        });
+
+        it('passes positional args beyond the schema length through to the handler', () => {
+            const handler = jest.fn().mockReturnValue('ok');
+            const wrapped = Validator.ipcValidate(handler, [Joi.string().required()]);
+
+            expect(wrapped(event, 'channel', 1n, null, {})).toBe('ok');
+            expect(handler).toHaveBeenCalledWith(event, 'channel', 1n, null, {});
+        });
+
+        it('invokes the handler when no schemas are provided', () => {
+            const handler = jest.fn().mockReturnValue('ok');
+            const wrapped = Validator.ipcValidate(handler, []);
+
+            expect(wrapped(event, 'anything', 1n)).toBe('ok');
+            expect(handler).toHaveBeenCalledWith(event, 'anything', 1n);
         });
     });
 });

--- a/src/common/Validator.ts
+++ b/src/common/Validator.ts
@@ -352,3 +352,68 @@ function validateAgainstSchema<T>(data: T, schema: Joi.ObjectSchema<T> | Joi.Arr
     }
     return value as T;
 }
+
+export function ipcValidate<E, A extends unknown[], R>(
+    handler: (event: E, ...args: A) => R,
+    schemas: Joi.Schema[],
+): (event: E, ...args: A) => R {
+    return (event: E, ...args: A) => {
+        for (let i = 0; i < schemas.length; i++) {
+            const {error} = schemas[i].validate(args[i]);
+            if (error) {
+                log.error(`IPC validation failed at argument ${i}: ${error.message}`);
+                return undefined as R;
+            }
+        }
+        return handler(event, ...args);
+    };
+}
+export const themeSchema = Joi.object({
+    sidebarBg: Joi.string(),
+    sidebarText: Joi.string(),
+    sidebarUnreadText: Joi.string(),
+    sidebarTextHoverBg: Joi.string(),
+    sidebarTextActiveBorder: Joi.string(),
+    sidebarTextActiveColor: Joi.string(),
+    sidebarHeaderBg: Joi.string(),
+    sidebarTeamBarBg: Joi.string(),
+    sidebarHeaderTextColor: Joi.string(),
+    onlineIndicator: Joi.string(),
+    awayIndicator: Joi.string(),
+    dndIndicator: Joi.string(),
+    mentionBg: Joi.string(),
+    mentionColor: Joi.string(),
+    centerChannelBg: Joi.string(),
+    centerChannelColor: Joi.string(),
+    newMessageSeparator: Joi.string(),
+    linkColor: Joi.string(),
+    buttonBg: Joi.string(),
+    buttonColor: Joi.string(),
+    errorTextColor: Joi.string(),
+    mentionHighlightBg: Joi.string(),
+    mentionHighlightLink: Joi.string(),
+    codeTheme: Joi.string(),
+    isUsingSystemTheme: Joi.boolean(),
+}).unknown(true);
+
+export const popoutViewPropsSchema = Joi.object({
+    titleTemplate: Joi.string(),
+    isRHS: Joi.boolean(),
+}).unknown(true);
+
+export const joinCallOptsSchema = Joi.object({
+    callID: Joi.string().required(),
+    title: Joi.string().allow('').required(),
+    rootID: Joi.string().allow('').required(),
+    channelURL: Joi.string().required(),
+    startingCall: Joi.boolean(),
+});
+
+export const desktopSourcesOptsSchema = Joi.object({
+    types: Joi.array().items(Joi.string().valid('screen', 'window')).required(),
+    thumbnailSize: Joi.object({
+        height: Joi.number().required(),
+        width: Joi.number().required(),
+    }),
+    fetchWindowIcons: Joi.boolean(),
+});

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -8,6 +8,7 @@ import type {IpcMainInvokeEvent} from 'electron';
 import {app, BrowserWindow, ipcMain, nativeTheme, net, protocol, session} from 'electron';
 import installExtension, {REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS} from 'electron-devtools-installer';
 import isDev from 'electron-is-dev';
+import Joi from 'joi';
 
 import MainWindow from 'app/mainWindow/mainWindow';
 import MenuManager from 'app/menus';
@@ -44,6 +45,7 @@ import {Logger} from 'common/log';
 import ServerManager from 'common/servers/serverManager';
 import {parseURL} from 'common/utils/url';
 import {setTestField} from 'common/utils/util';
+import {ipcValidate} from 'common/Validator';
 import ViewManager from 'common/views/viewManager';
 import AppVersionManager from 'main/AppVersionManager';
 import AutoLauncher from 'main/AutoLauncher';
@@ -246,7 +248,15 @@ function initializeBeforeAppReady() {
 }
 
 function initializeInterCommunicationEventListeners() {
-    ipcMain.handle(NOTIFY_MENTION, handleMentionNotification);
+    ipcMain.handle(NOTIFY_MENTION, ipcValidate(handleMentionNotification, [
+        Joi.string().allow('').required(),
+        Joi.string().allow('').required(),
+        Joi.string().min(1).required(),
+        Joi.string().min(1).required(),
+        Joi.string().min(1).required(),
+        Joi.boolean().required(),
+        Joi.string().allow('').required(),
+    ]));
     ipcMain.handle(GET_APP_INFO, handleAppVersion);
 
     if (process.platform !== 'darwin') {

--- a/src/main/themeManager.ts
+++ b/src/main/themeManager.ts
@@ -119,7 +119,7 @@ export class ThemeManager {
             return;
         }
         if (!server.theme.isUsingSystemTheme) {
-            const themeSource = isLightColor(server.theme.centerChannelBg) ? 'light' : 'dark';
+            const themeSource = isLightColor(server.theme.centerChannelBg || '#fff') ? 'light' : 'dark';
             if (nativeTheme.themeSource !== themeSource) {
                 nativeTheme.themeSource = themeSource;
             }


### PR DESCRIPTION
#### Summary
Several `ipcMain` handlers consumed renderer-supplied arguments without runtime type checks. When the renderer sent unexpected payload shapes, those handlers could throw errors.

This PR adds an `ipcValidate` wrapper in `Validator.ts` that applies Joi schemas to handler arguments at the registration boundary, drops the call and logs on validation failure.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68874

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Regression Risk:** The PR adds a shared runtime validation wrapper (ipcValidate) and new Joi schemas used across multiple modules (callsWidgetWindow, navigationManager, webContentsManager, popoutManager, initialize, Validator exports). This alters the runtime contract for renderer-supplied positional arguments — calls that fail schema validation are dropped and logged rather than forwarded — which can break existing user-facing flows (calls, screen sharing, call joining, navigation pushes, theme updates, popouts, mention notifications) if schemas are stricter than current renderer payloads. Risk is mitigated by added unit tests for ipcValidate and targeted application of the wrapper, but several touched files are critical UI flows and may lack full integration coverage, so regression potential remains.

**QA Recommendation:** Medium to high manual QA. Perform end-to-end tests for affected flows: calls widget (resize, share, desktop sources, join flows), navigation/history pushes, theme updates (including system/server theme paths), popout open/send/title flows, and mention notifications. Verify valid renderer args pass through and invalid ones are dropped with observable logged errors; review logs during QA to identify schema mismatches and adjust schemas as needed.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->