### PR TITLE
E2E: Main-process test hooks and shared helpers

### DIFF
--- a/e2e/helpers/dialog.ts
+++ b/e2e/helpers/dialog.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {ElectronApplication} from 'playwright';
+
+type MessageBoxResponse = {
+    response: number;
+    checkboxChecked?: boolean;
+};
+
+export async function stubMessageBoxResponses(
+    app: ElectronApplication,
+    responses: MessageBoxResponse[],
+): Promise<void> {
+    if (responses.length === 0) {
+        throw new Error('stubMessageBoxResponses requires at least one response');
+    }
+
+    await app.evaluate((_electron, value) => {
+        const stub = (global as any).__e2eStubMessageBoxResponses as ((responses: MessageBoxResponse[]) => void) | undefined;
+        if (!stub) {
+            throw new Error('__e2eStubMessageBoxResponses is not available');
+        }
+        stub(value);
+    }, responses);
+}
+
+export async function restoreMessageBox(app: ElectronApplication): Promise<void> {
+    await app.evaluate(() => {
+        const restore = (global as any).__e2eRestoreMessageBox as (() => void) | undefined;
+        if (restore) {
+            restore();
+        }
+    });
+}
+
+export async function clearCertificateErrorCallbacks(app: ElectronApplication): Promise<void> {
+    await app.evaluate(() => {
+        const clear = (global as any).__e2eClearCertificateErrorCallbacks as (() => void) | undefined;
+        clear?.();
+    });
+}

--- a/e2e/helpers/directLaunch.ts
+++ b/e2e/helpers/directLaunch.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {ElectronApplication} from 'playwright';
+import {_electron as electron} from 'playwright';
+
+import {waitForAppReady} from './appReadiness';
+import {electronBinaryPath, appDir, writeConfigFile, type AppConfig} from './config';
+import {registerElectronMainProcess} from './electronApp';
+
+export const DIRECT_LAUNCH_ARGS = [
+    '--no-sandbox',
+    '--disable-gpu',
+    '--disable-gpu-sandbox',
+    '--disable-dev-shm-usage',
+    '--no-zygote',
+    '--disable-software-rasterizer',
+    '--disable-breakpad',
+    '--disable-features=SpareRendererForSitePerProcess',
+    '--disable-features=CrossOriginOpenerPolicy',
+    '--disable-renderer-backgrounding',
+    '--no-first-run',
+    '--disable-default-apps',
+    '--disable-crash-reporter',
+    '--force-color-profile=srgb',
+    '--mute-audio',
+];
+
+export type LaunchDirectTestAppOptions = {
+    extraEnv?: Record<string, string>;
+    writeConfig?: boolean;
+};
+
+function resolveLaunchOptions(
+    extraEnvOrOptions: Record<string, string> | LaunchDirectTestAppOptions,
+): LaunchDirectTestAppOptions {
+    if ('writeConfig' in extraEnvOrOptions || 'extraEnv' in extraEnvOrOptions) {
+        return extraEnvOrOptions;
+    }
+    return {extraEnv: extraEnvOrOptions};
+}
+
+export async function launchDirectTestApp(
+    userDataDir: string,
+    config: AppConfig | object,
+    extraEnvOrOptions: Record<string, string> | LaunchDirectTestAppOptions = {},
+): Promise<ElectronApplication> {
+    const {extraEnv = {}, writeConfig = true} = resolveLaunchOptions(extraEnvOrOptions);
+
+    if (writeConfig) {
+        writeConfigFile(userDataDir, config as AppConfig);
+    }
+
+    const app = await electron.launch({
+        executablePath: electronBinaryPath,
+        args: [appDir, `--user-data-dir=${userDataDir}`, ...DIRECT_LAUNCH_ARGS],
+        env: {
+            ...process.env,
+            NODE_ENV: 'test',
+            RESOURCES_PATH: appDir,
+            ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
+            ELECTRON_NO_ATTACH_CONSOLE: 'true',
+            NODE_OPTIONS: '--no-warnings',
+            ...extraEnv,
+        },
+        timeout: process.platform === 'win32' ? 120_000 : 90_000,
+    });
+
+    registerElectronMainProcess(app.process()?.pid);
+    await waitForAppReady(app);
+    return app;
+}

