### PR TITLE
E2E: Tray, settings, and deep linking

### DIFF
--- a/e2e/helpers/deeplink.ts
+++ b/e2e/helpers/deeplink.ts
@@ -7,8 +7,9 @@ import type {ElectronApplication} from 'playwright';
 import {buildServerMap} from './serverMap';
 
 export function mattermostDeepLinkUrl(hostAndPath: string): string {
-    const protocol = process.env.NODE_ENV === 'test' ? 'mattermost-dev' : 'mattermost';
-    return `${protocol}://${hostAndPath}`;
+    // E2E always launches the unpacked binary (electron-is-dev=true), so deep links
+    // must use mattermost-dev:// regardless of the Playwright worker's NODE_ENV.
+    return `mattermost-dev://${hostAndPath}`;
 }
 
 /** Build a channel deep link that preserves the team path from the configured server URL. */

--- a/e2e/helpers/deeplink.ts
+++ b/e2e/helpers/deeplink.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect} from '@playwright/test';
+import type {ElectronApplication} from 'playwright';
+
+import {buildServerMap} from './serverMap';
+
+export function mattermostDeepLinkUrl(hostAndPath: string): string {
+    const protocol = process.env.NODE_ENV === 'test' ? 'mattermost-dev' : 'mattermost';
+    return `${protocol}://${hostAndPath}`;
+}
+
+/** Build a channel deep link that preserves the team path from the configured server URL. */
+export function channelDeepLinkUrl(serverUrl: string, channelName: string): string {
+    const normalized = serverUrl.endsWith('/') ? serverUrl : `${serverUrl}/`;
+    const parsed = new URL(normalized);
+    const teamPath = parsed.pathname.replace(/\/$/, '');
+    const channelPath = teamPath ? `${teamPath}/channels/${channelName}` : `/channels/${channelName}`;
+    return mattermostDeepLinkUrl(`${parsed.host}${channelPath}`);
+}
+
+export async function openDeepLinkInApp(app: ElectronApplication, url: string): Promise<void> {
+    await app.evaluate((_, deepLinkUrl) => {
+        const openDeepLink = (global as any).__e2eOpenDeepLink as ((value: string) => void) | undefined;
+        if (!openDeepLink) {
+            throw new Error('__e2eOpenDeepLink not exposed (NODE_ENV must be test)');
+        }
+        openDeepLink(deepLinkUrl);
+    }, url);
+}
+
+/** Poll any tab for the server until one navigates to the expected channel. */
+export async function waitForServerChannelNavigation(
+    app: ElectronApplication,
+    serverName: string,
+    channelName: string,
+    options?: {timeout?: number},
+): Promise<void> {
+    await expect.poll(async () => {
+        const map = await buildServerMap(app);
+        const entries = map[serverName] ?? [];
+        for (const entry of entries) {
+            const url = await entry.win.url();
+            if (url.includes(channelName)) {
+                return true;
+            }
+        }
+        return false;
+    }, {
+        timeout: options?.timeout ?? 15_000,
+        message: `Server view should navigate to ${channelName}`,
+    }).toBe(true);
+}

--- a/e2e/specs/deep_linking/deeplink.test.ts
+++ b/e2e/specs/deep_linking/deeplink.test.ts
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 
 import type {ElectronApplication} from 'playwright';
@@ -10,7 +9,7 @@ import type {ElectronApplication} from 'playwright';
 import {test, expect} from '../../fixtures/index';
 import {waitForAppReady} from '../../helpers/appReadiness';
 import {electronBinaryPath, appDir, demoConfig} from '../../helpers/config';
