### PR TITLE
[MM-69197] Add setting to disable Session Attribute collection

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -250,6 +250,8 @@
   "renderer.components.settingsPage.enableMetrics.description": "Sends usage data about the application and its performance to your configured servers that accept it.",
   "renderer.components.settingsPage.enableSentry": "Send error reports to help improve the app",
   "renderer.components.settingsPage.enableSentry.description": "If enabled, error reports and crash information will be sent to help identify and fix issues in the application. Setting takes effect after restarting the app.",
+  "renderer.components.settingsPage.enableSessionAttributes": "Enable session attributes",
+  "renderer.components.settingsPage.enableSessionAttributes.description": "Sends device and network information to your configured servers for use in permission policies. Some resources may be inaccessible if this setting is disabled.",
   "renderer.components.settingsPage.flashWindow": "Flash taskbar icon when a new message is received",
   "renderer.components.settingsPage.flashWindow.description": "If enabled, the taskbar icon will flash for a few seconds when a new message is received.",
   "renderer.components.settingsPage.flashWindow.description.linuxFunctionality": "This functionality may not work with all Linux window managers.",

--- a/src/common/Validator.test.js
+++ b/src/common/Validator.test.js
@@ -219,6 +219,7 @@ describe('common/Validator', () => {
             themeSyncing: true,
             enableMetrics: true,
             enableSentry: true,
+            enableSessionAttributes: true,
             useNativeTitleBar: false,
         };
 

--- a/src/common/Validator.ts
+++ b/src/common/Validator.ts
@@ -185,6 +185,7 @@ const configDataSchemaV4 = Joi.object<ConfigV4>({
     appLanguage: Joi.string().allow(''),
     enableMetrics: Joi.boolean().default(true),
     enableSentry: Joi.boolean().default(true),
+    enableSessionAttributes: Joi.boolean().default(true),
     viewLimit: Joi.number().integer().min(1),
     themeSyncing: Joi.boolean().default(true),
     skippedVersions: Joi.array().items(Joi.string()).default([]),

--- a/src/common/config/defaultPreferences.ts
+++ b/src/common/config/defaultPreferences.ts
@@ -53,6 +53,7 @@ const defaultPreferences: ConfigV4 = {
     logLevel: 'info',
     enableMetrics: true,
     enableSentry: true,
+    enableSessionAttributes: true,
     viewLimit: 15,
     themeSyncing: true,
     useNativeTitleBar: false,

--- a/src/common/config/index.ts
+++ b/src/common/config/index.ts
@@ -241,6 +241,10 @@ export class Config extends EventEmitter {
         return this.combinedData?.enableSentry ?? true;
     }
 
+    get enableSessionAttributes() {
+        return this.combinedData?.enableSessionAttributes ?? true;
+    }
+
     get viewLimit() {
         return this.combinedData?.viewLimit ?? 15;
     }

--- a/src/main/sessionAttributes/collector/sessionAttributeCollector.ts
+++ b/src/main/sessionAttributes/collector/sessionAttributeCollector.ts
@@ -31,7 +31,14 @@ export class SessionAttributeCollector {
     }
 
     getOSPlatform(): string {
-        return process.platform;
+        switch (process.platform) {
+        case 'darwin':
+            return 'macos';
+        case 'win32':
+            return 'windows';
+        default:
+            return process.platform;
+        }
     }
 
     getOSVersion() {

--- a/src/main/sessionAttributes/sessionAttributesManager.test.ts
+++ b/src/main/sessionAttributes/sessionAttributesManager.test.ts
@@ -10,6 +10,7 @@ import {
     SESSION_ATTRIBUTES_MANIFEST_INVALIDATED,
     SESSION_ATTRIBUTES_RESEND_REQUESTED,
 } from 'common/communication';
+import Config from 'common/config';
 import {COOKIE_NAME_AUTH_TOKEN} from 'common/constants';
 import ServerManager from 'common/servers/serverManager';
 import {updateServerInfos} from 'main/app/utils';
@@ -29,6 +30,13 @@ jest.mock('app/views/webContentsManager', () => ({
     __esModule: true,
     default: {
         getViewByWebContentsId: jest.fn(),
+    },
+}));
+
+jest.mock('common/config', () => ({
+    __esModule: true,
+    default: {
+        enableSessionAttributes: true,
     },
 }));
 
@@ -64,6 +72,7 @@ const server = {
     url: new URL('https://chat.example.com'),
 };
 
+const ConfigMock = jest.mocked(Config);
 const ServerManagerMock = jest.mocked(ServerManager);
 const WebContentsManagerMock = jest.mocked(WebContentsManager);
 const updateServerInfosMock = jest.mocked(updateServerInfos);
@@ -78,6 +87,7 @@ describe('main/sessionAttributes/sessionAttributesManager', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        ConfigMock.enableSessionAttributes = true;
         ServerManagerMock.on.mockImplementation((event, handler) => {
             if (event === SERVER_REMOVED) {
                 serverRemovedHandler = handler;
@@ -99,6 +109,17 @@ describe('main/sessionAttributes/sessionAttributesManager', () => {
         updateServerInfosMock.mockResolvedValue(undefined);
 
         manager = new SessionAttributesManager();
+    });
+
+    it('returns undefined when session attributes are disabled', () => {
+        ConfigMock.enableSessionAttributes = false;
+
+        const header = manager.getHeaderForRequest(server.url.toString(), {
+            Cookie: `${COOKIE_NAME_AUTH_TOKEN}=abc123`,
+        });
+
+        expect(header).toBeUndefined();
+        expect(SessionAttributeCollectorMock.getClientIPAddress).not.toHaveBeenCalled();
     });
 
     it('returns undefined without MMAUTHTOKEN cookie', () => {

--- a/src/main/sessionAttributes/sessionAttributesManager.ts
+++ b/src/main/sessionAttributes/sessionAttributesManager.ts
@@ -12,6 +12,7 @@ import {
     SESSION_ATTRIBUTES_MANIFEST_INVALIDATED,
     SESSION_ATTRIBUTES_RESEND_REQUESTED,
 } from 'common/communication';
+import Config from 'common/config';
 import {COOKIE_NAME_AUTH_TOKEN} from 'common/constants';
 import {Logger} from 'common/log';
 import type {MattermostServer} from 'common/servers/MattermostServer';
@@ -41,6 +42,10 @@ export class SessionAttributesManager {
         requestURL: string,
         requestHeaders: Record<string, string | string[]>,
     ): string | undefined => {
+        if (!Config.enableSessionAttributes) {
+            return undefined;
+        }
+
         // Without a session, we can't send session attributes.
         if (!this.hasAuthCookie(requestHeaders)) {
             return undefined;

--- a/src/renderer/components/SettingsModal/definition.tsx
+++ b/src/renderer/components/SettingsModal/definition.tsx
@@ -512,6 +512,24 @@ const definition: (intl: IntlShape) => Promise<SettingsDefinition> = async (intl
                     },
                 },
                 {
+                    id: 'enableSessionAttributes',
+                    component: CheckSetting,
+                    props: {
+                        label: (
+                            <FormattedMessage
+                                id='renderer.components.settingsPage.enableSessionAttributes'
+                                defaultMessage='Enable session attributes'
+                            />
+                        ),
+                        subLabel: (
+                            <FormattedMessage
+                                id='renderer.components.settingsPage.enableSessionAttributes.description'
+                                defaultMessage='Sends device and network information to your configured servers for use in permission policies. Some resources may be inaccessible if this setting is disabled.'
+                            />
+                        ),
+                    },
+                },
+                {
                     id: 'enableHardwareAcceleration',
                     component: CheckSetting,
                     props: {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -57,6 +57,7 @@ export type ConfigV4 = {
     appLanguage?: string;
     enableMetrics?: boolean;
     enableSentry?: boolean;
+    enableSessionAttributes?: boolean;
     viewLimit?: number;
     themeSyncing?: boolean;
     skippedVersions?: string[];


### PR DESCRIPTION
#### Summary
This PR adds an **Enable session attributes** toggle under Advanced settings (on by default). When disabled, `SessionAttributesManager` stops sending the `X-MM-Session-Attributes` header while manifest fetching continues unchanged. 

It also fixes a bug so that `getOSPlatform()` maps to the correct platform names.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69197

#### Screenshots
<img width="550" height="95" alt="Screenshot 2026-06-11 at 3 53 09 PM" src="https://github.com/user-attachments/assets/2e8e061f-68dd-4c08-9353-9128f1224582" />

#### Release Note
```release-note
Added an advanced setting to enable or disable session attributes. Some resources may be inaccessible when disabled.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** 
The changes touch session/authentication-related functionality (`SessionAttributesManager`) which handles inter-service communication headers. While the feature is gated behind a configuration flag with a safe default (`true`), any behavioral changes to header injection could affect request handling across the system. The `getOSPlatform()` platform name mapping change (`darwin` → `macos`, `win32` → `windows`) modifies output format for session attribute collectors, which could impact downstream consumers if they rely on specific platform string formats. The `getHeaderForRequest` method is the integration point for request header injection, confirming this is a critical flow. However, the early-return gate in `getHeaderForRequest()` is straightforward with low logic complexity, and test coverage explicitly validates the disabled path.

**QA Recommendation:** 
Manual QA should focus on: (1) verifying that disabling the setting prevents `X-MM-Session-Attributes` headers from being sent while maintaining manifest fetching, (2) testing the enabled state maintains current behavior, (3) validating that the platform name mapping produces correct values on macOS and Windows builds, and (4) ensuring config persistence and UI toggle function correctly across application restarts. Since the feature spans session management (a critical path), smoke testing integration scenarios where servers depend on session attributes is recommended, particularly testing that request flow and server communication remain unaffected when the setting is toggled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->