### PR TITLE
[MM-69253] Restrict call leave to the view that created it and the widget

### DIFF
--- a/e2e/specs/calls/calls_functionality.test.ts
+++ b/e2e/specs/calls/calls_functionality.test.ts
@@ -7,7 +7,6 @@ import type {ElectronApplication} from 'playwright';
 import {test, expect} from '../../fixtures/index';
 import {findCallsWidgetWindow, waitForCallsWidgetWindow} from '../../helpers/callsWidget';
 import {demoMattermostConfig} from '../../helpers/config';
-import {CALLS_LEAVE_CALL} from '../../helpers/ipcChannels';
 import {loginToMattermost} from '../../helpers/login';
 import type {ServerView} from '../../helpers/serverView';
 
@@ -205,9 +204,9 @@ async function closeCallsWidget(
     });
 
     if (!leaveClicked) {
-        await electronApp.evaluate(({ipcMain}, channel) => {
-            ipcMain.emit(channel);
-        }, CALLS_LEAVE_CALL);
+        await widgetWindow.evaluate(() => {
+            (window as unknown as {desktopAPI?: {leaveCall: () => void}}).desktopAPI?.leaveCall();
+        });
     }
 
     await expect.poll(

--- a/src/app/callsWidgetWindow.test.js
+++ b/src/app/callsWidgetWindow.test.js
@@ -363,6 +363,38 @@ describe('main/windows/callsWidgetWindow', () => {
         expect(callsWidgetWindow.win.webContents.send).toHaveBeenCalledWith(CALLS_WIDGET_SHARE_SCREEN, 'sourceId', true);
     });
 
+    describe('handleCallsLeave', () => {
+        const callsWidgetWindow = new CallsWidgetWindow();
+
+        beforeEach(() => {
+            callsWidgetWindow.close = jest.fn();
+            callsWidgetWindow.mainView = {webContentsId: 'mainViewID'};
+            callsWidgetWindow.win = {webContents: {id: 'widgetID'}, isDestroyed: () => false};
+            callsWidgetWindow.popOut = undefined;
+        });
+
+        afterEach(() => {
+            jest.clearAllMocks();
+            delete callsWidgetWindow.mainView;
+            delete callsWidgetWindow.win;
+        });
+
+        it('should not close when the sender is a different server', () => {
+            callsWidgetWindow.handleCallsLeave({sender: {id: 'otherServerID'}});
+            expect(callsWidgetWindow.close).not.toHaveBeenCalled();
+        });
+
+        it('should close when the sender is the calls widget', () => {
+            callsWidgetWindow.handleCallsLeave({sender: {id: 'widgetID'}});
+            expect(callsWidgetWindow.close).toHaveBeenCalled();
+        });
+
+        it('should close when the sender is the main view of the call', () => {
+            callsWidgetWindow.handleCallsLeave({sender: {id: 'mainViewID'}});
+            expect(callsWidgetWindow.close).toHaveBeenCalled();
+        });
+    });
+
     describe('onPopOutOpen', () => {
         const callsWidgetWindow = new CallsWidgetWindow();
 

--- a/src/app/callsWidgetWindow.ts
+++ b/src/app/callsWidgetWindow.ts
@@ -615,8 +615,13 @@ export class CallsWidgetWindow {
         return promise;
     };
 
-    private handleCallsLeave = () => {
+    private handleCallsLeave = (event: IpcMainEvent) => {
         log.debug('handleCallsLeave');
+
+        if (!this.isCallsWidget(event.sender.id) && this.mainView?.webContentsId !== event.sender.id) {
+            log.debug('handleCallsLeave', 'blocked on wrong webContentsId');
+            return;
+        }
 
         this.close();
     };


### PR DESCRIPTION
#### Summary
The `leaveCall` desktop API did not validate the sender, so a server view could affect a call owned by a different server. This PR adds sender validation so the request is only honored when it comes from the server that owns the call.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69253

#### Release Note
```release-note
Fixed an issue where other views could end an active call
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟠 Medium

**Regression Risk:** This changes sender validation in the call-leave IPC flow, which is a user-facing call-control path and introduces authorization-like checks. The affected code is localized to the Calls widget window, and the new tests cover the main allowed/denied cases, but there is still risk around edge cases where sender identity or window state differs.

**QA Recommendation:** Recommend targeted manual QA for leaving calls from the widget and from the owning view, plus a quick negative check that other views cannot end the call.
*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->