-import {waitForLockFileRelease} from '../../helpers/cleanup';
+import {closeElectronAppFast, registerElectronMainProcess} from '../../helpers/electronApp';
 import {buildServerMap} from '../../helpers/serverMap';
 
 test.describe('application', () => {
@@ -18,8 +17,6 @@ test.describe('application', () => {
     let userDataDir: string;
 
     test.beforeAll(async ({}, testInfo) => {
-        test.skip(process.platform !== 'win32', 'Windows only deep link test');
-
         userDataDir = path.join(testInfo.outputDir, 'userdata');
         fs.mkdirSync(userDataDir, {recursive: true});
         fs.writeFileSync(path.join(userDataDir, 'config.json'), JSON.stringify(demoConfig));
@@ -36,19 +33,12 @@ test.describe('application', () => {
             timeout: 60_000,
         });
 
-        const pid = app.process()?.pid;
-        if (pid) {
-            const registry = path.join(os.tmpdir(), 'mattermost-desktop-e2e-main-pids.txt');
-            try {
-                fs.appendFileSync(registry, `${pid}\n`, 'utf8');
-            } catch { /* non-fatal */ }
-        }
+        registerElectronMainProcess(app.process()?.pid);
     });
 
     test.afterAll(async () => {
-        await app?.close();
-        if (userDataDir) {
-            await waitForLockFileRelease(userDataDir).catch(() => {});
+        if (app && userDataDir) {
+            await closeElectronAppFast(app, userDataDir);
         }
     });
 
@@ -97,7 +87,64 @@ test.describe('application', () => {
             const freshView = freshMap[serverName]?.[0]?.win;
             return freshView?.url() ?? '';
         }, {timeout: 30_000, message: 'deep-linked webContents did not navigate to the expected URL'}).toContain('github.com/test/url');
-        const dropdownButtonText = await mainWindow.innerText('.ServerDropdownButton');
-        expect(dropdownButtonText).toBe('github');
+
+        await expect.poll(
+            () => mainWindow.innerText('.ServerDropdownButton'),
+            {timeout: 15_000, message: 'deep link should activate the github server in the UI'},
+        ).toBe('github');
     });
+});
+
+test.describe('macOS open-url deep link', () => {
+    let app: ElectronApplication | undefined;
+    let userDataDir: string;
+
+    test.beforeAll(async ({}, testInfo) => {
+        userDataDir = path.join(testInfo.outputDir, 'open-url-userdata');
+        fs.mkdirSync(userDataDir, {recursive: true});
+        fs.writeFileSync(path.join(userDataDir, 'config.json'), JSON.stringify(demoConfig));
+
+        const {_electron: electron} = await import('playwright');
+
+        app = await electron.launch({
+            executablePath: electronBinaryPath,
+            args: [appDir, `--user-data-dir=${userDataDir}`, '--no-sandbox', '--disable-gpu'],
+            env: {...process.env, NODE_ENV: 'test'},
+            timeout: 60_000,
+        });
+
+        registerElectronMainProcess(app.process()?.pid);
+    });
+
+    test.afterAll(async () => {
+        if (app && userDataDir) {
+            await closeElectronAppFast(app, userDataDir);
+        }
+    });
+
+    test(
+        'DL-02 macOS cold start via open-url event navigates to deep link',
+        {tag: ['@P1', '@darwin']},
+        async () => {
+            await waitForAppReady(app!);
+
+            await app!.evaluate(({app: electronApp}) => {
+                electronApp.emit('open-url', {preventDefault: () => undefined}, 'mattermost-dev://github.com/test/url');
+            });
+
+            const serverName = demoConfig.servers[1].name;
+            await expect.poll(async () => {
+                const freshMap = await buildServerMap(app!);
+                const freshView = freshMap[serverName]?.[0]?.win;
+                return freshView?.url() ?? '';
+            }, {timeout: 30_000, message: 'open-url deep link should navigate the target server view'}).toContain('github.com/test/url');
+
+            const mainWindow = app!.windows().find((window) => window.url().includes('index'));
+            expect(mainWindow).toBeDefined();
+            await expect.poll(
+                () => mainWindow!.innerText('.ServerDropdownButton'),
+                {timeout: 15_000},
+            ).toBe('github');
+        },
+    );
 });

--- a/e2e/specs/deep_linking/deeplink.test.ts
+++ b/e2e/specs/deep_linking/deeplink.test.ts
@@ -96,53 +96,25 @@ test.describe('application', () => {
 });
 
 test.describe('macOS open-url deep link', () => {
-    let app: ElectronApplication | undefined;
-    let userDataDir: string;
-
-    test.beforeAll(async ({}, testInfo) => {
-        userDataDir = path.join(testInfo.outputDir, 'open-url-userdata');
-        fs.mkdirSync(userDataDir, {recursive: true});
-        fs.writeFileSync(path.join(userDataDir, 'config.json'), JSON.stringify(demoConfig));
-
-        const {_electron: electron} = await import('playwright');
-
-        app = await electron.launch({
-            executablePath: electronBinaryPath,
-            args: [appDir, `--user-data-dir=${userDataDir}`, '--no-sandbox', '--disable-gpu'],
-            env: {...process.env, NODE_ENV: 'test'},
-            timeout: 60_000,
-        });
-
-        registerElectronMainProcess(app.process()?.pid);
-    });
-
-    test.afterAll(async () => {
-        if (app && userDataDir) {
-            await closeElectronAppFast(app, userDataDir);
-        }
-    });
+    test.use({appConfig: demoConfig});
 
     test(
         'DL-02 macOS cold start via open-url event navigates to deep link',
         {tag: ['@P1', '@darwin']},
-        async () => {
-            await waitForAppReady(app!);
-
-            await app!.evaluate(({app: electronApp}) => {
+        async ({electronApp, mainWindow}) => {
+            await electronApp.evaluate(({app: electronApp}) => {
                 electronApp.emit('open-url', {preventDefault: () => undefined}, 'mattermost-dev://github.com/test/url');
             });
 
             const serverName = demoConfig.servers[1].name;
             await expect.poll(async () => {
-                const freshMap = await buildServerMap(app!);
+                const freshMap = await buildServerMap(electronApp);
                 const freshView = freshMap[serverName]?.[0]?.win;
                 return freshView?.url() ?? '';
             }, {timeout: 30_000, message: 'open-url deep link should navigate the target server view'}).toContain('github.com/test/url');
 
-            const mainWindow = app!.windows().find((window) => window.url().includes('index'));
-            expect(mainWindow).toBeDefined();
             await expect.poll(
-                () => mainWindow!.innerText('.ServerDropdownButton'),
+                () => mainWindow.innerText('.ServerDropdownButton'),
                 {timeout: 15_000},
             ).toBe('github');
         },

--- a/e2e/specs/deep_linking/deeplink_running.test.ts
+++ b/e2e/specs/deep_linking/deeplink_running.test.ts
@@ -1,10 +1,9 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {execSync} from 'child_process';
-
-import {test, expect} from '../../fixtures/index';
-import {mattermostURL, demoMattermostConfig} from '../../helpers/config';
+import {test} from '../../fixtures/index';
+import {mattermostURL, demoMattermostConfig, type AppConfig} from '../../helpers/config';
+import {channelDeepLinkUrl, openDeepLinkInApp, waitForServerChannelNavigation} from '../../helpers/deeplink';
 import {loginToMattermost} from '../../helpers/login';
 
 // Use a real Mattermost server config so serverMap.example points to localhost:8065
@@ -13,12 +12,7 @@ test.use({appConfig: demoMattermostConfig});
 test(
     'deep link navigates to correct server while app is running',
     {tag: ['@P1', '@darwin', '@win32']},
-    async ({serverMap}) => {
-        if (process.platform === 'linux') {
-            test.skip(true, 'Deep link not supported on Linux');
-            return;
-        }
-
+    async ({electronApp, serverMap}) => {
         if (!process.env.MM_TEST_SERVER_URL) {
             test.skip(true, 'MM_TEST_SERVER_URL required');
             return;
@@ -33,23 +27,53 @@ test(
         await loginToMattermost(serverWin);
         await serverWin.waitForSelector('#sidebarItem_town-square', {timeout: 30_000});
 
-        // Trigger deep link from the OS
         const channelName = 'town-square';
-        const deepLink = `mattermost://${new URL(mattermostURL).host}/channels/${channelName}`;
+        const deepLink = channelDeepLinkUrl(mattermostURL, channelName);
 
-        if (process.platform === 'darwin') {
-            execSync(`open "${deepLink}"`);
-        } else if (process.platform === 'win32') {
-            execSync(`start "" "${deepLink}"`);
-        }
-
-        // Wait for navigation to the linked channel
-        await expect.poll(
-            () => serverWin!.url(),
-            {
-                timeout: 15_000,
-                message: `Server view should navigate to ${channelName}`,
-            },
-        ).toContain(channelName);
+        await openDeepLinkInApp(electronApp, deepLink);
+        await waitForServerChannelNavigation(electronApp, 'example', channelName);
     },
 );
+
+test.describe('deep link server URL without trailing slash', () => {
+    const serverUrlWithoutSlash = mattermostURL.replace(/\/$/, '');
+    const configWithoutTrailingSlash: AppConfig = {
+        ...demoMattermostConfig,
+        servers: demoMattermostConfig.servers.map((server, index) => (
+            index === 0 ? {...server, url: serverUrlWithoutSlash} : server
+        )),
+    };
+
+    test.use({appConfig: configWithoutTrailingSlash});
+
+    test(
+        'DL-01 deep link navigates when configured server URL has no trailing slash',
+        {tag: ['@P1', '@darwin', '@win32']},
+        async ({electronApp, serverMap}) => {
+            if (!process.env.MM_TEST_SERVER_URL) {
+                test.skip(true, 'MM_TEST_SERVER_URL required');
+                return;
+            }
+
+            const serverWin = serverMap.example?.[0]?.win;
+            if (!serverWin) {
+                test.skip(true, 'No server view available');
+                return;
+            }
+
+            await loginToMattermost(serverWin);
+            await serverWin.waitForSelector('#sidebarItem_town-square', {timeout: 30_000});
+
+            const channelName = 'off-topic';
+            const deepLink = channelDeepLinkUrl(serverUrlWithoutSlash, channelName);
+
+            await openDeepLinkInApp(electronApp, deepLink);
+            await waitForServerChannelNavigation(
+                electronApp,
+                'example',
+                channelName,
+                {timeout: 15_000},
+            );
+        },
+    );
+});

--- a/e2e/specs/deep_linking/oauth_callback.test.ts
+++ b/e2e/specs/deep_linking/oauth_callback.test.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {test, expect} from '../../fixtures/index';
+import {waitForAppReady} from '../../helpers/appReadiness';
+import {demoConfig} from '../../helpers/config';
+import {mattermostDeepLinkUrl, openDeepLinkInApp} from '../../helpers/deeplink';
+import {buildServerMap} from '../../helpers/serverMap';
+
+test(
+    'DL-03 OAuth callback deep link navigates the active server view',
+    {tag: ['@P1', '@all']},
+    async ({electronApp}) => {
+        await waitForAppReady(electronApp);
+
+        const serverName = demoConfig.servers[0].name;
+        const oauthPath = '/oauth/authorize?client_id=desktop&response_type=code&state=e2e-test';
+        const deepLink = mattermostDeepLinkUrl(`example.com${oauthPath}`);
+
+        await openDeepLinkInApp(electronApp, deepLink);
+
+        await expect.poll(async () => {
+            const serverMap = await buildServerMap(electronApp);
+            const view = serverMap[serverName]?.[0]?.win;
+            return view?.url() ?? '';
+        }, {
+            timeout: 30_000,
+            message: 'OAuth callback deep link should navigate the example server view',
+        }).toContain('example.com/oauth/authorize');
+
+        const mainWindow = electronApp.windows().find((window) => window.url().includes('index'));
+        expect(mainWindow).toBeDefined();
+        await expect.poll(
+            () => mainWindow!.innerText('.ServerDropdownButton'),
+            {timeout: 15_000},
+        ).toBe(serverName);
+    },
+);

--- a/e2e/specs/policy/policy.test.ts
+++ b/e2e/specs/policy/policy.test.ts
@@ -9,8 +9,8 @@ import {_electron as electron} from 'playwright';
 
 import {test, expect} from '../../fixtures/index';
 import {waitForAppReady} from '../../helpers/appReadiness';
-import {waitForLockFileRelease} from '../../helpers/cleanup';
 import {appDir, demoConfig, electronBinaryPath, exampleURL, mattermostURL, writeConfigFile} from '../../helpers/config';
+import {closeElectronAppFast} from '../../helpers/electronApp';
 import {buildServerMap} from '../../helpers/serverMap';
 
 const isSupported = (process.platform === 'win32' || process.platform === 'darwin') && process.env.RUN_POLICY_E2E === 'true';
@@ -187,8 +187,10 @@ async function launchPolicyApp(testInfo: {outputDir: string}, options: LaunchOpt
 }
 
 async function closePolicyApp(app: Awaited<ReturnType<typeof electron.launch>> | undefined, userDataDir: string) {
-    await app?.close().catch(() => {});
-    await waitForLockFileRelease(userDataDir).catch(() => {});
+    if (!app) {
+        return;
+    }
+    await closeElectronAppFast(app, userDataDir);
 }
 
 async function getMainWindow(app: Awaited<ReturnType<typeof electron.launch>>) {

--- a/e2e/specs/popup.test.ts
+++ b/e2e/specs/popup.test.ts
@@ -9,7 +9,7 @@ import {test, expect} from '../fixtures/index';
 import {cmdOrCtrl, demoMattermostConfig} from '../helpers/config';
 import {waitForAppReady} from '../helpers/appReadiness';
 import {appDir, electronBinaryPath, writeConfigFile} from '../helpers/config';
-import {waitForWindow, closeElectronApp} from '../helpers/electronApp';
+import {waitForWindow, closeElectronAppFast} from '../helpers/electronApp';
 import {loginToMattermost} from '../helpers/login';
 import {buildServerMap} from '../helpers/serverMap';
 import type {ServerView} from '../helpers/serverView';
@@ -128,7 +128,7 @@ test.describe('popup', () => {
     });
 
     test.afterAll(async () => {
-        await closeElectronApp(electronApp, userDataDir);
+        await closeElectronAppFast(electronApp, userDataDir);
     });
 
     test('MM-T2827_1 should be able to select all in popup windows', {tag: ['@P2', '@all']}, async () => {

--- a/e2e/specs/settings.test.ts
+++ b/e2e/specs/settings.test.ts
@@ -74,11 +74,7 @@ test.describe('Settings', () => {
             });
 
             test.describe('Save tray icon setting on mac', () => {
-                test("MM-T4393_2 should be saved when it's selected", {tag: ['@P2', '@all']}, async ({electronApp}, testInfo) => {
-                    if (!['darwin', 'linux'].includes(process.platform)) {
-                        test.skip(true, 'darwin/linux only');
-                        return;
-                    }
+                test("MM-T4393_2 should be saved when it's selected", {tag: ['@P2', '@darwin', '@linux']}, async ({electronApp}, testInfo) => {
                     const settingsWindow = await openSettingsWindow(electronApp);
                     await settingsWindow.waitForSelector('#settingCategoryButton-general');
                     await settingsWindow.click('#settingCategoryButton-general');
@@ -100,11 +96,7 @@ test.describe('Settings', () => {
             });
 
             test.describe('Save tray icon theme on linux', () => {
-                test("MM-T4393_3 should be saved when it's selected", {tag: ['@P2', '@all']}, async ({electronApp}, testInfo) => {
-                    if (process.platform !== 'linux') {
-                        test.skip(true, 'Linux only');
-                        return;
-                    }
+                test("MM-T4393_3 should be saved when it's selected", {tag: ['@P2', '@linux']}, async ({electronApp}, testInfo) => {
                     const settingsWindow = await openSettingsWindow(electronApp);
                     await settingsWindow.waitForSelector('#settingCategoryButton-general');
                     await settingsWindow.click('#settingCategoryButton-general');
@@ -208,11 +200,7 @@ test.describe('Settings', () => {
         });
 
         test.describe('Enable automatic check for updates', () => {
-            test('MM-T4549 should save selected option', {tag: ['@P2', '@all']}, async ({electronApp}, testInfo) => {
-                if (process.platform === 'darwin') {
-                    test.skip(true, 'Not applicable on macOS');
-                    return;
-                }
+            test('MM-T4549 should save selected option', {tag: ['@P2', '@win32', '@linux']}, async ({electronApp}, testInfo) => {
                 const ID_INPUT_ENABLE_AUTO_UPDATES = '#CheckSetting_autoCheckForUpdates button';
                 const settingsWindow = await openSettingsWindow(electronApp);
                 await settingsWindow.waitForSelector('#settingCategoryButton-general');

--- a/e2e/specs/settings/autostart.test.ts
+++ b/e2e/specs/settings/autostart.test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {test, expect} from '../../fixtures/index';
+
+const SHOW_SETTINGS_WINDOW = 'show-settings-window';
+
+async function openSettingsWindow(electronApp: import('playwright').ElectronApplication) {
+    for (let attempt = 0; attempt < 5; attempt++) {
+        const existingWindow = electronApp.windows().find((window) => window.url().includes('settings'));
+        if (existingWindow) {
+            await existingWindow.waitForLoadState().catch(() => {});
+            return existingWindow;
+        }
+
+        try {
+            await electronApp.evaluate(({ipcMain}, showWindow) => {
+                ipcMain.emit(showWindow);
+            }, SHOW_SETTINGS_WINDOW);
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            if (!message.includes('Execution context was destroyed') || attempt === 4) {
+                throw error;
+            }
+        }
+
+        try {
+            const settingsWindow = electronApp.windows().find((window) => window.url().includes('settings')) ??
+                await electronApp.waitForEvent('window', {
+                    predicate: (window) => window.url().includes('settings'),
+                    timeout: 3_000,
+                });
+
+            await settingsWindow.waitForLoadState().catch(() => {});
+            return settingsWindow;
+        } catch (error) {
+            if (attempt === 4) {
+                throw error;
+            }
+            await new Promise((resolve) => setTimeout(resolve, 250));
+        }
+    }
+
+    throw new Error('Settings window did not open');
+}
+
+test(
+    'SET-01 toggling autostart updates config.json',
+    {tag: ['@P1', '@win32', '@linux']},
+    async ({electronApp}, testInfo) => {
+        const configFilePath = path.join(testInfo.outputDir, 'userdata', 'config.json');
+        const settingsWindow = await openSettingsWindow(electronApp);
+        await settingsWindow.click('#settingCategoryButton-general');
+
+        const autostartToggle = settingsWindow.locator('#CheckSetting_autostart button');
+        await autostartToggle.waitFor({state: 'visible', timeout: 10_000});
+
+        const initialConfig = JSON.parse(fs.readFileSync(configFilePath, 'utf-8')) as {autostart: boolean};
+        await autostartToggle.click();
+        await settingsWindow.waitForSelector('.SettingsModal__saving :text("Changes saved")', {timeout: 15_000});
+
+        const updatedConfig = JSON.parse(fs.readFileSync(configFilePath, 'utf-8')) as {autostart: boolean};
+        expect(updatedConfig.autostart).toBe(!initialConfig.autostart);
+    },
+);

--- a/e2e/specs/settings/autostart.test.ts
+++ b/e2e/specs/settings/autostart.test.ts
@@ -59,10 +59,18 @@ test(
         await autostartToggle.waitFor({state: 'visible', timeout: 10_000});
 
         const initialConfig = JSON.parse(fs.readFileSync(configFilePath, 'utf-8')) as {autostart: boolean};
-        await autostartToggle.click();
-        await settingsWindow.waitForSelector('.SettingsModal__saving :text("Changes saved")', {timeout: 15_000});
+        try {
+            await autostartToggle.click();
+            await settingsWindow.waitForSelector('.SettingsModal__saving :text("Changes saved")', {timeout: 15_000});
 
-        const updatedConfig = JSON.parse(fs.readFileSync(configFilePath, 'utf-8')) as {autostart: boolean};
-        expect(updatedConfig.autostart).toBe(!initialConfig.autostart);
+            const updatedConfig = JSON.parse(fs.readFileSync(configFilePath, 'utf-8')) as {autostart: boolean};
+            expect(updatedConfig.autostart).toBe(!initialConfig.autostart);
+        } finally {
+            const currentConfig = JSON.parse(fs.readFileSync(configFilePath, 'utf-8')) as {autostart: boolean};
+            if (currentConfig.autostart !== initialConfig.autostart) {
+                await autostartToggle.click();
+                await settingsWindow.waitForSelector('.SettingsModal__saving :text("Changes saved")', {timeout: 15_000});
+            }
+        }
     },
 );

--- a/e2e/specs/settings/tray_icon_hide.test.ts
+++ b/e2e/specs/settings/tray_icon_hide.test.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {test, expect} from '../../fixtures/index';
+
+// ── MM-T1299: Do not show Mattermost icon in the menu bar ─────────────
+// Tests that disabling the tray icon setting actually hides the tray icon.
+// The production path: Config.showTrayIcon controls whether the TrayIcon
+// module creates a tray icon. When false, no tray should exist.
+//
+// Related: settings.test.ts MM-T4393_1 tests the checkbox exists;
+// this test verifies the behavioural effect of toggling it off.
+
+test.describe('settings/tray_icon_hide', () => {
+    test('MM-T1299 Do not show Mattermost icon in the menu bar',
+        {tag: ['@P2', '@darwin', '@linux']},
+        async ({electronApp}) => {
+            // Verify the tray icon setting can be read from config
+            const trayIconConfigAccessible = await electronApp.evaluate(() => {
+                const refs = (global as any).__e2eTestRefs;
+                const Config = refs?.Config;
+                if (!Config) {
+                    return false;
+                }
+                return typeof Config.showTrayIcon === 'boolean';
+            });
+            expect(trayIconConfigAccessible, 'showTrayIcon config must be accessible').toBe(true);
+
+            try {
+                // Disable tray icon
+                await electronApp.evaluate(() => {
+                    const refs = (global as any).__e2eTestRefs;
+                    refs?.Config?.set('showTrayIcon', false);
+                });
+
+                // Verify the config was updated
+                const trayIconDisabled = await electronApp.evaluate(() => {
+                    const refs = (global as any).__e2eTestRefs;
+                    const Config = refs?.Config;
+                    return Config ? Config.showTrayIcon === false : false;
+                });
+                expect(trayIconDisabled, 'showTrayIcon must be false after disabling').toBe(true);
+
+                // Tray teardown is async — poll until TrayIcon.tray is gone.
+                await expect.poll(
+                    () => electronApp.evaluate(() => {
+                        const refs = (global as any).__e2eTestRefs;
+                        const TrayIcon = refs?.TrayIcon;
+                        return TrayIcon ? TrayIcon.tray === null || TrayIcon.tray === undefined : false;
+                    }),
+                    {timeout: 10_000, message: 'Tray icon must be torn down after showTrayIcon=false'},
+                ).toBe(true);
+            } finally {
+                // Always re-enable so later specs in the same Electron process
+                // (and the user data dir for the next run) aren't left with a
+                // mutated tray setting.
+                await electronApp.evaluate(() => {
+                    const refs = (global as any).__e2eTestRefs;
+                    refs?.Config?.set('showTrayIcon', true);
+                });
+            }
+        },
+    );
+});

--- a/e2e/specs/system/tray_menu.test.ts
+++ b/e2e/specs/system/tray_menu.test.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {test, expect} from '../../fixtures/index';
+import {demoConfig} from '../../helpers/config';
+import {buildServerMap} from '../../helpers/serverMap';
+import {clickTrayMenuItem, emitTrayIconClick, isMainWindowVisible} from '../../helpers/tray';
+import {evaluateInMainProcess} from '../../helpers/testRefs';
+
+const trayConfig = {
+    ...demoConfig,
+    showTrayIcon: true,
+    minimizeToTray: true,
+};
+
+test.describe('system/tray_menu', () => {
+    test.describe.configure({mode: 'serial'});
+    test.use({appConfig: trayConfig});
+
+    test(
+        'TRAY-01 tray icon click restores hidden window when minimizeToTray is enabled',
+        {tag: ['@P0', '@linux', '@win32']},
+        async ({electronApp}) => {
+            await expect.poll(
+                () => isMainWindowVisible(electronApp),
+                {timeout: 10_000, message: 'Main window should be visible after launch'},
+            ).toBe(true);
+
+            await evaluateInMainProcess(electronApp, () => {
+                const refs = (global as any).__e2eTestRefs;
+                refs?.MainWindow?.get?.()?.hide();
+            });
+
+            await expect.poll(
+                () => isMainWindowVisible(electronApp),
+                {timeout: 5_000, message: 'Main window should be hidden'},
+            ).toBe(false);
+
+            await emitTrayIconClick(electronApp);
+
+            await expect.poll(
+                () => isMainWindowVisible(electronApp),
+                {timeout: 10_000, message: 'Tray icon click should restore the main window'},
+            ).toBe(true);
+        },
+    );
+
+    test(
+        'TRAY-02 tray server menu click switches server and raises hidden window',
+        {tag: ['@P0', '@linux', '@win32']},
+        async ({electronApp, mainWindow}) => {
+            await expect.poll(
+                () => mainWindow.innerText('.ServerDropdownButton'),
+                {timeout: 15_000},
+            ).toBe(demoConfig.servers[0].name);
+
+            await evaluateInMainProcess(electronApp, () => {
+                const refs = (global as any).__e2eTestRefs;
+                refs?.MainWindow?.get?.()?.hide();
+            });
+
+            await expect.poll(
+                () => isMainWindowVisible(electronApp),
+                {timeout: 5_000},
+            ).toBe(false);
+
+            const targetServer = demoConfig.servers[1].name;
+            await clickTrayMenuItem(electronApp, targetServer);
+
+            await expect.poll(
+                () => isMainWindowVisible(electronApp),
+                {timeout: 10_000, message: 'Tray server menu click should raise the main window'},
+            ).toBe(true);
+
+            await expect.poll(
+                () => mainWindow.innerText('.ServerDropdownButton'),
+                {timeout: 15_000, message: 'Tray server menu click should switch the active server'},
+            ).toBe(targetServer);
+
+            await expect.poll(async () => {
+                const serverMap = await buildServerMap(electronApp);
+                const view = serverMap[targetServer]?.[0]?.win;
+                return view?.url() ?? '';
+            }, {timeout: 20_000}).toContain('github.com');
+        },
+    );
+});

--- a/e2e/specs/system/tray_restore.test.ts
+++ b/e2e/specs/system/tray_restore.test.ts
@@ -8,7 +8,7 @@ import {_electron as electron} from 'playwright';
 import {test, expect} from '../../fixtures/index';
 import {waitForAppReady} from '../../helpers/appReadiness';
 import {electronBinaryPath, appDir, demoConfig, writeConfigFile} from '../../helpers/config';
-import {waitForLockFileRelease} from '../../helpers/cleanup';
+import {closeElectronAppFast} from '../../helpers/electronApp';
 
 test(
     'main window can be hidden to tray and restored',
@@ -83,8 +83,7 @@ test(
                 {timeout: 5_000, message: 'Window did not reappear after show()'},
             ).toBe(true);
         } finally {
-            await app.close();
-            await waitForLockFileRelease(userDataDir);
+            await closeElectronAppFast(app, userDataDir);
         }
     },
 );

--- a/e2e/specs/system/window_close_tray.test.ts
+++ b/e2e/specs/system/window_close_tray.test.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {test, expect} from '../../fixtures/index';
+import {demoConfig, type AppConfig} from '../../helpers/config';
+import {restoreMessageBox, stubMessageBoxResponses} from '../../helpers/dialog';
+import {isMainWindowVisible} from '../../helpers/tray';
+import {evaluateInMainProcess} from '../../helpers/testRefs';
+
+const closeDialogConfig: AppConfig = {
+    ...demoConfig,
+    minimizeToTray: false,
+    alwaysClose: false,
+};
+
+test.describe('system/window_close_tray', () => {
+    test.use({appConfig: closeDialogConfig});
+
+    test(
+        'WIN-02 close button shows quit dialog and keeps app running when user chooses No',
+        {tag: ['@P1', '@win32', '@linux']},
+        async ({electronApp}) => {
+            await expect.poll(
+                () => isMainWindowVisible(electronApp),
+                {timeout: 10_000},
+            ).toBe(true);
+
+            await stubMessageBoxResponses(electronApp, [{response: 1}]);
+            try {
+                await evaluateInMainProcess(electronApp, () => {
+                    const refs = (global as any).__e2eTestRefs;
+                    refs?.MainWindow?.get?.()?.close();
+                });
+
+                await expect.poll(
+                    () => electronApp.windows().some((window) => window.url().includes('index')),
+                    {timeout: 10_000, message: 'App should remain running after declining quit'},
+                ).toBe(true);
+            } finally {
+                await restoreMessageBox(electronApp);
+            }
+        },
+    );
+});


### PR DESCRIPTION
## Summary
Stacked PR **10/10** — final slice: tray, settings, deep linking, policy, popup.

Completes the #3847 split when merged after PRs 1–9.

## Test plan
- [ ] `e2e/specs/system/tray_menu.test.ts`
- [ ] `e2e/specs/deep_linking/`
- [ ] `e2e/specs/settings/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Changes are isolated to end-to-end test helpers and test coverage, but they touch shared E2E utilities, app lifecycle/teardown helpers, and several scenarios around tray, settings, and deep linking. That creates moderate risk of brittle test regressions or flaky behavior, though production code is not directly affected.

**QA Recommendation:** Automated coverage should catch most issues; targeted manual QA is optional but recommended for the new tray and deep-link flows if there’s concern about platform-specific behavior.
*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->