### PR TITLE
Fix incorrect download URL for Linux releases

### DIFF
--- a/src/common/config/buildConfig.ts
+++ b/src/common/config/buildConfig.ts
@@ -38,7 +38,7 @@ const buildConfig: BuildConfig = {
     macAppStoreUpdateURL: 'macappstore://apps.apple.com/us/app/mattermost-desktop/id1614666244',
     windowsStoreUpdateURL: 'ms-windows-store://pdp/?productid=XP8BR8MH3LPKLT',
     linuxUpdateURL: 'https://docs.mattermost.com/deployment-guide/desktop/linux-desktop-install.html',
-    linuxGitHubReleaseURL: 'https://github.com/mattermost/desktop/releases/tag/v',
+    linuxGitHubReleaseURL: 'https://github.com/mattermost/desktop/releases/tag',
     managedResources: ['trusted'],
     allowedProtocols: [
         'mattermost',


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Fixes the construction of the Linux "Download options" release URL in the updater. Removes an extraneous 'v' in the GitHub release link so it now points to the correct release page (e.g. https://github.com/mattermost/desktop/releases/tag/vX.Y.Z) instead of, in the current case, github.com/mattermost/desktop/releases/tag/v/v6.2.2 (opens `Release V` from October 2022.

#### Ticket Link
Closes #3869 

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features) 
- [ ] Has UI changes
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [ ] executed `npm run lint:js` for proper code formatting
- [ ] Run E2E tests by adding label `E2E/Run`

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Fix download URL construction in "Download Options" for Linux releases
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change presents minimal regression risk. The modification is a straightforward bug fix that corrects a malformed URL construction by removing an extraneous `/v` from the `linuxGitHubReleaseURL` configuration value. The previous behavior was objectively broken (generating URLs like `...releases/tag/v/v6.2.2`), and the fix produces the correct format (`...releases/tag/vX.Y.Z`). The configuration value is only used in one location (`src/main/updateNotifier.ts`) within a Linux-specific update notification flow, with no complex dependencies or side effects.

**QA Recommendation:** Manual QA can be minimal. Given the isolated nature of this change (single configuration value used in one code path), automated testing should suffice. Manual verification could be limited to confirming that on Linux systems, clicking the update download option generates a correctly formatted GitHub release URL without the double 'v' prefix. No regression testing across other platforms or features is necessary.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->