### PR TITLE
[MM-69013] Disallow server adding via deep link when server management is disabled

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4,6 +4,8 @@
   "app.menus.contextMenu.openInNewWindow": "Open in new window",
   "app.navigationManager.invalidLinkDescription": "The link you clicked appears to be malformed and cannot be opened. Please check the URL for errors before trying again.",
   "app.navigationManager.invalidLinkTitle": "Invalid Link",
+  "app.navigationManager.serverManagementDisabledDescription": "Your organization's settings don't allow adding new servers, so this link couldn't be opened. Contact your system administrator for more information.",
+  "app.navigationManager.serverManagementDisabledTitle": "Unable to add server",
   "app.navigationManager.viewLimitReached": "View limit reached",
   "app.navigationManager.viewLimitReached.description": "You have reached the maximum number of open windows and tabs for this server. Please close an existing window or tab, or adjust the view limit in the Settings modal.",
   "callsWidgetWindow.cannotStartCall.message": "There is an in-progress call on another server that must be ended before joining a new call.",

--- a/src/app/navigationManager.test.js
+++ b/src/app/navigationManager.test.js
@@ -215,6 +215,21 @@ describe('app/navigationManager', () => {
             expect(handleWelcomeScreenModal).toHaveBeenCalledWith('server-2.com/deep/link?thing=yes');
         });
 
