### PR TITLE
Fix #3869 upgrade notification URL

### DIFF
--- a/src/common/config/buildConfig.ts
+++ b/src/common/config/buildConfig.ts
@@ -38,7 +38,7 @@ const buildConfig: BuildConfig = {
     macAppStoreUpdateURL: 'macappstore://apps.apple.com/us/app/mattermost-desktop/id1614666244',
     windowsStoreUpdateURL: 'ms-windows-store://pdp/?productid=XP8BR8MH3LPKLT',
     linuxUpdateURL: 'https://docs.mattermost.com/deployment-guide/desktop/linux-desktop-install.html',
-    linuxGitHubReleaseURL: 'https://github.com/mattermost/desktop/releases/tag/v',
+    linuxGitHubReleaseURL: 'https://github.com/mattermost/desktop/releases/tag',
     managedResources: ['trusted'],
     allowedProtocols: [
         'mattermost',


### PR DESCRIPTION
#### Summary
Fixes the upgrade notification URL, the linuxGitHubReleaseURL variable already had a `/v` and then when building the notification string another `/v${version}` was being added.

Cleaner fix was to remove the initial `/v` from the variable.

#### Ticket Link

  Fixes https://github.com/mattermost/desktop/issues/3869


#### Checklist
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [x] executed `npm run lint:js` for proper code formatting


#### Device Information
This PR was tested on: Thinkpad T495, Fedora 44

#### Release Note


```release-note
Fixed the New Version notification Github URL.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: Low 🟢

**Regression Risk:** Limited to a single configuration value used for the desktop upgrade notification link. The change is isolated and unlikely to affect unrelated flows, with low blast radius.

**QA Recommendation:** Light verification of the New Version notification link on affected platforms to confirm it resolves to the correct GitHub release tag.
*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->