### PR TITLE
Fixed an issue where upstream Electron fails to extract

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10410,15 +10410,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -16060,7 +16051,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
@@ -19779,13 +19771,17 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.1.tgz",
+      "integrity": "sha512-RNPCUkiE/ZgO4w8i9U5yDQVHaFDdnzaFANElRvpJteCspvmv2VqrRb9lvS6odVD+jqI/zDsxAHJVsafpcheVQQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -181,5 +181,8 @@
     "valid-url": "1.0.9",
     "windows-focus-assist": "1.4.0",
     "yargs": "17.7.2"
+  },
+  "overrides": {
+    "yauzl": "3.3.1"
   }
 }


### PR DESCRIPTION
#### Summary
An upstream issue with Electron's dependencies (https://github.com/electron/electron/issues/51619) causes Node 24 to fail to extract the binary, causing tests to fail unexpectedly.

This PR adds an override for the library that was failing so that it will work on Node 24.

```release-note
NOTE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Minimal. This change only adds a dependency override in `package.json` to force `yauzl` version `3.3.1`, which is a build-time dependency used by Electron for binary extraction. No application code logic is modified, and the override is narrowly scoped to resolve a specific Node 24 compatibility issue with Electron's binary extraction process. The change does not affect runtime behavior, core logic, or shared utilities.

**QA Recommendation:** Manual QA can be safely skipped for this change. Verification should focus on confirming that the build process completes successfully on Node 24 and that tests pass as expected (which appears to be the original issue being fixed). Automated build and test pipelines should provide sufficient validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->