### PR TITLE
Revert production touchpoints; keep E2E on test-only hooks

### DIFF
--- a/e2e/helpers/dialog.ts
+++ b/e2e/helpers/dialog.ts
@@ -40,13 +40,3 @@ export async function clearCertificateErrorCallbacks(app: ElectronApplication): 
         clear?.();
     });
 }
-
-export async function setAutoTrustCertificate(app: ElectronApplication, enabled: boolean): Promise<void> {
-    await app.evaluate((_electron, value) => {
-        const setAutoTrust = (global as any).__e2eSetAutoTrustCertificate as ((enabled: boolean) => void) | undefined;
-        if (!setAutoTrust) {
-            throw new Error('__e2eSetAutoTrustCertificate not exposed (NODE_ENV must be test)');
-        }
-        setAutoTrust(value);
-    }, enabled);
-}

--- a/e2e/specs/menu_bar/help_menu.test.ts
+++ b/e2e/specs/menu_bar/help_menu.test.ts
@@ -21,10 +21,10 @@ test.describe('menu_bar/help_menu', () => {
 
             await electronApp.evaluate(() => {
                 const refs = (global as any).__e2eTestRefs;
-                refs.UpdateManager.__e2eCheckForUpdatesCalls = 0;
-                refs.UpdateManager.__e2eOriginalCheckForUpdates = refs.UpdateManager.checkForUpdates;
-                refs.UpdateManager.checkForUpdates = () => {
-                    refs.UpdateManager.__e2eCheckForUpdatesCalls += 1;
+                refs.updateNotifier.__e2eCheckForUpdatesCalls = 0;
+                refs.updateNotifier.__e2eOriginalCheckForUpdates = refs.updateNotifier.checkForUpdates;
+                refs.updateNotifier.checkForUpdates = () => {
+                    refs.updateNotifier.__e2eCheckForUpdatesCalls += 1;
                 };
             });
 
@@ -34,15 +34,15 @@ test.describe('menu_bar/help_menu', () => {
                 await expect.poll(async () => {
                     return electronApp.evaluate(() => {
                         const refs = (global as any).__e2eTestRefs;
-                        return refs?.UpdateManager?.__e2eCheckForUpdatesCalls ?? 0;
+                        return refs?.updateNotifier?.__e2eCheckForUpdatesCalls ?? 0;
                     });
                 }, {timeout: 10_000}).toBeGreaterThan(0);
             } finally {
                 await electronApp.evaluate(() => {
                     const refs = (global as any).__e2eTestRefs;
-                    if (refs?.UpdateManager?.__e2eOriginalCheckForUpdates) {
-                        refs.UpdateManager.checkForUpdates = refs.UpdateManager.__e2eOriginalCheckForUpdates;
-                        delete refs.UpdateManager.__e2eOriginalCheckForUpdates;
+                    if (refs?.updateNotifier?.__e2eOriginalCheckForUpdates) {
+                        refs.updateNotifier.checkForUpdates = refs.updateNotifier.__e2eOriginalCheckForUpdates;
+                        delete refs.updateNotifier.__e2eOriginalCheckForUpdates;
                     }
                 });
             }

--- a/e2e/specs/server_management/certificate_trust.test.ts
+++ b/e2e/specs/server_management/certificate_trust.test.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import {test, expect} from '../../fixtures/index';
 import {waitForAppReady} from '../../helpers/appReadiness';
 import {electronBinaryPath, appDir, demoConfig} from '../../helpers/config';
-import {clearCertificateErrorCallbacks, restoreMessageBox, setAutoTrustCertificate} from '../../helpers/dialog';
+import {clearCertificateErrorCallbacks, restoreMessageBox, stubMessageBoxResponses} from '../../helpers/dialog';
 import {closeElectronAppFast} from '../../helpers/electronApp';
 import {waitForErrorView} from '../../helpers/errorView';
 
@@ -50,7 +50,7 @@ test(
             await waitForErrorView(app);
 
             await clearCertificateErrorCallbacks(app);
-            await setAutoTrustCertificate(app, true);
+            await stubMessageBoxResponses(app, [{response: 0}, {response: 0}]);
 
             await app.evaluate(() => {
                 const refs = (global as any).__e2eTestRefs;
@@ -75,7 +75,6 @@ test(
             const certificateStore = JSON.parse(fs.readFileSync(certificateStorePath, 'utf-8')) as Record<string, unknown>;
             expect(Object.keys(certificateStore).length).toBeGreaterThan(0);
         } finally {
-            await setAutoTrustCertificate(app, false).catch(() => {});
             await restoreMessageBox(app).catch(() => {});
             await closeElectronAppFast(app, userDataDir);
         }

--- a/src/app/navigationManager.test.js
+++ b/src/app/navigationManager.test.js
@@ -149,7 +149,6 @@ describe('app/navigationManager', () => {
 
             navigationManager.openLinkInPrimaryTab('mattermost://server-1.com/deep/link?thing=yes');
 
-            expect(TabManager.switchToTab).toHaveBeenCalledWith('view1');
             expect(baseView.load).toHaveBeenCalledWith('http://server-1.com/deep/link?thing=yes');
         });
 

--- a/src/app/navigationManager.ts
+++ b/src/app/navigationManager.ts
@@ -121,8 +121,8 @@ export class NavigationManager {
                     this.showViewLimitReachedError();
                     return undefined;
                 }
+                TabManager.switchToTab(view.id);
             }
-            TabManager.switchToTab(view.id);
             return view;
         });
     };

--- a/src/main/app/app.ts
+++ b/src/main/app/app.ts
@@ -98,23 +98,8 @@ export async function handleAppCertificateError(event: Event, webContents: WebCo
     } else if (CertificateStore.isTrusted(parsedURL, certificate)) {
         event.preventDefault();
         callback(true);
-    } else if (process.env.NODE_ENV === 'test' && (global as {__e2eAutoTrustCertificate?: boolean}).__e2eAutoTrustCertificate) {
-        event.preventDefault();
-
-        const view = WebContentsManager.getViewByWebContentsId(webContents.id);
-        CertificateStore.add(parsedURL, certificate);
-        CertificateStore.save();
-        callback(true);
-
-        if (view) {
-            view.load(url);
-        } else {
-            webContents.loadURL(url);
-        }
     } else {
-        event.preventDefault();
-
-        // update the callback
+    // update the callback
         const errorID = `${parsedURL.origin}:${error}`;
 
         const view = WebContentsManager.getViewByWebContentsId(webContents.id);

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -67,7 +67,7 @@ import PreAuthManager from 'main/security/preAuthManager';
 import sentryHandler from 'main/sentryHandler';
 import SessionAttributesManager from 'main/sessionAttributes/sessionAttributesManager';
 import {installMessageBoxStub, restoreMessageBoxStub} from 'main/testMessageBoxStub';
-import UpdateManager from 'main/updateNotifier';
+import updateNotifier from 'main/updateNotifier';
 import UserActivityMonitor from 'main/UserActivityMonitor';
 
 import {
@@ -303,7 +303,7 @@ async function initializeAfterAppReady() {
         TrayIcon: Tray,
         NotificationManager,
         Diagnostics,
-        UpdateManager,
+        updateNotifier,
     });
 
     setTestField('__e2eOpenDeepLink', (url: string) => {
@@ -377,9 +377,6 @@ async function initializeAfterAppReady() {
         setTestField('__e2eStubMessageBoxResponses', installMessageBoxStub);
         setTestField('__e2eRestoreMessageBox', restoreMessageBoxStub);
         setTestField('__e2eClearCertificateErrorCallbacks', () => certificateErrorCallbacks.clear());
-        setTestField('__e2eSetAutoTrustCertificate', (enabled: boolean) => {
-            (global as {__e2eAutoTrustCertificate?: boolean}).__e2eAutoTrustCertificate = enabled;
-        });
         if (process.env.MM_E2E_STUB_MESSAGE_BOX === 'cancel') {
             installMessageBoxStub([{response: 1}]);
         } else if (process.env.MM_E2E_STUB_MESSAGE_BOX === 'trust') {
@@ -455,7 +452,7 @@ async function initializeAfterAppReady() {
             log.debug('checkForUpdates');
             if (Config.canUpgrade && Config.autoCheckForUpdates) {
                 setTimeout(() => {
-                    UpdateManager.checkForUpdates(false);
+                    updateNotifier.checkForUpdates(false);
                 }, 5000);
             } else {
                 log.info(`Autoupgrade disabled: ${Config.canUpgrade}`);
@@ -463,7 +460,7 @@ async function initializeAfterAppReady() {
         });
     } else if (Config.canUpgrade && Config.autoCheckForUpdates) {
         setTimeout(() => {
-            UpdateManager.checkForUpdates(false);
+            updateNotifier.checkForUpdates(false);
         }, 5000);
     } else {
         log.info(`Autoupgrade disabled: ${Config.canUpgrade}`);

--- a/src/main/security/certificateStore.ts
+++ b/src/main/security/certificateStore.ts
@@ -39,25 +39,18 @@ export class CertificateStore {
 
     constructor(storeFile: string) {
         this.storeFile = storeFile;
-        this.data = this.readStoreFile(storeFile);
-    }
-
-    private readStoreFile = (storeFile: string) => {
+        let storeStr;
         try {
-            const storeStr = fs.readFileSync(storeFile, 'utf-8');
+            storeStr = fs.readFileSync(storeFile, 'utf-8');
             const result = Validator.validateCertificateStore(storeStr);
             if (!result) {
                 throw new Error('Provided certificate store file does not validate, using defaults instead.');
             }
-            return result;
+            this.data = result;
         } catch (e) {
-            return {};
+            this.data = {};
         }
-    };
-
-    reloadFromDisk = () => {
-        this.data = this.readStoreFile(this.storeFile);
-    };
+    }
 
     save = () => {
         fs.writeFileSync(this.storeFile, JSON.stringify(this.data, null, '  '));
@@ -93,11 +86,10 @@ export class CertificateStore {
     };
 }
 
-const certificateStore = new CertificateStore(certificateStorePath);
+let certificateStore = new CertificateStore(certificateStorePath);
 export default certificateStore;
 
 ipcMain.on(UPDATE_PATHS, () => {
     new Logger('certificateStore').debug('UPDATE_PATHS');
-    certificateStore.storeFile = certificateStorePath;
-    certificateStore.reloadFromDisk();
+    certificateStore = new CertificateStore(certificateStorePath);
 });


### PR DESCRIPTION
## Summary

- Reverts CodeRabbit-flagged production behavior changes from #3847 back to master: `navigationManager` tab switching, `certificateStore` singleton reload, and cert auto-trust in `handleAppCertificateError`.
- Keeps E2E main-process hooks in `initialize.ts` (deep link, tray menu, message-box stub) gated on `NODE_ENV === 'test'`.
- Adapts E2E specs to avoid production shortcuts: `certificate_trust` uses dialog stub for trust flow; `help_menu` uses `refs.updateNotifier`.

## Why

Stacked on `migrate_RF_desktop` so CI can validate that the Playwright migration passes without production/runtime regressions in navigation, updates, or certificate handling.

## Test plan

- [ ] CI `build-linux` / `build-mac` / `build-win` pass (lint + unit)
- [ ] E2E Linux/macOS/Windows on this branch
- [ ] Spot-check if flagged: `certificate_trust.test.ts`, `bad_servers.test.ts` (pre-trusted cert), `oauth_callback.test.ts`, `help_menu.test.ts`


Made with [Cursor](https://cursor.com)