### PR TITLE
Allow trusted embedded media origins

### DIFF
--- a/resources/mac/mdm/README.md
+++ b/resources/mac/mdm/README.md
@@ -16,7 +16,7 @@ This folder contains an example plist you can install so the Mattermost desktop 
    sudo chmod 644 "/Library/Managed Preferences/Mattermost.Desktop.plist"
    ```
 
-3. Launch (or relaunch) the Mattermost desktop app. It will read `DefaultServerList`, `EnableServerManagement`, and `EnableAutoUpdater` from this plist via CFPreferences.
+3. Launch (or relaunch) the Mattermost desktop app. It will read `DefaultServerList`, `EnableServerManagement`, `EnableAutoUpdater`, and `TrustedEmbeddedMediaOrigins` from this plist via CFPreferences.
 
 ## Uninstall
 
@@ -31,5 +31,6 @@ Edit `example-managed-preferences.plist` before copying:
 - **DefaultServerList**: Array of dicts with `name` (string) and `url` (string). Add more `<dict>…</dict>` entries for extra servers.
 - **EnableServerManagement**: `true` or `false`.
 - **EnableAutoUpdater**: `true` or `false`.
+- **TrustedEmbeddedMediaOrigins**: Array of dicts with `serverOrigin` (string) and `embeddedOrigin` (string). Add one entry for each embedded media origin that should be allowed to reuse media permissions granted to the matching Mattermost server origin.
 
 The bundle ID (`com.Mattermost.Desktop`) must match the built app; it comes from `electron-builder.json` (mac `appId`).

--- a/resources/mac/mdm/example-managed-preferences.plist
+++ b/resources/mac/mdm/example-managed-preferences.plist
@@ -15,5 +15,14 @@
 	<true/>
 	<key>EnableAutoUpdater</key>
 	<true/>
+	<key>TrustedEmbeddedMediaOrigins</key>
+	<array>
+		<dict>
+			<key>serverOrigin</key>
+			<string>https://chat.example.com</string>
+			<key>embeddedOrigin</key>
+			<string>https://meet.example.com</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/resources/windows/gpo/en-US/mattermost.adml
+++ b/resources/windows/gpo/en-US/mattermost.adml
@@ -17,10 +17,15 @@
 If this policy is disabled, the Server Management section is hidden in the app settings and only servers defined by Group Policy can be used.</string>
 			<string id="DefaultServerList">DefaultServerList</string>
 			<string id="DefaultServerListDescription">If this policy is enabled, you can define one or more Mattermost servers that will be pre-configured for users when they launch the app. "Value name" represents the name of the corresponding server tab and "Value" is the URL of the Mattermost server.</string>
+			<string id="TrustedEmbeddedMediaOrigins">TrustedEmbeddedMediaOrigins</string>
+			<string id="TrustedEmbeddedMediaOriginsDescription">If this policy is enabled, you can define one or more embedded origins that may reuse media permissions granted to a Mattermost server origin. "Value name" must be unique and "Value" must be a JSON object with serverOrigin and embeddedOrigin string properties, for example {"serverOrigin":"https://chat.example.com","embeddedOrigin":"https://meet.example.com"}.</string>
 		</stringTable>
 		<presentationTable>
 			<presentation id="DefaultServerList">
 				<listBox refId="DefaultServerList">List of default Mattermost servers:</listBox>
+			</presentation>
+			<presentation id="TrustedEmbeddedMediaOrigins">
+				<listBox refId="TrustedEmbeddedMediaOrigins">List of trusted embedded media origins:</listBox>
 			</presentation>
 		</presentationTable>
 	</resources>

--- a/resources/windows/gpo/mattermost.admx
+++ b/resources/windows/gpo/mattermost.admx
@@ -41,5 +41,12 @@
 				<list id="DefaultServerList" key="Software\Policies\Mattermost\DefaultServerList" additive="true" explicitValue="true" />
 			</elements>
 		</policy>
+		<policy name="TrustedEmbeddedMediaOrigins" class="Both" displayName="$(string.TrustedEmbeddedMediaOrigins)" explainText="$(string.TrustedEmbeddedMediaOriginsDescription)" presentation="$(presentation.TrustedEmbeddedMediaOrigins)" key="Software\Policies\Mattermost">
+			<parentCategory ref="mattermost" />
+			<supportedOn ref="RequiresMattermost51" />
+			<elements>
+				<list id="TrustedEmbeddedMediaOrigins" key="Software\Policies\Mattermost\TrustedEmbeddedMediaOrigins" additive="true" explicitValue="true" />
+			</elements>
+		</policy>
 	</policies>
 </policyDefinitions>

--- a/src/common/Validator.test.js
+++ b/src/common/Validator.test.js
@@ -240,6 +240,19 @@ describe('common/Validator', () => {
             };
             expect(Validator.validateV4ConfigData(modifiedConfig)).not.toHaveProperty('spellCheckerURL');
         });
+
+        it('should reject trusted embedded media values that are not origins', () => {
+            const modifiedConfig = {
+                ...config,
+                trustedEmbeddedMediaOrigins: [
+                    {
+                        serverOrigin: 'https://chat.example.com/path',
+                        embeddedOrigin: 'https://meet.example.com',
+                    },
+                ],
+            };
+            expect(Validator.validateV4ConfigData(modifiedConfig)).toBeNull();
+        });
     });
 
     describe('validateAllowedProtocols', () => {

--- a/src/common/Validator.test.js
+++ b/src/common/Validator.test.js
@@ -221,6 +221,12 @@ describe('common/Validator', () => {
             enableSentry: true,
             enableSessionAttributes: true,
             useNativeTitleBar: false,
+            trustedEmbeddedMediaOrigins: [
+                {
+                    serverOrigin: 'https://chat.example.com',
+                    embeddedOrigin: 'https://meet.example.com',
+                },
+            ],
         };
 
         it('should validate v4 config data', () => {

--- a/src/common/Validator.ts
+++ b/src/common/Validator.ts
@@ -22,6 +22,19 @@ const defaultWindowHeight = 700;
 const minWindowWidth = 400;
 const minWindowHeight = 240;
 
+const originOnlyStringSchema = Joi.string().custom((value, helpers) => {
+    try {
+        const url = new URL(value);
+        if (url.origin !== value) {
+            return helpers.error('string.uri');
+        }
+
+        return value;
+    } catch {
+        return helpers.error('string.uri');
+    }
+});
+
 const argsSchema = Joi.object<Args>({
     hidden: Joi.boolean(),
     disableDevMode: Joi.boolean(),
@@ -191,8 +204,8 @@ const configDataSchemaV4 = Joi.object<ConfigV4>({
     skippedVersions: Joi.array().items(Joi.string()).default([]),
     useNativeTitleBar: Joi.boolean().default(false),
     trustedEmbeddedMediaOrigins: Joi.array().items(Joi.object({
-        serverOrigin: Joi.string().uri().required(),
-        embeddedOrigin: Joi.string().uri().required(),
+        serverOrigin: originOnlyStringSchema.required(),
+        embeddedOrigin: originOnlyStringSchema.required(),
     })).default([]),
 });
 

--- a/src/common/Validator.ts
+++ b/src/common/Validator.ts
@@ -190,6 +190,10 @@ const configDataSchemaV4 = Joi.object<ConfigV4>({
     themeSyncing: Joi.boolean().default(true),
     skippedVersions: Joi.array().items(Joi.string()).default([]),
     useNativeTitleBar: Joi.boolean().default(false),
+    trustedEmbeddedMediaOrigins: Joi.array().items(Joi.object({
+        serverOrigin: Joi.string().uri().required(),
+        embeddedOrigin: Joi.string().uri().required(),
+    })).default([]),
 });
 
 // eg. data['community.mattermost.com'] = { data: 'certificate data', issuerName: 'COMODO RSA Domain Validation Secure Server CA'};

--- a/src/common/config/buildConfig.ts
+++ b/src/common/config/buildConfig.ts
@@ -21,6 +21,7 @@ import {DEFAULT_ACADEMY_LINK, DEFAULT_HELP_LINK, DEFAULT_UPGRADE_LINK} from '../
  *                                          when "enableServerManagement is set to false
  * @prop {[]} managedResources - Defines which paths are managed
  * @prop {[]} allowedProtocols - Defines which protocols should be automatically allowed
+ * @prop {[]} trustedEmbeddedMediaOrigins - Explicit origin pairs that may share media permissions for embedded content
  */
 const buildConfig: BuildConfig = {
     defaultServers: [/*
@@ -46,6 +47,7 @@ const buildConfig: BuildConfig = {
         'mailto',
         'tel',
     ],
+    trustedEmbeddedMediaOrigins: [],
 };
 
 export default buildConfig;

--- a/src/common/config/defaultPreferences.ts
+++ b/src/common/config/defaultPreferences.ts
@@ -57,6 +57,7 @@ const defaultPreferences: ConfigV4 = {
     viewLimit: 15,
     themeSyncing: true,
     useNativeTitleBar: false,
+    trustedEmbeddedMediaOrigins: [],
 };
 
 export default defaultPreferences;

--- a/src/common/config/policyConfigLoader.test.js
+++ b/src/common/config/policyConfigLoader.test.js
@@ -22,7 +22,7 @@ jest.mock('registry-js', () => {
                 }
                 if (key.endsWith('TrustedEmbeddedMediaOrigins')) {
                     return [
-                        {name: 'https://chat-lm.example.com', data: 'https://meet-lm.example.com'},
+                        {name: 'jitsi-lm', data: JSON.stringify({serverOrigin: 'https://chat-lm.example.com', embeddedOrigin: 'https://meet-lm.example.com'})},
                     ];
                 }
                 if (key.includes('SOFTWARE\\Policies\\Mattermost')) {
@@ -42,7 +42,7 @@ jest.mock('registry-js', () => {
                 }
                 if (key.endsWith('TrustedEmbeddedMediaOrigins')) {
                     return [
-                        {name: 'https://chat-cu.example.com', data: 'https://meet-cu.example.com'},
+                        {name: 'jitsi-cu', data: JSON.stringify({serverOrigin: 'https://chat-cu.example.com', embeddedOrigin: 'https://meet-cu.example.com'})},
                     ];
                 }
                 if (key.includes('SOFTWARE\\Policies\\Mattermost')) {
@@ -163,6 +163,25 @@ describe('common/config/policyConfigLoader', () => {
                 expect(data.servers[1]).toEqual({name: 'server-2', url: 'http://server-2.com'});
             });
 
+            it('filters malformed trusted embedded media registry data', () => {
+                enumerateValues.mockImplementation((hive, key) => {
+                    if (key.endsWith('TrustedEmbeddedMediaOrigins') && hive === 'HKEY_LOCAL_MACHINE') {
+                        return [
+                            {name: 'valid-1', data: JSON.stringify({serverOrigin: 'https://chat.example.com', embeddedOrigin: 'https://meet.example.com'})},
+                            {name: 'invalid-json', data: '{not-json'},
+                            {name: 'missing-origin', data: JSON.stringify({serverOrigin: 'https://chat.example.com'})},
+                            {name: 'not-string', data: 1},
+                        ];
+                    }
+
+                    return [];
+                });
+                const data = policyConfigLoader.getPolicyConfig();
+                expect(data.trustedEmbeddedMediaOrigins).toEqual([
+                    {serverOrigin: 'https://chat.example.com', embeddedOrigin: 'https://meet.example.com'},
+                ]);
+            });
+
             it('returns consistent data from multiple calls', () => {
                 const first = policyConfigLoader.getPolicyConfig();
                 const second = policyConfigLoader.getPolicyConfig();
@@ -206,6 +225,18 @@ describe('common/config/policyConfigLoader', () => {
                 });
                 const data = policyConfigLoader.getPolicyConfig();
                 expect(data.servers).toEqual([]);
+            });
+
+            it('returns no trusted embedded media origins when the macOS value is not an array', () => {
+                getCFPreferenceValue.mockImplementation((key) => {
+                    if (key === 'TrustedEmbeddedMediaOrigins') {
+                        return {serverOrigin: 'https://chat.example.com', embeddedOrigin: 'https://meet.example.com'};
+                    }
+
+                    return undefined;
+                });
+                const data = policyConfigLoader.getPolicyConfig();
+                expect(data.trustedEmbeddedMediaOrigins).toEqual([]);
             });
         });
     });

--- a/src/common/config/policyConfigLoader.test.js
+++ b/src/common/config/policyConfigLoader.test.js
@@ -20,6 +20,11 @@ jest.mock('registry-js', () => {
                         {name: 'server-lm-2', data: 'http://server-lm-2.com'},
                     ];
                 }
+                if (key.endsWith('TrustedEmbeddedMediaOrigins')) {
+                    return [
+                        {name: 'https://chat-lm.example.com', data: 'https://meet-lm.example.com'},
+                    ];
+                }
                 if (key.includes('SOFTWARE\\Policies\\Mattermost')) {
                     return [
                         {name: 'EnableServerManagement', data: 1},
@@ -33,6 +38,11 @@ jest.mock('registry-js', () => {
                     return [
                         {name: 'server-cu-1', data: 'http://server-cu-1.com'},
                         {name: 'server-cu-2', data: 'http://server-cu-2.com'},
+                    ];
+                }
+                if (key.endsWith('TrustedEmbeddedMediaOrigins')) {
+                    return [
+                        {name: 'https://chat-cu.example.com', data: 'https://meet-cu.example.com'},
                     ];
                 }
                 if (key.includes('SOFTWARE\\Policies\\Mattermost')) {
@@ -57,6 +67,11 @@ jest.mock('cf-prefs', () => ({
             return [
                 {name: 'server-a', url: 'https://a.com'},
                 {name: 'server-b', url: 'https://b.com'},
+            ];
+        }
+        if (key === 'TrustedEmbeddedMediaOrigins') {
+            return [
+                {serverOrigin: 'https://chat.example.com', embeddedOrigin: 'https://meet.example.com'},
             ];
         }
         if (key === 'EnableServerManagement') {
@@ -93,6 +108,14 @@ describe('common/config/policyConfigLoader', () => {
                 expect(data.servers).toContainEqual({name: 'server-cu-1', url: 'http://server-cu-1.com'});
                 expect(data.enableServerManagement).toBe(false);
                 expect(data.enableUpdateNotifications).toBe(true);
+                expect(data.trustedEmbeddedMediaOrigins).toContainEqual({
+                    serverOrigin: 'https://chat-lm.example.com',
+                    embeddedOrigin: 'https://meet-lm.example.com',
+                });
+                expect(data.trustedEmbeddedMediaOrigins).toContainEqual({
+                    serverOrigin: 'https://chat-cu.example.com',
+                    embeddedOrigin: 'https://meet-cu.example.com',
+                });
             });
 
             it('handles undefined from one hive', () => {
@@ -161,6 +184,9 @@ describe('common/config/policyConfigLoader', () => {
                 ]);
                 expect(data.enableServerManagement).toBe(true);
                 expect(data.enableUpdateNotifications).toBe(false);
+                expect(data.trustedEmbeddedMediaOrigins).toEqual([
+                    {serverOrigin: 'https://chat.example.com', embeddedOrigin: 'https://meet.example.com'},
+                ]);
             });
 
             it('returns empty servers and undefined booleans when no managed prefs', () => {

--- a/src/common/config/policyConfigLoader.ts
+++ b/src/common/config/policyConfigLoader.ts
@@ -8,7 +8,7 @@ import {HKEY, enumerateValues} from 'registry-js';
 
 import {Logger} from 'common/log';
 
-import type {RegistryConfig as RegistryConfigType, Server} from 'types/config';
+import type {RegistryConfig as RegistryConfigType, Server, TrustedEmbeddedMediaOrigin} from 'types/config';
 
 const log = new Logger('PolicyConfigLoader');
 const WINDOWS_REGISTRY_PATH = 'SOFTWARE\\Policies\\Mattermost';
@@ -20,6 +20,7 @@ export class PolicyConfigLoader {
             servers: this.getServerList(),
             enableServerManagement: this.getSingleBooleanValue('EnableServerManagement'),
             enableUpdateNotifications: this.getSingleBooleanValue('EnableAutoUpdater'),
+            trustedEmbeddedMediaOrigins: this.getTrustedEmbeddedMediaOrigins(),
         };
     };
 
@@ -50,6 +51,17 @@ export class PolicyConfigLoader {
         }
     };
 
+    private getTrustedEmbeddedMediaOrigins = (): TrustedEmbeddedMediaOrigin[] => {
+        switch (process.platform) {
+        case 'win32':
+            return this.getWindowsTrustedEmbeddedMediaOrigins();
+        case 'darwin':
+            return this.getMacOSTrustedEmbeddedMediaOrigins();
+        default:
+            return [];
+        }
+    };
+
     private getWindowsServerList = (): Server[] => {
         const results = this.getWindowsValues('DefaultServerList');
         return results.map((item) => ({name: item.name, url: item.data as string}));
@@ -58,6 +70,18 @@ export class PolicyConfigLoader {
     private getMacOSServerList = (): Server[] => {
         const results = this.getMacOSValue('DefaultServerList') as Array<Record<string, string>> | undefined;
         return (results ?? []).map((item) => ({name: item.name, url: item.url}));
+    };
+
+    private getWindowsTrustedEmbeddedMediaOrigins = (): TrustedEmbeddedMediaOrigin[] => {
+        const results = this.getWindowsValues('TrustedEmbeddedMediaOrigins');
+        return results.
+            filter((item) => typeof item.name === 'string' && typeof item.data === 'string').
+            map((item) => ({serverOrigin: item.name, embeddedOrigin: item.data as string}));
+    };
+
+    private getMacOSTrustedEmbeddedMediaOrigins = (): TrustedEmbeddedMediaOrigin[] => {
+        const results = this.getMacOSValue('TrustedEmbeddedMediaOrigins') as TrustedEmbeddedMediaOrigin[] | undefined;
+        return (results ?? []).filter((item) => typeof item.serverOrigin === 'string' && typeof item.embeddedOrigin === 'string');
     };
 
     private getSingleBooleanValue = (valueName: string): boolean | undefined => {

--- a/src/common/config/policyConfigLoader.ts
+++ b/src/common/config/policyConfigLoader.ts
@@ -75,13 +75,43 @@ export class PolicyConfigLoader {
     private getWindowsTrustedEmbeddedMediaOrigins = (): TrustedEmbeddedMediaOrigin[] => {
         const results = this.getWindowsValues('TrustedEmbeddedMediaOrigins');
         return results.
-            filter((item) => typeof item.name === 'string' && typeof item.data === 'string').
-            map((item) => ({serverOrigin: item.name, embeddedOrigin: item.data as string}));
+            map((item) => this.parseTrustedEmbeddedMediaOrigin(item.data)).
+            filter((item): item is TrustedEmbeddedMediaOrigin => Boolean(item));
     };
 
     private getMacOSTrustedEmbeddedMediaOrigins = (): TrustedEmbeddedMediaOrigin[] => {
-        const results = this.getMacOSValue('TrustedEmbeddedMediaOrigins') as TrustedEmbeddedMediaOrigin[] | undefined;
-        return (results ?? []).filter((item) => typeof item.serverOrigin === 'string' && typeof item.embeddedOrigin === 'string');
+        const results = this.getMacOSValue('TrustedEmbeddedMediaOrigins');
+        if (!Array.isArray(results)) {
+            return [];
+        }
+
+        return results.filter((item): item is TrustedEmbeddedMediaOrigin => this.isTrustedEmbeddedMediaOrigin(item));
+    };
+
+    private parseTrustedEmbeddedMediaOrigin = (value: RegistryValue['data']): TrustedEmbeddedMediaOrigin | undefined => {
+        if (typeof value !== 'string') {
+            return undefined;
+        }
+
+        try {
+            const parsed = JSON.parse(value);
+            if (this.isTrustedEmbeddedMediaOrigin(parsed)) {
+                return parsed;
+            }
+        } catch (error) {
+            log.debug('Error parsing TrustedEmbeddedMediaOrigins registry value', {error});
+        }
+
+        return undefined;
+    };
+
+    private isTrustedEmbeddedMediaOrigin = (value: unknown): value is TrustedEmbeddedMediaOrigin => {
+        if (!value || typeof value !== 'object') {
+            return false;
+        }
+
+        const originPair = value as Partial<TrustedEmbeddedMediaOrigin>;
+        return typeof originPair.serverOrigin === 'string' && typeof originPair.embeddedOrigin === 'string';
     };
 
     private getSingleBooleanValue = (valueName: string): boolean | undefined => {

--- a/src/main/security/permissionsManager.test.js
+++ b/src/main/security/permissionsManager.test.js
@@ -43,16 +43,13 @@ jest.mock('common/utils/url', () => ({
 }));
 
 jest.mock('common/config', () => ({
-    __esModule: true,
-    default: {
-        data: {
-            trustedEmbeddedMediaOrigins: [],
-        },
-        registryData: {
-            servers: [
-                {url: 'http://gposerver.com'},
-            ],
-        },
+    data: {
+        trustedEmbeddedMediaOrigins: [],
+    },
+    registryData: {
+        servers: [
+            {url: 'http://gposerver.com'},
+        ],
     },
 }));
 

--- a/src/main/security/permissionsManager.test.js
+++ b/src/main/security/permissionsManager.test.js
@@ -8,6 +8,7 @@ import MainWindow from 'app/mainWindow/mainWindow';
 import WebContentsManager from 'app/views/webContentsManager';
 import Config from 'common/config';
 import {parseURL, isTrustedURL} from 'common/utils/url';
+import {localizeMessage} from 'main/i18nManager';
 
 import {PermissionsManager} from './permissionsManager';
 
@@ -42,13 +43,16 @@ jest.mock('common/utils/url', () => ({
 }));
 
 jest.mock('common/config', () => ({
-    data: {
-        trustedEmbeddedMediaOrigins: [],
-    },
-    registryData: {
-        servers: [
-            {url: 'http://gposerver.com'},
-        ],
+    __esModule: true,
+    default: {
+        data: {
+            trustedEmbeddedMediaOrigins: [],
+        },
+        registryData: {
+            servers: [
+                {url: 'http://gposerver.com'},
+            ],
+        },
     },
 }));
 
@@ -271,6 +275,16 @@ describe('main/PermissionsManager', () => {
             await permissionsManager.handlePermissionRequest({id: 2}, 'media', cb, {securityOrigin: 'http://meet.anyurl.com'});
             expect(permissionsManager.json['http://anyurl.com'].media.allowed).toBe(true);
             expect(permissionsManager.json['http://meet.anyurl.com']).toBeUndefined();
+            expect(localizeMessage).toHaveBeenCalledWith(
+                'main.permissionsManager.checkPermission.dialog.message.media',
+                '{appName} ({url}) is requesting the "{permission}" permission.',
+                {
+                    appName: 'Mattermost',
+                    url: 'http://anyurl.com (via http://meet.anyurl.com)',
+                    permission: 'media',
+                    externalURL: undefined,
+                },
+            );
             expect(permissionsManager.writeToFile).toHaveBeenCalled();
             expect(cb).toHaveBeenCalledWith(true);
         });

--- a/src/main/security/permissionsManager.test.js
+++ b/src/main/security/permissionsManager.test.js
@@ -42,6 +42,9 @@ jest.mock('common/utils/url', () => ({
 }));
 
 jest.mock('common/config', () => ({
+    data: {
+        trustedEmbeddedMediaOrigins: [],
+    },
     registryData: {
         servers: [
             {url: 'http://gposerver.com'},
@@ -176,6 +179,7 @@ describe('main/PermissionsManager', () => {
                     url: 'http://gposerver.com',
                 },
             ];
+            Config.data.trustedEmbeddedMediaOrigins = [];
         });
 
         afterEach(() => {
@@ -223,6 +227,52 @@ describe('main/PermissionsManager', () => {
             const cb = jest.fn();
             await permissionsManager.handlePermissionRequest({id: 2}, 'media', cb, {securityOrigin: 'http://wrongurl.com'});
             expect(cb).toHaveBeenCalledWith(false);
+        });
+
+        it('should deny media from an embedded origin that is not explicitly trusted', async () => {
+            const permissionsManager = new PermissionsManager('anyfile.json');
+            const cb = jest.fn();
+            await permissionsManager.handlePermissionRequest({id: 2}, 'media', cb, {securityOrigin: 'http://meet.anyurl.com'});
+            expect(cb).toHaveBeenCalledWith(false);
+        });
+
+        it('should allow media from an explicitly trusted embedded origin using the server permission', async () => {
+            Config.data.trustedEmbeddedMediaOrigins = [
+                {
+                    serverOrigin: 'http://anyurl.com',
+                    embeddedOrigin: 'http://meet.anyurl.com',
+                },
+            ];
+            const permissionsManager = new PermissionsManager('anyfile.json');
+            permissionsManager.json = {
+                'http://anyurl.com': {
+                    media: {
+                        allowed: true,
+                    },
+                },
+            };
+            const cb = jest.fn();
+            await permissionsManager.handlePermissionRequest({id: 2}, 'media', cb, {securityOrigin: 'http://meet.anyurl.com'});
+            expect(cb).toHaveBeenCalledWith(true);
+            expect(dialog.showMessageBox).not.toHaveBeenCalled();
+        });
+
+        it('should store media decisions for trusted embedded origins on the server origin', async () => {
+            Config.data.trustedEmbeddedMediaOrigins = [
+                {
+                    serverOrigin: 'http://anyurl.com',
+                    embeddedOrigin: 'http://meet.anyurl.com',
+                },
+            ];
+            const permissionsManager = new PermissionsManager('anyfile.json');
+            permissionsManager.writeToFile = jest.fn();
+            const cb = jest.fn();
+            dialog.showMessageBox.mockReturnValue(Promise.resolve({response: 2}));
+            await permissionsManager.handlePermissionRequest({id: 2}, 'media', cb, {securityOrigin: 'http://meet.anyurl.com'});
+            expect(permissionsManager.json['http://anyurl.com'].media.allowed).toBe(true);
+            expect(permissionsManager.json['http://meet.anyurl.com']).toBeUndefined();
+            expect(permissionsManager.writeToFile).toHaveBeenCalled();
+            expect(cb).toHaveBeenCalledWith(true);
         });
 
         it('should allow if dialog is not required', async () => {

--- a/src/main/security/permissionsManager.ts
+++ b/src/main/security/permissionsManager.ts
@@ -168,6 +168,7 @@ export class PermissionsManager extends JsonFileManager<PermissionsByOrigin> {
         const isExternalFullscreen = permission === 'fullscreen' && parsedURL.origin !== serverURL.origin;
         const isTrustedEmbeddedMedia = permission === 'media' && this.isTrustedEmbeddedMediaOrigin(parsedURL, serverURL);
         const permissionOrigin = isTrustedEmbeddedMedia ? serverURL.origin : parsedURL.origin;
+        const dialogOrigin = isTrustedEmbeddedMedia ? `${serverURL.origin} (via ${parsedURL.origin})` : parsedURL.origin;
 
         // is the requesting url trusted?
         if (!(isTrustedURL(parsedURL, serverURL) || (permission === 'media' && parsedURL.origin === serverURL.origin) || isTrustedEmbeddedMedia || isExternalFullscreen)) {
@@ -207,7 +208,7 @@ export class PermissionsManager extends JsonFileManager<PermissionsByOrigin> {
                 // Show the dialog to ask the user
                 dialog.showMessageBox(mainWindow, {
                     title: localizeMessage('main.permissionsManager.checkPermission.dialog.title', 'Permission Requested'),
-                    message: localizeMessage(`main.permissionsManager.checkPermission.dialog.message.${permission}`, '{appName} ({url}) is requesting the "{permission}" permission.', {appName: app.name, url: parsedURL.origin, permission, externalURL: details.externalURL}),
+                    message: localizeMessage(`main.permissionsManager.checkPermission.dialog.message.${permission}`, '{appName} ({url}) is requesting the "{permission}" permission.', {appName: app.name, url: dialogOrigin, permission, externalURL: details.externalURL}),
                     detail: localizeMessage(`main.permissionsManager.checkPermission.dialog.detail.${permission}`, 'Would you like to grant {appName} this permission?', {appName: app.name}),
                     type: 'question',
                     buttons: [

--- a/src/main/security/permissionsManager.ts
+++ b/src/main/security/permissionsManager.ts
@@ -166,15 +166,17 @@ export class PermissionsManager extends JsonFileManager<PermissionsByOrigin> {
         // Exception for embedded videos such as YouTube
         // We still want to ask permission to do this though
         const isExternalFullscreen = permission === 'fullscreen' && parsedURL.origin !== serverURL.origin;
+        const isTrustedEmbeddedMedia = permission === 'media' && this.isTrustedEmbeddedMediaOrigin(parsedURL, serverURL);
+        const permissionOrigin = isTrustedEmbeddedMedia ? serverURL.origin : parsedURL.origin;
 
         // is the requesting url trusted?
-        if (!(isTrustedURL(parsedURL, serverURL) || (permission === 'media' && parsedURL.origin === serverURL.origin) || isExternalFullscreen)) {
+        if (!(isTrustedURL(parsedURL, serverURL) || (permission === 'media' && parsedURL.origin === serverURL.origin) || isTrustedEmbeddedMedia || isExternalFullscreen)) {
             return false;
         }
 
         // For certain permission types, we need to confirm with the user
         if (authorizablePermissionTypes.includes(permission) || isExternalFullscreen) {
-            const currentPermission = this.json[parsedURL.origin]?.[permission];
+            const currentPermission = this.json[permissionOrigin]?.[permission];
 
             // If previously allowed, just allow
             if (currentPermission?.allowed) {
@@ -191,7 +193,7 @@ export class PermissionsManager extends JsonFileManager<PermissionsByOrigin> {
             }
 
             // Make sure we don't pop multiple dialogs for the same permission check
-            const permissionKey = `${parsedURL.origin}:${permission}`;
+            const permissionKey = `${permissionOrigin}:${permission}`;
             if (this.inflightPermissionChecks.has(permissionKey)) {
                 return this.inflightPermissionChecks.get(permissionKey)!;
             }
@@ -219,8 +221,8 @@ export class PermissionsManager extends JsonFileManager<PermissionsByOrigin> {
                         allowed: response === 2,
                         alwaysDeny: (response === 1) ? true : undefined,
                     };
-                    this.json[parsedURL.origin] = {
-                        ...this.json[parsedURL.origin],
+                    this.json[permissionOrigin] = {
+                        ...this.json[permissionOrigin],
                         [permission]: newPermission,
                     };
                     this.writeToFile();
@@ -241,6 +243,14 @@ export class PermissionsManager extends JsonFileManager<PermissionsByOrigin> {
 
         // We've checked everything so we're okay to grant the remaining cases
         return true;
+    };
+
+    private isTrustedEmbeddedMediaOrigin = (requestURL: URL, serverURL: URL) => {
+        return Config.data?.trustedEmbeddedMediaOrigins?.some((originPair) => {
+            const serverOrigin = parseURL(originPair.serverOrigin);
+            const embeddedOrigin = parseURL(originPair.embeddedOrigin);
+            return serverOrigin?.origin === serverURL.origin && embeddedOrigin?.origin === requestURL.origin;
+        }) ?? false;
     };
 
     private openWindowsCameraPreferences = () => shell.openExternal('ms-settings:privacy-webcam');

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -6,6 +6,11 @@ export type Server = {
     url: string;
 }
 
+export type TrustedEmbeddedMediaOrigin = {
+    serverOrigin: string;
+    embeddedOrigin: string;
+}
+
 export type ConfigServer = Server & {
     order: number;
     isPredefined?: boolean;
@@ -62,6 +67,7 @@ export type ConfigV4 = {
     themeSyncing?: boolean;
     skippedVersions?: string[];
     useNativeTitleBar?: boolean;
+    trustedEmbeddedMediaOrigins?: TrustedEmbeddedMediaOrigin[];
 }
 
 export type ConfigV3 = Omit<ConfigV4,
@@ -137,12 +143,14 @@ export type BuildConfig = {
     linuxGitHubReleaseURL: string;
     managedResources: string[];
     allowedProtocols: string[];
+    trustedEmbeddedMediaOrigins?: TrustedEmbeddedMediaOrigin[];
 }
 
 export type RegistryConfig = {
     servers: Server[];
     enableServerManagement: boolean;
     enableUpdateNotifications: boolean;
+    trustedEmbeddedMediaOrigins: TrustedEmbeddedMediaOrigin[];
 }
 
 export type CombinedConfig = Omit<CurrentConfig, 'servers'> & Omit<BuildConfig, 'defaultServers'> & {


### PR DESCRIPTION
## Summary

Follow-up to the stale PR https://github.com/mattermost/desktop/pull/3331 for https://github.com/mattermost/desktop/issues/3074.

That PR correctly identified the Mattermost Desktop embedded Jitsi failure mode: media permission requests originate from the embedded Jitsi origin, while the user has granted media permissions to the Mattermost server origin. The broad subdomain trust approach in that PR was rejected because it could implicitly trust arbitrary subdomains.

This PR keeps the same user-facing goal but changes the trust model to explicit opt-in origin pairs:

- `serverOrigin`: the Mattermost server origin whose media permission should be reused.
- `embeddedOrigin`: the embedded page origin allowed to reuse that server permission.

No wildcard subdomain matching is added. If an embedded origin is not explicitly configured for the current server origin, the existing deny behavior is unchanged.

## Changes

- Add `trustedEmbeddedMediaOrigins` to desktop config/build config/policy config.
- Allow `media` permission requests from explicitly configured embedded origins to use the current server origin's stored media permission.
- Add managed policy loading for the allowlist:
  - macOS: `TrustedEmbeddedMediaOrigins` managed preference array of `{serverOrigin, embeddedOrigin}`.
  - Windows: `TrustedEmbeddedMediaOrigins` registry key with uniquely named values whose data is a JSON object containing `serverOrigin` and `embeddedOrigin`.
- Add unit coverage for configured and unconfigured embedded media origins.

## Test

```sh
npx jest --runTestsByPath src/main/security/permissionsManager.test.js src/common/config/policyConfigLoader.test.js src/common/Validator.test.js --runInBand
npx eslint src/main/security/permissionsManager.ts src/main/security/permissionsManager.test.js src/common/config/policyConfigLoader.ts src/common/config/policyConfigLoader.test.js src/common/Validator.ts src/common/Validator.test.js src/common/config/buildConfig.ts src/common/config/defaultPreferences.ts src/types/config.ts
npm run check-types
```

## Release-note

```release-note
Added support for explicitly trusted embedded media origins for media permission requests.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: High 🔴

**Regression Risk:** This change affects permission handling and persistence for media access, including embedded-origin trust decisions across desktop config, policy loading, and platform-specific managed preferences. It also changes how permission keys are resolved and stored, so regressions could impact whether media prompts are shown or reused correctly.

**QA Recommendation:** Perform focused manual QA on trusted and untrusted embedded media flows across desktop, macOS policy loading, and Windows policy loading, with special attention to permission reuse, persistence, and deny behavior.
*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->