### PR TITLE
test(e2e): Playwright harness and main-process hooks for migration stack

### DIFF
--- a/.github/actions/install-os-dependencies/action.yaml
+++ b/.github/actions/install-os-dependencies/action.yaml
@@ -62,6 +62,9 @@ runs:
       if: inputs.os == 'macOS'
       shell: bash
       run: |
+        # GitHub-hosted macOS runners ship aws/tap and azure/bicep pre-tapped.
+        # Trust them so Homebrew does not warn on every brew invocation.
+        brew trust aws/tap azure/bicep 2>/dev/null || true
         brew install nss
 
     - name: Install Windows Dependencies

--- a/.github/workflows/cmt-provisioner.yml
+++ b/.github/workflows/cmt-provisioner.yml
@@ -3,29 +3,38 @@ name: CMT Provisioner
 # Lightweight trigger workflow for Compatibility Matrix Testing (CMT).
 #
 # Matterwick listens for this workflow's workflow_run:requested event, then provisions one
-# Mattermost cloud instance per version in its hardcoded CMT version set (Matterwick's
-# CMTServerVersions config / CMTVersions, e.g. the active ESR plus the current feature
-# release) and dispatches compatibility-matrix-testing.yml with the CMT_MATRIX input.
-# When compatibility-matrix-testing.yml completes, Matterwick destroys the provisioned
-# instances (cleanup is keyed off the completed workflow_run, matched by commit SHA).
+# Mattermost cloud instance per version in its CMT version set (auto-derived from Mattermost
+# releases, with CMTServerVersions in matterwick config as a manual override) and dispatches
+# compatibility-matrix-testing.yml with the CMT_MATRIX input. When that test workflow
+# completes, Matterwick destroys the provisioned instances (cleanup is keyed off the
+# completed workflow_run run id).
 #
 # The server-version set lives in Matterwick config (managed via gitops), so this workflow
 # takes no inputs. Run it manually from the Actions tab, or let it fire automatically on
-# release branches (below).
+# RC tags (below).
 #
-# NOTE (intentional duplicate coverage): a release-v* push ALSO triggers Matterwick's normal
+# Triggers:
+#   - Desktop RC tag push (e.g. v6.2.2-rc.1). Desktop does NOT use release-v* branches —
+#     releases are tag-based. Each RC tag push re-runs CMT against the new RC commit.
+#   - Manual run from the Actions tab (workflow_dispatch, any ref).
+#
+# Matterwick is the authoritative gate: its shouldTriggerCMT requires head_branch to match
+# the RC tag pattern ^v?\d+\.\d+\.\d+-rc[.\-]?\d+$ (or be a manual dispatch). The tag
+# glob below is a coarse GitHub-side filter; Matterwick re-validates.
+#
+# NOTE (intentional duplicate coverage): an RC tag push ALSO triggers Matterwick's normal
 # release E2E flow (whole suite against the single latest server version). CMT additionally
 # runs the whole suite against its multi-version matrix, whose set includes the latest server.
-# So on a release push the latest server version gets the suite run twice (once by the normal
+# So on an RC tag push the latest server version gets the suite run twice (once by the normal
 # release flow, once by the CMT latest-version leg). This is expected and accepted.
 
 on:
-  # Run CMT when a release branch is cut and on every subsequent push to it. The first push
-  # that creates release-v* is the "cut"; later pushes to it re-run CMT.
+  # Run CMT on every desktop RC tag push. The glob matches tags like v6.2.2-rc.1,
+  # v10.0.0-rc.2, etc. Matterwick's isRCTag regex is the authoritative gate.
   push:
-    branches:
-      - "release-v*"
-  # Manual runs from the Actions tab (against any branch).
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
+  # Manual runs from the Actions tab (against any branch or tag).
   workflow_dispatch: {}
 
 # This workflow does not use GITHUB_TOKEN. Its only purpose is to emit a workflow_run event

--- a/.github/workflows/cmt-provisioner.yml
+++ b/.github/workflows/cmt-provisioner.yml
@@ -1,41 +1,16 @@
 name: CMT Provisioner
 
-# Trigger workflow for Compatibility Matrix Testing (CMT).
-#
-# Matterwick listens for this workflow's workflow_run:requested event, then provisions one
-# Mattermost cloud instance per version in its CMT version set (auto-derived from Mattermost
-# releases, with CMTServerVersions in matterwick config as a manual override) and dispatches
-# compatibility-matrix-testing.yml with the CMT_MATRIX input. When that test workflow
-# completes, Matterwick destroys the provisioned instances (cleanup is keyed off the
-# completed workflow_run run id).
-#
-# The server-version set lives in Matterwick config (managed via gitops), so this workflow
-# takes no inputs. Run it manually from the Actions tab, or let it fire automatically on
-# RC tags (below).
-#
-# Triggers:
-#   - Desktop RC tag push (e.g. v6.2.2-rc.1). Desktop does NOT use release-v* branches —
-#     releases are tag-based. Each RC tag push re-runs CMT against the new RC commit.
-#     CMT runs the full suite across its multi-version matrix; no separate release E2E run
-#     is needed (Matterwick's push handler ignores tag pushes — only branch pushes trigger
-#     the push E2E flow).
-#   - Manual run from the Actions tab (workflow_dispatch, any ref).
-#
-# Matterwick is the authoritative gate: its shouldTriggerCMT requires head_branch to match
-# the RC tag pattern ^v?\d+\.\d+\.\d+-rc[.\-]?\d+$ (or be a manual dispatch). The tag
-# glob below is a coarse GitHub-side filter; Matterwick re-validates.
+# Lightweight signal workflow for Compatibility Matrix Testing (CMT).
+# When this runs, matterwick detects the workflow_run:requested event, provisions one
+# cloud server per version in its CMT set, and dispatches compatibility-matrix-testing.yml.
+# Triggers: RC tag pushes (e.g. v6.2.2-rc.1) and manual workflow_dispatch.
 
 on:
-  # Fire on each RC tag cut (e.g. v6.2.2-rc.1, v10.0.0-rc.2).
-  # Matterwick's isRCTag regex is the authoritative gate.
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
-  # Manual runs from the Actions tab (any ref).
   workflow_dispatch: {}
 
-# This workflow does not use GITHUB_TOKEN. Its only purpose is to emit a
-# workflow_run event that matterwick reacts to.
 permissions: {}
 
 jobs:

--- a/.github/workflows/e2e-functional-template.yml
+++ b/.github/workflows/e2e-functional-template.yml
@@ -188,7 +188,9 @@ jobs:
         run: |
           RUNNER_OS=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')
           echo "RUNNER_OS=${RUNNER_OS}" >> $GITHUB_ENV
-          echo "CI_ENVIRONMENT_NAME=@${RUNNER_OS}" >> $GITHUB_ENV
+          # Report-only tag for Playwright blob/HTML output (@ci-* avoids colliding with
+          # platform selection grep tokens @linux/@darwin/@win32 in playwright.config.ts).
+          echo "CI_ENVIRONMENT_NAME=@ci-${RUNNER_OS}" >> $GITHUB_ENV
           
           # Define build type and suffix
           # inputs.TYPE takes precedence when provided by the caller (e.g. RELEASE, MASTER, PR).
@@ -235,8 +237,19 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22.x'
-          cache: "npm"
-          cache-dependency-path: package-lock.json
+          package-manager-cache: false
+          # node_modules is cached in e2e/cache-node-modules; disable setup-node's
+          # npm cache so actions/cache v5 does not hit legacy entries.
+
+      - name: e2e/use-gnu-tar-macos
+        if: runner.os == 'macOS'
+        run: |
+          # BSD tar on macOS can corrupt actions/cache v5 archives; prefer GNU tar when present.
+          if [ -x /opt/homebrew/opt/gnu-tar/libexec/gnubin/gtar ]; then
+            echo "/opt/homebrew/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
+          elif [ -x /usr/local/opt/gnu-tar/libexec/gnubin/gtar ]; then
+            echo "/usr/local/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
+          fi
 
       - name: e2e/cache-node-modules
         id: cache-node-modules
@@ -244,17 +257,41 @@ jobs:
         with:
           path: |
             node_modules
-            C:\Users\runneradmin\.electron-gyp
-          key: ${{ runner.os }}-build-node-modules-${{ hashFiles('**/package-lock.json') }}
+            e2e/node_modules
+          enableCrossOsArchive: false
+          # v7: exact restore only — avoids probing legacy v6 blobs that warn on macOS
+          key: ${{ runner.os }}-build-node-modules-v7-${{ hashFiles('**/package-lock.json') }}
+
+      - name: e2e/cache-electron-gyp-windows
+        if: runner.os == 'Windows'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: C:\Users\runneradmin\.electron-gyp
+          enableCrossOsArchive: false
+          key: ${{ runner.os }}-electron-gyp-v7-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-build-node-modules
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+            ${{ runner.os }}-electron-gyp-v7-${{ hashFiles('**/package-lock.json') }}
+
+      # Clear pip's HTTP cache on macOS-26 runners before setup-python. The pre-baked
+      # image cache contains entries serialized by an older pip that the newer pip
+      # shipped with Python 3.10 cannot deserialize, producing the noisy
+      # "WARNING: Cache entry deserialization failed, entry ignored" lines in CI.
+      # See actions/setup-python#1317.
+      - name: e2e/clear-pip-cache-macos
+        if: runner.os == 'macOS'
+        run: |
+          rm -rf "${HOME}/Library/Caches/pip" || true
+          python3 -m pip cache purge >/dev/null 2>&1 || true
 
       - name: e2e/setup-python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        env:
+          # Bypass pip's on-disk HTTP cache entirely so a stale/corrupt entry on the
+          # runner image cannot trigger deserialization warnings.
+          PIP_NO_CACHE_DIR: "1"
         with:
           python-version: "3.10"
+          # Omit `cache` — setup-python only accepts pip/pipenv/poetry, not `false`.
 
       - name: e2e/install-os-dependencies
         uses: ./.github/actions/install-os-dependencies
@@ -287,7 +324,7 @@ jobs:
           cd e2e
           export PW_CHROMIUM_ARGS="--disable-gpu --no-sandbox --disable-dev-shm-usage"
           set +e
-          xvfb-run --auto-servernum --server-args='-screen 0 1024x768x24' npm test
+          xvfb-run --auto-servernum --server-args='-screen 0 1024x768x24' npm test -- --project=linux
           echo "PLAYWRIGHT_EXIT_CODE=$?" >> $GITHUB_ENV
         env:
           SERVER_VERSION: ${{ inputs.MM_SERVER_VERSION }}
@@ -303,7 +340,7 @@ jobs:
           echo "Running E2E tests…"
           cd e2e
           set +e
-          npm test
+          npm test -- --project=darwin
           echo "PLAYWRIGHT_EXIT_CODE=$?" >> $GITHUB_ENV
         env:
           SERVER_VERSION: ${{ inputs.MM_SERVER_VERSION }}
@@ -316,7 +353,7 @@ jobs:
           npm run build-test
           cd e2e
           set +e
-          npm test
+          npm test -- --project=win32
           echo "PLAYWRIGHT_EXIT_CODE=$?" >> $GITHUB_ENV
         env:
           SERVER_VERSION: ${{ inputs.MM_SERVER_VERSION }}
@@ -368,10 +405,9 @@ jobs:
           script: |
             process.chdir('./e2e');
             const { analyzeFlakyTests } = require('./utils/analyze-flaky-test.js');
-            const { failureCount, passCount, skipCount, totalCount, os } = analyzeFlakyTests();
+            const { failureCount, passCount, skipCount, totalCount, os, testStatus } = analyzeFlakyTests();
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
             const reportUrl = process.env.PER_OS_REPORT_URL || runUrl;