--- a/e2e/helpers/login.ts
+++ b/e2e/helpers/login.ts
@@ -1,22 +1,43 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {expect} from '@playwright/test';
+
 import type {ServerView} from './serverView';
 
-async function waitForAppShell(win: ServerView, timeout: number) {
-    const results = await Promise.allSettled([
-        win.waitForSelector('#post_textbox', {timeout}),
-        win.waitForSelector('#channelHeaderTitle', {timeout}),
-        win.waitForSelector('input.search-bar.form-control', {timeout}),
-    ]);
+async function isMattermostServerUrl(win: ServerView): Promise<boolean> {
+    const url = await win.url().catch(() => '');
+    return url.startsWith('http://') || url.startsWith('https://');
+}
 
-    return results.some((result) => result.status === 'fulfilled');
+async function hasAppShell(win: ServerView): Promise<boolean> {
+    if (!(await isMattermostServerUrl(win))) {
+        return false;
+    }
+
+    return win.runInRenderer<boolean>(`
+        return Boolean(
+            document.querySelector('#post_textbox')
+            || document.querySelector('#channelHeaderTitle')
+            || document.querySelector('input.search-bar.form-control'),
+        );
+    `).catch(() => false);
+}
+
+async function hasLoginForm(win: ServerView): Promise<boolean> {
+    if (!(await isMattermostServerUrl(win))) {
+        return false;
+    }
+
+    return win.runInRenderer<boolean>(`
+        return Boolean(document.querySelector('#input_loginId'));
+    `).catch(() => false);
 }
 
 /**
  * Log in to a Mattermost server in the given window/page.
- * Requires MM_TEST_USER_NAME and MM_TEST_PASSWORD env vars.
- * Requires MM_TEST_SERVER_URL to be set in the app config (use demoMattermostConfig).
+ * Callers must ensure the server WebContentsView is loaded first
+ * (switch server, prepareMattermostServerView, waitForMattermostShell).
  */
 export async function loginToMattermost(win: ServerView): Promise<void> {
     const username = process.env.MM_TEST_USER_NAME;
@@ -26,33 +47,37 @@ export async function loginToMattermost(win: ServerView): Promise<void> {
         throw new Error('MM_TEST_USER_NAME and MM_TEST_PASSWORD must be set for tests requiring login');
     }
 
-    const timeout = process.platform === 'win32' ? 60_000 : 30_000;
-
+    const timeout = process.platform === 'win32' ? 60_000 : 45_000;
     const loginSelector = '#input_loginId';
     const passwordSelector = '#input_password-input, input[type="password"]';
-    const submitSelector = 'button[type="submit"]';
+    const submitSelector = '#saveSetting, button[type="submit"]';
 
-    let onLoginPage = false;
-    try {
-        await win.waitForSelector(loginSelector, {timeout});
-        onLoginPage = true;
-    } catch {
-        if (await waitForAppShell(win, 5_000)) {
-            return;
+    await expect.poll(async () => {
+        if (await hasAppShell(win)) {
+            return 'logged-in';
         }
-    }
+        if (await hasLoginForm(win)) {
+            return 'login-form';
+        }
+        return 'loading';
+    }, {
+        timeout,
+        intervals: [500, 1000, 2000],
+        message: `Mattermost login form or app shell must appear (URL: ${await win.url()})`,
+    }).not.toBe('loading');
 
-    if (!onLoginPage) {
-        throw new Error(`loginToMattermost: login form was not found and the app shell never appeared. Current URL: ${await win.url()}`);
+    if (await hasAppShell(win)) {
+        return;
     }
 
     await win.fill(loginSelector, username);
     await win.fill(passwordSelector, password);
     await win.click(submitSelector);
 
-    // Wait for login to complete: URL leaves /login
     await win.waitForURL((url) => !url.pathname.startsWith('/login'), {timeout});
-    if (!await waitForAppShell(win, timeout)) {
-        throw new Error(`loginToMattermost: login succeeded but the app shell never became ready. Current URL: ${await win.url()}`);
-    }
+    await expect.poll(async () => hasAppShell(win), {
+        timeout,
+        intervals: [500, 1000, 2000],
+        message: `Mattermost app shell must appear after login (URL: ${await win.url()})`,
+    }).toBe(true);
 }

--- a/e2e/helpers/notificationEffects.ts
+++ b/e2e/helpers/notificationEffects.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {ElectronApplication} from 'playwright';
+
+/**
+ * Invoke the production flashFrame() helper from src/main/notifications/index.ts.
+ *
+ * OS notification delivery is unreliable in headless CI (Electron's Notification
+ * often emits `failed` without `show`), so flash_taskbar and dock_bounce tests
+ * exercise the same flashFrame() gate the notification `show` handler calls.
+ */
+export async function triggerFlashEffects(app: ElectronApplication, flash = true): Promise<void> {
+    await app.evaluate((_, shouldFlash: boolean) => {
+        const trigger = (global as any).__e2eFlashEffects as ((value: boolean) => void) | undefined;
+        if (!trigger) {
+            throw new Error('__e2eFlashEffects not exposed (NODE_ENV must be test)');
+        }
+        trigger(shouldFlash);
+    }, flash);
+}

--- a/e2e/helpers/overlayWindows.ts
+++ b/e2e/helpers/overlayWindows.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {ElectronApplication} from 'playwright';
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export async function closeOverlayWindowsIfOpen(app: ElectronApplication, timeoutMs = 3_000): Promise<void> {
+    // app.evaluate can hang if the Electron main process is blocked or unresponsive
+    // (e.g. during teardown). Cap the wait so setup/teardown never deadlock.
+    const closePromise = app.evaluate(({BrowserWindow}) => {
+        for (const win of BrowserWindow.getAllWindows()) {
+            if (win.isDestroyed()) {
+                continue;
+            }
+            try {
+                const url = win.webContents.getURL();
+                if (url.includes('dropdown') || url.includes('downloadsDropdown.html')) {
+                    win.close();
+                }
+            } catch {
+                // Ignore windows that disappear while iterating.
+            }
+        }
+    }).catch(() => {
+        // Ignore evaluation failures (e.g. app already shutting down).
+    });
+
+    await Promise.race([closePromise, sleep(timeoutMs)]);
+}

--- a/e2e/helpers/prepareServerView.ts
+++ b/e2e/helpers/prepareServerView.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {ElectronApplication} from 'playwright';
+
+import {closeOverlayWindowsIfOpen} from './overlayWindows';
+
+/**
+ * Close overlay windows and focus a Mattermost server WebContentsView so
+ * renderer automation targets the channel UI instead of dropdown overlays.
+ */
+export async function prepareMattermostServerView(
+    app: ElectronApplication,
+    webContentsId: number,
+): Promise<void> {
+    await closeOverlayWindowsIfOpen(app);
+    await app.evaluate(({webContents}, id) => {
+        const wc = webContents.fromId(id);
+        if (!wc || wc.isDestroyed()) {
+            throw new Error(`webContents ${id} is not available`);
+        }
+        wc.focus();
+    }, webContentsId);
+}

--- a/e2e/helpers/serverMap.ts
+++ b/e2e/helpers/serverMap.ts
@@ -28,7 +28,14 @@ export async function buildServerMap(app: ElectronApplication): Promise<ServerMa
                 const servers = refs.ServerManager.getAllServers();
                 return servers.flatMap((server: {id: string; name: string}) => {
                     const views = refs.ViewManager.getViewsByServerId(server.id);
-                    return views.map((view: {id: string}) => {
+                    const orderedTabs: Array<{id: string}> = refs.TabManager?.getOrderedTabsForServer?.(server.id) ?? [];
+                    const orderedTabIds = orderedTabs.map((tab) => tab.id);
+                    const sortedViews = [...views].sort((a: {id: string}, b: {id: string}) => {
+                        const ai = orderedTabIds.indexOf(a.id);
+                        const bi = orderedTabIds.indexOf(b.id);
+                        return (ai === -1 ? Number.MAX_SAFE_INTEGER : ai) - (bi === -1 ? Number.MAX_SAFE_INTEGER : bi);
+                    });
+                    return sortedViews.map((view: {id: string}) => {
                         const webContentsView = refs.WebContentsManager.getView(view.id);
                         if (!webContentsView) {
                             return null;
@@ -64,10 +71,6 @@ export async function buildServerMap(app: ElectronApplication): Promise<ServerMa
                 webContentsId: entry.webContentsId,
             });
         }
-
-        Object.values(map).forEach((serverEntries) => {
-            serverEntries.sort((left, right) => left.webContentsId - right.webContentsId);
-        });
 
         if (Object.keys(map).length > 0) {
             return map;

--- a/e2e/helpers/serverView.ts
+++ b/e2e/helpers/serverView.ts
@@ -525,7 +525,11 @@ export class ServerView {
                 throw new Error(`${result.__e2eError}${result.__e2eStack ? `\n${result.__e2eStack}` : ''}`);
             }
 
-            return result?.__e2eResult;
+            let value = result?.__e2eResult;
+            if (value && typeof (value as Promise<unknown>).then === 'function') {
+                value = await value;
+            }
+            return value;
         }, {id: this.webContentsId, body, userGesture}) as Promise<T>;
     }
 
@@ -535,10 +539,21 @@ export class ServerView {
     }
 
     async url() {
-        return this.app.evaluate(({webContents}, id) => {
-            const wc = webContents.fromId(id);
-            return wc?.getURL() ?? '';
-        }, this.webContentsId);
+        try {
+            return await this.app.evaluate(({webContents}, id) => {
+                const wc = webContents.fromId(id);
+                return wc?.getURL() ?? '';
+            }, this.webContentsId);
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            if (
+                message.includes('Execution context was destroyed') ||
+                message.includes('Target page, context or browser has been closed')
+            ) {
+                return '';
+            }
+            throw error;
+        }
     }
 
     async waitForFunction<T>(

--- a/e2e/helpers/testRefs.ts
+++ b/e2e/helpers/testRefs.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect} from '@playwright/test';
+import type {ElectronApplication} from 'playwright';
+
+const TRANSIENT_EVALUATE_ERRORS = [
+    'Execution context was destroyed',
+    'Target page, context or browser has been closed',
+    'Unable to find context',
+];
+
+export function isTransientEvaluateError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return TRANSIENT_EVALUATE_ERRORS.some((part) => message.includes(part));
+}
+
+export async function evaluateInMainProcess<T>(
+    app: ElectronApplication,
+    pageFunction: () => T,
+    options: {timeoutMs?: number; retryDelayMs?: number} = {},
+): Promise<T> {
+    const timeoutMs = options.timeoutMs ?? 15_000;
+    const retryDelayMs = options.retryDelayMs ?? 100;
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+        try {
+            return await app.evaluate(pageFunction);
+        } catch (error) {
+            if (!isTransientEvaluateError(error)) {
+                throw error;
+            }
+            await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+        }
+    }
+
+    throw new Error('Timed out waiting for electron main-process evaluate');
+}
+
+type MainProcessEvaluatorWithArg<T, A> = (
+    _electron: typeof import('electron'),
+    arg: A,
+) => T | Promise<T>;
+
+export async function evaluateInMainProcessWithArg<T, A>(
+    app: ElectronApplication,
+    pageFunction: MainProcessEvaluatorWithArg<T, A>,
+    arg: A,
+    options: {timeoutMs?: number; retryDelayMs?: number} = {},
+): Promise<T> {
+    const timeoutMs = options.timeoutMs ?? 15_000;
+    const retryDelayMs = options.retryDelayMs ?? 100;
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+        try {
+            // Must call on `app` — extracting `app.evaluate` drops `this` and breaks _channel.
+            return await (app.evaluate as (
+                fn: MainProcessEvaluatorWithArg<T, A>,
+                value: A,
+            ) => Promise<T>).call(app, pageFunction, arg);
+        } catch (error) {
+            if (!isTransientEvaluateError(error)) {
+                throw error;
+            }
+            await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+        }
+    }
+
+    throw new Error('Timed out waiting for electron main-process evaluate');
+}
+
+export async function getMainWindowId(app: ElectronApplication): Promise<number> {
+    let mainWindowId: number | null = null;
+    await expect.poll(async () => {
+        try {
+            mainWindowId = await app.evaluate(() => {
+                const refs = (global as any).__e2eTestRefs;
+                const win = refs?.MainWindow?.get?.();
+                return win?.id ?? null;
+            });
+            return mainWindowId;
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            if (
+                message.includes('Execution context was destroyed') ||
+                message.includes('Target page, context or browser has been closed')
+            ) {
+                return null;
+            }
+            throw error;
+        }
+    }, {
+        timeout: 30_000,
+        intervals: [200, 500, 1000],
+        message: 'MainWindow id must be resolvable via __e2eTestRefs',
+    }).not.toBeNull();
+
+    if (mainWindowId == null) {
+        throw new Error('MainWindow id was not available via __e2eTestRefs');
+    }
+    return mainWindowId;
+}
+
+export async function getActiveServerWebContentsId(app: ElectronApplication): Promise<number> {
+    const id = await app.evaluate(() => {
+        const refs = (global as any).__e2eTestRefs;
+        const view = refs?.TabManager?.getCurrentActiveTabView?.();
+        return view?.webContentsId ?? null;
+    });
+    if (id == null) {
+        throw new Error('Active server webContents id was not available via TabManager');
+    }
+    return id;
+}

--- a/e2e/helpers/tray.ts
+++ b/e2e/helpers/tray.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {ElectronApplication} from 'playwright';
+
+import {evaluateInMainProcess, evaluateInMainProcessWithArg} from './testRefs';
+
+export async function emitTrayIconClick(app: ElectronApplication): Promise<void> {
+    await evaluateInMainProcess(app, () => {
+        const refs = (global as any).__e2eTestRefs;
+        const tray = refs?.TrayIcon?.tray;
+        if (!tray || tray.isDestroyed?.()) {
+            throw new Error('Tray icon is not initialized');
+        }
+        tray.emit('click');
+    });
+}
+
+export async function clickTrayMenuItem(app: ElectronApplication, label: string): Promise<void> {
+    await evaluateInMainProcessWithArg(app, (_electron, menuLabel) => {
+        const clickTrayMenuItem = (global as any).__e2eClickTrayMenuItem as ((value: string) => void) | undefined;
+        if (!clickTrayMenuItem) {
+            throw new Error('__e2eClickTrayMenuItem not exposed (NODE_ENV must be test)');
+        }
+        clickTrayMenuItem(menuLabel);
+    }, label);
+}
+
+export async function isMainWindowVisible(app: ElectronApplication): Promise<boolean> {
+    return evaluateInMainProcess(app, () => {
+        const refs = (global as any).__e2eTestRefs;
+        const mainWindow = refs?.MainWindow?.get?.();
+        return Boolean(mainWindow && !mainWindow.isDestroyed() && mainWindow.isVisible());
+    });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "eslint-plugin-no-only-tests": "3.1.0",
         "eslint-plugin-react": "7.34.0",
         "eslint-plugin-react-hooks": "4.6.0",
+        "fast-xml-parser": "^5.8.0",
         "html-webpack-plugin": "5.5.0",
         "jest": "29.4.1",
         "jest-junit": "13.1.0",
@@ -85,7 +86,7 @@
     },
     "api-types": {
       "name": "@mattermost/desktop-api",
-      "version": "6.2.0-1",
+      "version": "6.3.0-1",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -4051,6 +4052,18 @@
         }
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ]
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -6017,6 +6030,18 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ]
     },
     "node_modules/app-builder-bin": {
       "version": "5.0.0-alpha.12",
@@ -10382,6 +10407,44 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -15978,6 +16041,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -18234,6 +18312,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
+    },
     "node_modules/style-loader": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