+        it('should not handle welcome screen modal when server management is disabled by policy', () => {
+            ModalManager.removeModal.mockClear();
+            handleWelcomeScreenModal.mockClear();
+            ServerManager.hasServers.mockReturnValue(false);
+            ServerManager.lookupServerByURL.mockReturnValue(null);
+            Config.enableServerManagement = false;
+
+            navigationManager.openLinkInPrimaryTab('mattermost://server-2.com/deep/link?thing=yes');
+
+            expect(ModalManager.removeModal).not.toHaveBeenCalled();
+            expect(handleWelcomeScreenModal).not.toHaveBeenCalled();
+
+            Config.enableServerManagement = true;
+        });
+
         it('should handle null URL gracefully', () => {
             navigationManager.openLinkInPrimaryTab(null);
 

--- a/src/app/navigationManager.test.js
+++ b/src/app/navigationManager.test.js
@@ -11,6 +11,7 @@ import TabManager from 'app/tabs/tabManager';
 import WebContentsManager from 'app/views/webContentsManager';
 import PopoutManager from 'app/windows/popoutManager';
 import {BROWSER_HISTORY_PUSH} from 'common/communication';
+import Config from 'common/config';
 import ServerManager from 'common/servers/serverManager';
 import Utils from 'common/utils/util';
 import {ViewType} from 'common/views/MattermostView';
@@ -71,6 +72,10 @@ jest.mock('common/servers/serverManager', () => ({
     hasServers: jest.fn(),
     getRemoteInfo: jest.fn(),
     getServer: jest.fn(),
+}));
+
+jest.mock('common/config', () => ({
+    enableServerManagement: true,
 }));
 
 jest.mock('app/mainWindow/mainWindow', () => ({
@@ -187,6 +192,19 @@ describe('app/navigationManager', () => {
             expect(ServerHub.showNewServerModal).toHaveBeenCalledWith('server-2.com/deep/link?thing=yes');
         });
 
+        it('should not open new server modal when server management is disabled by policy', () => {
+            ServerHub.showNewServerModal.mockClear();
+            ServerManager.hasServers.mockReturnValue(true);
+            ServerManager.lookupServerByURL.mockReturnValue(null);
+            Config.enableServerManagement = false;
+
+            navigationManager.openLinkInPrimaryTab('mattermost://server-2.com/deep/link?thing=yes');
+
+            expect(ServerHub.showNewServerModal).not.toHaveBeenCalled();
+
+            Config.enableServerManagement = true;
+        });
+
         it('should handle welcome screen modal when no servers exist', () => {
             ServerManager.hasServers.mockReturnValue(false);
             ServerManager.lookupServerByURL.mockReturnValue(null);
@@ -271,6 +289,18 @@ describe('app/navigationManager', () => {
             navigationManager.openLinkInNewTab('mattermost://server-2.com/deep/link?thing=yes');
 
             expect(ServerHub.showNewServerModal).toHaveBeenCalledWith('server-2.com/deep/link?thing=yes');
+        });
+
+        it('should not open new server modal when server management is disabled by policy', () => {
+            ServerManager.hasServers.mockReturnValue(true);
+            ServerManager.lookupServerByURL.mockReturnValue(null);
+            Config.enableServerManagement = false;
+
+            navigationManager.openLinkInNewTab('mattermost://server-2.com/deep/link?thing=yes');
+
+            expect(ServerHub.showNewServerModal).not.toHaveBeenCalled();
+
+            Config.enableServerManagement = true;
         });
 
         it('should handle welcome screen modal when no servers exist', () => {

--- a/src/app/navigationManager.test.js
+++ b/src/app/navigationManager.test.js
@@ -192,8 +192,9 @@ describe('app/navigationManager', () => {
             expect(ServerHub.showNewServerModal).toHaveBeenCalledWith('server-2.com/deep/link?thing=yes');
         });
 
-        it('should not open new server modal when server management is disabled by policy', () => {
+        it('should not open new server modal but show a dialog when server management is disabled by policy', () => {
             ServerHub.showNewServerModal.mockClear();
+            dialog.showErrorBox.mockClear();
             ServerManager.hasServers.mockReturnValue(true);
             ServerManager.lookupServerByURL.mockReturnValue(null);
             Config.enableServerManagement = false;
@@ -201,6 +202,7 @@ describe('app/navigationManager', () => {
             navigationManager.openLinkInPrimaryTab('mattermost://server-2.com/deep/link?thing=yes');
 
             expect(ServerHub.showNewServerModal).not.toHaveBeenCalled();
+            expect(dialog.showErrorBox).toHaveBeenCalled();
 
             Config.enableServerManagement = true;
         });
@@ -215,9 +217,10 @@ describe('app/navigationManager', () => {
             expect(handleWelcomeScreenModal).toHaveBeenCalledWith('server-2.com/deep/link?thing=yes');
         });
 
-        it('should not handle welcome screen modal when server management is disabled by policy', () => {
+        it('should not handle welcome screen modal but show a dialog when server management is disabled by policy', () => {
             ModalManager.removeModal.mockClear();
             handleWelcomeScreenModal.mockClear();
+            dialog.showErrorBox.mockClear();
             ServerManager.hasServers.mockReturnValue(false);
             ServerManager.lookupServerByURL.mockReturnValue(null);
             Config.enableServerManagement = false;
@@ -226,6 +229,7 @@ describe('app/navigationManager', () => {
 
             expect(ModalManager.removeModal).not.toHaveBeenCalled();
             expect(handleWelcomeScreenModal).not.toHaveBeenCalled();
+            expect(dialog.showErrorBox).toHaveBeenCalled();
 
             Config.enableServerManagement = true;
         });
@@ -306,7 +310,7 @@ describe('app/navigationManager', () => {
             expect(ServerHub.showNewServerModal).toHaveBeenCalledWith('server-2.com/deep/link?thing=yes');
         });
 
-        it('should not open new server modal when server management is disabled by policy', () => {
+        it('should not open new server modal but show a dialog when server management is disabled by policy', () => {
             ServerManager.hasServers.mockReturnValue(true);
             ServerManager.lookupServerByURL.mockReturnValue(null);
             Config.enableServerManagement = false;
@@ -314,6 +318,7 @@ describe('app/navigationManager', () => {
             navigationManager.openLinkInNewTab('mattermost://server-2.com/deep/link?thing=yes');
 
             expect(ServerHub.showNewServerModal).not.toHaveBeenCalled();
+            expect(dialog.showErrorBox).toHaveBeenCalled();
 
             Config.enableServerManagement = true;
         });

--- a/src/app/navigationManager.ts
+++ b/src/app/navigationManager.ts
@@ -89,17 +89,14 @@ export class NavigationManager {
                 webContentsView.once(LOAD_FAILED, this.deeplinkFailed);
                 webContentsView.load(urlWithSchema);
             }
+        } else if (!Config.enableServerManagement) {
+            dialog.showErrorBox(
+                localizeMessage('app.navigationManager.serverManagementDisabledTitle', 'Unable to add server'),
+                localizeMessage('app.navigationManager.serverManagementDisabledDescription', 'Your organization\'s settings don\'t allow adding new servers, so this link couldn\'t be opened. Contact your system administrator for more information.'),
+            );
         } else if (ServerManager.hasServers()) {
-            if (!Config.enableServerManagement) {
-                log.warn('Ignoring deep link to add a new server because server management is disabled by policy');
-                return;
-            }
             ServerHub.showNewServerModal(`${parsedURL.host}${parsedURL.pathname}${parsedURL.search}`);
         } else {
-            if (!Config.enableServerManagement) {
-                log.warn('Ignoring deep link to add a new server because server management is disabled by policy');
-                return;
-            }
             ModalManager.removeModal('welcomeScreen');
             const prefillURL = `${parsedURL.host}${parsedURL.pathname}${parsedURL.search}`;
             handleWelcomeScreenModal(prefillURL);

--- a/src/app/navigationManager.ts
+++ b/src/app/navigationManager.ts
@@ -11,6 +11,7 @@ import ServerHub from 'app/serverHub';
 import TabManager from 'app/tabs/tabManager';
 import WebContentsManager from 'app/views/webContentsManager';
 import {BROWSER_HISTORY_PUSH, HISTORY, LOAD_FAILED, LOAD_SUCCESS, REQUEST_BROWSER_HISTORY_STATUS} from 'common/communication';
+import Config from 'common/config';
 import {Logger} from 'common/log';
 import type {MattermostServer} from 'common/servers/MattermostServer';
 import ServerManager from 'common/servers/serverManager';
@@ -89,6 +90,10 @@ export class NavigationManager {
                 webContentsView.load(urlWithSchema);
             }
         } else if (ServerManager.hasServers()) {
+            if (!Config.enableServerManagement) {
+                log.warn('Ignoring deep link to add a new server because server management is disabled by policy');
+                return;
+            }
             ServerHub.showNewServerModal(`${parsedURL.host}${parsedURL.pathname}${parsedURL.search}`);
         } else {
             ModalManager.removeModal('welcomeScreen');

--- a/src/app/navigationManager.ts
+++ b/src/app/navigationManager.ts
@@ -96,6 +96,10 @@ export class NavigationManager {
             }
             ServerHub.showNewServerModal(`${parsedURL.host}${parsedURL.pathname}${parsedURL.search}`);
         } else {
+            if (!Config.enableServerManagement) {
+                log.warn('Ignoring deep link to add a new server because server management is disabled by policy');
+                return;
+            }
             ModalManager.removeModal('welcomeScreen');
             const prefillURL = `${parsedURL.host}${parsedURL.pathname}${parsedURL.search}`;
             handleWelcomeScreenModal(prefillURL);


### PR DESCRIPTION
#### Summary
The `enableServerManagement` policy is meant to stop users from adding new servers in locked-down deployments, but the deep link handler never consulted it. As a result, opening a `mattermost://` link to an unconfigured server would still surface the **Add Server** dialog and let the server be persisted, even with the policy set to `false`.

This PR adds the policy check to the deep link path in `NavigationManager`. When a deep link points to a server that isn't already configured and `enableServerManagement` is disabled, we log and bail out instead of opening the new-server modal.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69013

#### Release Note
```release-note
Fixed an issue where a mattermost:// deep link could open the Add Server dialog
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Moderate risk: this introduces a policy-based early-exit in the desktop app’s deep-link/navigation handling for missing/unconfigured servers. While it only gates UI flows (dialogs/modals) and doesn’t affect auth/session/data integrity, it changes user-visible behavior across both primary-tab and new-tab link paths and may have edge-case variations depending on server/welcome-screen state.  
**QA Recommendation:** Light manual QA. Validate `mattermost://` deep links in both primary tab and new tab for: (1) an already configured server, and (2) a non-configured/missing server with `enableServerManagement` toggled true vs false, confirming the expected error/dialog behavior.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->