-            const testStatus = failureCount > 0 || Number(process.env.PLAYWRIGHT_EXIT_CODE || 0) !== 0 ? 'failure' : 'success';
             const setOSOutputs = (suffix) => {
               core.setOutput(`NEW_FAILURES_${suffix}`, String(failureCount));
               core.setOutput(`REPORT_LINK_${suffix}`, reportUrl);

--- a/.github/workflows/e2e-functional-template.yml
+++ b/.github/workflows/e2e-functional-template.yml
@@ -243,13 +243,7 @@ jobs:
 
       - name: e2e/use-gnu-tar-macos
         if: runner.os == 'macOS'
-        run: |
-          # BSD tar on macOS can corrupt actions/cache v5 archives; prefer GNU tar when present.
-          if [ -x /opt/homebrew/opt/gnu-tar/libexec/gnubin/gtar ]; then
-            echo "/opt/homebrew/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
-          elif [ -x /usr/local/opt/gnu-tar/libexec/gnubin/gtar ]; then
-            echo "/usr/local/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
-          fi
+        run: echo "/opt/homebrew/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
 
       - name: e2e/cache-node-modules
         id: cache-node-modules
@@ -272,25 +266,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-electron-gyp-v7-${{ hashFiles('**/package-lock.json') }}
 
-      # Clear pip's HTTP cache on macOS-26 runners before setup-python. The pre-baked
-      # image cache contains entries serialized by an older pip that the newer pip
-      # shipped with Python 3.10 cannot deserialize, producing the noisy
-      # "WARNING: Cache entry deserialization failed, entry ignored" lines in CI.
-      # See actions/setup-python#1317.
-      - name: e2e/clear-pip-cache-macos
-        if: runner.os == 'macOS'
-        run: |
-          rm -rf "${HOME}/Library/Caches/pip" || true
-          python3 -m pip cache purge >/dev/null 2>&1 || true
-
       - name: e2e/setup-python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         env:
           # Bypass pip's on-disk HTTP cache entirely so a stale/corrupt entry on the
-          # runner image cannot trigger deserialization warnings.
+          # runner image cannot trigger deserialization warnings (actions/setup-python#1317).
           PIP_NO_CACHE_DIR: "1"
         with:
-          python-version: "3.10"
+          # Use a version pre-installed on macOS-26 (3.13 is in its toolcache), so
+          # setup-python doesn't install a mismatched interpreter whose pip can't
+          # deserialize the image's pre-baked cache. PIP_NO_CACHE_DIR above is the
+          # remaining guard for non-macOS runners.
+          python-version: "3.13"
           # Omit `cache` — setup-python only accepts pip/pipenv/poetry, not `false`.
 
       - name: e2e/install-os-dependencies

--- a/.github/workflows/e2e-functional.yml
+++ b/.github/workflows/e2e-functional.yml
@@ -247,10 +247,10 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           # BSD tar on macOS can corrupt actions/cache v5 archives; prefer GNU tar when present.
+          # All current macOS runners are arm64 (Homebrew under /opt/homebrew); keep the
+          # -x guard so a future non-arm64 matrix entry falls back to BSD tar safely.
           if [ -x /opt/homebrew/opt/gnu-tar/libexec/gnubin/gtar ]; then
             echo "/opt/homebrew/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
-          elif [ -x /usr/local/opt/gnu-tar/libexec/gnubin/gtar ]; then
-            echo "/usr/local/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
           fi
 
       - name: e2e/cache-node-modules
@@ -274,25 +274,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-electron-gyp-v7-${{ hashFiles('**/package-lock.json') }}
 
-      # Clear pip's HTTP cache on macOS-26 runners before setup-python. The pre-baked
-      # image cache contains entries serialized by an older pip that the newer pip
-      # shipped with Python 3.10 cannot deserialize, producing the noisy
-      # "WARNING: Cache entry deserialization failed, entry ignored" lines in CI.
-      # See actions/setup-python#1317.
-      - name: e2e/clear-pip-cache-macos
-        if: runner.os == 'macOS'
-        run: |
-          rm -rf "${HOME}/Library/Caches/pip" || true
-          python3 -m pip cache purge >/dev/null 2>&1 || true
-
       - name: e2e/setup-python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         env:
           # Bypass pip's on-disk HTTP cache entirely so a stale/corrupt entry on the
-          # runner image cannot trigger deserialization warnings.
+          # runner image cannot trigger deserialization warnings (actions/setup-python#1317).
           PIP_NO_CACHE_DIR: "1"
         with:
-          python-version: "3.10"
+          # Use a version pre-installed on macOS-26 (3.13 is in its toolcache), so
+          # setup-python doesn't install a mismatched interpreter whose pip can't
+          # deserialize the image's pre-baked cache. PIP_NO_CACHE_DIR above is the
+          # remaining guard for non-macOS runners.
+          python-version: "3.13"
           # Omit `cache` — setup-python only accepts pip/pipenv/poetry, not `false`.
 
       - name: e2e/install-os-dependencies

--- a/.github/workflows/e2e-functional.yml
+++ b/.github/workflows/e2e-functional.yml
@@ -239,8 +239,19 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22.x'
-          cache: "npm"
-          cache-dependency-path: package-lock.json
+          package-manager-cache: false
+          # node_modules is cached in e2e/cache-node-modules; disable setup-node's
+          # npm cache so actions/cache v5 does not hit legacy entries.
+
+      - name: e2e/use-gnu-tar-macos
+        if: runner.os == 'macOS'
+        run: |
+          # BSD tar on macOS can corrupt actions/cache v5 archives; prefer GNU tar when present.
+          if [ -x /opt/homebrew/opt/gnu-tar/libexec/gnubin/gtar ]; then
+            echo "/opt/homebrew/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
+          elif [ -x /usr/local/opt/gnu-tar/libexec/gnubin/gtar ]; then
+            echo "/usr/local/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
+          fi
 
       - name: e2e/cache-node-modules
         id: cache-node-modules
@@ -248,17 +259,41 @@ jobs:
         with:
           path: |
             node_modules
-            C:\Users\runneradmin\.electron-gyp
-          key: ${{ runner.os }}-build-node-modules-${{ hashFiles('**/package-lock.json') }}
+            e2e/node_modules
+          enableCrossOsArchive: false
+          # v7: exact restore only — avoids probing legacy v6 blobs that warn on macOS
+          key: ${{ runner.os }}-build-node-modules-v7-${{ hashFiles('**/package-lock.json') }}
+
+      - name: e2e/cache-electron-gyp-windows
+        if: runner.os == 'Windows'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: C:\Users\runneradmin\.electron-gyp
+          enableCrossOsArchive: false
+          key: ${{ runner.os }}-electron-gyp-v7-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-build-node-modules
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+            ${{ runner.os }}-electron-gyp-v7-${{ hashFiles('**/package-lock.json') }}
+
+      # Clear pip's HTTP cache on macOS-26 runners before setup-python. The pre-baked
+      # image cache contains entries serialized by an older pip that the newer pip
+      # shipped with Python 3.10 cannot deserialize, producing the noisy
+      # "WARNING: Cache entry deserialization failed, entry ignored" lines in CI.
+      # See actions/setup-python#1317.
+      - name: e2e/clear-pip-cache-macos
+        if: runner.os == 'macOS'
+        run: |
+          rm -rf "${HOME}/Library/Caches/pip" || true
+          python3 -m pip cache purge >/dev/null 2>&1 || true
 
       - name: e2e/setup-python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        env:
+          # Bypass pip's on-disk HTTP cache entirely so a stale/corrupt entry on the
+          # runner image cannot trigger deserialization warnings.
+          PIP_NO_CACHE_DIR: "1"
         with:
           python-version: "3.10"
+          # Omit `cache` — setup-python only accepts pip/pipenv/poetry, not `false`.
 
       - name: e2e/install-os-dependencies
         uses: ./.github/actions/install-os-dependencies

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -44,6 +44,26 @@ await exampleServer.waitForSelector('#sidebarItem_town-square');
 - Reuse helpers from `e2e/helpers` before creating new launch, login, or server-discovery logic.
 - Do not add new `electron-mocha`, `robotjs`, or Mochawesome-based code.
 
+## Declarative platform tags
+
+Platform selection is handled by Playwright **projects** in `e2e/playwright.config.ts`, not runtime `test.skip()` guards.
+
+Every test must declare:
+
+- **Priority:** `@P0`, `@P1`, or `@P2`
+- **Platform:** `@all` (runs on every OS) or one or more of `@linux`, `@darwin`, `@win32`
+
+Special tags:
+
+- `@wayland` — Wayland-only coverage (`linux/wayland_launch.test.ts`). Runs only when `E2E_WAYLAND=true` on Linux via the `wayland` project; excluded from normal Linux CI.
+- Policy specs under `specs/policy/` — excluded from the main CI run unless `RUN_POLICY_E2E=true`.
+
+Do **not** add `test.skip()` for platform gating when tags already express the intended OS. Keep runtime skips only for conditional cases (missing server URL, license/feature unavailable on the test instance).
+
+CI report labels (`@ci-linux`, `@ci-macos`, `@ci-windows`) come from `CI_ENVIRONMENT_NAME` and must not be used as test tags — they would collide with platform grep.
+
+Local/CI runs use `--project=<linux|darwin|win32>` to match the host OS (set automatically in GitHub Actions).
+
 ## Version Compatibility
 
 Treat dependency upgrades as infrastructure changes, not routine edits.
@@ -137,6 +157,8 @@ Many server-backed specs require:
 - `MM_TEST_PASSWORD`
 
 Do not remove skips or platform guards unless the test can actually run in the current environment.
+
+Platform guards belong in test **tags** (`@linux`, `@darwin`, `@win32`, `@all`, `@wayland`), not `test.skip()` — see [Declarative platform tags](#declarative-platform-tags).
 
 Examples:
 - Tests tagged for Windows or Linux are not truthfully verified on macOS.

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -2,8 +2,6 @@
 // See LICENSE.txt for license information.
 
 import * as fs from 'fs/promises';
-import * as fsSync from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 
 import {test as base, type Page} from '@playwright/test';
@@ -11,8 +9,14 @@ import type {ElectronApplication} from 'playwright';
 import {_electron as electron} from 'playwright';
 
 import {waitForAppReady} from '../helpers/appReadiness';
-import {waitForLockFileRelease} from '../helpers/cleanup';
 import {electronBinaryPath, appDir, demoConfig, writeConfigFile, type AppConfig} from '../helpers/config';
+import {
+    closeElectronApp,
+    FAST_TEARDOWN,
+    registerElectronMainProcess,
+    cleanupRegisteredElectronProcesses,
+} from '../helpers/electronApp';
+import {closeOverlayWindowsIfOpen} from '../helpers/overlayWindows';
 import {buildServerMap, type ServerMap} from '../helpers/serverMap';
 
 export type {ServerMap, ServerEntry} from '../helpers/serverMap';
@@ -48,17 +52,31 @@ type Fixtures = {
     mainWindow: Page;
 };
 
-export const test = base.extend<Fixtures>({
+type WorkerFixtures = {
+
+    /** Worker-scoped cleanup for orphaned Electron main processes. */
+    workerElectronCleanup: void;
+};
+
+export const test = base.extend<Fixtures, WorkerFixtures>({
+    workerElectronCleanup: [async ({}, use) => {
+        await use();
+        await Promise.race([
+            cleanupRegisteredElectronProcesses(),
+            new Promise<void>((resolve) => setTimeout(resolve, 20_000)),
+        ]);
+    }, {scope: 'worker'}],
+
     appConfig: async ({}, use) => {
         await use(demoConfig);
     },
 
-    electronApp: async ({appConfig}, use, testInfo) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    electronApp: async ({appConfig, workerElectronCleanup: _workerElectronCleanup}, use, testInfo) => {
         const userDataDir = path.join(testInfo.outputDir, 'userdata');
         await fs.rm(userDataDir, {recursive: true, force: true});
         await fs.mkdir(userDataDir, {recursive: true});
 
-        // writeConfigFile is SYNCHRONOUS — must complete before electron.launch()
         writeConfigFile(userDataDir, appConfig);
 
         let launchTimeout: number;
@@ -70,35 +88,25 @@ export const test = base.extend<Fixtures>({
             launchTimeout = 60_000;
         }
 
-        const E2E_PROCESS_REGISTRY = path.join(os.tmpdir(), 'mattermost-desktop-e2e-main-pids.txt');
-
         const app = await electron.launch({
             executablePath: electronBinaryPath,
             args: [
-                appDir, // test build directory (e2e/dist)
+                appDir,
                 `--user-data-dir=${userDataDir}`,
-
-                // CI compatibility — required for Linux sandbox, GPU stability
                 '--no-sandbox',
                 '--disable-gpu',
                 '--disable-gpu-sandbox',
                 '--disable-dev-shm-usage',
                 '--no-zygote',
                 '--disable-software-rasterizer',
-
-                // Stability
                 '--disable-breakpad',
                 '--disable-features=SpareRendererForSitePerProcess',
                 '--disable-features=CrossOriginOpenerPolicy',
                 '--disable-renderer-backgrounding',
-
-                // Dialogs & first-run
                 '--no-first-run',
                 '--no-default-browser-check',
                 '--disable-default-apps',
                 '--disable-crash-reporter',
-
-                // Consistency
                 '--force-color-profile=srgb',
                 '--mute-audio',
             ],
@@ -113,54 +121,20 @@ export const test = base.extend<Fixtures>({
             timeout: launchTimeout,
         });
 
-        // Register PID for global teardown orphan cleanup.
-        // electronApp.process().pid is available here from Playwright at runtime,
-        // so we write it from the test side rather than from inside the app.
-        const launchPid = app.process()?.pid;
-        if (launchPid) {
-            try {
-                fsSync.appendFileSync(E2E_PROCESS_REGISTRY, `${launchPid}\n`, 'utf8');
-            } catch { /* non-fatal */ }
-        }
+        registerElectronMainProcess(app.process()?.pid);
 
         await use(app);
 
-        // Teardown strategy:
-        //   1. Try app.close() (clean Playwright shutdown) with a 10s cap.
-        //   2. If it hangs, send SIGTERM and return immediately — do NOT SIGKILL.
-        //   SIGKILL triggers macOS "Electron quit unexpectedly" crash dialogs.
-        //   SIGTERM does not. Global teardown (pkill targeting main process only)
-        //   will reap any lingering orphans after the full suite completes.
-        let pid: number | undefined;
-        try {
-            pid = app.process()?.pid;
-        } catch { /* app already disconnected */ }
-
-        let cleanClosed = false;
-        await Promise.race([
-            app.close().catch(() => {}).then(() => {
-                cleanClosed = true;
-            }),
-            new Promise<void>((resolve) => setTimeout(resolve, 10_000)),
-        ]);
-
-        if (!cleanClosed && pid) {
-            try {
-                process.kill(pid, 'SIGTERM');
-            } catch { /* already gone */ }
-            // Return immediately — don't wait for the process to exit.
-            // Lock-file cleanup is not needed: each test has a unique userDataDir
-            // so a lingering lock never blocks the next test.
-            return;
-        }
-
-        await waitForLockFileRelease(userDataDir).catch(() => {});
+        await closeElectronApp(app, userDataDir, FAST_TEARDOWN);
     },
 
-    // Deduplicated readiness gate. Both serverMap and mainWindow declare this
-    // as a dependency — Playwright runs it exactly once and tears it down once.
     appReady: async ({electronApp}, use) => {
         await waitForAppReady(electronApp);
+
+        // Setup path: the main process is freshly launched and responsive, so
+        // the default 3s bound is ample for sub-100ms dropdown closes and still
+        // fails fast if app.evaluate hangs. No larger setup timeout is needed.
+        await closeOverlayWindowsIfOpen(electronApp);
         await use();
     },
 

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -61,10 +61,20 @@ type WorkerFixtures = {
 export const test = base.extend<Fixtures, WorkerFixtures>({
     workerElectronCleanup: [async ({}, use) => {
         await use();
-        await Promise.race([
-            cleanupRegisteredElectronProcesses(),
-            new Promise<void>((resolve) => setTimeout(resolve, 20_000)),
-        ]);
+        let timeoutHandle: NodeJS.Timeout | undefined;
+        try {
+            await Promise.race([
+                cleanupRegisteredElectronProcesses(),
+                new Promise<void>((resolve) => {
+                    timeoutHandle = setTimeout(resolve, 20_000);
+                    timeoutHandle.unref?.();
+                }),
+            ]);
+        } finally {
+            if (timeoutHandle) {
+                clearTimeout(timeoutHandle);
+            }
+        }
     }, {scope: 'worker'}],
 
     appConfig: async ({}, use) => {

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -6,7 +6,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-const E2E_PROCESS_REGISTRY = path.join(os.tmpdir(), 'mattermost-desktop-e2e-main-pids.txt');
+import {clearAllRegistryFiles} from './helpers/electronApp';
+
 const MACOS_DEFAULTS_SNAPSHOT = path.join(os.tmpdir(), 'mattermost-desktop-e2e-macos-defaults-snapshot.json');
 
 function readMacOsDefault(domain: string, key: string): string | null {
@@ -17,45 +18,32 @@ function readMacOsDefault(domain: string, key: string): string | null {
     }
 }
 
-/**
- * Disable macOS window-restoration (Resume) for the Electron binary used in tests.
- *
- * When Electron is killed by a signal (SIGTERM from fixture teardown or SIGKILL from
- * Playwright's worker timeout), macOS marks the process as having "quit unexpectedly"
- * and shows a "Do you want to reopen its windows?" dialog on the next launch.
- * That dialog blocks the app UI, so __e2eAppReady is never set, waitForAppReady times
- * out, and fixture teardown hangs — causing more kills, more dialogs, and so on.
- *
- * NSQuitAlwaysKeepsWindows = false  — don't offer to restore windows after unexpected quit
- * ApplePersistenceIgnoreState = YES — skip saved-state restoration on every launch
- */
 export default async function globalSetup() {
+    // Clear stale per-worker PID shards (and any legacy shared file) from a
+    // prior crashed run. We only delete files here, never signal pids, because
+    // pids may have been reused by unrelated processes since that run.
     try {
-        fs.rmSync(E2E_PROCESS_REGISTRY, {force: true});
+        clearAllRegistryFiles();
     } catch {
         // ignore stale registry cleanup failures
     }
 
     if (process.platform === 'darwin') {
-        // Multiple bundle IDs may be involved: com.github.Electron (Electron binary
-        // launched directly) and the app's own bundle ID (when running signed builds).
         const bundleIDs = ['com.github.Electron'];
 
         for (const bundleID of bundleIDs) {
             try {
                 execFileSync('defaults', ['write', bundleID, 'NSQuitAlwaysKeepsWindows', '-bool', 'false'], {stdio: 'pipe'});
             } catch {
-                // Non-fatal — tests still run, just potentially with the Resume dialog
+                // non-fatal
             }
             try {
                 execFileSync('defaults', ['write', bundleID, 'ApplePersistenceIgnoreState', '-bool', 'YES'], {stdio: 'pipe'});
             } catch {
-                // Non-fatal
+                // non-fatal
             }
         }
 
-        // Snapshot system defaults we are about to override so global-teardown
-        // can restore them (or delete keys that did not exist before).
         try {
             const snapshot = {
                 LSQuarantine: readMacOsDefault('com.apple.LaunchServices', 'LSQuarantine'),
@@ -63,24 +51,19 @@ export default async function globalSetup() {
             };
             fs.writeFileSync(MACOS_DEFAULTS_SNAPSHOT, JSON.stringify(snapshot), 'utf8');
         } catch {
-            // Non-fatal — teardown will skip restore if file missing
+            // non-fatal
         }
 
-        // Apply system-level settings to suppress macOS dialogs that block
-        // Electron startup. These target system domains (LaunchServices,
-        // CrashReporter) rather than per-app bundle IDs.
         try {
             execFileSync('defaults', ['write', 'com.apple.LaunchServices', 'LSQuarantine', '-bool', 'false'], {stdio: 'pipe'});
         } catch {
-            // Non-fatal
+            // non-fatal
         }
 
-        // Suppress the macOS crash dialog ("Electron quit unexpectedly") that
-        // appears when a process exits via SIGTERM or other unexpected quits.
         try {
             execFileSync('defaults', ['write', 'com.apple.CrashReporter', 'DialogType', 'none'], {stdio: 'pipe'});
         } catch {
-            // Non-fatal
+            // non-fatal
         }
     }
 }

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -6,7 +6,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-const E2E_PROCESS_REGISTRY = path.join(os.tmpdir(), 'mattermost-desktop-e2e-main-pids.txt');
+import {cleanupAllRegisteredElectronProcesses} from './helpers/electronApp';
+
 const MACOS_DEFAULTS_SNAPSHOT = path.join(os.tmpdir(), 'mattermost-desktop-e2e-macos-defaults-snapshot.json');
 
 function restoreMacOsDefaultsSnapshot() {
@@ -44,87 +45,12 @@ function restoreMacOsDefaultsSnapshot() {
     }
 }
 
-/**
- * Kill any main Electron processes still running from this test suite.
- *
- * Main test processes append their PID to a temp registry during startup.
- * Teardown kills only those registered main-process PIDs, avoiding broad shell
- * matching across unrelated Electron helper processes.
- */
 export default async function globalTeardown() {
     restoreMacOsDefaultsSnapshot();
 
-    let pids: number[] = [];
-    try {
-        if (fs.existsSync(E2E_PROCESS_REGISTRY)) {
-            pids = Array.from(new Set(
-                fs.readFileSync(E2E_PROCESS_REGISTRY, 'utf8').
-                    split(/\s+/).
-                    map((value) => Number.parseInt(value, 10)).
-                    filter((value) => Number.isInteger(value) && value > 0),
-            ));
-        }
-        fs.rmSync(E2E_PROCESS_REGISTRY, {force: true});
-    } catch {
-        pids = [];
-    }
-
-    for (const pid of pids) {
-        if (process.platform === 'win32') {
-            try {
-                execFileSync('taskkill', ['/PID', String(pid), '/T', '/F'], {stdio: 'ignore'});
-            } catch {
-                // already exited
-            }
-            continue;
-        }
-
-        if (!isProcessAlive(pid)) {
-            continue;
-        }
-
-        try {
-            process.kill(pid, 'SIGTERM');
-        } catch {
-            continue;
-        }
-
-        // Give the process time to exit gracefully.
-        // On macOS, use a longer wait since Electron shutdown can be slow.
-        const waitMs = process.platform === 'darwin' ? 10_000 : 5_000;
-        const deadline = Date.now() + waitMs;
-        while (Date.now() < deadline) {
-            if (!isProcessAlive(pid)) {
-                break;
-            }
-            await sleep(200);
-        }
-
-        if (isProcessAlive(pid)) {
-            // On macOS, SIGKILL triggers the "quit unexpectedly" crash dialog
-            // which blocks subsequent Electron launches. Skip SIGKILL and let
-            // the process linger — global-setup clears the registry, and each
-            // test uses a unique userDataDir so orphans never block new tests.
-            if (process.platform !== 'darwin') {
-                try {
-                    process.kill(pid, 'SIGKILL');
-                } catch {
-                    // already exited
-                }
-            }
-        }
-    }
-}
-
-function isProcessAlive(pid: number) {
-    try {
-        process.kill(pid, 0);
-        return true;
-    } catch {
-        return false;
-    }
-}
-
-function sleep(ms: number) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+    // Reap any Electron main processes left registered across all workers (e.g.
+    // from workers that crashed or skipped their worker teardown), then remove
+    // every registry shard. Shared with the worker-scoped cleanup so the kill
+    // strategy lives in one place and stays consistent across platforms.
+    await cleanupAllRegisteredElectronProcesses();
 }

--- a/e2e/helpers/appReadiness.ts
+++ b/e2e/helpers/appReadiness.ts
@@ -4,30 +4,8 @@
 import {expect} from '@playwright/test';
 import type {ElectronApplication} from 'playwright';
 
-/**
- * Wait until the main process has set global.__e2eAppReady = true.
- *
- * This flag is set in src/main/app/initialize.ts after handleMainWindowIsShown()
- * when NODE_ENV === 'test'. It fires once per app launch, after all views are
- * initialized and the main window is shown.
- *
- * IMPORTANT: app.evaluate() runs in the MAIN process context.
- * ipcRenderer does NOT exist there — only main-process Electron APIs do.
- * We read the global directly, not via IPC.
- */
 export async function waitForAppReady(app: ElectronApplication): Promise<void> {
-    // macOS CI runners are slower and may show Resume dialogs that delay startup.
-    // Windows GitHub-hosted runners are similarly slow (cold-start Electron +
-    // Visual Studio environment); 30s consistently timed out on `windows-2022`.
-    // Linux (xvfb) is fastest. 60s on Windows matches the macOS budget.
-    let timeout: number;
-    if (process.platform === 'darwin') {
-        timeout = 60_000;
-    } else if (process.platform === 'win32') {
-        timeout = 60_000;
-    } else {
-        timeout = 30_000;
-    }
+    const timeout = process.platform === 'linux' ? 30_000 : 60_000;
 
     await expect.poll(
         async () => {
@@ -45,13 +23,7 @@ export async function waitForAppReady(app: ElectronApplication): Promise<void> {
             }
         },
         {
-            message: [
-                'Timed out waiting for __e2eAppReady.',
-                `Timeout: ${timeout}ms.`,
-                'Check that initialize.ts sets __e2eAppReady after handleMainWindowIsShown().',
-                'On macOS, verify that global-setup.ts successfully wrote NSQuitAlwaysKeepsWindows=false',
-                'to prevent the "Reopen windows" dialog from blocking startup.',
-            ].join(' '),
+            message: `Timed out waiting for __e2eAppReady (${timeout}ms)`,
             timeout,
             intervals: [200, 500, 1000, 2000],
         },

--- a/e2e/helpers/cleanup.ts
+++ b/e2e/helpers/cleanup.ts
@@ -31,7 +31,7 @@ export async function waitForLockFileRelease(userDataDir: string): Promise<void>
             },
         ).toBe(true);
     } catch {
-        if (fs.existsSync(lockFile)) {
+        if (process.platform === 'win32' && fs.existsSync(lockFile)) {
             try {
                 fs.unlinkSync(lockFile);
             } catch {

--- a/e2e/helpers/cleanup.ts
+++ b/e2e/helpers/cleanup.ts
@@ -19,12 +19,27 @@ import {expect} from '@playwright/test';
  */
 export async function waitForLockFileRelease(userDataDir: string): Promise<void> {
     const lockFile = path.join(userDataDir, 'SingletonLock');
-    await expect.poll(
-        () => !fs.existsSync(lockFile),
-        {
-            message: `SingletonLock not released at ${lockFile}`,
-            timeout: process.platform === 'win32' ? 10_000 : 5_000,
-            intervals: [100, 200, 500, 1000],
-        },
-    ).toBe(true);
+    const timeout = process.platform === 'win32' ? 15_000 : 5_000;
+
+    try {
+        await expect.poll(
+            () => !fs.existsSync(lockFile),
+            {
+                message: `SingletonLock not released at ${lockFile}`,
+                timeout,
+                intervals: [100, 200, 500, 1000],
+            },
+        ).toBe(true);
+    } catch {
+        if (fs.existsSync(lockFile)) {
+            try {
+                fs.unlinkSync(lockFile);
+            } catch {
+                // Best-effort cleanup when a child process kept the lock open.
+            }
+        }
+        if (fs.existsSync(lockFile)) {
+            throw new Error(`SingletonLock still present after cleanup attempt: ${lockFile}`);
+        }
+    }
 }

--- a/e2e/helpers/config.ts
+++ b/e2e/helpers/config.ts
@@ -34,6 +34,7 @@ export type AppConfig = {
     showTrayIcon: boolean;
     trayIconTheme: string;
     minimizeToTray: boolean;
+    alwaysClose?: boolean;
     notifications: {flashWindow: number; bounceIcon: boolean; bounceIconType: string};
     showUnreadBadge: boolean;
     useSpellChecker: boolean;

--- a/e2e/helpers/dialog.ts
+++ b/e2e/helpers/dialog.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {ElectronApplication} from 'playwright';
+
+type MessageBoxResponse = {
+    response: number;
+    checkboxChecked?: boolean;
+};
+
+export async function stubMessageBoxResponses(
+    app: ElectronApplication,
+    responses: MessageBoxResponse[],
+): Promise<void> {
+    if (responses.length === 0) {
+        throw new Error('stubMessageBoxResponses requires at least one response');
+    }
+
+    await app.evaluate((_electron, value) => {
+        const stub = (global as any).__e2eStubMessageBoxResponses as ((responses: MessageBoxResponse[]) => void) | undefined;
+        if (!stub) {
+            throw new Error('__e2eStubMessageBoxResponses is not available');
+        }
+        stub(value);
+    }, responses);
+}
+
+export async function restoreMessageBox(app: ElectronApplication): Promise<void> {
+    await app.evaluate(() => {
+        const restore = (global as any).__e2eRestoreMessageBox as (() => void) | undefined;
+        if (restore) {
+            restore();
+        }
+    });
+}
+
+export async function clearCertificateErrorCallbacks(app: ElectronApplication): Promise<void> {
+    await app.evaluate(() => {
+        const clear = (global as any).__e2eClearCertificateErrorCallbacks as (() => void) | undefined;
+        clear?.();
+    });
+}

--- a/e2e/helpers/directLaunch.ts
+++ b/e2e/helpers/directLaunch.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {ElectronApplication} from 'playwright';
+import {_electron as electron} from 'playwright';
+
+import {waitForAppReady} from './appReadiness';
+import {electronBinaryPath, appDir, writeConfigFile, type AppConfig} from './config';
+import {registerElectronMainProcess} from './electronApp';
+
+export const DIRECT_LAUNCH_ARGS = [
+    '--no-sandbox',
+    '--disable-gpu',
+    '--disable-gpu-sandbox',
+    '--disable-dev-shm-usage',
+    '--no-zygote',
+    '--disable-software-rasterizer',
+    '--disable-breakpad',
+    '--disable-features=SpareRendererForSitePerProcess',
+    '--disable-features=CrossOriginOpenerPolicy',
+    '--disable-renderer-backgrounding',
+    '--no-first-run',
+    '--disable-default-apps',
+    '--disable-crash-reporter',
+    '--force-color-profile=srgb',
+    '--mute-audio',
+];
+
+export type LaunchDirectTestAppOptions = {
+    extraEnv?: Record<string, string>;
+    writeConfig?: boolean;
+};
+
+function resolveLaunchOptions(
+    extraEnvOrOptions: Record<string, string> | LaunchDirectTestAppOptions,
+): LaunchDirectTestAppOptions {
+    if ('writeConfig' in extraEnvOrOptions || 'extraEnv' in extraEnvOrOptions) {
+        return extraEnvOrOptions;
+    }
+    return {extraEnv: extraEnvOrOptions};
+}
+
+export async function launchDirectTestApp(
+    userDataDir: string,
+    config: AppConfig | object,
+    extraEnvOrOptions: Record<string, string> | LaunchDirectTestAppOptions = {},
+): Promise<ElectronApplication> {
+    const {extraEnv = {}, writeConfig = true} = resolveLaunchOptions(extraEnvOrOptions);
+
+    if (writeConfig) {
+        writeConfigFile(userDataDir, config as AppConfig);
+    }
+
+    const app = await electron.launch({
+        executablePath: electronBinaryPath,
+        args: [appDir, `--user-data-dir=${userDataDir}`, ...DIRECT_LAUNCH_ARGS],
+        env: {
+            ...process.env,
+            NODE_ENV: 'test',
+            RESOURCES_PATH: appDir,
+            ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
+            ELECTRON_NO_ATTACH_CONSOLE: 'true',
+            NODE_OPTIONS: '--no-warnings',
+            ...extraEnv,
+        },
+        timeout: process.platform === 'win32' ? 120_000 : 90_000,
+    });
+
+    registerElectronMainProcess(app.process()?.pid);
+    await waitForAppReady(app);
+    return app;
+}

--- a/e2e/helpers/electronApp.ts
+++ b/e2e/helpers/electronApp.ts
@@ -281,6 +281,7 @@ function signalShutdownAndReturn(pid: number): void {
 
 async function attemptClose(app: ElectronApplication, timeoutMs: number): Promise<boolean> {
     let closed = false;
+
     // Only mark closed on successful resolve; a rejected close() must leave
     // closed=false so the caller's SIGTERM/SIGKILL fallback runs.
     const closePromise = app.close().then(() => {

--- a/e2e/helpers/electronApp.ts
+++ b/e2e/helpers/electronApp.ts
@@ -180,6 +180,17 @@ async function reapPids(pids: number[]): Promise<void> {
         }
         await sleep(200);
     }
+
+    // SIGTERM alone can leave a blocked macOS process alive past the poll,
+    // leaking orphans across runs. Linux already SIGKILL'd above; Windows used
+    // taskkill /F. Escalate survivors on macOS to SIGKILL.
+    if (process.platform === 'darwin') {
+        for (const pid of alive) {
+            if (isProcessAlive(pid)) {
+                signalProcessGroup(pid, 'SIGKILL');
+            }
+        }
+    }
 }
 
 function sleep(ms: number) {
@@ -227,10 +238,14 @@ function forceKillLinuxProcessTree(pid: number): void {
     signalProcessGroup(pid, 'SIGKILL');
 }
 
-async function drainPlaywrightClose(closePromise: Promise<void>): Promise<void> {
+async function drainPlaywrightClose(closePromise: Promise<void>, remainingMs: number): Promise<void> {
     // Playwright keeps a gracefullyClose entry until app.close() settles (#29431).
-    // Cap the wait so worker teardown does not hang for 90s when close never settles.
-    await Promise.race([closePromise, sleep(3_000)]);
+    // Drain within the remaining budget so teardown never exceeds the caller's
+    // timeout (previously +3s on top of the race budget).
+    if (remainingMs <= 0) {
+        return;
+    }
+    await Promise.race([closePromise, sleep(remainingMs)]);
 }
 
 async function forceShutdownLinux(pid: number): Promise<void> {
@@ -266,11 +281,14 @@ function signalShutdownAndReturn(pid: number): void {
 
 async function attemptClose(app: ElectronApplication, timeoutMs: number): Promise<boolean> {
     let closed = false;
-    const closePromise = app.close().catch(() => {}).then(() => {
+    // Only mark closed on successful resolve; a rejected close() must leave
+    // closed=false so the caller's SIGTERM/SIGKILL fallback runs.
+    const closePromise = app.close().then(() => {
         closed = true;
-    });
+    }, () => {});
+    const start = Date.now();
     await Promise.race([closePromise, sleep(timeoutMs)]);
-    await drainPlaywrightClose(closePromise);
+    await drainPlaywrightClose(closePromise, timeoutMs - (Date.now() - start));
     return closed;
 }
 

--- a/e2e/helpers/electronApp.ts
+++ b/e2e/helpers/electronApp.ts
@@ -1,9 +1,278 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {execFileSync} from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
 import {waitForLockFileRelease} from './cleanup';
 
 type ElectronApplication = Awaited<ReturnType<typeof import('playwright')['_electron']['launch']>>;
+
+/**
+ * PID registry for orphaned Electron main processes.
+ *
+ * Each Playwright worker is a separate Node process, so the registry is sharded
+ * per worker (`...-<workerPid>.txt`). This avoids the read-modify-write races a
+ * single shared file had under fullyParallel: a worker only ever touches its
+ * own shard, and tests run serially within a worker, so register/unregister
+ * never contend. Worker teardown reaps this worker's shard; global teardown
+ * enumerates every shard (plus a legacy shared file from older runs) as the
+ * final backstop.
+ */
+const REGISTRY_DIR = os.tmpdir();
+const REGISTRY_PREFIX = 'mattermost-desktop-e2e-main-pids';
+const LEGACY_REGISTRY = path.join(REGISTRY_DIR, 'mattermost-desktop-e2e-main-pids.txt');
+
+export type CloseElectronAppOptions = {
+    skipLockWaitUnlessCleanClose?: boolean;
+};
+
+/** Unique per-test userDataDir (fixture path): abandon fast, reap via worker cleanup. */
+export const FAST_TEARDOWN: CloseElectronAppOptions = {
+    skipLockWaitUnlessCleanClose: true,
+};
+
+/** Convenience wrapper for {@link FAST_TEARDOWN}. */
+export async function closeElectronAppFast(
+    app: ElectronApplication,
+    dataDir?: string,
+): Promise<void> {
+    return closeElectronApp(app, dataDir, FAST_TEARDOWN);
+}
+
+function workerRegistryPath(workerPid: number = process.pid): string {
+    return path.join(REGISTRY_DIR, `${REGISTRY_PREFIX}-${workerPid}.txt`);
+}
+
+function listRegistryFiles(): string[] {
+    const files: string[] = [];
+    try {
+        for (const entry of fs.readdirSync(REGISTRY_DIR)) {
+            if (entry.startsWith(`${REGISTRY_PREFIX}-`) && entry.endsWith('.txt')) {
+                files.push(path.join(REGISTRY_DIR, entry));
+            }
+        }
+    } catch {
+        // tmpdir unreadable; best-effort
+    }
+    if (fs.existsSync(LEGACY_REGISTRY)) {
+        files.push(LEGACY_REGISTRY);
+    }
+    return files;
+}
+
+function readPidsFromFile(file: string): number[] {
+    try {
+        if (!fs.existsSync(file)) {
+            return [];
+        }
+        return Array.from(new Set(
+            fs.readFileSync(file, 'utf8').
+                split(/\s+/).
+                map((value) => Number.parseInt(value, 10)).
+                filter((value) => Number.isInteger(value) && value > 0),
+        ));
+    } catch {
+        return [];
+    }
+}
+
+export function registerElectronMainProcess(pid: number | undefined) {
+    if (!pid) {
+        return;
+    }
+    try {
+        fs.appendFileSync(workerRegistryPath(), `${pid}\n`, 'utf8');
+    } catch {
+        // non-fatal
+    }
+}
+
+export function unregisterElectronMainProcess(pid: number | undefined) {
+    if (!pid) {
+        return;
+    }
+
+    // Only the current worker touches its own shard (tests are serial within a
+    // worker), so a plain read-modify-write here is race-free.
+    const file = workerRegistryPath();
+    try {
+        if (!fs.existsSync(file)) {
+            return;
+        }
+        const remaining = fs.readFileSync(file, 'utf8').
+            split(/\n/).
+            filter((line) => {
+                const value = Number.parseInt(line.trim(), 10);
+                return Number.isInteger(value) && value > 0 && value !== pid;
+            });
+        if (remaining.length > 0) {
+            fs.writeFileSync(file, `${remaining.join('\n')}\n`, 'utf8');
+        } else {
+            fs.rmSync(file, {force: true});
+        }
+    } catch {
+        // non-fatal
+    }
+}
+
+/**
+ * Reap this worker's registered Electron main processes. Called from the
+ * worker-scoped fixture teardown, so it only touches this worker's shard.
+ */
+export async function cleanupRegisteredElectronProcesses(): Promise<void> {
+    const file = workerRegistryPath();
+    const pids = readPidsFromFile(file);
+    fs.rmSync(file, {force: true});
+    await reapPids(pids);
+}
+
+/**
+ * Reap every worker's registered Electron main processes. Called from global
+ * teardown as the final backstop for processes left by workers that crashed or
+ * skipped their worker-scoped teardown.
+ */
+export async function cleanupAllRegisteredElectronProcesses(): Promise<void> {
+    const files = listRegistryFiles();
+    const pids = Array.from(new Set(files.flatMap(readPidsFromFile)));
+    for (const file of files) {
+        fs.rmSync(file, {force: true});
+    }
+    await reapPids(pids);
+}
+
+/**
+ * Remove every registry shard without reaping. Used at global setup to clear
+ * stale files from a prior crashed run; we deliberately do not signal any pids
+ * here because they may have been reused by unrelated processes since that run.
+ */
+export function clearAllRegistryFiles(): void {
+    for (const file of listRegistryFiles()) {
+        fs.rmSync(file, {force: true});
+    }
+}
+
+async function reapPids(pids: number[]): Promise<void> {
+    if (pids.length === 0) {
+        return;
+    }
+
+    const alive = pids.filter(isProcessAlive);
+    if (alive.length === 0) {
+        return;
+    }
+
+    for (const pid of alive) {
+        if (process.platform === 'linux') {
+            signalProcessGroup(pid, 'SIGKILL');
+            forceKillLinuxProcessTree(pid);
+        } else {
+            signalShutdownAndReturn(pid);
+        }
+    }
+
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline) {
+        if (alive.every((pid) => !isProcessAlive(pid))) {
+            return;
+        }
+        await sleep(200);
+    }
+}
+
+function sleep(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isProcessAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        if (!isProcessAlive(pid)) {
+            return true;
+        }
+        await sleep(200);
+    }
+    return !isProcessAlive(pid);
+}
+
+function signalProcessGroup(pid: number, signal: NodeJS.Signals): void {
+    try {
+        process.kill(-pid, signal);
+    } catch {
+        try {
+            process.kill(pid, signal);
+        } catch {
+            // already exited
+        }
+    }
+}
+
+function forceKillLinuxProcessTree(pid: number): void {
+    try {
+        execFileSync('pkill', ['-KILL', '-P', String(pid)], {stdio: 'ignore'});
+    } catch {
+        // no child processes
+    }
+    signalProcessGroup(pid, 'SIGKILL');
+}
+
+async function drainPlaywrightClose(closePromise: Promise<void>): Promise<void> {
+    // Playwright keeps a gracefullyClose entry until app.close() settles (#29431).
+    // Cap the wait so worker teardown does not hang for 90s when close never settles.
+    await Promise.race([closePromise, sleep(3_000)]);
+}
+
+async function forceShutdownLinux(pid: number): Promise<void> {
+    if (!isProcessAlive(pid)) {
+        return;
+    }
+
+    signalProcessGroup(pid, 'SIGTERM');
+    if (await waitForProcessExit(pid, 3_000)) {
+        return;
+    }
+
+    forceKillLinuxProcessTree(pid);
+    await waitForProcessExit(pid, 10_000);
+}
+
+function signalShutdownAndReturn(pid: number): void {
+    if (process.platform === 'win32') {
+        try {
+            execFileSync('taskkill', ['/PID', String(pid), '/T', '/F'], {stdio: 'ignore'});
+        } catch {
+            // already exited
+        }
+        return;
+    }
+
+    try {
+        process.kill(pid, 'SIGTERM');
+    } catch {
+        // already exited
+    }
+}
+
+async function attemptClose(app: ElectronApplication, timeoutMs: number): Promise<boolean> {
+    let closed = false;
+    const closePromise = app.close().catch(() => {}).then(() => {
+        closed = true;
+    });
+    await Promise.race([closePromise, sleep(timeoutMs)]);
+    await drainPlaywrightClose(closePromise);
+    return closed;
+}
 
 export async function waitForWindow(app: ElectronApplication, pattern: string, timeout = 30_000) {
     const timeoutAt = Date.now() + timeout;
@@ -21,13 +290,17 @@ export async function waitForWindow(app: ElectronApplication, pattern: string, t
             return win;
         }
 
-        await new Promise((resolve) => setTimeout(resolve, 200));
+        await sleep(200);
     }
 
     throw new Error(`Timed out waiting for window matching "${pattern}"`);
 }
 
-export async function closeElectronApp(app: ElectronApplication, dataDir: string) {
+export async function closeElectronApp(
+    app: ElectronApplication,
+    dataDir?: string,
+    options: CloseElectronAppOptions = {},
+) {
     let pid: number | undefined;
     try {
         pid = app.process()?.pid;
@@ -35,21 +308,42 @@ export async function closeElectronApp(app: ElectronApplication, dataDir: string
         pid = undefined;
     }
 
-    let cleanClosed = false;
-    await Promise.race([
-        app.close().catch(() => {}).then(() => {
-            cleanClosed = true;
-        }),
-        new Promise<void>((resolve) => setTimeout(resolve, 10_000)),
-    ]);
+    // `skipLockWaitUnlessCleanClose` marks a unique per-test userDataDir (the
+    // fixture path): teardown abandons fast and lets worker/global cleanup reap
+    // orphans, matching master's model. Without it (direct-launch specs), the
+    // same userDataDir may be relaunched, so we force-kill on failure (Linux)
+    // and always wait for the SingletonLock to release.
+    const fastTeardown = Boolean(options.skipLockWaitUnlessCleanClose);
+
+    const cleanClosed = await attemptClose(app, 10_000);
 
     if (!cleanClosed && pid) {
-        try {
-            process.kill(pid, 'SIGTERM');
-        } catch {
-            // already exited
+        if (process.platform === 'linux') {
+            // Always SIGKILL stuck trees on Linux so worker teardown does not sit
+            // in Playwright's 90s gracefullyClose wait with live Electron PIDs.
+            await forceShutdownLinux(pid);
+        } else {
+            signalShutdownAndReturn(pid);
         }
     }
 
-    await waitForLockFileRelease(dataDir).catch(() => {});
+    // Fast path on a failed close: return immediately (master-style). The lock
+    // lives in an abandoned dir and worker/global cleanup reaps any live PID.
+    if (fastTeardown && !cleanClosed) {
+        if (pid && !isProcessAlive(pid)) {
+            unregisterElectronMainProcess(pid);
+        }
+        return;
+    }
+
+    // Full path always waits for the lock; fast path only on a clean close.
+    if (dataDir && (cleanClosed || !fastTeardown)) {
+        await waitForLockFileRelease(dataDir).catch(() => {});
+    }
+
+    // Drop the PID from the registry only once it's actually gone; a live
+    // leftover stays for worker/global cleanup to reap (matches master).
+    if (!pid || !isProcessAlive(pid)) {
+        unregisterElectronMainProcess(pid);
+    }
 }

--- a/e2e/helpers/login.ts
+++ b/e2e/helpers/login.ts
@@ -3,6 +3,7 @@
 
 import {expect} from '@playwright/test';
 
+import {isTransientEvaluateError} from './testRefs';
 import type {ServerView} from './serverView';
 
 async function isMattermostServerUrl(win: ServerView): Promise<boolean> {
@@ -10,18 +11,29 @@ async function isMattermostServerUrl(win: ServerView): Promise<boolean> {
     return url.startsWith('http://') || url.startsWith('https://');
 }
 
+async function runRendererProbe(win: ServerView, body: string): Promise<boolean> {
+    try {
+        return await win.runInRenderer<boolean>(body);
+    } catch (error) {
+        if (isTransientEvaluateError(error)) {
+            return false;
+        }
+        throw error;
+    }
+}
+
 async function hasAppShell(win: ServerView): Promise<boolean> {
     if (!(await isMattermostServerUrl(win))) {
         return false;
     }
 
-    return win.runInRenderer<boolean>(`
+    return runRendererProbe(win, `
         return Boolean(
             document.querySelector('#post_textbox')
             || document.querySelector('#channelHeaderTitle')
             || document.querySelector('input.search-bar.form-control'),
         );
-    `).catch(() => false);
+    `);
 }
 
 async function hasLoginForm(win: ServerView): Promise<boolean> {
@@ -29,9 +41,9 @@ async function hasLoginForm(win: ServerView): Promise<boolean> {
         return false;
     }
 
-    return win.runInRenderer<boolean>(`
+    return runRendererProbe(win, `
         return Boolean(document.querySelector('#input_loginId'));
-    `).catch(() => false);
+    `);
 }
 
 /**

--- a/e2e/helpers/login.ts
+++ b/e2e/helpers/login.ts
@@ -1,22 +1,43 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {expect} from '@playwright/test';
+
 import type {ServerView} from './serverView';
 
-async function waitForAppShell(win: ServerView, timeout: number) {
-    const results = await Promise.allSettled([
-        win.waitForSelector('#post_textbox', {timeout}),
-        win.waitForSelector('#channelHeaderTitle', {timeout}),
-        win.waitForSelector('input.search-bar.form-control', {timeout}),
-    ]);
+async function isMattermostServerUrl(win: ServerView): Promise<boolean> {
+    const url = await win.url().catch(() => '');
+    return url.startsWith('http://') || url.startsWith('https://');
+}
 
-    return results.some((result) => result.status === 'fulfilled');
+async function hasAppShell(win: ServerView): Promise<boolean> {
+    if (!(await isMattermostServerUrl(win))) {
+        return false;
+    }
+
+    return win.runInRenderer<boolean>(`
+        return Boolean(
+            document.querySelector('#post_textbox')
+            || document.querySelector('#channelHeaderTitle')
+            || document.querySelector('input.search-bar.form-control'),
+        );
+    `).catch(() => false);
+}
+
+async function hasLoginForm(win: ServerView): Promise<boolean> {
+    if (!(await isMattermostServerUrl(win))) {
+        return false;
+    }
+
+    return win.runInRenderer<boolean>(`
+        return Boolean(document.querySelector('#input_loginId'));
+    `).catch(() => false);
 }
 
 /**
  * Log in to a Mattermost server in the given window/page.
- * Requires MM_TEST_USER_NAME and MM_TEST_PASSWORD env vars.
- * Requires MM_TEST_SERVER_URL to be set in the app config (use demoMattermostConfig).
+ * Callers must ensure the server WebContentsView is loaded first
+ * (switch server, prepareMattermostServerView, waitForMattermostShell).
  */
 export async function loginToMattermost(win: ServerView): Promise<void> {
     const username = process.env.MM_TEST_USER_NAME;
@@ -26,33 +47,37 @@ export async function loginToMattermost(win: ServerView): Promise<void> {
         throw new Error('MM_TEST_USER_NAME and MM_TEST_PASSWORD must be set for tests requiring login');
     }
 
-    const timeout = process.platform === 'win32' ? 60_000 : 30_000;
-
+    const timeout = process.platform === 'win32' ? 60_000 : 45_000;
     const loginSelector = '#input_loginId';
     const passwordSelector = '#input_password-input, input[type="password"]';
-    const submitSelector = 'button[type="submit"]';
+    const submitSelector = '#saveSetting, button[type="submit"]';
 
-    let onLoginPage = false;
-    try {
-        await win.waitForSelector(loginSelector, {timeout});
-        onLoginPage = true;
-    } catch {
-        if (await waitForAppShell(win, 5_000)) {
-            return;
+    await expect.poll(async () => {
+        if (await hasAppShell(win)) {
+            return 'logged-in';
         }
-    }
+        if (await hasLoginForm(win)) {
+            return 'login-form';
+        }
+        return 'loading';
+    }, {
+        timeout,
+        intervals: [500, 1000, 2000],
+        message: `Mattermost login form or app shell must appear (URL: ${await win.url()})`,
+    }).not.toBe('loading');
 
-    if (!onLoginPage) {
-        throw new Error(`loginToMattermost: login form was not found and the app shell never appeared. Current URL: ${await win.url()}`);
+    if (await hasAppShell(win)) {
+        return;
     }
 
     await win.fill(loginSelector, username);
     await win.fill(passwordSelector, password);
     await win.click(submitSelector);
 
-    // Wait for login to complete: URL leaves /login
     await win.waitForURL((url) => !url.pathname.startsWith('/login'), {timeout});
-    if (!await waitForAppShell(win, timeout)) {
-        throw new Error(`loginToMattermost: login succeeded but the app shell never became ready. Current URL: ${await win.url()}`);
-    }
+    await expect.poll(async () => hasAppShell(win), {
+        timeout,
+        intervals: [500, 1000, 2000],
+        message: `Mattermost app shell must appear after login (URL: ${await win.url()})`,
+    }).toBe(true);
 }

--- a/e2e/helpers/notificationEffects.ts
+++ b/e2e/helpers/notificationEffects.ts
@@ -10,11 +10,11 @@ import type {ElectronApplication} from 'playwright';
  * often emits `failed` without `show`), so flash_taskbar and dock_bounce tests
  * exercise the same flashFrame() gate the notification `show` handler calls.
  */
-export async function triggerFlashEffects(app: ElectronApplication, flash = true): Promise<void> {
+export async function triggerNotificationEffects(app: ElectronApplication, flash = true): Promise<void> {
     await app.evaluate((_, shouldFlash: boolean) => {
-        const trigger = (global as any).__e2eFlashEffects as ((value: boolean) => void) | undefined;
+        const trigger = (global as any).__e2eNotificationEffects as ((value: boolean) => void) | undefined;
         if (!trigger) {
-            throw new Error('__e2eFlashEffects not exposed (NODE_ENV must be test)');
+            throw new Error('__e2eNotificationEffects not exposed (NODE_ENV must be test)');
         }
         trigger(shouldFlash);
     }, flash);

--- a/e2e/helpers/notificationEffects.ts
+++ b/e2e/helpers/notificationEffects.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {ElectronApplication} from 'playwright';
+
+/**
+ * Invoke the production flashFrame() helper from src/main/notifications/index.ts.
+ *
+ * OS notification delivery is unreliable in headless CI (Electron's Notification
+ * often emits `failed` without `show`), so flash_taskbar and dock_bounce tests
+ * exercise the same flashFrame() gate the notification `show` handler calls.
+ */
+export async function triggerFlashEffects(app: ElectronApplication, flash = true): Promise<void> {
+    await app.evaluate((_, shouldFlash: boolean) => {
+        const trigger = (global as any).__e2eFlashEffects as ((value: boolean) => void) | undefined;
+        if (!trigger) {
+            throw new Error('__e2eFlashEffects not exposed (NODE_ENV must be test)');
+        }
+        trigger(shouldFlash);
+    }, flash);
+}

--- a/e2e/helpers/overlayWindows.ts
+++ b/e2e/helpers/overlayWindows.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {ElectronApplication} from 'playwright';
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export async function closeOverlayWindowsIfOpen(app: ElectronApplication, timeoutMs = 3_000): Promise<void> {
+    // app.evaluate can hang if the Electron main process is blocked or unresponsive
+    // (e.g. during teardown). Cap the wait so setup/teardown never deadlock.
+    const closePromise = app.evaluate(({BrowserWindow}) => {
+        for (const win of BrowserWindow.getAllWindows()) {
+            if (win.isDestroyed()) {
+                continue;
+            }
+            try {
+                const url = win.webContents.getURL();
+                if (url.includes('dropdown') || url.includes('downloadsDropdown.html')) {
+                    win.close();
+                }
+            } catch {
+                // Ignore windows that disappear while iterating.
+            }
+        }
+    }).catch(() => {
+        // Ignore evaluation failures (e.g. app already shutting down).
+    });
+
+    await Promise.race([closePromise, sleep(timeoutMs)]);
+}

--- a/e2e/helpers/prepareServerView.ts
+++ b/e2e/helpers/prepareServerView.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {ElectronApplication} from 'playwright';
+
+import {closeOverlayWindowsIfOpen} from './overlayWindows';
+
+/**
+ * Close overlay windows and focus a Mattermost server WebContentsView so
+ * renderer automation targets the channel UI instead of dropdown overlays.
+ */
+export async function prepareMattermostServerView(
+    app: ElectronApplication,
+    webContentsId: number,
+): Promise<void> {
+    await closeOverlayWindowsIfOpen(app);
+    await app.evaluate(({webContents}, id) => {
+        const wc = webContents.fromId(id);
+        if (!wc || wc.isDestroyed()) {
+            throw new Error(`webContents ${id} is not available`);
+        }
+        wc.focus();
+    }, webContentsId);
+}

--- a/e2e/helpers/serverMap.ts
+++ b/e2e/helpers/serverMap.ts
@@ -28,7 +28,14 @@ export async function buildServerMap(app: ElectronApplication): Promise<ServerMa
                 const servers = refs.ServerManager.getAllServers();
                 return servers.flatMap((server: {id: string; name: string}) => {
                     const views = refs.ViewManager.getViewsByServerId(server.id);
-                    return views.map((view: {id: string}) => {
+                    const orderedTabs: Array<{id: string}> = refs.TabManager?.getOrderedTabsForServer?.(server.id) ?? [];
+                    const orderedTabIds = orderedTabs.map((tab) => tab.id);
+                    const sortedViews = [...views].sort((a: {id: string}, b: {id: string}) => {
+                        const ai = orderedTabIds.indexOf(a.id);
+                        const bi = orderedTabIds.indexOf(b.id);
+                        return (ai === -1 ? Number.MAX_SAFE_INTEGER : ai) - (bi === -1 ? Number.MAX_SAFE_INTEGER : bi);
+                    });
+                    return sortedViews.map((view: {id: string}) => {
                         const webContentsView = refs.WebContentsManager.getView(view.id);
                         if (!webContentsView) {
                             return null;
@@ -64,10 +71,6 @@ export async function buildServerMap(app: ElectronApplication): Promise<ServerMa
                 webContentsId: entry.webContentsId,
             });
         }
-
-        Object.values(map).forEach((serverEntries) => {
-            serverEntries.sort((left, right) => left.webContentsId - right.webContentsId);
-        });
 
         if (Object.keys(map).length > 0) {
             return map;

--- a/e2e/helpers/serverView.ts
+++ b/e2e/helpers/serverView.ts
@@ -525,7 +525,11 @@ export class ServerView {
                 throw new Error(`${result.__e2eError}${result.__e2eStack ? `\n${result.__e2eStack}` : ''}`);
             }
 
-            return result?.__e2eResult;
+            let value = result?.__e2eResult;
+            if (value && typeof (value as Promise<unknown>).then === 'function') {
+                value = await value;
+            }
+            return value;
         }, {id: this.webContentsId, body, userGesture}) as Promise<T>;
     }
 
@@ -535,10 +539,21 @@ export class ServerView {
     }
 
     async url() {
-        return this.app.evaluate(({webContents}, id) => {
-            const wc = webContents.fromId(id);
-            return wc?.getURL() ?? '';
-        }, this.webContentsId);
+        try {
+            return await this.app.evaluate(({webContents}, id) => {
+                const wc = webContents.fromId(id);
+                return wc?.getURL() ?? '';
+            }, this.webContentsId);
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            if (
+                message.includes('Execution context was destroyed') ||
+                message.includes('Target page, context or browser has been closed')
+            ) {
+                return '';
+            }
+            throw error;
+        }
     }
 
     async waitForFunction<T>(

--- a/e2e/helpers/testRefs.ts
+++ b/e2e/helpers/testRefs.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect} from '@playwright/test';
+import type {ElectronApplication} from 'playwright';
+
+const TRANSIENT_EVALUATE_ERRORS = [
+    'Execution context was destroyed',
+    'Target page, context or browser has been closed',
+    'Unable to find context',
+];
+
+export function isTransientEvaluateError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return TRANSIENT_EVALUATE_ERRORS.some((part) => message.includes(part));
+}
+
+export async function evaluateInMainProcess<T>(
+    app: ElectronApplication,
+    pageFunction: () => T,
+    options: {timeoutMs?: number; retryDelayMs?: number} = {},
+): Promise<T> {
+    const timeoutMs = options.timeoutMs ?? 15_000;
+    const retryDelayMs = options.retryDelayMs ?? 100;
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+        try {
+            return await app.evaluate(pageFunction);
+        } catch (error) {
+            if (!isTransientEvaluateError(error)) {
+                throw error;
+            }
+            await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+        }
+    }
+
+    throw new Error('Timed out waiting for electron main-process evaluate');
+}
+
+type MainProcessEvaluatorWithArg<T, A> = (
+    _electron: typeof import('electron'),
+    arg: A,
+) => T | Promise<T>;
+
+export async function evaluateInMainProcessWithArg<T, A>(
+    app: ElectronApplication,
+    pageFunction: MainProcessEvaluatorWithArg<T, A>,
+    arg: A,
+    options: {timeoutMs?: number; retryDelayMs?: number} = {},
+): Promise<T> {
+    const timeoutMs = options.timeoutMs ?? 15_000;
+    const retryDelayMs = options.retryDelayMs ?? 100;
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+        try {
+            // Must call on `app` — extracting `app.evaluate` drops `this` and breaks _channel.
+            return await (app.evaluate as (
+                fn: MainProcessEvaluatorWithArg<T, A>,
+                value: A,
+            ) => Promise<T>).call(app, pageFunction, arg);
+        } catch (error) {
+            if (!isTransientEvaluateError(error)) {
+                throw error;
+            }
+            await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+        }
+    }
+
+    throw new Error('Timed out waiting for electron main-process evaluate');
+}
+
+export async function getMainWindowId(app: ElectronApplication): Promise<number> {
+    let mainWindowId: number | null = null;
+    await expect.poll(async () => {
+        try {
+            mainWindowId = await app.evaluate(() => {
+                const refs = (global as any).__e2eTestRefs;
+                const win = refs?.MainWindow?.get?.();
+                return win?.id ?? null;
+            });
+            return mainWindowId;
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            if (
+                message.includes('Execution context was destroyed') ||
+                message.includes('Target page, context or browser has been closed')
+            ) {
+                return null;
+            }
+            throw error;
+        }
+    }, {
+        timeout: 30_000,
+        intervals: [200, 500, 1000],
+        message: 'MainWindow id must be resolvable via __e2eTestRefs',
+    }).not.toBeNull();
+
+    if (mainWindowId == null) {
+        throw new Error('MainWindow id was not available via __e2eTestRefs');
+    }
+    return mainWindowId;
+}
+
+export async function getActiveServerWebContentsId(app: ElectronApplication): Promise<number> {
+    const id = await app.evaluate(() => {
+        const refs = (global as any).__e2eTestRefs;
+        const view = refs?.TabManager?.getCurrentActiveTabView?.();
+        return view?.webContentsId ?? null;
+    });
+    if (id == null) {
+        throw new Error('Active server webContents id was not available via TabManager');
+    }
+    return id;
+}

--- a/e2e/helpers/testRefs.ts
+++ b/e2e/helpers/testRefs.ts
@@ -82,11 +82,7 @@ export async function getMainWindowId(app: ElectronApplication): Promise<number>
             });
             return mainWindowId;
         } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            if (
-                message.includes('Execution context was destroyed') ||
-                message.includes('Target page, context or browser has been closed')
-            ) {
+            if (isTransientEvaluateError(error)) {
                 return null;
             }
             throw error;
@@ -104,7 +100,7 @@ export async function getMainWindowId(app: ElectronApplication): Promise<number>
 }
 
 export async function getActiveServerWebContentsId(app: ElectronApplication): Promise<number> {
-    const id = await app.evaluate(() => {
+    const id = await evaluateInMainProcess(app, () => {
         const refs = (global as any).__e2eTestRefs;
         const view = refs?.TabManager?.getCurrentActiveTabView?.();
         return view?.webContentsId ?? null;

--- a/e2e/helpers/tray.ts
+++ b/e2e/helpers/tray.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {ElectronApplication} from 'playwright';
+
+import {evaluateInMainProcess, evaluateInMainProcessWithArg} from './testRefs';
+
+export async function emitTrayIconClick(app: ElectronApplication): Promise<void> {
+    await evaluateInMainProcess(app, () => {
+        const refs = (global as any).__e2eTestRefs;
+        const tray = refs?.TrayIcon?.tray;
+        if (!tray || tray.isDestroyed?.()) {
+            throw new Error('Tray icon is not initialized');
+        }
+        tray.emit('click');
+    });
+}
+
+export async function clickTrayMenuItem(app: ElectronApplication, label: string): Promise<void> {
+    await evaluateInMainProcessWithArg(app, (_electron, menuLabel) => {
+        const clickTrayMenuItem = (global as any).__e2eClickTrayMenuItem as ((value: string) => void) | undefined;
+        if (!clickTrayMenuItem) {
+            throw new Error('__e2eClickTrayMenuItem not exposed (NODE_ENV must be test)');
+        }
+        clickTrayMenuItem(menuLabel);
+    }, label);
+}
+
+export async function isMainWindowVisible(app: ElectronApplication): Promise<boolean> {
+    return evaluateInMainProcess(app, () => {
+        const refs = (global as any).__e2eTestRefs;
+        const mainWindow = refs?.MainWindow?.get?.();
+        return Boolean(mainWindow && !mainWindow.isDestroyed() && mainWindow.isVisible());
+    });
+}

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -15,7 +15,8 @@
       },
       "devDependencies": {
         "@playwright/test": "1.61.0",
-        "cross-env": "^10.1.0"
+        "cross-env": "^10.1.0",
+        "playwright": "1.61.0"
       }
     },
     "node_modules/@epic-web/invariant": {

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -14,7 +14,7 @@
         "ps-node": "0.1.6"
       },
       "devDependencies": {
-        "@playwright/test": "1.58.0",
+        "@playwright/test": "1.61.0",
         "cross-env": "^10.1.0"
       }
     },
@@ -26,13 +26,13 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
-      "integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.0"
+        "playwright": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -106,6 +106,21 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -124,13 +139,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
-      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.0"
+        "playwright-core": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -143,9 +158,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
-      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -153,20 +168,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/ps-node": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@playwright/test": "1.61.0",
-    "cross-env": "^10.1.0"
+    "cross-env": "^10.1.0",
+    "playwright": "1.61.0"
   }
 }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -24,7 +24,7 @@
     "ps-node": "0.1.6"
   },
   "devDependencies": {
-    "@playwright/test": "1.58.0",
+    "@playwright/test": "1.61.0",
     "cross-env": "^10.1.0"
   }
 }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -29,7 +29,8 @@ const PLATFORM_GREP: Record<Platform, RegExp> = {
 // count locally (max 4). Override with E2E_WORKERS env var.
 const cpuCount = os.cpus().length;
 const defaultWorkers = process.env.CI ? 2 : Math.min(4, Math.max(1, Math.floor(cpuCount / 2)));
-const workers = process.env.E2E_WORKERS ? parseInt(process.env.E2E_WORKERS, 10) : defaultWorkers;
+const parsedWorkers = process.env.E2E_WORKERS ? Number.parseInt(process.env.E2E_WORKERS, 10) : NaN;
+const workers = Number.isFinite(parsedWorkers) && parsedWorkers > 0 ? parsedWorkers : defaultWorkers;
 
 // Prepended to each test in blob/HTML reports so multi-environment runs are distinguishable
 // when merging. Must NOT reuse platform grep tokens (@linux, @darwin, @win32, @all) —
@@ -69,6 +70,7 @@ function buildPlatformProjects(): Project[] {
         projects.push({
             name: 'wayland',
             grep: /@wayland/,
+            ...policyFilter,
         });
     }
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -3,16 +3,25 @@
 
 import * as os from 'os';
 
-import {defineConfig} from '@playwright/test';
+import {defineConfig, type Project} from '@playwright/test';
 
-let platformGrep: RegExp;
-if (process.platform === 'darwin') {
-    platformGrep = /@all|@darwin/;
-} else if (process.platform === 'win32') {
-    platformGrep = /@all|@win32/;
-} else {
-    platformGrep = /@all|@linux/;
+type Platform = 'linux' | 'darwin' | 'win32';
+
+function getActivePlatform(): Platform {
+    if (process.platform === 'darwin') {
+        return 'darwin';
+    }
+    if (process.platform === 'win32') {
+        return 'win32';
+    }
+    return 'linux';
 }
+
+const PLATFORM_GREP: Record<Platform, RegExp> = {
+    linux: /@all|@linux/,
+    darwin: /@all|@darwin/,
+    win32: /@all|@win32/,
+};
 
 // Each test gets its own isolated userDataDir (testInfo.outputDir/userdata), so each
 // Electron instance has its own SingletonLock — parallel workers never conflict.
@@ -21,7 +30,51 @@ if (process.platform === 'darwin') {
 const cpuCount = os.cpus().length;
 const defaultWorkers = process.env.CI ? 2 : Math.min(4, Math.max(1, Math.floor(cpuCount / 2)));
 const workers = process.env.E2E_WORKERS ? parseInt(process.env.E2E_WORKERS, 10) : defaultWorkers;
-const ciEnvironmentTag = process.env.CI_ENVIRONMENT_NAME;
+
+// Prepended to each test in blob/HTML reports so multi-environment runs are distinguishable
+// when merging. Must NOT reuse platform grep tokens (@linux, @darwin, @win32, @all) —
+// Playwright inherits config tags onto file suites, which would make Linux grep match
+// every test when CI used to set CI_ENVIRONMENT_NAME=@linux.
+function getReportTag(): string | undefined {
+    const raw = process.env.CI_ENVIRONMENT_NAME;
+    if (!raw) {
+        return undefined;
+    }
+
+    const legacyReportTags: Record<string, string> = {
+        '@linux': '@ci-linux',
+        '@macos': '@ci-macos',
+        '@windows': '@ci-windows',
+    };
+
+    return legacyReportTags[raw] ?? raw;
+}
+
+const reportTag = getReportTag();
+const excludePolicyFromMainRun = Boolean(process.env.CI) && process.env.RUN_POLICY_E2E !== 'true';
+const activePlatform = getActivePlatform();
+
+function buildPlatformProjects(): Project[] {
+    const policyFilter = excludePolicyFromMainRun ? {grepInvert: /[/\\]policy[/\\]/} : {};
+
+    const projects: Project[] = [
+        {
+            name: activePlatform,
+            grep: PLATFORM_GREP[activePlatform],
+            ...policyFilter,
+        },
+    ];
+
+    if (process.env.E2E_WAYLAND === 'true' && activePlatform === 'linux') {
+        projects.push({
+            name: 'wayland',
+            grep: /@wayland/,
+        });
+    }
+
+    return projects;
+}
+
 const reporters = process.env.CI ? [
     ['blob', {outputDir: 'blob-report'}],
     ['line'],
@@ -49,7 +102,13 @@ export default defineConfig({
     // while still failing reasonably fast on a genuinely-stuck test.
     timeout: 90_000,
 
-    ...(ciEnvironmentTag ? {tag: ciEnvironmentTag} : {}),
+    // Worker teardown reaps this worker's orphaned Electron main processes. The
+    // per-worker PID registry + concurrent SIGKILL reap keep this to ~2s even
+    // with several leftovers, so 90s is ample headroom. If teardown ever
+    // approaches this it signals a reaping gap to fix, not a timeout to raise.
+    workerTeardownTimeout: 90_000,
+
+    ...(reportTag ? {tag: reportTag} : {}),
 
     reporter: reporters,
 
@@ -59,10 +118,5 @@ export default defineConfig({
         video: 'retain-on-failure',
     },
 
-    projects: [
-        {
-            name: process.platform,
-            grep: platformGrep,
-        },
-    ],
+    projects: buildPlatformProjects(),
 });

--- a/e2e/utils/analyze-flaky-test.js
+++ b/e2e/utils/analyze-flaky-test.js
@@ -17,7 +17,14 @@ function getXMLParserClass() {
         try {
             const {XMLParser} = createRequire(packageJson)('fast-xml-parser');
             return XMLParser;
-        } catch {
+        } catch (error) {
+            const isModuleNotFound =
+                error &&
+                (error.code === 'MODULE_NOT_FOUND' || error.code === 'ERR_MODULE_NOT_FOUND');
+            if (!isModuleNotFound) {
+                throw error;
+            }
+
             // try the other package root (e2e/ vs repo root)
         }
     }

--- a/e2e/utils/analyze-flaky-test.js
+++ b/e2e/utils/analyze-flaky-test.js
@@ -3,10 +3,27 @@
 
 const fs = require('fs');
 const path = require('path');
-
-const {XMLParser} = require('fast-xml-parser');
+const {createRequire} = require('module');
 
 const JUNIT_REPORT_PATH = path.join(__dirname, '..', 'test-results', 'e2e-junit.xml');
+
+function getXMLParserClass() {
+    const packageCandidates = [
+        path.join(__dirname, '..', 'package.json'),
+        path.join(__dirname, '..', '..', 'package.json'),
+    ];
+
+    for (const packageJson of packageCandidates) {
+        try {
+            const {XMLParser} = createRequire(packageJson)('fast-xml-parser');
+            return XMLParser;
+        } catch {
+            // try the other package root (e2e/ vs repo root)
+        }
+    }
+
+    throw new Error('fast-xml-parser is not installed. Run npm ci in the repo root and e2e/.');
+}
 
 function toNumber(value) {
     const parsed = parseInt(value, 10);
@@ -187,8 +204,9 @@ function getOutcomeCounts(report) {
 
 function analyzeFlakyTests() {
     const exitCode = toNumber(process.env.PLAYWRIGHT_EXIT_CODE || '0');
+    const hasJunit = fs.existsSync(JUNIT_REPORT_PATH);
 
-    if (!fs.existsSync(JUNIT_REPORT_PATH)) {
+    if (!hasJunit) {
         const failureCount = exitCode === 0 ? 0 : 1;
         return {
             failureCount,
@@ -197,9 +215,11 @@ function analyzeFlakyTests() {
             totalCount: failureCount,
             newFailedTests: new Array(failureCount).fill('unknown'),
             os: process.platform,
+            testStatus: failureCount > 0 ? 'failure' : 'success',
         };
     }
 
+    const XMLParser = getXMLParserClass();
     const parser = new XMLParser({
         ignoreAttributes: false,
         attributeNamePrefix: '',
@@ -215,6 +235,7 @@ function analyzeFlakyTests() {
     // `failureCount` and reconcile the rest.
     const reconciledFailed = failureCount;
     const reconciledPassed = Math.max(0, outcomes.total - reconciledFailed - outcomes.skipped);
+    const testStatus = reconciledFailed > 0 ? 'failure' : 'success';
 
     return {
         failureCount,
@@ -223,6 +244,7 @@ function analyzeFlakyTests() {
         totalCount: reconciledFailed + reconciledPassed + outcomes.skipped,
         newFailedTests: new Array(failureCount).fill('failed'),
         os: process.platform,
+        testStatus,
     };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "eslint-plugin-no-only-tests": "3.1.0",
         "eslint-plugin-react": "7.34.0",
         "eslint-plugin-react-hooks": "4.6.0",
+        "fast-xml-parser": "^5.8.0",
         "html-webpack-plugin": "5.5.0",
         "jest": "29.4.1",
         "jest-junit": "13.1.0",
@@ -85,7 +86,7 @@
     },
     "api-types": {
       "name": "@mattermost/desktop-api",
-      "version": "6.2.0-1",
+      "version": "6.3.0-1",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -4051,6 +4052,18 @@
         }
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ]
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -6017,6 +6030,18 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ]
     },
     "node_modules/app-builder-bin": {
       "version": "5.0.0-alpha.12",
@@ -10382,6 +10407,44 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -15978,6 +16041,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -18234,6 +18312,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
+    },
     "node_modules/style-loader": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
@@ -19693,6 +19786,21 @@
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
       "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
       "dev": true
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "eslint-plugin-no-only-tests": "3.1.0",
     "eslint-plugin-react": "7.34.0",
     "eslint-plugin-react-hooks": "4.6.0",
+    "fast-xml-parser": "^5.8.0",
     "html-webpack-plugin": "5.5.0",
     "jest": "29.4.1",
     "jest-junit": "13.1.0",

--- a/src/main/app/initialize.test.js
+++ b/src/main/app/initialize.test.js
@@ -197,6 +197,11 @@ jest.mock('app/tabs/tabManager', () => ({
     on: jest.fn(),
 }));
 
+jest.mock('app/windows/popoutManager', () => ({
+    __esModule: true,
+    default: {},
+}));
+
 jest.mock('main/developerMode', () => ({
     on: jest.fn(),
     switchOff: jest.fn(),
@@ -215,6 +220,10 @@ jest.mock('common/views/viewManager', () => ({
 
 jest.mock('app/menus', () => ({
     refreshMenu: jest.fn(),
+}));
+jest.mock('app/menus/tray', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({items: []})),
 }));
 
 jest.mock('main/security/preAuthManager', () => ({

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -311,28 +311,30 @@ async function initializeAfterAppReady() {
     });
 
     setTestField('__e2eClickTrayMenuItem', (label: string) => {
-        const menu = createTrayMenu();
-        const stack = [...menu.items];
-        while (stack.length > 0) {
-            const item = stack.shift();
-            if (!item) {
-                continue;
+        const truncated = label.length > 50 ? `${label.slice(0, 50)}...` : label;
+
+        function clickItem(items: Electron.MenuItem[]): boolean {
+            for (const item of items) {
+                const itemLabel = typeof item.label === 'string' ? item.label : '';
+                if (
+                    (itemLabel === label || itemLabel === truncated) &&
+                    item.enabled !== false &&
+                    item.visible !== false &&
+                    typeof item.click === 'function'
+                ) {
+                    item.click();
+                    return true;
+                }
+                if (item.submenu?.items && clickItem(item.submenu.items)) {
+                    return true;
+                }
             }
-            const itemLabel = typeof item.label === 'string' ? item.label : '';
-            const truncatedMenuLabel = label.length > 50 ? `${label.slice(0, 50)}...` : label;
-            if (
-                (itemLabel === label || itemLabel === truncatedMenuLabel) &&
-                item.enabled !== false &&
-                item.visible !== false &&
-                typeof item.click === 'function'
-            ) {
-                item.click();
-                return;
-            }
-            const submenuItems = item.submenu?.items ?? [];
-            stack.push(...submenuItems);
+            return false;
         }
-        throw new Error(`Tray menu item not found: ${label}`);
+
+        if (!clickItem(createTrayMenu().items)) {
+            throw new Error(`Tray menu item not found: ${label}`);
+        }
     });
 
     // Block all NTLM/Negotiate requests by default
@@ -378,10 +380,10 @@ async function initializeAfterAppReady() {
     ServerManager.on(SERVER_URL_CHANGED, updateServerInfo);
     ServerManager.on(SERVER_PRE_AUTH_SECRET_CHANGED, updateServerInfo);
 
+    setTestField('__e2eStubMessageBoxResponses', installMessageBoxStub);
+    setTestField('__e2eRestoreMessageBox', restoreMessageBoxStub);
+    setTestField('__e2eClearCertificateErrorCallbacks', () => certificateErrorCallbacks.clear());
     if (process.env.NODE_ENV === 'test') {
-        setTestField('__e2eStubMessageBoxResponses', installMessageBoxStub);
-        setTestField('__e2eRestoreMessageBox', restoreMessageBoxStub);
-        setTestField('__e2eClearCertificateErrorCallbacks', () => certificateErrorCallbacks.clear());
         if (process.env.MM_E2E_STUB_MESSAGE_BOX === 'cancel') {
             installMessageBoxStub([{response: 1}]);
         } else if (process.env.MM_E2E_STUB_MESSAGE_BOX === 'trust') {

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -322,7 +322,12 @@ async function initializeAfterAppReady() {
             }
             const itemLabel = typeof item.label === 'string' ? item.label : '';
             const truncatedMenuLabel = label.length > 50 ? `${label.slice(0, 50)}...` : label;
-            if ((itemLabel === label || itemLabel === truncatedMenuLabel) && typeof item.click === 'function') {
+            if (
+                (itemLabel === label || itemLabel === truncatedMenuLabel) &&
+                item.enabled !== false &&
+                item.visible !== false &&
+                typeof item.click === 'function'
+            ) {
                 item.click();
                 return;
             }

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -12,11 +12,13 @@ import Joi from 'joi';
 
 import MainWindow from 'app/mainWindow/mainWindow';
 import MenuManager from 'app/menus';
+import createTrayMenu from 'app/menus/tray';
 import NavigationManager from 'app/navigationManager';
 import {setupBadge} from 'app/system/badge';
 import Tray from 'app/system/tray/tray';
 import TabManager from 'app/tabs/tabManager';
 import WebContentsManager from 'app/views/webContentsManager';
+import PopoutManager from 'app/windows/popoutManager';
 import {
     QUIT,
     NOTIFY_MENTION,
@@ -52,10 +54,11 @@ import AutoLauncher from 'main/AutoLauncher';
 import {configPath, updatePaths} from 'main/constants';
 import CriticalErrorHandler from 'main/CriticalErrorHandler';
 import DeveloperMode from 'main/developerMode';
+import Diagnostics from 'main/diagnostics';
 import downloadsManager from 'main/downloadsManager';
 import i18nManager from 'main/i18nManager';
 import NonceManager from 'main/nonceManager';
-import {getDoNotDisturb} from 'main/notifications';
+import NotificationManager, {getDoNotDisturb} from 'main/notifications';
 import parseArgs from 'main/ParseArgs';
 import PerformanceMonitor from 'main/performanceMonitor';
 import secureStorage from 'main/secureStorage';
@@ -64,6 +67,7 @@ import PermissionsManager from 'main/security/permissionsManager';
 import PreAuthManager from 'main/security/preAuthManager';
 import sentryHandler from 'main/sentryHandler';
 import SessionAttributesManager from 'main/sessionAttributes/sessionAttributesManager';
+import {installMessageBoxStub, restoreMessageBoxStub} from 'main/testMessageBoxStub';
 import updateNotifier from 'main/updateNotifier';
 import UserActivityMonitor from 'main/UserActivityMonitor';
 
@@ -75,6 +79,7 @@ import {
     handleAppWillFinishLaunching,
     handleAppWindowAllClosed,
     handleChildProcessGone,
+    certificateErrorCallbacks,
 } from './app';
 import {
     handleConfigUpdate,
@@ -98,6 +103,7 @@ import {
 import {
     clearAppCache,
     getDeeplinkingURL,
+    openDeepLink,
     shouldShowTrayIcon,
     updateSpellCheckerLocales,
     wasUpdated,
@@ -294,6 +300,36 @@ async function initializeAfterAppReady() {
         TabManager,
         ViewManager,
         WebContentsManager,
+        Config,
+        TrayIcon: Tray,
+        NotificationManager,
+        Diagnostics,
+        updateNotifier,
+        PopoutManager,
+    });
+
+    setTestField('__e2eOpenDeepLink', (url: string) => {
+        openDeepLink(url);
+    });
+
+    setTestField('__e2eClickTrayMenuItem', (label: string) => {
+        const menu = createTrayMenu();
+        const stack = [...menu.items];
+        while (stack.length > 0) {
+            const item = stack.shift();
+            if (!item) {
+                continue;
+            }
+            const itemLabel = typeof item.label === 'string' ? item.label : '';
+            const truncatedMenuLabel = label.length > 50 ? `${label.slice(0, 50)}...` : label;
+            if ((itemLabel === label || itemLabel === truncatedMenuLabel) && typeof item.click === 'function') {
+                item.click();
+                return;
+            }
+            const submenuItems = item.submenu?.items ?? [];
+            stack.push(...submenuItems);
+        }
+        throw new Error(`Tray menu item not found: ${label}`);
     });
 
     // Block all NTLM/Negotiate requests by default
@@ -338,6 +374,17 @@ async function initializeAfterAppReady() {
     ServerManager.on(SERVER_ADDED, updateServerInfo);
     ServerManager.on(SERVER_URL_CHANGED, updateServerInfo);
     ServerManager.on(SERVER_PRE_AUTH_SECRET_CHANGED, updateServerInfo);
+
+    if (process.env.NODE_ENV === 'test') {
+        setTestField('__e2eStubMessageBoxResponses', installMessageBoxStub);
+        setTestField('__e2eRestoreMessageBox', restoreMessageBoxStub);
+        setTestField('__e2eClearCertificateErrorCallbacks', () => certificateErrorCallbacks.clear());
+        if (process.env.MM_E2E_STUB_MESSAGE_BOX === 'cancel') {
+            installMessageBoxStub([{response: 1}]);
+        } else if (process.env.MM_E2E_STUB_MESSAGE_BOX === 'trust') {
+            installMessageBoxStub([{response: 0}, {response: 0}]);
+        }
+    }
 
     ServerManager.on(SERVER_ADDED, PreAuthManager.loadPreAuthSecretForServer);
     ServerManager.init();

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -58,7 +58,7 @@ import Diagnostics from 'main/diagnostics';
 import downloadsManager from 'main/downloadsManager';
 import i18nManager from 'main/i18nManager';
 import NonceManager from 'main/nonceManager';
-import NotificationManager, {getDoNotDisturb} from 'main/notifications';
+import {getDoNotDisturb} from 'main/notifications';
 import parseArgs from 'main/ParseArgs';
 import PerformanceMonitor from 'main/performanceMonitor';
 import secureStorage from 'main/secureStorage';
@@ -302,9 +302,7 @@ async function initializeAfterAppReady() {
         WebContentsManager,
         Config,
         TrayIcon: Tray,
-        NotificationManager,
         Diagnostics,
-        updateNotifier,
         PopoutManager,
     });
 

--- a/src/main/notifications/index.ts
+++ b/src/main/notifications/index.ts
@@ -12,6 +12,7 @@ import {PLAY_SOUND, NOTIFICATION_CLICKED, BROWSER_HISTORY_PUSH, OPEN_NOTIFICATIO
 import Config from 'common/config';
 import {Logger} from 'common/log';
 import ServerManager from 'common/servers/serverManager';
+import {setTestField} from 'common/utils/util';
 import viewManager from 'common/views/viewManager';
 import DeveloperMode from 'main/developerMode';
 import PermissionsManager from 'main/security/permissionsManager';
@@ -276,6 +277,10 @@ function flashFrame(flash: boolean) {
     if (process.platform === 'darwin' && Config.notifications.bounceIcon && Config.notifications.bounceIconType) {
         app.dock?.bounce(Config.notifications.bounceIconType);
     }
+}
+
+if (process.env.NODE_ENV === 'test') {
+    setTestField('__e2eFlashEffects', flashFrame);
 }
 
 const notificationManager = new NotificationManager();

--- a/src/main/notifications/index.ts
+++ b/src/main/notifications/index.ts
@@ -280,7 +280,7 @@ function flashFrame(flash: boolean) {
 }
 
 if (process.env.NODE_ENV === 'test') {
-    setTestField('__e2eFlashEffects', flashFrame);
+    setTestField('__e2eNotificationEffects', flashFrame);
 }
 
 const notificationManager = new NotificationManager();

--- a/src/main/testMessageBoxStub.ts
+++ b/src/main/testMessageBoxStub.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {dialog} from 'electron';
+
+type MessageBoxResponse = {
+    response: number;
+    checkboxChecked?: boolean;
+};
+
+let restoreMessageBox: typeof dialog.showMessageBox | undefined;
+
+export function installMessageBoxStub(responses: MessageBoxResponse[]) {
+    if (responses.length === 0) {
+        throw new Error('installMessageBoxStub requires at least one response');
+    }
+
+    if (!restoreMessageBox) {
+        restoreMessageBox = dialog.showMessageBox.bind(dialog);
+    }
+
+    let index = 0;
+    dialog.showMessageBox = async () => {
+        const next = responses[index] ?? responses[responses.length - 1];
+        index += 1;
+        return {
+            response: next.response,
+            checkboxChecked: next.checkboxChecked ?? false,
+        };
+    };
+}
+
+export function restoreMessageBoxStub() {
+    if (restoreMessageBox) {
+        dialog.showMessageBox = restoreMessageBox;
+        restoreMessageBox = undefined;
+    }
+}


### PR DESCRIPTION
This is a small set of changes to get CI running Playwright. This will put in the main hooks required by e2e tests specs to run tests from these pr. ([#3857](https://github.com/mattermost/desktop/pull/3857)–[#3864](https://github.com/mattermost/desktop/pull/3864)).

## Summary

Playwright’s Electron driver gives us a `BrowserWindow` pages for the app shell. Each Mattermost server renders in a **`WebContentsView`**, which is not a page we get from normal playwright execution. Finding and driving a specific server means going through main-process singletons like ViewManager, WebContentsManager, etc and not the page.click() alone.

To automate these flow we are using hooks. The `app.evaluate()` (main-process context) plus `global.__e2e*` refs to reach `ViewManager`, `WebContentsManager`, tray actions, etc. 

Its the same case with tray menus and native certificate dialogs. They are OS/main-process and not in the DOM. We need the `global.__e2e` refs.

---


In master we already have  ___e2eTestRefs_ (MainWindow, ServerManager, TabManager, ViewManager, WebContentsManager), ___e2eAppReady_ (intercom.ts), dock/taskbar badge hooks (badge.ts).

In this PR we are add more helper to test the scenarios mentioned in the beginning. 

> Why gate on NODE_ENV === 'test' (vs webapp-style always-on testdata)?

We do not want to push hooks to production app. In webapp we attache test fields to DOM. Here we're publishing handles on the Node main-process global. NODE_ENV === 'test' keeps normal user installs from getting those globals.

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Refactors and expands the cross-platform Playwright/Electron E2E harness (worker/global Electron main-process lifecycle, PID-registry reaping, teardown/“fast teardown” termination behavior, and evaluation/timeout/retry logic), plus CI workflow/caching and report-tag generation. While production runtime behavior is gated to `NODE_ENV=test` via `setTestField`/test-only stubs (message box, tray/deep-link/menu click wiring, flash effects exposure), the teardown and main-process evaluation/timeout paths are sensitive and could cause flaky E2E behavior, orphaned processes, or teardown timing regressions—especially on macOS.

**QA Recommendation:** Rely primarily on automated CI E2E coverage; minimal manual QA. If any failures occur, manually validate on the failing OS job(s) that the existing specs run under Playwright, the failing scenario reproduces reliably, and Electron shuts down cleanly with no orphan processes (and that behavior differs as expected between normal vs “fast teardown”), paying extra attention to macOS defaults snapshot/restore.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->