@@ -19693,6 +19786,21 @@
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
       "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
       "dev": true
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "eslint-plugin-no-only-tests": "3.1.0",
     "eslint-plugin-react": "7.34.0",
     "eslint-plugin-react-hooks": "4.6.0",
+    "fast-xml-parser": "^5.8.0",
     "html-webpack-plugin": "5.5.0",
     "jest": "29.4.1",
     "jest-junit": "13.1.0",

--- a/src/main/app/initialize.test.js
+++ b/src/main/app/initialize.test.js
@@ -197,6 +197,11 @@ jest.mock('app/tabs/tabManager', () => ({
     on: jest.fn(),
 }));
 
+jest.mock('app/windows/popoutManager', () => ({
+    __esModule: true,
+    default: {},
+}));
+
 jest.mock('main/developerMode', () => ({
     on: jest.fn(),
     switchOff: jest.fn(),
@@ -215,6 +220,10 @@ jest.mock('common/views/viewManager', () => ({
 
 jest.mock('app/menus', () => ({
     refreshMenu: jest.fn(),
+}));
+jest.mock('app/menus/tray', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({items: []})),
 }));
 
 jest.mock('main/security/preAuthManager', () => ({

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -12,11 +12,13 @@ import Joi from 'joi';
 
 import MainWindow from 'app/mainWindow/mainWindow';
 import MenuManager from 'app/menus';
+import createTrayMenu from 'app/menus/tray';
 import NavigationManager from 'app/navigationManager';
 import {setupBadge} from 'app/system/badge';
 import Tray from 'app/system/tray/tray';
 import TabManager from 'app/tabs/tabManager';
 import WebContentsManager from 'app/views/webContentsManager';
+import PopoutManager from 'app/windows/popoutManager';
 import {
     QUIT,
     NOTIFY_MENTION,
@@ -52,10 +54,11 @@ import AutoLauncher from 'main/AutoLauncher';
 import {configPath, updatePaths} from 'main/constants';
 import CriticalErrorHandler from 'main/CriticalErrorHandler';
 import DeveloperMode from 'main/developerMode';
+import Diagnostics from 'main/diagnostics';
 import downloadsManager from 'main/downloadsManager';
 import i18nManager from 'main/i18nManager';
 import NonceManager from 'main/nonceManager';
-import {getDoNotDisturb} from 'main/notifications';
+import NotificationManager, {getDoNotDisturb} from 'main/notifications';
 import parseArgs from 'main/ParseArgs';
 import PerformanceMonitor from 'main/performanceMonitor';
 import secureStorage from 'main/secureStorage';
@@ -64,6 +67,7 @@ import PermissionsManager from 'main/security/permissionsManager';
 import PreAuthManager from 'main/security/preAuthManager';
 import sentryHandler from 'main/sentryHandler';
 import SessionAttributesManager from 'main/sessionAttributes/sessionAttributesManager';
+import {installMessageBoxStub, restoreMessageBoxStub} from 'main/testMessageBoxStub';
 import updateNotifier from 'main/updateNotifier';
 import UserActivityMonitor from 'main/UserActivityMonitor';
 
@@ -75,6 +79,7 @@ import {
     handleAppWillFinishLaunching,
     handleAppWindowAllClosed,
     handleChildProcessGone,
+    certificateErrorCallbacks,
 } from './app';
 import {
     handleConfigUpdate,
@@ -98,6 +103,7 @@ import {
 import {
     clearAppCache,
     getDeeplinkingURL,
+    openDeepLink,
     shouldShowTrayIcon,
     updateSpellCheckerLocales,
     wasUpdated,
@@ -294,6 +300,36 @@ async function initializeAfterAppReady() {
         TabManager,
         ViewManager,
         WebContentsManager,
+        Config,
+        TrayIcon: Tray,
+        NotificationManager,
+        Diagnostics,
+        updateNotifier,
+        PopoutManager,
+    });
+
+    setTestField('__e2eOpenDeepLink', (url: string) => {
+        openDeepLink(url);
+    });
+
+    setTestField('__e2eClickTrayMenuItem', (label: string) => {
+        const menu = createTrayMenu();
+        const stack = [...menu.items];
+        while (stack.length > 0) {
+            const item = stack.shift();
+            if (!item) {
+                continue;
+            }
+            const itemLabel = typeof item.label === 'string' ? item.label : '';
+            const truncatedMenuLabel = label.length > 50 ? `${label.slice(0, 50)}...` : label;
+            if ((itemLabel === label || itemLabel === truncatedMenuLabel) && typeof item.click === 'function') {
+                item.click();
+                return;
+            }
+            const submenuItems = item.submenu?.items ?? [];
+            stack.push(...submenuItems);
+        }
+        throw new Error(`Tray menu item not found: ${label}`);
     });
 
     // Block all NTLM/Negotiate requests by default
@@ -338,6 +374,17 @@ async function initializeAfterAppReady() {
     ServerManager.on(SERVER_ADDED, updateServerInfo);
     ServerManager.on(SERVER_URL_CHANGED, updateServerInfo);
     ServerManager.on(SERVER_PRE_AUTH_SECRET_CHANGED, updateServerInfo);
+
+    if (process.env.NODE_ENV === 'test') {
+        setTestField('__e2eStubMessageBoxResponses', installMessageBoxStub);
+        setTestField('__e2eRestoreMessageBox', restoreMessageBoxStub);
+        setTestField('__e2eClearCertificateErrorCallbacks', () => certificateErrorCallbacks.clear());
+        if (process.env.MM_E2E_STUB_MESSAGE_BOX === 'cancel') {
+            installMessageBoxStub([{response: 1}]);
+        } else if (process.env.MM_E2E_STUB_MESSAGE_BOX === 'trust') {
+            installMessageBoxStub([{response: 0}, {response: 0}]);
+        }
+    }
 
     ServerManager.on(SERVER_ADDED, PreAuthManager.loadPreAuthSecretForServer);
     ServerManager.init();

--- a/src/main/notifications/index.ts
+++ b/src/main/notifications/index.ts
@@ -12,6 +12,7 @@ import {PLAY_SOUND, NOTIFICATION_CLICKED, BROWSER_HISTORY_PUSH, OPEN_NOTIFICATIO
 import Config from 'common/config';
 import {Logger} from 'common/log';
 import ServerManager from 'common/servers/serverManager';
+import {setTestField} from 'common/utils/util';
 import viewManager from 'common/views/viewManager';
 import DeveloperMode from 'main/developerMode';
 import PermissionsManager from 'main/security/permissionsManager';
@@ -276,6 +277,10 @@ function flashFrame(flash: boolean) {
     if (process.platform === 'darwin' && Config.notifications.bounceIcon && Config.notifications.bounceIconType) {
         app.dock?.bounce(Config.notifications.bounceIconType);
     }
+}
+
+if (process.env.NODE_ENV === 'test') {
+    setTestField('__e2eFlashEffects', flashFrame);
 }
 
 const notificationManager = new NotificationManager();

--- a/src/main/testMessageBoxStub.ts
+++ b/src/main/testMessageBoxStub.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {dialog} from 'electron';
+
+type MessageBoxResponse = {
+    response: number;
+    checkboxChecked?: boolean;
+};
+
+let restoreMessageBox: typeof dialog.showMessageBox | undefined;
+
+export function installMessageBoxStub(responses: MessageBoxResponse[]) {
+    if (responses.length === 0) {
+        throw new Error('installMessageBoxStub requires at least one response');
+    }
+
+    if (!restoreMessageBox) {
+        restoreMessageBox = dialog.showMessageBox.bind(dialog);
+    }
+
+    let index = 0;
+    dialog.showMessageBox = async () => {
+        const next = responses[index] ?? responses[responses.length - 1];
+        index += 1;
+        return {
+            response: next.response,
+            checkboxChecked: next.checkboxChecked ?? false,
+        };
+    };
+}
+
+export function restoreMessageBoxStub() {
+    if (restoreMessageBox) {
+        dialog.showMessageBox = restoreMessageBox;
+        restoreMessageBox = undefined;
+    }
+}


### PR DESCRIPTION
## Summary
Stacked PR **2/10** splitting #3847.

- Main-process E2E hooks (`initialize.ts`, message-box stub, flash effects)
- Shared helpers: `directLaunch`, `testRefs`, `dialog`, `tray`, etc.

## Test plan
- [ ] `npm run test:unit -- src/main/app/initialize.test.js`
- [ ] E2E smoke on existing specs

## Stack
Base: `e2e/01-harness-ci` · Next slices branch from this PR