### PR TITLE
[MM-69353] Fix overly strict IPC validation silently dropping notifications

### DIFF
--- a/src/common/Validator.test.js
+++ b/src/common/Validator.test.js
@@ -322,5 +322,30 @@ describe('common/Validator', () => {
             expect(wrapped(event, 'anything', 1n)).toBe('ok');
             expect(handler).toHaveBeenCalledWith(event, 'anything', 1n);
         });
+
+        it('accepts empty strings when schema uses .allow("")', () => {
+            const handler = jest.fn().mockReturnValue('ok');
+            const wrapped = Validator.ipcValidate(handler, [Joi.string().allow('').required()]);
+
+            expect(wrapped(event, '')).toBe('ok');
+            expect(handler).toHaveBeenCalledWith(event, '');
+        });
+
+        it('accepts empty strings for all NOTIFY_MENTION-style args', () => {
+            const handler = jest.fn().mockReturnValue('ok');
+            const mentionSchema = [
+                Joi.string().allow('').required(),
+                Joi.string().allow('').required(),
+                Joi.string().allow('').required(),
+                Joi.string().allow('').required(),
+                Joi.string().allow('').required(),
+                Joi.boolean().required(),
+                Joi.string().allow('').required(),
+            ];
+            const wrapped = Validator.ipcValidate(handler, mentionSchema);
+
+            expect(wrapped(event, 'Title', 'Body', '', '', '', false, '')).toBe('ok');
+            expect(handler).toHaveBeenCalledWith(event, 'Title', 'Body', '', '', '', false, '');
+        });
     });
 });

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -252,9 +252,9 @@ function initializeInterCommunicationEventListeners() {
     ipcMain.handle(NOTIFY_MENTION, ipcValidate(handleMentionNotification, [
         Joi.string().allow('').required(),
         Joi.string().allow('').required(),
-        Joi.string().min(1).required(),
-        Joi.string().min(1).required(),
-        Joi.string().min(1).required(),
+        Joi.string().allow('').required(),
+        Joi.string().allow('').required(),
+        Joi.string().allow('').required(),
         Joi.boolean().required(),
         Joi.string().allow('').required(),
     ]));


### PR DESCRIPTION
#### Summary

https://github.com/mattermost/desktop/pull/3833 fix introduced a regression of missing notifications due to having some notification fields be too restrictive and not accepting empty for channelId, teamId and URL - which are valid scenarios for DM/GMs and System messages. 

- Changed `channelId`, `teamId`, and `url` schemas in the `NOTIFY_MENTION` `ipcValidate` handler from `Joi.string().min(1).required()` to `Joi.string().allow('').required()`
- Fixes silent notification drops when the web app sends empty strings for these fields (DMs, group messages, system notifications)
- Adds `ipcValidate` unit tests covering the empty-string edge case

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69353

#### Test plan
- [ ] Confirm DM and group message notifications fire correctly
- [ ] Verify no regression on standard mention notifications

#### Release Note
```release-note
Fixed issue where notifications were dropped when the web app sent empty fields for DMs, groups messages or system notifications. 
```

Made with [Cursor](https://cursor.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Low to moderate. This PR fixes a regression introduced in a previous fix that made IPC validation too strict. The change is highly targeted—modifying validation for only 3 string fields (`channelId`, `teamId`, `url`) in the single `NOTIFY_MENTION` IPC handler to allow empty strings. Because this relaxes (rather than tightens) validation constraints, the risk of breaking existing callers is minimal. However, the changes affect a critical notification delivery path where previously valid payloads from the web application (legitimate empty strings in DMs, group messages, and system notifications) were being silently dropped. The new test coverage specifically validates the empty-string edge case, reducing the risk of regression on this specific scenario.

**QA Recommendation:** Targeted manual QA is recommended despite automated test additions. Test focus areas: (1) Verify notification delivery for direct messages and group messages works correctly, (2) Confirm system notifications display as expected, (3) Verify standard mention notifications still function without regression, (4) Run the unit test suite to confirm new tests pass. The blast radius is limited to the notification subsystem, making QA scoping straightforward. Given the high-priority nature (blocking v6.2.1 regression), expedited testing is appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->