### PR TITLE
fix(cmt): trigger on RC tag cut instead of release branch push

### DIFF
--- a/.github/workflows/cmt-provisioner.yml
+++ b/.github/workflows/cmt-provisioner.yml
@@ -1,44 +1,25 @@
 name: CMT Provisioner
 
-# Lightweight trigger workflow for Compatibility Matrix Testing (CMT).
-#
-# Matterwick listens for this workflow's workflow_run:requested event, then provisions one
-# Mattermost cloud instance per version in its hardcoded CMT version set (Matterwick's
-# CMTServerVersions config / CMTVersions, e.g. the active ESR plus the current feature
-# release) and dispatches compatibility-matrix-testing.yml with the CMT_MATRIX input.
-# When compatibility-matrix-testing.yml completes, Matterwick destroys the provisioned
-# instances (cleanup is keyed off the completed workflow_run, matched by commit SHA).
-#
-# The server-version set lives in Matterwick config (managed via gitops), so this workflow
-# takes no inputs. Run it manually from the Actions tab, or let it fire automatically on
-# release branches (below).
-#
-# NOTE (intentional duplicate coverage): a release-v* push ALSO triggers Matterwick's normal
-# release E2E flow (whole suite against the single latest server version). CMT additionally
-# runs the whole suite against its multi-version matrix, whose set includes the latest server.
-# So on a release push the latest server version gets the suite run twice (once by the normal
-# release flow, once by the CMT latest-version leg). This is expected and accepted.
+# Trigger workflow for Compatibility Matrix Testing (CMT).
+# When this workflow runs, GitHub fires a workflow_run webhook to matterwick.
+# Matterwick provisions one cloud server per version and dispatches
+# compatibility-matrix-testing.yml automatically.
 
 on:
-  # Run CMT when a release branch is cut and on every subsequent push to it. The first push
-  # that creates release-v* is the "cut"; later pushes to it re-run CMT.
+  # Run CMT when a release branch is cut and on every subsequent push to it.
   push:
     branches:
       - "release-v*"
   # Manual runs from the Actions tab (against any branch).
   workflow_dispatch: {}
 
-# This workflow does not use GITHUB_TOKEN. Its only purpose is to emit a workflow_run event
-# that Matterwick reacts to; it does not check out the repo or call the GitHub API. Drop all
-# GITHUB_TOKEN scopes so the runner-issued token cannot modify the repo if a step is added later.
+# This workflow does not use GITHUB_TOKEN. Its only purpose is to emit a
+# workflow_run event that matterwick reacts to.
 permissions: {}
 
 jobs:
-  signal:
+  trigger-matterwick:
     runs-on: ubuntu-22.04
     steps:
-      - name: Signal Matterwick to provision CMT servers
-        run: |
-          echo "CMT trigger started."
-          echo "Matterwick provisions one server per configured version and then"
-          echo "dispatches compatibility-matrix-testing.yml automatically."
+      - name: Signal matterwick
+        run: echo "CMT provisioning requested — matterwick will handle provisioning and dispatch."

--- a/.github/workflows/cmt-provisioner.yml
+++ b/.github/workflows/cmt-provisioner.yml
@@ -6,11 +6,11 @@ name: CMT Provisioner
 # compatibility-matrix-testing.yml automatically.
 
 on:
-  # Run CMT when a release branch is cut and on every subsequent push to it.
+  # Fire on each RC tag cut (v6.2.0-rc.1, v6.2.0-rc.2, …).
   push:
-    branches:
-      - "release-v*"
-  # Manual runs from the Actions tab (against any branch).
+    tags:
+      - "v*-rc*"
+  # Manual runs from the Actions tab (any ref).
   workflow_dispatch: {}
 
 # This workflow does not use GITHUB_TOKEN. Its only purpose is to emit a

--- a/.github/workflows/compatibility-matrix-testing.yml
+++ b/.github/workflows/compatibility-matrix-testing.yml
@@ -13,7 +13,8 @@ on:
 
 # Supersede an in-flight CMT run for the same ref (e.g. rapid release-branch pushes) so we don't
 # pay for overlapping multi-version matrices. Matterwick reaps the cancelled run's provisioned
-# servers on its workflow_run "completed" (cancelled) event, matched by commit SHA.
+# servers on its workflow_run "completed" (cancelled) event, matched by the dispatched test
+# workflow run id (not commit SHA).
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
**Summary:**

The CMT Provisioner was set to fire on every push to `release-v*` branches, but desktop release branches are named `release-X.Y` (no `v` prefix) so the trigger never matched in practice. This PR fixes that.

**What changed:**

- **Trigger corrected:** CMT Provisioner now fires on RC tag cuts (`v*-rc*`, e.g. `v6.2.0-rc.1`) instead of release branch pushes. This matches how the release process actually works. An RC tag is cut when QA is ready to test, not on every branch push.

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Isolated GitHub Actions workflow changes with a narrow blast radius. The main risk is missed or unexpected workflow triggering on RC tags, but runtime behavior of the underlying job logic is largely unchanged.

**QA Recommendation:** Minimal manual QA is sufficient—verify the workflow triggers on a `v*-rc*` tag and still runs via manual dispatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->