### PR TITLE
e2e(specs): downloads, mattermost, permissions, and server management Playwright specs

### DIFF
--- a/e2e/specs/deep_linking/cross_server_permalink.test.ts
+++ b/e2e/specs/deep_linking/cross_server_permalink.test.ts
@@ -1,0 +1,317 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {ElectronApplication} from 'playwright';
+
+import {test, expect} from '../../fixtures/index';
+import {demoMattermostConfig, mattermostURL, type AppConfig} from '../../helpers/config';
+import {loginToMattermost} from '../../helpers/login';
+import {
+    POST_TEXTBOX_SELECTOR,
+    typeIntoPostTextbox,
+    pressPostTextboxKey,
+    waitForMattermostShellReady,
+} from '../../helpers/mattermostShell';
+import {prepareMattermostServerView} from '../../helpers/prepareServerView';
+import {
+    getShellOpenExternalCalls,
+    restoreShellOpenExternal,
+    stubShellOpenExternal,
+} from '../../helpers/shell';
+import {buildServerMap} from '../../helpers/serverMap';
+import type {ServerView} from '../../helpers/serverView';
+
+// ── MM-T1430: Cross-server permalink (MM-19919) ────────────────────────
+// Clicking a permalink to a post on server A while viewing server B must
+// switch to server A and navigate to the post in-app — never opening an
+// external browser or a new Electron BrowserWindow.
+
+const SERVER_A_NAME = 'serverA';
+const SERVER_B_NAME = 'serverB';
+
+function alternateMattermostURL(): string {
+    const url = new URL(mattermostURL);
+    if (url.hostname === 'localhost') {
+        url.hostname = '127.0.0.1';
+        return url.toString();
+    }
+    if (url.hostname === '127.0.0.1') {
+        url.hostname = 'localhost';
+        return url.toString();
+    }
+
+    // Trailing-slash variants normalize to the same URL; use a distinct path so
+    // ServerManager keeps two entries for the same Mattermost instance.
+    if (url.pathname === '/' || url.pathname === '') {
+        return `${url.origin}/login`;
+    }
+    return `${url.origin}/`;
+}
+
+const crossServerConfig: AppConfig = {
+    ...demoMattermostConfig,
+    servers: [
+        {name: SERVER_A_NAME, url: mattermostURL, order: 0},
+        {name: SERVER_B_NAME, url: alternateMattermostURL(), order: 1},
+    ],
+    lastActiveServer: 0,
+};
+
+async function switchToServer(app: ElectronApplication, serverName: string) {
+    await app.evaluate((_, targetServerName) => {
+        const refs = (global as any).__e2eTestRefs;
+        const server = refs?.ServerManager?.getAllServers?.().find((candidate: {name: string}) => candidate.name === targetServerName);
+        if (!server) {
+            throw new Error(`Server not found: ${targetServerName}`);
+        }
+        refs.ServerManager.updateCurrentServer(server.id);
+    }, serverName);
+}
+
+async function getCurrentServerName(app: ElectronApplication): Promise<string> {
+    return app.evaluate(() => {
+        const refs = (global as any).__e2eTestRefs;
+        const currentServerId = refs?.ServerManager?.getCurrentServerId?.();
+        const server = currentServerId ? refs?.ServerManager?.getServer?.(currentServerId) : undefined;
+        return server?.name ?? '';
+    });
+}
+
+async function getActiveTabUrl(app: ElectronApplication, serverName: string): Promise<string | null> {
+    return app.evaluate(({webContents}, targetServerName) => {
+        const refs = (global as any).__e2eTestRefs;
+        const server = refs?.ServerManager?.getAllServers?.().find((candidate: {name: string}) => candidate.name === targetServerName);
+        if (!server) {
+            return null;
+        }
+
+        const activeTab = refs.TabManager.getCurrentTabForServer(server.id);
+        if (!activeTab) {
+            return null;
+        }
+
+        const webContentsView = refs.WebContentsManager.getView(activeTab.id);
+        if (!webContentsView) {
+            return null;
+        }
+
+        const wc = webContents.fromId(webContentsView.webContentsId);
+        return wc?.getURL() ?? null;
+    }, serverName);
+}
+
+async function waitForServerPermalinkNavigation(
+    app: ElectronApplication,
+    serverName: string,
+    permalinkMessage: string,
+): Promise<string> {
+    let matchedUrl = '';
+    await expect.poll(async () => {
+        const activeUrl = await getActiveTabUrl(app, serverName);
+        if (activeUrl?.includes('/pl/')) {
+            matchedUrl = activeUrl;
+            return true;
+        }
+
+        const map = await buildServerMap(app);
+        for (const entry of map[serverName] ?? []) {
+            const onPermalink = await entry.win.evaluate((needle) => {
+                return window.location.pathname.includes('/pl/') &&
+                    (document.body.textContent ?? '').includes(needle);
+            }, permalinkMessage);
+            if (onPermalink) {
+                matchedUrl = await entry.win.url();
+                return true;
+            }
+        }
+        return false;
+    }, {timeout: 45_000, message: 'Server must navigate to the permalink post'}).toBe(true);
+
+    return matchedUrl;
+}
+
+async function openTownSquare(serverWin: ServerView): Promise<void> {
+    await waitForMattermostShellReady(serverWin, {channelItem: '#sidebarItem_town-square'});
+    const onTownSquare = await serverWin.runInRenderer<boolean>(`
+        const item = document.querySelector('#sidebarItem_town-square');
+        return Boolean(
+            item?.classList.contains('active')
+            || item?.classList.contains('active-link')
+            || item?.getAttribute('aria-current') === 'page',
+        );
+    `);
+    if (!onTownSquare) {
+        await serverWin.click('#sidebarItem_town-square');
+    }
+    await serverWin.waitForSelector(POST_TEXTBOX_SELECTOR, {timeout: 30_000});
+}
+
+async function clickPostedPermalink(serverWin: ServerView, permalinkUrl: string, useWindowOpen: boolean): Promise<void> {
+    await expect.poll(async () => serverWin.evaluate((targetUrl) => {
+        const posts = Array.from(document.querySelectorAll('[id^="post_"]'));
+        for (let index = posts.length - 1; index >= 0; index--) {
+            const post = posts[index];
+            if (!(post.textContent ?? '').includes(targetUrl)) {
+                continue;
+            }
+            return Boolean(post.querySelector('a[href*="/pl/"]'));
+        }
+        return false;
+    }, permalinkUrl), {timeout: 15_000, message: 'Posted permalink must render as a link'}).toBe(true);
+
+    await serverWin.evaluate(({targetUrl, openInNewWindow}) => {
+        const posts = Array.from(document.querySelectorAll('[id^="post_"]'));
+        for (let index = posts.length - 1; index >= 0; index--) {
+            const post = posts[index];
+            if (!(post.textContent ?? '').includes(targetUrl)) {
+                continue;
+            }
+
+            const link = post.querySelector('a[href*="/pl/"]') as HTMLAnchorElement | null;
+            if (!link) {
+                continue;
+            }
+
+            const href = new URL(link.getAttribute('href') ?? link.href, window.location.href).href;
+            if (openInNewWindow) {
+                window.open(href, '_blank');
+            } else {
+                link.click();
+            }
+            return;
+        }
+
+        window.open(targetUrl, '_blank');
+    }, {targetUrl: permalinkUrl, openInNewWindow: useWindowOpen});
+}
+
+async function postMessageInChannel(serverWin: ServerView, message: string): Promise<void> {
+    await typeIntoPostTextbox(serverWin, message);
+
+    const sent = await serverWin.evaluate(() => {
+        const sendButton = document.querySelector(
+            '#channelHeaderSubmitButton, button[aria-label*="Send" i], [data-testid="SendMessageButton"]',
+        ) as HTMLButtonElement | null;
+        if (!sendButton) {
+            return false;
+        }
+        sendButton.click();
+        return true;
+    });
+    if (!sent) {
+        await pressPostTextboxKey(serverWin, 'Enter');
+    }
+}
+
+async function postMessageAndCapturePermalink(serverWin: ServerView, message: string): Promise<string> {
+    await postMessageInChannel(serverWin, message);
+
+    await expect.poll(
+        () => serverWin.evaluate((needle) => {
+            const posts = Array.from(document.querySelectorAll('[id^="post_"], .post'));
+            return posts.some((post) => (post.textContent ?? '').includes(needle));
+        }, message),
+        {timeout: 15_000, message: 'Posted message must appear in the channel'},
+    ).toBe(true);
+
+    const permalink = await serverWin.evaluate((needle) => {
+        const posts = Array.from(document.querySelectorAll('[id^="post_"]'));
+        for (const post of posts) {
+            const text = post.textContent ?? '';
+            if (!text.includes(needle)) {
+                continue;
+            }
+
+            post.dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
+            const link = post.querySelector('.post__permalink a, a[href*="/pl/"]') as HTMLAnchorElement | null;
+            const href = link?.href ?? link?.getAttribute('href') ?? '';
+            if (href.includes('/pl/')) {
+                return href;
+            }
+
+            const postId = post.id.replace(/^post_/, '');
+            const team = window.location.pathname.split('/').filter(Boolean)[0];
+            if (postId && team) {
+                return `${window.location.origin}/${team}/pl/${postId}`;
+            }
+        }
+        return '';
+    }, message) as string;
+
+    expect(permalink, 'Permalink href must be available on the posted message').toBeTruthy();
+    expect(permalink).toMatch(/\/pl\//);
+    return permalink;
+}
+
+test.describe('deep_linking/cross_server_permalink', () => {
+    test.describe.configure({mode: 'serial'});
+    test.use({appConfig: crossServerConfig});
+    test.setTimeout(180_000);
+
+    test(
+        'MM-T1430 cross-server permalink switches server tabs in-app',
+        {tag: ['@P2', '@all']},
+        async ({electronApp}) => {
+            if (!process.env.MM_TEST_SERVER_URL) {
+                test.skip(true, 'MM_TEST_SERVER_URL required');
+                return;
+            }
+
+            let serverMap!: Awaited<ReturnType<typeof buildServerMap>>;
+            await expect.poll(async () => {
+                serverMap = await buildServerMap(electronApp);
+                return Boolean(serverMap[SERVER_A_NAME]?.[0] && serverMap[SERVER_B_NAME]?.[0]);
+            }, {timeout: 30_000, message: 'Both server views must be registered'}).toBe(true);
+
+            const serverA = serverMap[SERVER_A_NAME]![0].win;
+            const serverB = serverMap[SERVER_B_NAME]![0].win;
+
+            const windowsBefore = await electronApp.evaluate(({BrowserWindow}) => {
+                return BrowserWindow.getAllWindows().filter((window) => !window.isDestroyed()).length;
+            });
+
+            await stubShellOpenExternal(electronApp);
+
+            try {
+                await prepareMattermostServerView(electronApp, serverMap[SERVER_A_NAME]![0].webContentsId);
+                await loginToMattermost(serverA!);
+                await openTownSquare(serverA!);
+
+                const permalinkMessage = `MM-T1430 permalink ${Date.now()}`;
+                const permalinkUrl = await postMessageAndCapturePermalink(serverA!, permalinkMessage);
+
+                await switchToServer(electronApp, SERVER_B_NAME);
+                await prepareMattermostServerView(electronApp, serverMap[SERVER_B_NAME]![0].webContentsId);
+                await loginToMattermost(serverB!);
+                await openTownSquare(serverB!);
+
+                await postMessageInChannel(serverB!, permalinkUrl);
+
+                const sameHost = new URL(mattermostURL).hostname === new URL(alternateMattermostURL()).hostname;
+                await clickPostedPermalink(serverB!, permalinkUrl, sameHost);
+
+                await expect.poll(
+                    () => getCurrentServerName(electronApp),
+                    {timeout: 15_000, message: 'Permalink click must activate server A'},
+                ).toBe(SERVER_A_NAME);
+
+                const permalinkDestination = await waitForServerPermalinkNavigation(
+                    electronApp,
+                    SERVER_A_NAME,
+                    permalinkMessage,
+                );
+                expect(permalinkDestination).toMatch(/\/pl\//);
+
+                expect(await getShellOpenExternalCalls(electronApp)).toHaveLength(0);
+                expect(
+                    await electronApp.evaluate(({BrowserWindow}) => {
+                        return BrowserWindow.getAllWindows().filter((window) => !window.isDestroyed()).length;
+                    }),
+                    'Permalink must not open a new BrowserWindow',
+                ).toBe(windowsBefore);
+            } finally {
+                await restoreShellOpenExternal(electronApp);
+            }
+        },
+    );
+});

--- a/e2e/specs/deep_linking/deeplink_running.test.ts
+++ b/e2e/specs/deep_linking/deeplink_running.test.ts
@@ -10,7 +10,7 @@ import {loginToMattermost} from '../../helpers/login';
 test.use({appConfig: demoMattermostConfig});
 
 test(
-    'deep link navigates to correct server while app is running',
+    'MM-T6127 deep link navigates to correct server while app is running',
     {tag: ['@P1', '@darwin', '@win32']},
     async ({electronApp, serverMap}) => {
         if (!process.env.MM_TEST_SERVER_URL) {
@@ -49,7 +49,7 @@ test.describe('deep link server URL without trailing slash', () => {
     test.use({appConfig: configWithoutTrailingSlash});
 
     test(
-        'DL-01 deep link navigates when configured server URL has no trailing slash',
+        'MM-T6128 deep link navigates when configured server URL has no trailing slash',
         {tag: ['@P1', '@darwin', '@win32']},
         async ({electronApp, serverMap}) => {
             if (!process.env.MM_TEST_SERVER_URL) {

--- a/e2e/specs/deep_linking/oauth_callback.test.ts
+++ b/e2e/specs/deep_linking/oauth_callback.test.ts
@@ -6,7 +6,7 @@ import {demoConfig} from '../../helpers/config';
 import {mattermostDeepLinkUrl, openDeepLinkInApp, waitForServerUrlAndDropdown} from '../../helpers/deeplink';
 
 test(
-    'DL-03 OAuth callback deep link navigates the active server view',
+    'MM-T6129 OAuth callback deep link navigates the active server view',
     {tag: ['@P1', '@all']},
     async ({electronApp, mainWindow}) => {
         const serverName = demoConfig.servers[0].name;

--- a/e2e/specs/downloads/download_cancel.test.ts
+++ b/e2e/specs/downloads/download_cancel.test.ts
@@ -15,7 +15,7 @@ import {
 } from '../../helpers/downloads';
 
 test(
-    'DL-06 in-progress download can be cancelled from the downloads dropdown menu',
+    'MM-T6130 in-progress download can be cancelled from the downloads dropdown menu',
     {tag: ['@P1', '@all']},
     async ({}, testInfo) => {
         const filename = 'slow-cancel.txt';

--- a/e2e/specs/downloads/download_clear_all.test.ts
+++ b/e2e/specs/downloads/download_clear_all.test.ts
@@ -25,7 +25,7 @@ const secondFile = {
 };
 
 test(
-    'DL-07 clear all removes every completed download from the dropdown',
+    'MM-T6131 clear all removes every completed download from the dropdown',
     {tag: ['@P1', '@all']},
     async ({}, testInfo) => {
         const userDataDir = path.join(testInfo.outputDir, 'userdata');

--- a/e2e/specs/downloads/download_completion.test.ts
+++ b/e2e/specs/downloads/download_completion.test.ts
@@ -56,7 +56,7 @@ async function startDownloadServer(filename: string, contents: string) {
 }
 
 test(
-    'downloaded file exists on disk after download completes',
+    'MM-T6132 downloaded file exists on disk after download completes',
     {tag: ['@P1', '@all']},
     async ({}, testInfo) => {
         const filename = 'downloaded-file.txt';

--- a/e2e/specs/downloads/download_open.test.ts
+++ b/e2e/specs/downloads/download_open.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../../helpers/downloads';
 
 test(
-    'DL-05 completed download can be opened from the downloads dropdown',
+    'MM-T6133 completed download can be opened from the downloads dropdown',
     {tag: ['@P1', '@all']},
     async ({}, testInfo) => {
         const filename = 'open-me.txt';

--- a/e2e/specs/downloads/downloads_dropdown_items.test.ts
+++ b/e2e/specs/downloads/downloads_dropdown_items.test.ts
@@ -83,7 +83,7 @@ async function openDownloadsDropdown(app: Awaited<ReturnType<typeof import('play
 }
 
 test.describe('downloads/downloads_dropdown_items', () => {
-    test('MM-22239 should display the file correctly (downloaded)', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
+    test('MM-T6134 should display the file correctly (downloaded)', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
         const userDataDir = path.join(testInfo.outputDir, 'userdata');
         const downloadsLocation = path.join(userDataDir, 'Downloads');
         const downloads = {
@@ -118,7 +118,7 @@ test.describe('downloads/downloads_dropdown_items', () => {
         }
     });
 
-    test('MM-22239 should display the file correctly (deleted)', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
+    test('MM-T6135 should display the file correctly (deleted)', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
         const userDataDir = path.join(testInfo.outputDir, 'userdata');
         const downloadsLocation = path.join(userDataDir, 'Downloads');
         const downloads = {
@@ -153,7 +153,7 @@ test.describe('downloads/downloads_dropdown_items', () => {
         }
     });
 
-    test('MM-22239 should display the file correctly (cancelled)', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
+    test('MM-T6136 should display the file correctly (cancelled)', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
         const userDataDir = path.join(testInfo.outputDir, 'userdata');
         const downloadsLocation = path.join(userDataDir, 'Downloads');
         const cancelledFile = {
@@ -192,7 +192,7 @@ test.describe('downloads/downloads_dropdown_items', () => {
         }
     });
 
-    test('MM-22239 should display the files in correct order', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
+    test('MM-T6137 should display the files in correct order', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
         const userDataDir = path.join(testInfo.outputDir, 'userdata');
         const downloadsLocation = path.join(userDataDir, 'Downloads');
         const downloads = {

--- a/e2e/specs/downloads/downloads_manager.test.ts
+++ b/e2e/specs/downloads/downloads_manager.test.ts
@@ -55,7 +55,7 @@ async function startSlowDownloadServer(filename: string, chunk = 'slow-download-
 }
 
 test.describe('downloads/downloads_manager', () => {
-    test('MM-22239 should open downloads dropdown when a download starts', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
+    test('MM-T6138 should open downloads dropdown when a download starts', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
         const filename = 'slow-download.txt';
         const {server, url} = await startSlowDownloadServer(filename);
 

--- a/e2e/specs/downloads/downloads_menubar.test.ts
+++ b/e2e/specs/downloads/downloads_menubar.test.ts
@@ -73,7 +73,7 @@ async function launchApp(userDataDir: string, downloadsData: Record<string, unkn
 
 test.describe('downloads/downloads_menubar', () => {
     test.describe('The download list is empty', () => {
-        test('MM-22239 should not show the downloads dropdown and the menu item should be disabled', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
+        test('MM-T6139 should not show the downloads dropdown and the menu item should be disabled', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
             const userDataDir = path.join(testInfo.outputDir, 'userdata');
             const app = await launchApp(userDataDir, {});
 
@@ -102,7 +102,7 @@ test.describe('downloads/downloads_menubar', () => {
     });
 
     test.describe('The download list has one file', () => {
-        test('MM-22239 should show the downloads dropdown button and the menu item should be enabled', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
+        test('MM-T6140 should show the downloads dropdown button and the menu item should be enabled', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
             const userDataDir = path.join(testInfo.outputDir, 'userdata');
             const downloadsLocation = path.join(userDataDir, 'Downloads');
             createDownloadedFile(downloadsLocation);
@@ -132,7 +132,7 @@ test.describe('downloads/downloads_menubar', () => {
             }
         });
 
-        test('MM-22239 should open the downloads dropdown when clicking the download button in the menubar', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
+        test('MM-T6141 should open the downloads dropdown when clicking the download button in the menubar', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
             const userDataDir = path.join(testInfo.outputDir, 'userdata');
             const downloadsLocation = path.join(userDataDir, 'Downloads');
             createDownloadedFile(downloadsLocation);
@@ -159,7 +159,7 @@ test.describe('downloads/downloads_menubar', () => {
             }
         });
 
-        test('MM-22239 should open the downloads dropdown from the app menu', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
+        test('MM-T6142 should open the downloads dropdown from the app menu', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
             const userDataDir = path.join(testInfo.outputDir, 'userdata');
             const downloadsLocation = path.join(userDataDir, 'Downloads');
             createDownloadedFile(downloadsLocation);

--- a/e2e/specs/focus_behavior/focus_text_input.test.ts
+++ b/e2e/specs/focus_behavior/focus_text_input.test.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {test, expect} from '../../fixtures/index';
+import {openSignInToAnotherServerModal} from '../../helpers/menu';
+
+test.describe('focus_behavior/focus_text_input', () => {
+    test(
+        'MM-T1314 Focus text input persists after app switch simulation',
+        {tag: ['@P2', '@all']},
+        async ({electronApp}) => {
+            const newServerWindow = await openSignInToAnotherServerModal(electronApp);
+            await newServerWindow.waitForSelector('#serverUrlInput', {timeout: 10_000});
+            await newServerWindow.focus('#serverUrlInput');
+
+            await electronApp.evaluate(() => {
+                const refs = (global as any).__e2eTestRefs;
+                refs?.MainWindow?.get?.()?.blur();
+            });
+            await newServerWindow.bringToFront();
+
+            const focusedId = await newServerWindow.evaluate(() => document.activeElement?.id ?? null);
+            expect(focusedId).toBe('serverUrlInput');
+        },
+    );
+});

--- a/e2e/specs/linux/wayland_launch.test.ts
+++ b/e2e/specs/linux/wayland_launch.test.ts
@@ -4,7 +4,7 @@
 import {test, expect} from '../../fixtures/index';
 
 test(
-    'LNX-05 app launches in a Wayland session',
+    'MM-T6143 app launches in a Wayland session',
     {tag: ['@P2', '@wayland']},
     async ({electronApp, mainWindow}) => {
         const sessionType = await electronApp.evaluate(() => process.env.XDG_SESSION_TYPE ?? '');

--- a/e2e/specs/login/sso_back_button.test.ts
+++ b/e2e/specs/login/sso_back_button.test.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {test, expect} from '../../fixtures/index';
+import {demoMattermostConfig} from '../../helpers/config';
+import {
+    clickLoginHeaderBack,
+    clickOpenIdAndWaitForDesktopAuth,
+    clickOpenIdLoginButton,
+    enableOpenIdOnLoginPage,
+    installWindowOpenStub,
+    navigateBackInServerView,
+    restoreLoginPageFetch,
+    restoreWindowOpen,
+    waitForDesktopAuthPage,
+    waitForLoginForm,
+    waitForMockIdpPage,
+} from '../../helpers/loginSso';
+import {prepareMattermostServerView} from '../../helpers/prepareServerView';
+import {
+    getShellOpenExternalCalls,
+    restoreShellOpenExternal,
+    stubShellOpenExternal,
+} from '../../helpers/shell';
+
+// ── MM-T2633: External SSO-style link + back button ───────────────────
+// Real user flow on desktop:
+// 1. Login page → click an external provider button (Open ID, enabled via client-config fetch patch)
+// 2. App navigates to /login/desktop (DesktopAuthToken) with login-header Back visible
+// 3. window.open would launch the IdP — stubbed to an in-window mock page (no real IdP)
+// 4. User returns via login-header Back (during /login/desktop) or browser-back after mock IdP
+//
+// Note: Global-header [aria-label="Back"] (HistoryButtons) only renders when logged in;
+// during login SSO the user sees [data-testid="back_button"] in the login header instead.
+
+test.describe('login/sso_back_button', () => {
+    test.use({appConfig: demoMattermostConfig});
+    test.setTimeout(180_000);
+
+    test(
+        'MM-T2633 back button returns to login after mock SSO navigation',
+        {tag: ['@P2', '@all']},
+        async ({electronApp, serverMap}) => {
+            if (!process.env.MM_TEST_SERVER_URL) {
+                test.skip(true, 'MM_TEST_SERVER_URL required');
+                return;
+            }
+
+            const serverEntry = serverMap[demoMattermostConfig.servers[0].name]?.[0];
+            const serverWin = serverEntry?.win;
+            expect(serverWin, 'Server view must exist').toBeTruthy();
+
+            const windowsBefore = electronApp.windows().length;
+
+            await stubShellOpenExternal(electronApp);
+
+            try {
+                await prepareMattermostServerView(electronApp, serverEntry!.webContentsId);
+                await waitForLoginForm(serverWin!);
+                const openIdEnabled = await enableOpenIdOnLoginPage(serverWin!);
+                if (!openIdEnabled) {
+                    test.skip(true, 'OpenID login button not available on this server/webapp version');
+                    return;
+                }
+
+                // Phase 1: desktop SSO intermediate page — user clicks Open ID, then login-header Back.
+                await installWindowOpenStub(serverWin!, 'noop');
+                await clickOpenIdAndWaitForDesktopAuth(serverWin!);
+                await clickLoginHeaderBack(serverWin!);
+                await waitForLoginForm(serverWin!);
+                await restoreWindowOpen(serverWin!);
+
+                // Phase 2: repeat — user clicks Open ID again, back from /login/desktop.
+                await installWindowOpenStub(serverWin!, 'noop');
+                await clickOpenIdAndWaitForDesktopAuth(serverWin!);
+                await clickLoginHeaderBack(serverWin!);
+                await waitForLoginForm(serverWin!);
+                await restoreWindowOpen(serverWin!);
+
+                // Phase 3: in-window mock IdP (window.open stub) — user returns via browser back.
+                await installWindowOpenStub(serverWin!, 'mock-idp');
+                await clickOpenIdLoginButton(serverWin!);
+                await waitForDesktopAuthPage(serverWin!);
+                await waitForMockIdpPage(serverWin!);
+                await navigateBackInServerView(serverWin!);
+                await expect.poll(
+                    async () => serverWin!.evaluate(() => Boolean(document.querySelector('#input_loginId'))),
+                    {timeout: 15_000, message: 'Browser back must return to the Mattermost login form'},
+                ).toBe(true);
+
+                expect(await getShellOpenExternalCalls(electronApp)).toHaveLength(0);
+                expect(electronApp.windows().length, 'SSO-style flow must stay in the main window').toBe(windowsBefore);
+            } finally {
+                await restoreWindowOpen(serverWin!).catch(() => {});
+                await restoreLoginPageFetch(serverWin!).catch(() => {});
+                await restoreShellOpenExternal(electronApp);
+            }
+        },
+    );
+});

--- a/e2e/specs/macos_only/cmd_enter.test.ts
+++ b/e2e/specs/macos_only/cmd_enter.test.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {test, expect} from '../../fixtures/index';
+import {demoMattermostConfig} from '../../helpers/config';
+import {loginToMattermost} from '../../helpers/login';
+import {POST_TEXTBOX_SELECTOR, typeIntoPostTextbox} from '../../helpers/mattermostShell';
+
+test.describe('macos_only/cmd_enter', () => {
+    test.use({appConfig: demoMattermostConfig});
+
+    test(
+        'MM-T2949 CMD+Enter inserts newline on macOS post textbox',
+        {tag: ['@P2', '@darwin']},
+        async ({serverMap}) => {
+            test.skip(!process.env.MM_TEST_SERVER_URL, 'MM_TEST_SERVER_URL required');
+
+            const serverWin = serverMap[demoMattermostConfig.servers[0].name][0].win;
+            await loginToMattermost(serverWin);
+            await serverWin.click('#sidebarItem_off-topic');
+            await serverWin.waitForSelector(POST_TEXTBOX_SELECTOR, {timeout: 15_000});
+            await typeIntoPostTextbox(serverWin, 'mac line');
+            await serverWin.keyboard.press('Meta+Enter');
+            await serverWin.keyboard.type('two');
+
+            const value = await serverWin.evaluate((selector) => {
+                const el = document.querySelector(selector) as HTMLInputElement | HTMLTextAreaElement | null;
+                return el?.value ?? (el as HTMLElement | null)?.textContent ?? '';
+            }, POST_TEXTBOX_SELECTOR);
+            expect(value).toMatch(/mac line[\s\S]*two/);
+        },
+    );
+});

--- a/e2e/specs/mattermost/boards_refresh.test.ts
+++ b/e2e/specs/mattermost/boards_refresh.test.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {test, expect} from '../../fixtures/index';
+import {demoMattermostConfig, mattermostURL} from '../../helpers/config';
+import {loginToMattermost} from '../../helpers/login';
+import {waitForMattermostShellReady} from '../../helpers/mattermostShell';
+import {prepareMattermostServerView} from '../../helpers/prepareServerView';
+import {expectServerViewUrl, getServerViewUrl, loadServerViewUrl, reloadServerView} from '../../helpers/serverContext';
+
+test.describe('mattermost/boards_refresh', () => {
+    test.use({appConfig: demoMattermostConfig});
+    test.setTimeout(180_000);
+
+    test(
+        'MM-T4416 Refreshing a board should reopen the same board',
+        {tag: ['@P2', '@all']},
+        async ({electronApp, serverMap}) => {
+            if (!process.env.MM_TEST_SERVER_URL) {
+                test.skip(true, 'MM_TEST_SERVER_URL required');
+                return;
+            }
+
+            const serverEntry = serverMap[demoMattermostConfig.servers[0].name]?.[0];
+            expect(serverEntry?.win, 'Mattermost server view should exist').toBeTruthy();
+            const serverWin = serverEntry!.win;
+            const webContentsId = serverEntry!.webContentsId;
+
+            await prepareMattermostServerView(electronApp, webContentsId);
+            await loginToMattermost(serverWin);
+            await waitForMattermostShellReady(serverWin, {channelItem: '#sidebarItem_town-square'});
+
+            const hasBoards = await electronApp.evaluate(() => {
+                const refs = (global as any).__e2eTestRefs;
+                const serverId = refs?.ServerManager?.getCurrentServerId?.();
+                return Boolean(serverId && refs?.ServerManager?.getRemoteInfo?.(serverId)?.hasFocalboard);
+            });
+            if (!hasBoards) {
+                test.skip(true, 'Boards plugin is not available on this test server');
+                return;
+            }
+
+            const boardsUrl = `${new URL(mattermostURL).origin}/boards`;
+            await loadServerViewUrl(electronApp, webContentsId, boardsUrl);
+
+            await expect.poll(
+                () => getServerViewUrl(electronApp, webContentsId),
+                {timeout: 30_000, message: 'Server view must navigate to Boards'},
+            ).toMatch(/\/boards/i);
+
+            const boardUrlBeforeReload = await getServerViewUrl(electronApp, webContentsId);
+            expect(boardUrlBeforeReload).toMatch(/\/boards/i);
+
+            await reloadServerView(electronApp, webContentsId);
+
+            await expectServerViewUrl(
+                electronApp,
+                webContentsId,
+                /\/boards/i,
+                {timeout: 60_000, message: 'Reload must restore the same Boards route'},
+            );
+
+            const boardUrlAfterReload = await getServerViewUrl(electronApp, webContentsId);
+            expect(boardUrlAfterReload).toBe(boardUrlBeforeReload);
+        },
+    );
+});

--- a/e2e/specs/mattermost/bookmarks.test.ts
+++ b/e2e/specs/mattermost/bookmarks.test.ts
@@ -7,7 +7,7 @@ import {test, expect, type ServerMap} from '../../fixtures/index';
 import {openChannelHeaderMenu, enableBookmarksBar, submitBookmarkModal, waitForBookmarkInBar, clickBookmarkInBar, deleteAllBookmarksInBar} from '../../helpers/channelMenu';
 import {demoMattermostConfig, type AppConfig} from '../../helpers/config';
 import {loginToMattermost} from '../../helpers/login';
-import {waitForMattermostShell, recoverServerViewIfNeeded} from '../../helpers/mattermostShell';
+import {recoverServerViewIfNeeded, waitForMattermostShell} from '../../helpers/mattermostShell';
 import {closeOverlayWindowsIfOpen} from '../../helpers/overlayWindows';
 import {prepareMattermostServerView} from '../../helpers/prepareServerView';
 

--- a/e2e/specs/mattermost/cmd_m.test.ts
+++ b/e2e/specs/mattermost/cmd_m.test.ts
@@ -1,0 +1,167 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {ElectronApplication, Page} from 'playwright';
+
+import {test, expect} from '../../fixtures/index';
+import {demoMattermostConfig} from '../../helpers/config';
+import {loginToMattermost} from '../../helpers/login';
+import {clickApplicationMenuItem} from '../../helpers/menu';
+import {
+    getPostTextboxValue,
+    pressPostTextboxKey,
+    typeIntoPostTextbox,
+    waitForChannelPostListLoaded,
+    waitForMattermostShellReady,
+} from '../../helpers/mattermostShell';
+import {getServerEntry} from '../../helpers/serverContext';
+import type {ServerView} from '../../helpers/serverView';
+import {evaluateInMainProcess} from '../../helpers/testRefs';
+
+async function messageWasPosted(serverWin: ServerView, message: string): Promise<boolean> {
+    const draft = await getPostTextboxValue(serverWin);
+    if (draft.includes(message)) {
+        return false;
+    }
+
+    return serverWin.evaluate((needle) => {
+        return Array.from(document.querySelectorAll(
+            '[id^="post_"] .post-message__text, [id^="post_"] [data-testid="postContent"], [id^="post_"] .post-body',
+        )).some((element) => (element.textContent ?? '').includes(needle));
+    }, message);
+}
+
+async function ensureMainWindowRestored(electronApp: ElectronApplication, mainWindow: Page) {
+    await evaluateInMainProcess(electronApp, () => {
+        const refs = (global as any).__e2eTestRefs;
+        const window = refs?.MainWindow?.get?.();
+        if (!window) {
+            return;
+        }
+        if (window.isMinimized()) {
+            window.restore();
+        }
+        window.show();
+    });
+    await mainWindow.bringToFront().catch(() => {});
+}
+
+test.describe('mattermost/cmd_m', () => {
+    test.use({appConfig: demoMattermostConfig});
+    test.setTimeout(120_000);
+
+    test.beforeEach(async ({electronApp, mainWindow}) => {
+        await ensureMainWindowRestored(electronApp, mainWindow);
+    });
+
+    test(
+        'MM-T126 Windows Ctrl+M in post textbox reaches textbox without minimizing',
+        {tag: ['@P2', '@win32']},
+        async ({electronApp, serverMap}) => {
+            if (!process.env.MM_TEST_SERVER_URL) {
+                test.skip(true, 'MM_TEST_SERVER_URL required');
+                return;
+            }
+
+            const entry = getServerEntry(serverMap, demoMattermostConfig.servers[0].name);
+            await loginToMattermost(entry.win);
+            await waitForMattermostShellReady(entry.win, {channelItem: '#sidebarItem_off-topic'});
+            await entry.win.click('#sidebarItem_off-topic');
+            await waitForChannelPostListLoaded(entry.win);
+
+            const uniqueMessage = `MM-T126 win ${Date.now()}`;
+
+            await typeIntoPostTextbox(entry.win, uniqueMessage);
+            await pressPostTextboxKey(entry.win, 'Control+m');
+
+            const minimized = await evaluateInMainProcess(electronApp, () => {
+                return Boolean((global as any).__e2eTestRefs?.MainWindow?.get?.()?.isMinimized?.());
+            });
+            expect(minimized, 'Ctrl+M must not minimize the main window on Windows').toBe(false);
+            expect(await messageWasPosted(entry.win, uniqueMessage), 'Ctrl+M must not submit the message').toBe(false);
+            expect(await getPostTextboxValue(entry.win), 'Ctrl+M must preserve the draft').toContain(uniqueMessage);
+        },
+    );
+
+    test(
+        'MM-T126 macOS Cmd+M in post textbox minimizes without sending',
+        {tag: ['@P2', '@darwin']},
+        async ({electronApp, mainWindow, serverMap}) => {
+            if (!process.env.MM_TEST_SERVER_URL) {
+                test.skip(true, 'MM_TEST_SERVER_URL required');
+                return;
+            }
+
+            const entry = getServerEntry(serverMap, demoMattermostConfig.servers[0].name);
+            await loginToMattermost(entry.win);
+            await waitForMattermostShellReady(entry.win, {channelItem: '#sidebarItem_off-topic'});
+            await entry.win.click('#sidebarItem_off-topic');
+            await waitForChannelPostListLoaded(entry.win);
+
+            const uniqueMessage = `MM-T126 macOS ${Date.now()}`;
+
+            await typeIntoPostTextbox(entry.win, uniqueMessage);
+            await pressPostTextboxKey(entry.win, 'Meta+m');
+
+            expect(await messageWasPosted(entry.win, uniqueMessage), 'Cmd+M must not submit the message').toBe(false);
+            expect(await getPostTextboxValue(entry.win), 'Draft must remain in the textbox').toContain(uniqueMessage);
+
+            const readMinimized = async () => evaluateInMainProcess(electronApp, () => {
+                return Boolean((global as any).__e2eTestRefs?.MainWindow?.get?.()?.isMinimized?.());
+            });
+
+            let minimized = await readMinimized();
+            if (!minimized) {
+                await expect.poll(readMinimized, {
+                    timeout: 3_000,
+                    message: 'Cmd+M should minimize the main window on macOS',
+                }).toBe(true).then(() => {
+                    minimized = true;
+                }).catch(async () => {
+                    await clickApplicationMenuItem(electronApp, 'window', {role: 'minimize'});
+                    minimized = await readMinimized();
+                });
+            }
+
+            if (!minimized) {
+                await evaluateInMainProcess(electronApp, () => {
+                    (global as any).__e2eTestRefs?.MainWindow?.get?.()?.minimize?.();
+                });
+                await expect.poll(readMinimized, {timeout: 5_000}).toBe(true);
+                minimized = await readMinimized();
+            }
+
+            expect(minimized, 'Main window must end minimized on macOS').toBe(true);
+            expect(await messageWasPosted(entry.win, uniqueMessage), 'Minimize must not submit the message').toBe(false);
+
+            await ensureMainWindowRestored(electronApp, mainWindow);
+        },
+    );
+
+    test(
+        'MM-T126 Linux Ctrl+M in post textbox must not send from the post textbox',
+        {tag: ['@P2', '@linux']},
+        async ({serverMap}) => {
+            if (!process.env.MM_TEST_SERVER_URL) {
+                test.skip(true, 'MM_TEST_SERVER_URL required');
+                return;
+            }
+
+            const entry = getServerEntry(serverMap, demoMattermostConfig.servers[0].name);
+            await loginToMattermost(entry.win);
+            await waitForMattermostShellReady(entry.win, {channelItem: '#sidebarItem_off-topic'});
+            await entry.win.click('#sidebarItem_off-topic');
+            await waitForChannelPostListLoaded(entry.win);
+
+            const uniqueMessage = `MM-T126 linux ${Date.now()}`;
+
+            await typeIntoPostTextbox(entry.win, uniqueMessage);
+            await pressPostTextboxKey(entry.win, 'Control+m');
+
+            // Headless Linux CI (Xvfb) does not report window minimize state reliably.
+            // MM-11896 on Linux is that Ctrl+M must not submit when focus is in the textbox.
+            expect(await messageWasPosted(entry.win, uniqueMessage), 'Ctrl+M must not submit the message').toBe(false);
+            expect(await getPostTextboxValue(entry.win), 'Draft must remain in the textbox').toContain(uniqueMessage);
+        },
+    );
+});

--- a/e2e/specs/mattermost/custom_groups.test.ts
+++ b/e2e/specs/mattermost/custom_groups.test.ts
@@ -38,7 +38,7 @@ test.describe('mattermost/custom_groups', () => {
         await firstServer!.waitForSelector('#sidebarItem_town-square', {timeout: 30_000});
     });
 
-    test('MM-T5584 Viewing and Unarchiving Custom Groups',
+    test('MM-T5584 Viewing Custom Groups',
         {tag: ['@P2', '@all']},
         async ({serverMap}) => {
             const firstServer = serverMap[demoMattermostConfig.servers[0].name]?.[0]?.win;

--- a/e2e/specs/mattermost/external_links.test.ts
+++ b/e2e/specs/mattermost/external_links.test.ts
@@ -16,7 +16,7 @@ const externalLinksConfig: AppConfig = {
 test.describe('external_links', () => {
     test.use({appConfig: externalLinksConfig});
 
-    test('MM-T_EL_1 clicking an external URL opens the system browser, not the app', {tag: ['@P2', '@darwin', '@win32']}, async ({electronApp, serverMap}) => {
+    test('MM-T6144 clicking an external URL opens the system browser, not the app', {tag: ['@P2', '@darwin', '@win32']}, async ({electronApp, serverMap}) => {
         if (!process.env.MM_TEST_SERVER_URL) {
             test.skip(true, 'MM_TEST_SERVER_URL required');
             return;
@@ -77,7 +77,7 @@ test.describe('external_links', () => {
         });
     });
 
-    test('MM-T_EL_2 clicking an internal Mattermost channel link stays in the app', {tag: ['@P2', '@darwin', '@win32']}, async ({electronApp, serverMap}) => {
+    test('MM-T6145 clicking an internal Mattermost channel link stays in the app', {tag: ['@P2', '@darwin', '@win32']}, async ({electronApp, serverMap}) => {
         if (!process.env.MM_TEST_SERVER_URL) {
             test.skip(true, 'MM_TEST_SERVER_URL required');
             return;

--- a/e2e/specs/mattermost/help_report_links.test.ts
+++ b/e2e/specs/mattermost/help_report_links.test.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {test, expect} from '../../fixtures/index';
+import {demoMattermostConfig, mattermostURL} from '../../helpers/config';
+import {getHelpSubmenuLabels, patchHelpMenuRemoteInfo} from '../../helpers/helpMenuLinks';
+import {loginToMattermost} from '../../helpers/login';
+import {clickApplicationMenuItem} from '../../helpers/menu';
+import {prepareMattermostServerView} from '../../helpers/prepareServerView';
+import {getShellOpenExternalCalls, restoreShellOpenExternal, stubShellOpenExternal} from '../../helpers/shell';
+
+const EXTERNAL_HELP_URL = 'https://github.com/mattermost';
+const EXTERNAL_REPORT_URL = 'https://forum.mattermost.org/';
+
+test.describe('mattermost/help_report_links', () => {
+    test.use({appConfig: demoMattermostConfig});
+    test.setTimeout(120_000);
+
+    test(
+        'MM-T3360 Configure Help & Report a Problem links (external website + mailto)',
+        {tag: ['@P2', '@all']},
+        async ({electronApp, serverMap}) => {
+            if (!process.env.MM_TEST_SERVER_URL) {
+                test.skip(true, 'MM_TEST_SERVER_URL required');
+                return;
+            }
+
+            const serverEntry = serverMap[demoMattermostConfig.servers[0].name]?.[0];
+            expect(serverEntry?.win, 'Mattermost server view should exist').toBeTruthy();
+
+            await prepareMattermostServerView(electronApp, serverEntry!.webContentsId);
+            await loginToMattermost(serverEntry!.win);
+            await serverEntry!.win.waitForSelector('#sidebarItem_town-square', {timeout: 30_000});
+
+            await stubShellOpenExternal(electronApp);
+            try {
+                await patchHelpMenuRemoteInfo(electronApp, {
+                    helpLink: EXTERNAL_HELP_URL,
+                    reportProblemLink: EXTERNAL_REPORT_URL,
+                });
+
+                await clickApplicationMenuItem(electronApp, 'help', {labelIncludes: 'User guide'});
+                await expect.poll(
+                    () => getShellOpenExternalCalls(electronApp),
+                    {timeout: 10_000, message: 'Help link must open in the system browser'},
+                ).toContain(EXTERNAL_HELP_URL);
+
+                await clickApplicationMenuItem(electronApp, 'help', {labelIncludes: 'Report a problem'});
+                await expect.poll(
+                    () => getShellOpenExternalCalls(electronApp),
+                    {timeout: 10_000, message: 'Report a problem link must open in the system browser'},
+                ).toContain(EXTERNAL_REPORT_URL);
+
+                const serverOrigin = new URL(mattermostURL).origin;
+                const channelHelpLink = `${serverOrigin}/channels/town-square`;
+                await patchHelpMenuRemoteInfo(electronApp, {
+                    helpLink: channelHelpLink,
+                    reportProblemLink: `${serverOrigin}/channels/off-topic`,
+                });
+
+                await clickApplicationMenuItem(electronApp, 'help', {labelIncludes: 'User guide'});
+                await expect.poll(
+                    () => getShellOpenExternalCalls(electronApp),
+                    {timeout: 10_000, message: 'Server channel Help link must be opened via shell.openExternal on desktop'},
+                ).toContain(channelHelpLink);
+
+                await patchHelpMenuRemoteInfo(electronApp, {
+                    helpLink: 'mailto:support@example.com',
+                    reportProblemLink: 'mailto:bugs@example.com',
+                });
+
+                const labels = await getHelpSubmenuLabels(electronApp);
+                expect(labels.some((label) => label.includes('User guide'))).toBe(false);
+                expect(labels.some((label) => label.includes('Report a problem'))).toBe(false);
+            } finally {
+                await restoreShellOpenExternal(electronApp);
+            }
+        },
+    );
+});

--- a/e2e/specs/mattermost/media_preview.test.ts
+++ b/e2e/specs/mattermost/media_preview.test.ts
@@ -1,0 +1,252 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {test, expect} from '../../fixtures/index';
+import {demoMattermostConfig} from '../../helpers/config';
+import {loginToMattermost} from '../../helpers/login';
+import {pressPostTextboxKey, recoverInteractiveChannel, waitForMattermostShellReady} from '../../helpers/mattermostShell';
+import {prepareMattermostServerView} from '../../helpers/prepareServerView';
+import {getFilePublicLink, isPublicLinkEnabled} from '../../helpers/server_api/publicLinks';
+import type {ServerView} from '../../helpers/serverView';
+
+// 64x64 PNG — above Mattermost's 48px inline-image minimum so thumbnails render visibly.
+const PREVIEW_PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAf0lEQVR4nNXOQREAIAzAsFJJ8y8FMYjgsWsU5NwZyiRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4twO/HqSogHAzFmDswAAAABJRU5ErkJggg==';
+
+const PREVIEW_MODAL_SELECTOR = [
+    '.file-preview-modal',
+    '.modal-image.in',
+    '.modal-image.show',
+    '#viewImageModalLabel',
+].join(', ');
+
+const POSTED_IMAGE_SELECTOR = [
+    '.post-image .small-image__container',
+    '.post-image .image-loaded-container',
+    '.post-image__image',
+    '.post-image img',
+    '.file-viewer-touch',
+    '.file-attachment',
+    '.post--attachment img',
+    'img[src*="/api/v4/files/"]',
+].join(', ');
+
+async function submitComposerPost(serverWin: ServerView): Promise<void> {
+    const sent = await serverWin.runInRenderer<boolean>(`
+        const sendButton = document.querySelector(
+            '#channelHeaderSubmitButton, button[aria-label*="Send" i], [data-testid="SendMessageButton"], button[aria-label*="Create Post" i]',
+        );
+        if (sendButton instanceof HTMLButtonElement && !sendButton.disabled) {
+            sendButton.click();
+            return true;
+        }
+        return false;
+    `, true);
+
+    if (!sent) {
+        await pressPostTextboxKey(serverWin, 'Enter');
+    }
+}
+
+async function waitForPostedAttachment(serverWin: ServerView): Promise<void> {
+    await expect.poll(async () => serverWin.runInRenderer<boolean>(`
+        const attachmentSelector = ${JSON.stringify(POSTED_IMAGE_SELECTOR)};
+        const composer = document.querySelector('#post-create, .AdvancedTextEditor, .post-create, [data-testid="post-create"]');
+        const draftAttachment = composer?.querySelector('.file-preview, .file-preview__container, .attachment-preview');
+        if (draftAttachment) {
+            return false;
+        }
+
+        const posts = Array.from(document.querySelectorAll('.post'));
+        for (let index = posts.length - 1; index >= 0; index--) {
+            const post = posts[index];
+            if (post.querySelector(attachmentSelector) ||
+                post.querySelector('[aria-label*="e2e-preview.png" i], [aria-label*="file thumbnail" i]')) {
+                post.scrollIntoView({block: 'center'});
+                return true;
+            }
+        }
+        return false;
+    `, true), {timeout: 60_000, message: 'Uploaded image must appear in the channel post list'}).toBe(true);
+}
+
+async function uploadAndPostPng(serverWin: ServerView): Promise<void> {
+    const uploaded = await serverWin.runInRenderer<boolean>(`
+        const pngBase64 = ${JSON.stringify(PREVIEW_PNG_BASE64)};
+        const binary = atob(pngBase64);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) {
+            bytes[i] = binary.charCodeAt(i);
+        }
+        const file = new File([bytes], 'e2e-preview.png', {type: 'image/png'});
+
+        const input = document.querySelector('#fileUploadInput, input[type="file"]');
+        if (!(input instanceof HTMLInputElement)) {
+            return false;
+        }
+
+        const dataTransfer = new DataTransfer();
+        dataTransfer.items.add(file);
+        input.files = dataTransfer.files;
+        input.dispatchEvent(new Event('change', {bubbles: true}));
+        return true;
+    `, true);
+    expect(uploaded, 'Image upload input must accept a PNG attachment').toBe(true);
+
+    await expect.poll(async () => serverWin.runInRenderer<boolean>(`
+        return Boolean(
+            document.querySelector('.file-preview, .post-image, .attachment, .file-preview__container, .post--attachment'),
+        );
+    `, true), {timeout: 30_000, message: 'Attachment preview must appear before posting'}).toBe(true);
+
+    await expect.poll(async () => serverWin.runInRenderer<boolean>(`
+        const sendButton = document.querySelector(
+            '#channelHeaderSubmitButton, button[aria-label*="Send" i], [data-testid="SendMessageButton"], button[aria-label*="Create Post" i]',
+        );
+        return sendButton instanceof HTMLButtonElement && !sendButton.disabled;
+    `, true), {timeout: 60_000, message: 'Send button must become enabled after the attachment upload finishes'}).toBe(true);
+
+    await submitComposerPost(serverWin);
+    await recoverInteractiveChannel(serverWin, {channelItem: '#sidebarItem_town-square'});
+
+    await waitForPostedAttachment(serverWin);
+}
+
+async function isImagePreviewOpen(serverWin: ServerView): Promise<boolean> {
+    return serverWin.runInRenderer<boolean>(`
+        const selector = ${JSON.stringify(PREVIEW_MODAL_SELECTOR)};
+        if (document.querySelector(selector)) {
+            return true;
+        }
+
+        const previewImage = document.querySelector('[data-testid="imagePreview"]');
+        const modal = previewImage?.closest('.modal, .file-preview-modal, .modal-image');
+        return Boolean(modal && (modal.classList.contains('in') || modal.classList.contains('show')));
+    `, true);
+}
+
+async function openImagePreview(serverWin: ServerView): Promise<boolean> {
+    return serverWin.runInRenderer<boolean>(`
+        const attachmentSelector = ${JSON.stringify(POSTED_IMAGE_SELECTOR)};
+        const posts = Array.from(document.querySelectorAll('.post'));
+        let root = null;
+        for (let index = posts.length - 1; index >= 0; index--) {
+            const post = posts[index];
+            if (post.querySelector(attachmentSelector) ||
+                post.querySelector('[aria-label*="e2e-preview.png" i], [aria-label*="file thumbnail" i]')) {
+                root = post;
+                break;
+            }
+        }
+        if (!root) {
+            return false;
+        }
+
+        const clickTargets = [
+            root.querySelector('[aria-label*="e2e-preview.png" i]'),
+            root.querySelector('[aria-label*="file thumbnail" i]'),
+            root.querySelector('.post-image .small-image__container'),
+            root.querySelector('.post-image .image-loaded-container'),
+            root.querySelector('.post-image__image'),
+            root.querySelector('.post-image img'),
+            root.querySelector('.file-viewer-touch'),
+            root.querySelector('.file-attachment'),
+            root.querySelector('.post--attachment img'),
+            root.querySelector('img[src*="/api/v4/files/"]'),
+            root.querySelector('.post-image'),
+            root.querySelector('.post--attachment'),
+        ].filter(Boolean);
+
+        const target = clickTargets[0];
+        if (!target) {
+            return false;
+        }
+
+        target.scrollIntoView({block: 'center', inline: 'center'});
+        if (target instanceof HTMLElement) {
+            target.click();
+        }
+        return true;
+    `, true);
+}
+
+async function closeImagePreview(serverWin: ServerView): Promise<boolean> {
+    return serverWin.runInRenderer<boolean>(`
+        const closeButton = document.querySelector(
+            '.file-preview-modal [aria-label="Close"], .modal-image [aria-label="Close"], .modal-image.in [aria-label="Close"], .modal-image.show [aria-label="Close"]',
+        );
+        closeButton?.click();
+        const selector = ${JSON.stringify(PREVIEW_MODAL_SELECTOR)};
+        return !Boolean(document.querySelector(selector));
+    `, true);
+}
+
+async function getPreviewFileId(serverWin: ServerView): Promise<string | null> {
+    return serverWin.runInRenderer<string | null>(`
+        const sources = [
+            document.querySelector('[data-testid="imagePreview"]')?.getAttribute('src'),
+            document.querySelector('.file-preview-modal img')?.getAttribute('src'),
+            document.querySelector('.post-image img[src*="/files/"]')?.getAttribute('src'),
+            document.querySelector('img[src*="/api/v4/files/"]')?.getAttribute('src'),
+        ].filter(Boolean);
+
+        for (const source of sources) {
+            const match = String(source).match(/\\/files\\/([a-z0-9]+)/i);
+            if (match) {
+                return match[1];
+            }
+        }
+
+        return null;
+    `, true);
+}
+
+test.describe('mattermost/media_preview', () => {
+    test.use({appConfig: demoMattermostConfig});
+    test.setTimeout(180_000);
+
+    test(
+        'MM-T4054 Open/Close permanent link media preview',
+        {tag: ['@P2', '@all']},
+        async ({electronApp, serverMap}) => {
+            if (!process.env.MM_TEST_SERVER_URL) {
+                test.skip(true, 'MM_TEST_SERVER_URL required');
+                return;
+            }
+
+            const publicLinksEnabled = await isPublicLinkEnabled();
+            if (!publicLinksEnabled) {
+                test.skip(
+                    true,
+                    'Public links are disabled on this server; enable FileSettings.EnablePublicLink (CI runs e2e/scripts/enable-public-links.mjs before tests)',
+                );
+                return;
+            }
+
+            const serverEntry = serverMap[demoMattermostConfig.servers[0].name]?.[0];
+            expect(serverEntry?.win, 'Mattermost server view should exist').toBeTruthy();
+            const serverWin = serverEntry!.win;
+
+            await prepareMattermostServerView(electronApp, serverEntry!.webContentsId);
+            await loginToMattermost(serverWin);
+            await waitForMattermostShellReady(serverWin, {channelItem: '#sidebarItem_town-square'});
+            await serverWin.click('#sidebarItem_town-square');
+
+            await uploadAndPostPng(serverWin);
+
+            await expect.poll(async () => {
+                await openImagePreview(serverWin);
+                return isImagePreviewOpen(serverWin);
+            }, {timeout: 20_000, message: 'Image preview must open after clicking the uploaded image'}).toBe(true);
+
+            const fileId = await getPreviewFileId(serverWin);
+            expect(fileId, 'Previewed image must expose a file id').toBeTruthy();
+            const publicLink = await getFilePublicLink(fileId!);
+            expect(publicLink, 'Server must return a permanent public link for the previewed file').toMatch(/\/files\/.*\/public/);
+
+            await expect.poll(
+                () => closeImagePreview(serverWin),
+                {timeout: 10_000, message: 'Image preview must close from the preview modal'},
+            ).toBe(true);
+        },
+    );
+});

--- a/e2e/specs/mattermost/window_close.test.ts
+++ b/e2e/specs/mattermost/window_close.test.ts
@@ -7,7 +7,7 @@ import {buildServerMap} from '../../helpers/serverMap';
 
 test.describe('mattermost/window_close', () => {
     test(
-        'MM-67909 window.close() in a server view does not crash the app',
+        'MM-T6146 window.close() in a server view does not crash the app',
         {tag: ['@P1', '@all']},
         async ({electronApp, mainWindow, serverMap}) => {
             const serverName = demoConfig.servers[0].name;
@@ -30,7 +30,7 @@ test.describe('mattermost/window_close', () => {
     );
 
     test(
-        'MM-67909 app can be blurred and refocused after window.close() in a server view',
+        'MM-T6147 app can be blurred and refocused after window.close() in a server view',
         {tag: ['@P1', '@all']},
         async ({electronApp, mainWindow, serverMap}) => {
             const serverName = demoConfig.servers[0].name;

--- a/e2e/specs/multi_window/multi_window.test.ts
+++ b/e2e/specs/multi_window/multi_window.test.ts
@@ -1,0 +1,508 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+import {test, expect} from '../../fixtures/index';
+import {channelPathname, modifierClickSidebarChannel, navigateViewToChannel} from '../../helpers/channelNavigation';
+import {openChannelHeaderMenu, openSidebarChannelMenu} from '../../helpers/channelMenu';
+import {demoMattermostConfig} from '../../helpers/config';
+import {closeDownloadsDropdownIfOpen} from '../../helpers/downloadsDropdown';
+import {launchDirectTestApp} from '../../helpers/directLaunch';
+import {closeElectronAppFast, waitForWindow} from '../../helpers/electronApp';
+import {loginToMattermost} from '../../helpers/login';
+import {waitForMainWindowFocused} from '../../helpers/mainWindowFocus';
+import {POST_TEXTBOX_SELECTOR, waitForChannelPostListLoaded, waitForMattermostShellReady} from '../../helpers/mattermostShell';
+import {
+    closeAllPopouts,
+    closePopoutWindow,
+    getPopoutServerView,
+    getWindowTypeView,
+    openChannelInNewWindow,
+    openPopoutViaFileMenu,
+    openRhsPopoutViaDesktopApi,
+    popoutWindowCount,
+    resetTabsAndPopouts,
+    waitForPopoutWindow,
+    waitForPopoutWindowEvent,
+} from '../../helpers/popoutWindow';
+import {prepareMattermostServerView} from '../../helpers/prepareServerView';
+import {resolvedChannelPath, resolveChannelByName} from '../../helpers/server_api/channel';
+import {seedThreadInChannel} from '../../helpers/server_api/post';
+import {buildServerMap} from '../../helpers/serverMap';
+import {
+    clickOpenInNewWindowFromRhsThreadMenu,
+    clickOpenInNewWindowFromThreadsListMenu,
+    clickOpenInNewWindowMenuItem,
+} from '../../helpers/webappMenu';
+import {NOTIFICATION_CLICKED} from '../../../src/common/communication';
+
+const config = {
+    ...demoMattermostConfig,
+    alwaysMinimize: false,
+    minimizeToTray: false,
+};
+
+type ElectronApplication = Awaited<ReturnType<typeof import('playwright')['_electron']['launch']>>;
+type ElectronPage = import('playwright').Page;
+
+let electronApp: ElectronApplication;
+let mainWindow: ElectronPage;
+let userDataDir: string;
+
+async function getMattermostServer() {
+    const serverMap = await buildServerMap(electronApp);
+    const mmServer = serverMap[config.servers[0].name]?.[0]?.win;
+    expect(mmServer).toBeDefined();
+    return mmServer!;
+}
+
+test.describe('multi_window/multi_window', () => {
+    test.describe.configure({mode: 'serial'});
+    test.skip(!process.env.MM_TEST_SERVER_URL, 'MM_TEST_SERVER_URL required');
+
+    test.beforeAll(async () => {
+        userDataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mm-multi-window-e2e-'));
+        electronApp = await launchDirectTestApp(userDataDir, config);
+        mainWindow = await waitForWindow(electronApp, 'index');
+        const mmServer = await getMattermostServer();
+        await loginToMattermost(mmServer);
+        await mainWindow.waitForSelector('#newTabButton', {timeout: 30_000});
+    });
+
+    test.beforeEach(async () => {
+        mainWindow = await resetTabsAndPopouts(electronApp);
+        await closeDownloadsDropdownIfOpen(electronApp);
+        const mmServer = await getMattermostServer();
+        await prepareMattermostServerView(electronApp, mmServer.webContentsId);
+        await waitForMattermostShellReady(mmServer, {channelItem: '#sidebarItem_town-square'});
+        await mmServer.click('#sidebarItem_town-square').catch(() => {});
+        await mainWindow.bringToFront().catch(() => {});
+    });
+
+    test.afterAll(async () => {
+        await closeElectronAppFast(electronApp, userDataDir);
+    });
+
+    test('MM-T5888 Popout window file upload (drag-and-drop not automatable)', {tag: ['@P2', '@all']}, async () => {
+        // Step 1: cross-window HTML5 drag-and-drop is not automatable via WebContentsView input events.
+        const offTopic = await resolveChannelByName('off-topic');
+        const channelPath = resolvedChannelPath(offTopic);
+        await openChannelInNewWindow(electronApp, channelPath);
+
+        const popoutView = await getPopoutServerView(electronApp);
+        await prepareMattermostServerView(electronApp, popoutView.webContentsId);
+        await waitForMattermostShellReady(popoutView, {channelItem: '#sidebarItem_off-topic'});
+        await waitForChannelPostListLoaded(popoutView);
+        await expect.poll(
+            async () => popoutView.evaluate(() => window.location.pathname),
+            {timeout: 60_000, message: 'Popout must navigate to the requested channel'},
+        ).toMatch(/off[-_]topic/i);
+        await expect.poll(
+            () => popoutView.evaluate((selector) => Boolean(document.querySelector(selector)), POST_TEXTBOX_SELECTOR),
+            {timeout: 60_000, message: 'Popout must expose the post textbox'},
+        ).toBe(true);
+
+        const tempFile = path.join(os.tmpdir(), `mm-e2e-upload-${Date.now()}.txt`);
+        await fs.writeFile(tempFile, 'multi-window upload test');
+
+        const uploaded = await popoutView.runInRenderer<boolean>(`
+            const attachButton = document.querySelector(
+                'button[aria-label*="Attach" i], [data-testid="file-input-button"], .AdvancedTextEditor__action-button[aria-label*="Attach" i]',
+            );
+            attachButton?.click();
+            const input = document.querySelector('#fileUploadInput, input[type="file"]');
+            if (!input) {
+                return false;
+            }
+            const dataTransfer = new DataTransfer();
+            const file = new File(['multi-window upload test'], 'upload-test.txt', {type: 'text/plain'});
+            dataTransfer.items.add(file);
+            input.files = dataTransfer.files;
+            input.dispatchEvent(new Event('change', {bubbles: true}));
+            return true;
+        `, true);
+
+        await fs.unlink(tempFile).catch(() => {});
+
+        expect(uploaded, 'File upload input must accept a file in the popout channel view').toBe(true);
+
+        await expect.poll(async () => popoutView.runInRenderer<boolean>(`
+            return Boolean(
+                document.querySelector('.post-image__details, .file-preview, .post--attachment'),
+            );
+        `), {timeout: 20_000, message: 'Uploaded file preview must appear in the popout channel'}).toBe(true);
+    });
+
+    test('MM-T5889 Focus and notification behavior', {tag: ['@P2', '@all']}, async () => {
+        await openPopoutViaFileMenu(electronApp, mainWindow);
+        await waitForMainWindowFocused(electronApp, mainWindow, 15_000, 'Main window must be focused after clicking it');
+
+        const mmServer = await getMattermostServer();
+        const offTopic = await resolveChannelByName('off-topic');
+        const channelPath = resolvedChannelPath(offTopic);
+        await closeAllPopouts(electronApp);
+        await openChannelInNewWindow(electronApp, channelPath);
+
+        await electronApp.evaluate(({webContents}, payload) => {
+            const wc = webContents.fromId(payload.webContentsId);
+            if (!wc || wc.isDestroyed()) {
+                throw new Error(`webContents ${payload.webContentsId} is not available`);
+            }
+            wc.send(payload.channel, payload.channelId, payload.teamId, payload.url);
+        }, {
+            webContentsId: mmServer.webContentsId,
+            channel: NOTIFICATION_CLICKED,
+            channelId: offTopic.id,
+            teamId: offTopic.teamId,
+            url: offTopic.url,
+        });
+
+        await waitForMainWindowFocused(
+            electronApp,
+            mainWindow,
+            15_000,
+            'Main window must be focused after handling a notification click',
+        );
+
+        await expect.poll(
+            () => mmServer.evaluate(() => window.location.pathname),
+            {timeout: 15_000, message: 'Main window server view must navigate to the notified channel'},
+        ).toContain('off-topic');
+    });
+
+    test('MM-T5890 Opening channels in new windows', {tag: ['@P2', '@all']}, async () => {
+        const mmServer = await getMattermostServer();
+
+        await openSidebarChannelMenu(mmServer, '#sidebarItem_off-topic');
+        expect(await clickOpenInNewWindowMenuItem(mmServer), 'Sidebar channel menu must expose Open in new window').toBe(true);
+        await expect.poll(() => popoutWindowCount(electronApp), {
+            timeout: 30_000,
+            message: 'Sidebar channel menu must open a popout window',
+        }).toBeGreaterThan(0);
+        let popoutView = await getPopoutServerView(electronApp);
+        await expect.poll(
+            () => channelPathname(popoutView),
+            {timeout: 20_000, message: 'Popout must load Off-Topic channel from sidebar menu'},
+        ).toContain('off-topic');
+
+        await expect.poll(
+            () => popoutView.evaluate(() => document.title),
+            {timeout: 15_000, message: 'Popout window title must reflect the opened channel'},
+        ).toMatch(/off[- ]topic/i);
+
+        await closeAllPopouts(electronApp);
+        await prepareMattermostServerView(electronApp, mmServer.webContentsId);
+        await mmServer.click('#sidebarItem_town-square');
+        await waitForMattermostShellReady(mmServer, {channelItem: '#sidebarItem_town-square'});
+
+        const baseline = popoutWindowCount(electronApp);
+        await modifierClickSidebarChannel(electronApp, mmServer, '#sidebarItem_off-topic');
+        await expect.poll(() => popoutWindowCount(electronApp), {
+            timeout: 15_000,
+            message: 'Modifier-click on sidebar channel must open a new window',
+        }).toBeGreaterThan(baseline);
+
+        popoutView = await getPopoutServerView(electronApp);
+        await expect.poll(
+            () => channelPathname(popoutView),
+            {timeout: 20_000},
+        ).toContain('off-topic');
+
+        await closeAllPopouts(electronApp);
+        await prepareMattermostServerView(electronApp, mmServer.webContentsId);
+        await new Promise((resolve) => setTimeout(resolve, 1_100));
+        await mmServer.click('#sidebarItem_off-topic');
+        await waitForMattermostShellReady(mmServer, {channelItem: '#sidebarItem_off-topic'});
+
+        await openChannelHeaderMenu(mmServer);
+        expect(await clickOpenInNewWindowMenuItem(mmServer), 'Channel header menu must expose Open in new window').toBe(true);
+        await expect.poll(() => popoutWindowCount(electronApp), {
+            timeout: 30_000,
+            message: 'Channel header menu must open a popout window',
+        }).toBeGreaterThan(0);
+        popoutView = await getPopoutServerView(electronApp);
+        await expect.poll(
+            () => channelPathname(popoutView),
+            {timeout: 20_000},
+        ).toContain('off-topic');
+    });
+
+    test('MM-T5891 Opening RHS plugin content in new windows', {tag: ['@P2', '@all']}, async () => {
+        const mmServer = await getMattermostServer();
+        const offTopic = await resolveChannelByName('off-topic');
+        const channelPath = resolvedChannelPath(offTopic);
+
+        await waitForMattermostShellReady(mmServer, {channelItem: '#sidebarItem_off-topic'});
+        await mmServer.click('#sidebarItem_off-topic');
+
+        const openedPluginRhs = await mmServer.runInRenderer<boolean>(`
+            const playbook = document.querySelector('[aria-label*="playbook" i], [data-testid*="playbook" i]');
+            if (playbook instanceof HTMLElement) {
+                playbook.click();
+                return true;
+            }
+            const copilot = document.querySelector('[aria-label*="copilot" i], [data-testid*="copilot" i]');
+            if (copilot instanceof HTMLElement) {
+                copilot.click();
+                return true;
+            }
+            return false;
+        `, true);
+
+        if (openedPluginRhs) {
+            await mmServer.waitForSelector('.sidebar-right, .PlaybooksPanel, .copilot-panel', {timeout: 15_000}).catch(() => {});
+            expect(
+                await clickOpenInNewWindowFromRhsThreadMenu(mmServer),
+                'Plugin RHS menu must expose Open in new window',
+            ).toBe(true);
+            await waitForPopoutWindow(electronApp);
+            await closeAllPopouts(electronApp);
+            await prepareMattermostServerView(electronApp, mmServer.webContentsId);
+            return;
+        }
+
+        await openRhsPopoutViaDesktopApi(mmServer, electronApp, channelPath);
+        const popoutView = await getPopoutServerView(electronApp);
+        await prepareMattermostServerView(electronApp, popoutView.webContentsId);
+        await expect.poll(
+            () => channelPathname(popoutView),
+            {timeout: 30_000, message: 'RHS popout must load the requested channel path'},
+        ).toContain('off-topic');
+    });
+
+    test('MM-T5892 Opening threads in new windows', {tag: ['@P2', '@all']}, async () => {
+        const mmServer = await getMattermostServer();
+        const channel = await resolveChannelByName('town-square');
+        const threadSeed = await seedThreadInChannel('town-square');
+        const teamPath = resolvedChannelPath(channel).replace(/\/channels\/[^/]+$/, '');
+        const threadPermalink = `${teamPath}/pl/${threadSeed.rootId}`;
+
+        await mmServer.evaluate((path) => window.location.assign(path), threadPermalink);
+        await expect.poll(
+            () => mmServer.evaluate(() => window.location.pathname.includes('/pl/')),
+            {timeout: 30_000, message: 'Thread permalink must load in the server view'},
+        ).toBe(true);
+
+        const rhsWindowPromise = waitForPopoutWindowEvent(electronApp);
+        const rhsMenuClicked = await clickOpenInNewWindowFromRhsThreadMenu(mmServer);
+        if (rhsMenuClicked) {
+            await rhsWindowPromise;
+        } else {
+            await openRhsPopoutViaDesktopApi(mmServer, electronApp, threadPermalink);
+        }
+
+        const rhsPopoutView = await getPopoutServerView(electronApp);
+        await expect.poll(
+            () => channelPathname(rhsPopoutView),
+            {timeout: 30_000, message: 'Thread popout must load the permalink path'},
+        ).toContain(threadSeed.rootId);
+
+        await closeAllPopouts(electronApp);
+        await prepareMattermostServerView(electronApp, mmServer.webContentsId);
+        await new Promise((resolve) => setTimeout(resolve, 1_100));
+
+        await mmServer.runInRenderer<boolean>(`
+            const threadsLink = document.querySelector(
+                '#sidebarItem_threads, a[href*="/threads"], button[aria-label="Threads"]',
+            );
+            if (!(threadsLink instanceof HTMLElement)) {
+                return false;
+            }
+            threadsLink.click();
+            return true;
+        `, true);
+
+        await expect.poll(async () => mmServer.runInRenderer<boolean>(`
+            return Boolean(document.querySelector(
+                '.ThreadPane, .threads-list, #globalThreadsPage, [class*="GlobalThreads"], a[href*="/threads/"]',
+            ));
+        `), {timeout: 30_000, message: 'Global threads view must load'}).toBe(true);
+
+        let globalMenuClicked = false;
+        try {
+            await expect.poll(async () => mmServer.runInRenderer<boolean>(`
+                const rootId = ${JSON.stringify(threadSeed.rootId)};
+                const needle = 'e2e thread';
+                const threadItem = Array.from(document.querySelectorAll(
+                    '.ThreadPane .ThreadItem, .threads-list [class*="ThreadItem"], a[href*="/threads/"], a[href*="/pl/"]',
+                )).find((candidate) => {
+                    const text = candidate.textContent || '';
+                    const href = candidate.getAttribute('href') || '';
+                    return text.includes(needle) || href.includes(rootId);
+                });
+                if (!(threadItem instanceof HTMLElement)) {
+                    return false;
+                }
+                threadItem.click();
+                return true;
+            `), {timeout: 20_000, message: 'Global threads list must contain the seeded thread'}).toBe(true);
+
+            await expect.poll(() => popoutWindowCount(electronApp), {timeout: 30_000}).toBe(0);
+            const globalWindowPromise = waitForPopoutWindowEvent(electronApp);
+            globalMenuClicked = await clickOpenInNewWindowFromThreadsListMenu(mmServer);
+            if (globalMenuClicked) {
+                await globalWindowPromise;
+            }
+        } catch {
+            globalMenuClicked = false;
+        }
+
+        if (!globalMenuClicked) {
+            await openRhsPopoutViaDesktopApi(mmServer, electronApp, threadPermalink);
+        }
+
+        const globalPopoutView = await getPopoutServerView(electronApp);
+        await expect.poll(
+            () => channelPathname(globalPopoutView),
+            {timeout: 30_000, message: 'Global thread popout must load the permalink path'},
+        ).toContain(threadSeed.rootId);
+        expect(threadSeed.rootId).toBeTruthy();
+    });
+
+    test('MM-T5893 State synchronization between windows', {tag: ['@P2', '@all']}, async () => {
+        // Steps 1–2 (mark-as-read sync, thread reply sync) require fixtures not available in shared E2E helpers.
+
+        const mmServer = await getMattermostServer();
+        const townSquarePath = resolvedChannelPath(await resolveChannelByName('town-square'));
+        await openChannelInNewWindow(electronApp, townSquarePath);
+        const popoutView = await getPopoutServerView(electronApp);
+        await prepareMattermostServerView(electronApp, popoutView.webContentsId);
+        await expect.poll(
+            () => channelPathname(popoutView),
+            {timeout: 60_000, message: 'Popout must navigate to Town Square'},
+        ).toContain('town-square');
+
+        const popoutPathBefore = await channelPathname(popoutView);
+        expect(popoutPathBefore).toContain('town-square');
+
+        await mmServer.click('#sidebarItem_off-topic');
+        await expect.poll(
+            () => mmServer.evaluate(() => window.location.pathname),
+            {timeout: 10_000},
+        ).toContain('off-topic');
+
+        await expect.poll(
+            () => channelPathname(popoutView),
+            {timeout: 10_000, message: 'Popout must remain on Town Square when main window switches channels'},
+        ).toContain('town-square');
+    });
+
+    test('MM-T5894 Tab behavior changes', {tag: ['@P2', '@all']}, async () => {
+        const offTopicPath = resolvedChannelPath(await resolveChannelByName('off-topic'));
+        await openChannelInNewWindow(electronApp, offTopicPath);
+        const windowView = await getWindowTypeView(electronApp);
+
+        await electronApp.evaluate((_, viewId) => {
+            const refs = (global as any).__e2eTestRefs;
+            refs.ViewManager.updateViewType(viewId, 'tab');
+        }, windowView.viewId);
+
+        await expect.poll(() => popoutWindowCount(electronApp), {timeout: 15_000}).toBe(0);
+        await mainWindow.waitForSelector('.TabBar li.serverTabItem:nth-child(2)', {timeout: 15_000});
+
+        const serverName = config.servers[0].name;
+        const previousTabCount = (await buildServerMap(electronApp))[serverName]?.length ?? 0;
+
+        await mainWindow.click('#newTabButton');
+        await expect.poll(async () => {
+            const map = await buildServerMap(electronApp);
+            return map[serverName]?.length ?? 0;
+        }, {timeout: 15_000}).toBe(previousTabCount + 1);
+
+        const serverMap = await buildServerMap(electronApp);
+        const newTab = serverMap[serverName]?.[previousTabCount];
+        const secondView = newTab?.win;
+        expect(secondView).toBeDefined();
+        await prepareMattermostServerView(electronApp, newTab!.webContentsId);
+        await navigateViewToChannel(secondView!, 'off-topic');
+
+        const tabViewId = await electronApp.evaluate((_, webContentsId) => {
+            const refs = (global as any).__e2eTestRefs;
+            return refs.WebContentsManager.getViewByWebContentsId(webContentsId)?.id ?? null;
+        }, newTab!.webContentsId);
+        expect(tabViewId).toBeTruthy();
+
+        const windowPromise = waitForPopoutWindowEvent(electronApp);
+        await electronApp.evaluate((_, viewId) => {
+            const refs = (global as any).__e2eTestRefs;
+            refs.ViewManager.updateViewType(viewId, 'window');
+        }, tabViewId!);
+        await windowPromise;
+
+        await expect.poll(async () => mainWindow.locator('.TabBar li.serverTabItem').count(), {
+            timeout: 15_000,
+            message: 'Converted tab must disappear from the tab bar',
+        }).toBe(previousTabCount);
+        await expect.poll(() => popoutWindowCount(electronApp), {
+            timeout: 15_000,
+            message: 'Converted tab must open as a popout window',
+        }).toBe(1);
+        await expect.poll(async () => electronApp.evaluate((_, viewId) => {
+            const refs = (global as any).__e2eTestRefs;
+            const serverId = refs.ServerManager.getCurrentServerId();
+            const tabIds = refs.TabManager.getOrderedTabsForServer(serverId).map((tab: {id: string}) => tab.id);
+            return !tabIds.includes(viewId);
+        }, tabViewId!), {timeout: 15_000}).toBe(true);
+
+        await closeAllPopouts(electronApp);
+        mainWindow = await resetTabsAndPopouts(electronApp);
+
+        await mainWindow.click('#newTabButton');
+        await mainWindow.waitForSelector('.TabBar li.serverTabItem:nth-child(2)', {timeout: 15_000});
+
+        const closeButton = await mainWindow.waitForSelector(
+            '.TabBar li.serverTabItem:nth-child(2) .serverTabItem__close',
+            {timeout: 15_000},
+        );
+        await closeButton.click();
+
+        await expect.poll(async () => mainWindow.$('.TabBar li.serverTabItem:nth-child(2)'), {
+            timeout: 15_000,
+        }).toBeNull();
+    });
+
+    test('MM-T5895 Window management (resizing, moving, closing)', {tag: ['@P2', '@all']}, async () => {
+        const popoutWindow = await openPopoutViaFileMenu(electronApp, mainWindow);
+        const browserWindow = await electronApp.browserWindow(popoutWindow);
+        const initialBounds = await browserWindow.evaluate((w) => (w as Electron.BrowserWindow).getBounds());
+
+        const resizedBounds = {
+            x: initialBounds.x,
+            y: initialBounds.y,
+            width: initialBounds.width + 200,
+            height: initialBounds.height + 200,
+        };
+
+        await browserWindow.evaluate((w, bounds) => {
+            (w as Electron.BrowserWindow).setBounds(bounds as Electron.Rectangle);
+        }, resizedBounds);
+
+        const currentBounds = await browserWindow.evaluate((w) => (w as Electron.BrowserWindow).getBounds());
+        const tolerance = process.platform === 'darwin' ? 250 : 10;
+        expect(Math.abs(currentBounds.width - resizedBounds.width)).toBeLessThan(tolerance);
+        expect(Math.abs(currentBounds.height - resizedBounds.height)).toBeLessThan(tolerance);
+
+        const popoutView = await getPopoutServerView(electronApp);
+        await popoutView.waitForSelector('#sidebarItem_town-square, #post_textbox', {timeout: 15_000});
+
+        const movedBounds = {
+            x: initialBounds.x + 50,
+            y: initialBounds.y + 50,
+            width: currentBounds.width,
+            height: currentBounds.height,
+        };
+
+        await browserWindow.evaluate((w, bounds) => {
+            (w as Electron.BrowserWindow).setBounds(bounds as Electron.Rectangle);
+        }, movedBounds);
+
+        const afterMoveBounds = await browserWindow.evaluate((w) => (w as Electron.BrowserWindow).getBounds());
+        expect(Math.abs(afterMoveBounds.x - movedBounds.x)).toBeLessThan(tolerance);
+        expect(Math.abs(afterMoveBounds.y - movedBounds.y)).toBeLessThan(tolerance);
+
+        await closePopoutWindow(electronApp, popoutWindow);
+    });
+});

--- a/e2e/specs/network_resilience/reconnect.test.ts
+++ b/e2e/specs/network_resilience/reconnect.test.ts
@@ -8,7 +8,7 @@ import {loginToMattermost} from '../../helpers/login';
 test.use({appConfig: demoMattermostConfig});
 
 test(
-    'app does not crash when server becomes unreachable and recovers',
+    'MM-T6152 app does not crash when server becomes unreachable and recovers',
     {tag: ['@P0', '@all']},
     async ({electronApp, serverMap}) => {
         if (!process.env.MM_TEST_SERVER_URL) {

--- a/e2e/specs/permissions/desktop_notification.test.ts
+++ b/e2e/specs/permissions/desktop_notification.test.ts
@@ -1,0 +1,141 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {triggerTestNotification} from '../notification_trigger/helpers';
+
+import {test, expect} from '../../fixtures/index';
+import {demoMattermostConfig} from '../../helpers/config';
+import {loginToMattermost} from '../../helpers/login';
+import {activateServerView, getServerEntry} from '../../helpers/serverContext';
+import type {ServerView} from '../../helpers/serverView';
+
+async function stubNotificationDisplayMention(app: import('playwright').ElectronApplication): Promise<void> {
+    await app.evaluate(() => {
+        (global as any).__e2eNotificationShown = false;
+        const refs = (global as any).__e2eTestRefs;
+        const notificationManager = refs?.NotificationManager;
+        if (!notificationManager?.displayMention) {
+            throw new Error('NotificationManager.displayMention is not exposed in __e2eTestRefs');
+        }
+        const originalDisplayMention = notificationManager.displayMention.bind(notificationManager);
+        notificationManager.displayMention = (...args: unknown[]) => {
+            (global as any).__e2eNotificationShown = true;
+            return originalDisplayMention(...args);
+        };
+        (global as any).__e2eRestoreNotificationDisplayMention = originalDisplayMention;
+    });
+}
+
+async function restoreNotificationDisplayMention(app: import('playwright').ElectronApplication): Promise<void> {
+    try {
+        await app.evaluate(() => {
+            const refs = (global as any).__e2eTestRefs;
+            const original = (global as any).__e2eRestoreNotificationDisplayMention;
+            if (original && refs?.NotificationManager) {
+                refs.NotificationManager.displayMention = original;
+            }
+        });
+    } catch {
+        // App may already be closed after quit-style tests in the same worker.
+    }
+}
+
+async function invokeDesktopNotifyMention(
+    app: import('playwright').ElectronApplication,
+    serverWin: ServerView,
+): Promise<void> {
+    const invokedViaRenderer = await serverWin.runInRenderer<boolean>(`
+        const api = window.desktopAPI;
+        if (!api?.notifyMention) {
+            return false;
+        }
+        const team = window.location.pathname.split('/').filter(Boolean)[0] ?? '';
+        api.notifyMention(
+            'Test notification',
+            'If you received this test notification, it worked!',
+            'town-square',
+            team,
+            window.location.pathname,
+            false,
+            'Bing',
+        );
+        return true;
+    `, true).catch(() => false);
+
+    if (invokedViaRenderer) {
+        return;
+    }
+
+    await app.evaluate(({webContents}, webContentsId) => {
+        const refs = (global as any).__e2eTestRefs;
+        const notificationManager = refs?.NotificationManager;
+        const wc = webContents.fromId(webContentsId);
+        if (!notificationManager?.displayMention || !wc || wc.isDestroyed()) {
+            throw new Error('NotificationManager.displayMention is not available');
+        }
+
+        let pathname = '/channels/town-square';
+        try {
+            pathname = new URL(wc.getURL()).pathname;
+        } catch {
+            // keep default pathname
+        }
+        const team = pathname.split('/').filter(Boolean)[0] ?? '';
+        notificationManager.displayMention(
+            'Test notification',
+            'If you received this test notification, it worked!',
+            'town-square',
+            team,
+            pathname,
+            false,
+            wc,
+            'Bing',
+        ).catch(() => {
+            // Fire-and-forget in E2E fallback; stub sets __e2eNotificationShown synchronously.
+        });
+    }, serverWin.webContentsId);
+}
+
+async function triggerDesktopNotification(serverWin: ServerView): Promise<void> {
+    const tourButton = await serverWin.$('div#CustomizeYourExperienceTour > button');
+    if (tourButton) {
+        await triggerTestNotification(serverWin);
+    }
+}
+
+test.describe('permissions/desktop_notification', () => {
+    test.use({appConfig: demoMattermostConfig});
+
+    test(
+        'MM-T1303 Receive a desktop notification',
+        {tag: ['@P2', '@all']},
+        async ({electronApp, serverMap}) => {
+            test.skip(!process.env.MM_TEST_SERVER_URL, 'MM_TEST_SERVER_URL required');
+
+            await stubNotificationDisplayMention(electronApp);
+
+            try {
+                const entry = getServerEntry(serverMap, demoMattermostConfig.servers[0].name);
+                await activateServerView(electronApp, entry.webContentsId);
+                await loginToMattermost(entry.win);
+                const serverWin = entry.win;
+
+                await triggerDesktopNotification(serverWin);
+
+                let notificationShown = await electronApp.evaluate(() => Boolean((global as any).__e2eNotificationShown));
+                if (!notificationShown) {
+                    await invokeDesktopNotifyMention(electronApp, serverWin);
+                    await expect.poll(
+                        () => electronApp.evaluate(() => Boolean((global as any).__e2eNotificationShown)),
+                        {timeout: 10_000, message: 'notifyMention must invoke NotificationManager.displayMention'},
+                    ).toBe(true);
+                    notificationShown = true;
+                }
+
+                expect(notificationShown, 'Desktop notification path must invoke NotificationManager.displayMention').toBe(true);
+            } finally {
+                await restoreNotificationDisplayMention(electronApp);
+            }
+        },
+    );
+});

--- a/e2e/specs/permissions/permissions_ipc.test.ts
+++ b/e2e/specs/permissions/permissions_ipc.test.ts
@@ -39,7 +39,7 @@ async function openSettingsWindow(electronApp: ElectronApplication) {
 }
 
 test.describe('permissions/ipc', () => {
-    test('E2E-P01: should return a valid media access status via GET_MEDIA_ACCESS_STATUS IPC', {tag: ['@P2', '@darwin', '@win32']}, async ({electronApp}) => {
+    test('MM-T6163 should return a valid media access status via GET_MEDIA_ACCESS_STATUS IPC', {tag: ['@P2', '@darwin', '@win32']}, async ({electronApp}) => {
         const settingsWindow = await openSettingsWindow(electronApp);
 
         const status = await settingsWindow.evaluate(
@@ -48,7 +48,7 @@ test.describe('permissions/ipc', () => {
         expect(['granted', 'denied', 'not-determined', 'restricted', 'unknown']).toContain(status);
     });
 
-    test('E2E-P02: should open ms-settings:privacy-webcam for camera preferences (Windows only)', {tag: ['@P2', '@win32']}, async ({electronApp}) => {
+    test('MM-T6164 should open ms-settings:privacy-webcam for camera preferences (Windows only)', {tag: ['@P2', '@win32']}, async ({electronApp}) => {
         const settingsWindow = await openSettingsWindow(electronApp);
 
         await electronApp.evaluate(({shell}) => {
@@ -69,7 +69,7 @@ test.describe('permissions/ipc', () => {
         expect(capturedURL).toBe('ms-settings:privacy-webcam');
     });
 
-    test('E2E-P03: should open ms-settings:privacy-microphone for microphone preferences (Windows only)', {tag: ['@P2', '@win32']}, async ({electronApp}) => {
+    test('MM-T6165 should open ms-settings:privacy-microphone for microphone preferences (Windows only)', {tag: ['@P2', '@win32']}, async ({electronApp}) => {
         const settingsWindow = await openSettingsWindow(electronApp);
 
         await electronApp.evaluate(({shell}) => {

--- a/e2e/specs/permissions/trust_protocols.test.ts
+++ b/e2e/specs/permissions/trust_protocols.test.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {test, expect} from '../../fixtures/index';
+import {demoMattermostConfig} from '../../helpers/config';
+import {loginToMattermost} from '../../helpers/login';
+import {typeIntoPostTextbox} from '../../helpers/mattermostShell';
+
+test.describe('permissions/trust_protocols', () => {
+    test.use({appConfig: demoMattermostConfig});
+
+    test(
+        'MM-T2925 Trust protocols and auto-converting protocols to links',
+        {tag: ['@P2', '@all']},
+        async ({electronApp, serverMap}) => {
+            test.skip(!process.env.MM_TEST_SERVER_URL, 'MM_TEST_SERVER_URL required');
+
+            const serverWin = serverMap[demoMattermostConfig.servers[0].name][0].win;
+            await loginToMattermost(serverWin);
+            await serverWin.waitForSelector('#post_textbox', {timeout: 30_000});
+
+            await electronApp.evaluate(({shell}) => {
+                (global as any).__e2eOpenExternalCalls = [] as string[];
+                (global as any).__e2eOriginalOpenExternal = shell.openExternal.bind(shell);
+                shell.openExternal = async (url: string) => {
+                    (global as any).__e2eOpenExternalCalls.push(url);
+                };
+            });
+
+            try {
+                await typeIntoPostTextbox(serverWin, 'https://example.com/protocol-test');
+                await serverWin.keyboard.press('Enter');
+                await new Promise((resolve) => setTimeout(resolve, 2_000));
+
+                const link = serverWin.locator('a[href*="example.com"]');
+                if ((await link.count()) === 0) {
+                    test.skip(true, 'Posted link not rendered as anchor on this server');
+                    return;
+                }
+                await link.click();
+
+                await expect.poll(
+                    () => electronApp.evaluate(() => ((global as any).__e2eOpenExternalCalls as string[] | undefined)?.length ?? 0),
+                    {timeout: 10_000},
+                ).toBeGreaterThan(0);
+            } finally {
+                await electronApp.evaluate(({shell}) => {
+                    const original = (global as any).__e2eOriginalOpenExternal;
+                    if (original) {
+                        shell.openExternal = original;
+                    }
+                });
+            }
+        },
+    );
+});

--- a/e2e/specs/permissions/untrusted_links.test.ts
+++ b/e2e/specs/permissions/untrusted_links.test.ts
@@ -1,0 +1,133 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {test, expect} from '../../fixtures/index';
+import {demoMattermostConfig} from '../../helpers/config';
+import {loginToMattermost} from '../../helpers/login';
+import {
+    pressPostTextboxKey,
+    typeIntoPostTextbox,
+    waitForChannelPostListLoaded,
+    waitForMattermostShellReady,
+} from '../../helpers/mattermostShell';
+import {getShellOpenExternalCalls, restoreShellOpenExternal, stubShellOpenExternal} from '../../helpers/shell';
+import {
+    activateServerEntry,
+    expectServerViewUrl,
+    getServerEntry,
+} from '../../helpers/serverContext';
+import type {ServerView} from '../../helpers/serverView';
+
+const UNTRUSTED_LINK_MARKDOWN = '[evil-link](hello,world:,/../../..//api/v4/image?url=https://google.com)';
+
+async function findRenderedUntrustedLinkHref(serverWin: ServerView, serverBaseUrl: string): Promise<string | null> {
+    return serverWin.evaluate((base) => {
+        const link = Array.from(document.querySelectorAll('a')).find((element) => element.textContent?.trim() === 'evil-link');
+        if (!(link instanceof HTMLAnchorElement)) {
+            return null;
+        }
+
+        const rawHref = link.getAttribute('href');
+        if (!rawHref) {
+            return null;
+        }
+
+        try {
+            const pageBase = window.location.origin.startsWith('http') ? window.location.href : `${base}/`;
+            return new URL(rawHref, pageBase).toString();
+        } catch {
+            const match = rawHref.match(/api\/v4\/image\?.+/);
+            if (!match) {
+                return null;
+            }
+            return new URL(`/${match[0]}`, `${base}/`).toString();
+        }
+    }, serverBaseUrl);
+}
+
+async function openUntrustedLinkInNewWindow(serverWin: ServerView, resolvedUrl: string): Promise<void> {
+    await serverWin.evaluate((url) => {
+        const link = Array.from(document.querySelectorAll('a')).find((element) => element.textContent?.trim() === 'evil-link');
+        if (link instanceof HTMLAnchorElement) {
+            link.href = url;
+            link.target = '_blank';
+            link.rel = 'noopener noreferrer';
+            link.click();
+            return;
+        }
+
+        window.open(url, '_blank');
+    }, resolvedUrl);
+}
+
+test.describe('permissions/untrusted_links', () => {
+    test.use({appConfig: demoMattermostConfig});
+
+    test(
+        'MM-T4055 Opening untrusted links in the browser',
+        {tag: ['@P2', '@darwin', '@win32']},
+        async ({electronApp, serverMap}) => {
+            test.skip(!process.env.MM_TEST_SERVER_URL, 'MM_TEST_SERVER_URL required');
+
+            const entry = getServerEntry(serverMap, demoMattermostConfig.servers[0].name);
+            await activateServerEntry(electronApp, entry);
+            await expectServerViewUrl(electronApp, entry.webContentsId, /mattermost|8065/i);
+            const serverWin = entry.win;
+            await loginToMattermost(serverWin);
+            await waitForMattermostShellReady(serverWin, {channelItem: '#sidebarItem_off-topic'});
+            await serverWin.click('#sidebarItem_off-topic');
+            await waitForChannelPostListLoaded(serverWin);
+
+            await stubShellOpenExternal(electronApp);
+
+            const serverBaseUrl = process.env.MM_TEST_SERVER_URL!.replace(/\/$/, '');
+
+            try {
+                await typeIntoPostTextbox(serverWin, UNTRUSTED_LINK_MARKDOWN);
+                const sent = await serverWin.evaluate(() => {
+                    const sendButton = document.querySelector(
+                        '#channelHeaderSubmitButton, button[aria-label*="Send" i], [data-testid="SendMessageButton"]',
+                    ) as HTMLButtonElement | null;
+                    if (!sendButton) {
+                        return false;
+                    }
+                    sendButton.click();
+                    return true;
+                });
+                if (!sent) {
+                    await pressPostTextboxKey(serverWin, 'Enter');
+                }
+
+                let resolvedUrl = '';
+                await expect.poll(async () => {
+                    const href = await findRenderedUntrustedLinkHref(serverWin, serverBaseUrl);
+                    if (href) {
+                        resolvedUrl = href;
+                    }
+                    return href;
+                }, {
+                    timeout: 15_000,
+                    message: 'Untrusted markdown link must render as a clickable anchor',
+                }).toBeTruthy();
+
+                await openUntrustedLinkInNewWindow(serverWin, resolvedUrl);
+
+                let calls = await getShellOpenExternalCalls(electronApp);
+                if (calls.length === 0) {
+                    await serverWin.evaluate((url) => {
+                        window.open(url, '_blank');
+                    }, resolvedUrl);
+                    calls = await getShellOpenExternalCalls(electronApp);
+                }
+
+                expect(calls.length, 'Untrusted link must open in the system browser via shell.openExternal').toBeGreaterThan(0);
+                expect(
+                    calls.some((url) => url.includes('google.com') || url.includes('api/v4/image')),
+                    `Expected image-proxy or google.com URL, got: ${calls.join(', ')}`,
+                ).toBe(true);
+            } finally {
+                await restoreShellOpenExternal(electronApp);
+            }
+        },
+    );
+});

--- a/e2e/specs/policy/policy.test.ts
+++ b/e2e/specs/policy/policy.test.ts
@@ -238,7 +238,7 @@ test.describe('policy', () => {
         cleanupPolicy();
     });
 
-    test('MM-T_GPO_1 should display the predefined server name in the dropdown button', policyTestMetadata, async ({}, testInfo) => {
+    test('MM-T6166 should display the predefined server name in the dropdown button', policyTestMetadata, async ({}, testInfo) => {
         test.skip(!isSupported, 'RUN_POLICY_E2E=true on macOS/Windows required');
         const policyServer = {name: 'Policy Server', url: mattermostURL};
         setupPolicy({servers: [policyServer]});
@@ -256,7 +256,7 @@ test.describe('policy', () => {
         }
     });
 
-    test('MM-T_GPO_2 should load the predefined server URL in a BrowserView', policyTestMetadata, async ({}, testInfo) => {
+    test('MM-T6167 should load the predefined server URL in a BrowserView', policyTestMetadata, async ({}, testInfo) => {
         test.skip(!isSupported, 'RUN_POLICY_E2E=true on macOS/Windows required');
         const policyServer = {name: 'Policy Server', url: mattermostURL};
         setupPolicy({servers: [policyServer]});
@@ -270,7 +270,7 @@ test.describe('policy', () => {
         }
     });
 
-    test('MM-T_GPO_3 should hide the Add Server button when server management is disabled by policy', policyTestMetadata, async ({}, testInfo) => {
+    test('MM-T6168 should hide the Add Server button when server management is disabled by policy', policyTestMetadata, async ({}, testInfo) => {
         test.skip(!isSupported, 'RUN_POLICY_E2E=true on macOS/Windows required');
         setupPolicy({
             servers: [{name: 'Managed Server', url: mattermostURL}],
@@ -286,7 +286,7 @@ test.describe('policy', () => {
         }
     });
 
-    test('MM-T_GPO_NP_1 should show the welcome screen when no policy and no config exist', policyTestMetadata, async ({}, testInfo) => {
+    test('MM-T6169 should show the welcome screen when no policy and no config exist', policyTestMetadata, async ({}, testInfo) => {
         test.skip(!isSupported, 'RUN_POLICY_E2E=true on macOS/Windows required');
         test.skip(!canRunBaseline, 'Baseline policy tests require no HKLM policy');
 
@@ -308,7 +308,7 @@ test.describe('policy', () => {
         }
     });
 
-    test('MM-T_GPO_NP_2 should show the Add Server button when no policy restricts server management', policyTestMetadata, async ({}, testInfo) => {
+    test('MM-T6170 should show the Add Server button when no policy restricts server management', policyTestMetadata, async ({}, testInfo) => {
         test.skip(!isSupported, 'RUN_POLICY_E2E=true on macOS/Windows required');
         test.skip(!canRunBaseline, 'Baseline policy tests require no HKLM policy');
 
@@ -325,7 +325,7 @@ test.describe('policy', () => {
         }
     });
 
-    test('MM-T_GPO_5 should display all predefined servers from policy in the dropdown', policyTestMetadata, async ({}, testInfo) => {
+    test('MM-T6171 should display all predefined servers from policy in the dropdown', policyTestMetadata, async ({}, testInfo) => {
         test.skip(!isSupported, 'RUN_POLICY_E2E=true on macOS/Windows required');
         const policyServers = [
             {name: 'Policy Server 1', url: mattermostURL},
@@ -347,7 +347,7 @@ test.describe('policy', () => {
         }
     });
 
-    test('MM-T_GPO_6 should show edit button but hide remove button for a predefined policy server', policyTestMetadata, async ({}, testInfo) => {
+    test('MM-T6172 should show edit button but hide remove button for a predefined policy server', policyTestMetadata, async ({}, testInfo) => {
         test.skip(!isSupported, 'RUN_POLICY_E2E=true on macOS/Windows required');
         setupPolicy({
             servers: [{name: 'Managed Server', url: mattermostURL}],
@@ -364,7 +364,7 @@ test.describe('policy', () => {
         }
     });
 
-    test('MM-T_GPO_7 should display both the policy server and the user-configured server in the dropdown', policyTestMetadata, async ({}, testInfo) => {
+    test('MM-T6173 should display both the policy server and the user-configured server in the dropdown', policyTestMetadata, async ({}, testInfo) => {
         test.skip(!isSupported, 'RUN_POLICY_E2E=true on macOS/Windows required');
         const policyServer = {name: 'Policy Server', url: mattermostURL};
         setupPolicy({servers: [policyServer]});
@@ -390,7 +390,7 @@ test.describe('policy', () => {
         }
     });
 
-    test('MM-T_GPO_4 should report enableUpdateNotifications=false when auto-updater is disabled by policy', policyTestMetadata, async ({}, testInfo) => {
+    test('MM-T6174 should report enableUpdateNotifications=false when auto-updater is disabled by policy', policyTestMetadata, async ({}, testInfo) => {
         test.skip(!isSupported, 'RUN_POLICY_E2E=true on macOS/Windows required');
         setupPolicy({enableAutoUpdater: false});
 

--- a/e2e/specs/right_click_menu_options/context_menu.test.ts
+++ b/e2e/specs/right_click_menu_options/context_menu.test.ts
@@ -15,7 +15,7 @@ import type {ServerView} from '../../helpers/serverView';
 // Channel menus use webapp .Menu components; team sidebar uses Chromium's
 // native context menu since MM-57962 removed the webapp Copy Link menu.
 
-test.describe('mattermost/context_menu', () => {
+test.describe('right_click_menu_options/context_menu', () => {
     test.describe.configure({mode: 'serial'});
     test.use({appConfig: demoMattermostConfig});
     test.setTimeout(120_000);

--- a/e2e/specs/right_click_menu_options/spellcheck.test.ts
+++ b/e2e/specs/right_click_menu_options/spellcheck.test.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {test, expect} from '../../fixtures/index';
+import {demoMattermostConfig} from '../../helpers/config';
+import {loginToMattermost} from '../../helpers/login';
+import {
+    POST_TEXTBOX_SELECTOR,
+    applySpellcheckSuggestion,
+    getPostTextboxWordPoint,
+    listenForNativeContextMenu,
+    rightClickAtPoint,
+    typeIntoPostTextbox,
+    waitForNativeContextMenu,
+    waitForMattermostShell,
+} from '../../helpers/mattermostShell';
+import {prepareMattermostServerView} from '../../helpers/prepareServerView';
+
+const MISSPELLED_WORD = 'helo';
+const EXPECTED_SUGGESTION = 'hello';
+
+test.describe('right_click_menu_options/spellcheck', () => {
+    test.use({appConfig: {...demoMattermostConfig, useSpellChecker: true}});
+    test.setTimeout(120_000);
+
+    test(
+        'MM-T829 Desktop App shows spell check options when you right click',
+        {tag: ['@P2', '@all']},
+        async ({electronApp, serverMap}) => {
+            test.skip(!process.env.MM_TEST_SERVER_URL, 'MM_TEST_SERVER_URL required');
+
+            const serverEntry = serverMap[demoMattermostConfig.servers[0].name]?.[0];
+            expect(serverEntry, 'Server view must exist').toBeTruthy();
+            const serverWin = serverEntry!.win;
+            await prepareMattermostServerView(electronApp, serverEntry!.webContentsId);
+            await loginToMattermost(serverWin);
+            await waitForMattermostShell(serverWin);
+            await serverWin.click('#sidebarItem_off-topic');
+            await serverWin.waitForSelector(POST_TEXTBOX_SELECTOR, {timeout: 15_000});
+
+            await typeIntoPostTextbox(serverWin, MISSPELLED_WORD);
+            const point = await getPostTextboxWordPoint(serverWin, MISSPELLED_WORD);
+            if (!point) {
+                test.skip(true, 'Could not locate misspelled word in post textbox');
+                return;
+            }
+
+            await listenForNativeContextMenu(electronApp, serverEntry.webContentsId);
+            await rightClickAtPoint(electronApp, serverEntry.webContentsId, point);
+            const menuParams = await waitForNativeContextMenu(electronApp);
+
+            if (!menuParams.misspelledWord) {
+                test.skip(true, 'OS spellchecker did not report a misspelled word in headless CI');
+                return;
+            }
+            expect(menuParams.misspelledWord).toBe(MISSPELLED_WORD);
+            const suggestions = menuParams.dictionarySuggestions as string[] | undefined;
+            expect(Array.isArray(suggestions)).toBe(true);
+            expect(suggestions!.length).toBeGreaterThan(0);
+        },
+    );
+
+    test(
+        'MM-T1320 Use spell-check suggestion',
+        {tag: ['@P2', '@all']},
+        async ({electronApp, serverMap}) => {
+            test.skip(!process.env.MM_TEST_SERVER_URL, 'MM_TEST_SERVER_URL required');
+
+            const serverEntry = serverMap[demoMattermostConfig.servers[0].name]?.[0];
+            expect(serverEntry, 'Server view must exist').toBeTruthy();
+            const serverWin = serverEntry!.win;
+            await prepareMattermostServerView(electronApp, serverEntry!.webContentsId);
+            await loginToMattermost(serverWin);
+            await waitForMattermostShell(serverWin);
+            await serverWin.click('#sidebarItem_off-topic');
+            await serverWin.waitForSelector(POST_TEXTBOX_SELECTOR, {timeout: 15_000});
+
+            await typeIntoPostTextbox(serverWin, MISSPELLED_WORD);
+            const point = await getPostTextboxWordPoint(serverWin, MISSPELLED_WORD);
+            if (!point) {
+                test.skip(true, 'Could not locate misspelled word in post textbox');
+                return;
+            }
+
+            await listenForNativeContextMenu(electronApp, serverEntry.webContentsId);
+            await rightClickAtPoint(electronApp, serverEntry.webContentsId, point);
+            const menuParams = await waitForNativeContextMenu(electronApp);
+            const suggestions = menuParams.dictionarySuggestions as string[] | undefined;
+            if (!suggestions?.length) {
+                test.skip(true, 'No spell-check suggestions returned by the OS spellchecker');
+                return;
+            }
+
+            const suggestion = suggestions.find((item) => item.toLowerCase() === EXPECTED_SUGGESTION) ?? suggestions[0];
+            await applySpellcheckSuggestion(electronApp, serverEntry.webContentsId, suggestion);
+
+            const value = await serverWin.evaluate((selector) => {
+                const el = document.querySelector(selector) as HTMLInputElement | HTMLTextAreaElement | HTMLElement | null;
+                if (!el) {
+                    return '';
+                }
+                if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+                    return el.value;
+                }
+                return el.textContent ?? el.innerText ?? '';
+            }, POST_TEXTBOX_SELECTOR) as string;
+            expect(value.toLowerCase()).toContain(suggestion.toLowerCase());
+        },
+    );
+});

--- a/e2e/specs/search_box/search_box.test.ts
+++ b/e2e/specs/search_box/search_box.test.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {test, expect} from '../../fixtures/index';
+import {demoMattermostConfig} from '../../helpers/config';
+import {closeDownloadsDropdownIfOpen} from '../../helpers/downloadsDropdown';
+import {loginToMattermost} from '../../helpers/login';
+import {waitForMattermostShell} from '../../helpers/mattermostShell';
+import {
+    activateServerEntry,
+    expectServerViewUrl,
+    getServerEntry,
+    openServerSearch,
+    SEARCH_INPUT,
+    waitForSearchBarFocused,
+} from '../../helpers/serverContext';
+
+test.describe('search_box/search_box', () => {
+    test.use({appConfig: demoMattermostConfig});
+
+    test(
+        'MM-T1309 Type some text in the search box',
+        {tag: ['@P2', '@all']},
+        async ({electronApp, serverMap}) => {
+            test.skip(!process.env.MM_TEST_SERVER_URL, 'MM_TEST_SERVER_URL required');
+
+            const entry = getServerEntry(serverMap, demoMattermostConfig.servers[0].name);
+            await activateServerEntry(electronApp, entry);
+            await expectServerViewUrl(electronApp, entry.webContentsId, /mattermost|8065/i);
+            const serverWin = entry.win;
+            await loginToMattermost(serverWin);
+            await waitForMattermostShell(serverWin);
+            await closeDownloadsDropdownIfOpen(electronApp);
+            await activateServerEntry(electronApp, entry);
+
+            if (process.platform === 'darwin') {
+                await serverWin.keyboard.press('Meta+f');
+            } else {
+                await openServerSearch(electronApp, entry.webContentsId);
+            }
+
+            await waitForSearchBarFocused(serverWin);
+            await serverWin.fill(SEARCH_INPUT, 'hello');
+            await serverWin.click(SEARCH_INPUT);
+            await serverWin.keyboard.press('ArrowLeft');
+            await serverWin.keyboard.press('ArrowLeft');
+            await serverWin.keyboard.press('Backspace');
+
+            expect(await serverWin.inputValue(SEARCH_INPUT)).toBe('helo');
+        },
+    );
+});

--- a/e2e/specs/server_management/bad_servers.test.ts
+++ b/e2e/specs/server_management/bad_servers.test.ts
@@ -158,7 +158,7 @@ test.describe('Bad Server Configurations', () => {
         // ever leak state, prefer sending CLOSE_SERVERS_DROPDOWN via IPC instead of
         // Page.close(), or press Escape at test end.
 
-        test('should handle server with unresolvable DNS', {tag: ['@P2', '@all']}, async () => {
+        test('MM-T6175 should handle server with unresolvable DNS', {tag: ['@P2', '@all']}, async () => {
             const app = sharedApp;
             const userDataDir = sharedUserDataDir;
             const newServerView = await openAddServerModal(app);
@@ -179,7 +179,7 @@ test.describe('Bad Server Configurations', () => {
             expect(errorInfo).toContain('ERR_NAME_NOT_RESOLVED');
         });
 
-        test('should handle server with expired certificate', {tag: ['@P2', '@all']}, async () => {
+        test('MM-T6176 should handle server with expired certificate', {tag: ['@P2', '@all']}, async () => {
             const app = sharedApp;
             const userDataDir = sharedUserDataDir;
             const newServerView = await openAddServerModal(app);
@@ -200,7 +200,7 @@ test.describe('Bad Server Configurations', () => {
             expect(errorInfo).toContain('ERR_CERT_DATE_INVALID');
         });
 
-        test('should handle server using TLS 1.0', {tag: ['@P2', '@all']}, async () => {
+        test('MM-T6177 should handle server using TLS 1.0', {tag: ['@P2', '@all']}, async () => {
             const app = sharedApp;
             const userDataDir = sharedUserDataDir;
             const newServerView = await openAddServerModal(app);
@@ -224,7 +224,7 @@ test.describe('Bad Server Configurations', () => {
             }, {timeout: 15_000, message: 'TLS 1.0 server must surface a connection error'}).not.toBeNull();
         });
 
-        test('should handle server using RC4 cipher', {tag: ['@P2', '@all']}, async () => {
+        test('MM-T6178 should handle server using RC4 cipher', {tag: ['@P2', '@all']}, async () => {
             const app = sharedApp;
             const userDataDir = sharedUserDataDir;
             const newServerView = await openAddServerModal(app);
@@ -250,7 +250,7 @@ test.describe('Bad Server Configurations', () => {
     });
 
     test.describe('Pre-configured servers', () => {
-        test('MULTI-01 unreachable server at startup does not block other servers', {tag: ['@P0', '@all']}, async ({}, testInfo) => {
+        test('MM-T6179 unreachable server at startup does not block other servers', {tag: ['@P0', '@all']}, async ({}, testInfo) => {
             const badConfig = {
                 ...demoConfig,
                 servers: [
@@ -290,7 +290,7 @@ test.describe('Bad Server Configurations', () => {
             }
         });
 
-        test('should handle pre-configured unreachable server', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
+        test('MM-T6180 should handle pre-configured unreachable server', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
             const badConfig = {
                 ...demoConfig,
                 servers: [
@@ -318,7 +318,7 @@ test.describe('Bad Server Configurations', () => {
             }
         });
 
-        test('should handle pre-configured unreachable server and still allow login to working Mattermost server', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
+        test('MM-T6181 should handle pre-configured unreachable server and still allow login to working Mattermost server', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
             test.setTimeout(120_000);
             if (!process.env.MM_TEST_SERVER_URL) {
                 test.skip(true, 'MM_TEST_SERVER_URL required');
@@ -379,7 +379,7 @@ test.describe('Bad Server Configurations', () => {
             }
         });
 
-        test('should handle pre-configured server with expired certificate', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
+        test('MM-T6182 should handle pre-configured server with expired certificate', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
             const badConfig = {
                 ...demoConfig,
                 servers: [
@@ -407,7 +407,7 @@ test.describe('Bad Server Configurations', () => {
             }
         });
 
-        test('should load pre-configured server with expired certificate when certificate is trusted in CertificateStore', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
+        test('MM-T6183 should load pre-configured server with expired certificate when certificate is trusted in CertificateStore', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
             const {mkdirSync} = await import('fs');
             const userDataDir = path.join(testInfo.outputDir, 'custom-userdata');
             mkdirSync(userDataDir, {recursive: true});
@@ -464,7 +464,7 @@ test.describe('Bad Server Configurations', () => {
             }
         });
 
-        test('should handle pre-configured server using TLS 1.1', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
+        test('MM-T6184 should handle pre-configured server using TLS 1.1', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
             const badConfig = {
                 ...demoConfig,
                 servers: [
@@ -494,7 +494,7 @@ test.describe('Bad Server Configurations', () => {
             }
         });
 
-        test('should handle pre-configured server using RC4 cipher', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
+        test('MM-T6185 should handle pre-configured server using RC4 cipher', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
             const badConfig = {
                 ...demoConfig,
                 servers: [

--- a/e2e/specs/server_management/certificate_trust.test.ts
+++ b/e2e/specs/server_management/certificate_trust.test.ts
@@ -15,7 +15,7 @@ import {evaluateInMainProcess} from '../../helpers/testRefs';
 const EXPIRED_CERT_URL = 'https://expired.badssl.com';
 
 test(
-    'SEC-03 trusting an invalid certificate allows the server view to load',
+    'MM-T2631 SEC-03 trusting an invalid certificate allows the server view to load',
     {tag: ['@P1', '@all']},
     async ({}, testInfo) => {
         const userDataDir = path.join(testInfo.outputDir, 'userdata');

--- a/e2e/specs/server_management/drag_and_drop.test.ts
+++ b/e2e/specs/server_management/drag_and_drop.test.ts
@@ -12,7 +12,8 @@ import {launchDirectTestApp} from '../../helpers/directLaunch';
 import {closeElectronAppFast, waitForWindow} from '../../helpers/electronApp';
 import {loginToMattermost} from '../../helpers/login';
 import {waitForMattermostShell, waitForMattermostShellReady, recoverServerViewIfNeeded} from '../../helpers/mattermostShell';
-import {prepareMattermostServerView} from '../../helpers/prepareServerView';
+import {closeOverlayWindowsIfOpen} from '../../helpers/overlayWindows';
+import {activateServerView} from '../../helpers/serverContext';
 import {buildServerMap} from '../../helpers/serverMap';
 
 if (!process.env.MM_TEST_SERVER_URL) {
@@ -47,6 +48,8 @@ async function getMattermostServer() {
 }
 
 async function resetState() {
+    await closeOverlayWindowsIfOpen(electronApp);
+
     await electronApp.evaluate(() => {
         const refs = (global as any).__e2eTestRefs;
         const servers = refs?.ServerManager?.getAllServers?.() ?? [];
@@ -84,7 +87,7 @@ async function resetState() {
     await mainWindow.keyboard.press('Escape').catch(() => {});
 
     const mmServer = await getMattermostServer();
-    await prepareMattermostServerView(electronApp, mmServer.webContentsId);
+    await activateServerView(electronApp, mmServer.webContentsId);
     await waitForMattermostShell(mmServer, {timeout: 45_000});
     await recoverServerViewIfNeeded(mmServer);
     await mmServer.click('#sidebarItem_town-square').catch(() => {});
@@ -150,12 +153,14 @@ async function navigateToSecondAndThirdTabs(serverName: string) {
     const secondTab = await mainWindow.waitForSelector('.TabBar li.serverTabItem:nth-child(2)', {timeout: 10_000});
     await secondTab.click();
     const secondView = localServerMap[serverName][1].win;
+    await activateServerView(electronApp, localServerMap[serverName][1].webContentsId);
     await waitForMattermostShellReady(secondView, {channelItem: '#sidebarItem_off-topic'});
     await secondView.click('#sidebarItem_off-topic');
 
     const thirdTab = await mainWindow.waitForSelector('.TabBar li.serverTabItem:nth-child(3)', {timeout: 10_000});
     await thirdTab.click();
     const thirdView = localServerMap[serverName][2].win;
+    await activateServerView(electronApp, localServerMap[serverName][2].webContentsId);
     await waitForMattermostShellReady(thirdView, {channelItem: '#sidebarItem_town-square'});
     await thirdView.click('#sidebarItem_town-square');
 

--- a/e2e/specs/server_management/popout_windows.test.ts
+++ b/e2e/specs/server_management/popout_windows.test.ts
@@ -10,7 +10,11 @@ import {demoMattermostConfig} from '../../helpers/config';
 import {launchDirectTestApp} from '../../helpers/directLaunch';
 import {closeElectronAppFast, waitForWindow} from '../../helpers/electronApp';
 import {loginToMattermost} from '../../helpers/login';
-import {clickApplicationMenuItem} from '../../helpers/menu';
+import {
+    closeAllPopouts,
+    closePopoutWindow,
+    openPopoutWindow,
+} from '../../helpers/popoutWindow';
 import {buildServerMap} from '../../helpers/serverMap';
 
 const config = {
@@ -33,103 +37,6 @@ async function getMattermostServer() {
     return mmServer!;
 }
 
-async function openPopoutWindow() {
-    await mainWindow.bringToFront().catch(() => {});
-
-    const popoutTimeout = process.platform === 'linux' ? 45_000 : 30_000;
-
-    // Filter on popout.html rather than accepting the first 'window' event:
-    // PopoutManager attaches a separate LoadingScreen WebContentsView (its own
-    // loadingScreen.html) to the same BrowserWindow before the real content
-    // view loads popout.html (src/app/views/loadingScreen.ts), so the first
-    // 'window' event can be the loading screen, not the popout content. The
-    // predicate is re-evaluated on every 'window' event (not just the first),
-    // so it correctly waits for the later event whose URL actually matches —
-    // confirmed via CI: removing this predicate broke the test (the loading
-    // screen page's URL never becomes popout.html, since it's a different
-    // WebContents entirely), so it's a genuine requirement, not just a
-    // theoretical race.
-    const windowPromise = electronApp.waitForEvent('window', {
-        timeout: popoutTimeout,
-        predicate: (page) => {
-            try {
-                return page.url().includes('popout.html');
-            } catch {
-                return false;
-            }
-        },
-    });
-
-    // Trigger through the real File → New Window menu item (which calls
-    // PopoutManager.createNewWindow for the current server) so the
-    // menu → popout wiring stays covered, rather than calling the manager directly.
-    await clickApplicationMenuItem(electronApp, 'file', {label: 'New Window'});
-
-    const popout = await windowPromise;
-    await popout.waitForLoadState('domcontentloaded').catch(() => {});
-    return popout;
-}
-
-async function closePopoutWindow(popoutWindow: import('playwright').Page, waitForAllClosed = true) {
-    const browserWindow = await electronApp.browserWindow(popoutWindow);
-    const closeTimeout = process.platform === 'linux' ? 5_000 : 15_000;
-    await Promise.all([
-        popoutWindow.waitForEvent('close', {timeout: closeTimeout}),
-        browserWindow.evaluate((w) => (w as Electron.BrowserWindow).close()),
-    ]).catch(async () => {
-        await browserWindow.evaluate((w) => {
-            if (!(w as Electron.BrowserWindow).isDestroyed()) {
-                (w as Electron.BrowserWindow).destroy();
-            }
-        }).catch(() => {});
-    });
-
-    if (!waitForAllClosed) {
-        return;
-    }
-
-    await expect.poll(() => {
-        return electronApp.windows().filter((window) => {
-            try {
-                return window.url().includes('popout.html');
-            } catch {
-                return false;
-            }
-        }).length;
-    }, {timeout: 10_000}).toBe(0);
-}
-
-async function closeAllPopouts() {
-    const popoutWindows = electronApp.windows().filter((window) => {
-        try {
-            return window.url().includes('popout.html');
-        } catch {
-            return false;
-        }
-    });
-
-    // Close every window first without waiting for the full count to reach 0
-    // per-window — with multiple popouts open, waiting inside each call added
-    // up to a 10s timeout per extra window. Poll for the batch once instead.
-    for (const popout of popoutWindows) {
-        await closePopoutWindow(popout, false).catch(() => {});
-    }
-
-    if (popoutWindows.length === 0) {
-        return;
-    }
-
-    await expect.poll(() => {
-        return electronApp.windows().filter((window) => {
-            try {
-                return window.url().includes('popout.html');
-            } catch {
-                return false;
-            }
-        }).length;
-    }, {timeout: 10_000}).toBe(0);
-}
-
 test.describe('server_management/popout_windows', () => {
     test.describe.configure({mode: 'serial'});
     test.skip(!process.env.MM_TEST_SERVER_URL, 'MM_TEST_SERVER_URL required');
@@ -144,7 +51,7 @@ test.describe('server_management/popout_windows', () => {
     });
 
     test.beforeEach(async () => {
-        await closeAllPopouts();
+        await closeAllPopouts(electronApp);
         const mmServer = await getMattermostServer();
         await mmServer.waitForSelector('#sidebarItem_town-square', {timeout: 15_000});
         await mmServer.click('#sidebarItem_town-square').catch(() => {});
@@ -157,13 +64,13 @@ test.describe('server_management/popout_windows', () => {
 
     test.describe('MM-TXXXX popout window functionality', () => {
         test('MM-TXXXX_1 should create a new popout window', {tag: ['@P2', '@all']}, async () => {
-            const popoutWindow = await openPopoutWindow();
+            const popoutWindow = await openPopoutWindow(electronApp, mainWindow);
             expect(popoutWindow).toBeDefined();
             expect(electronApp.windows().filter((w) => w.url().includes('popout.html')).length).toBe(1);
         });
 
         test('MM-TXXXX_2 should allow resizing the popout window', {tag: ['@P2', '@all']}, async () => {
-            const popoutWindow = await openPopoutWindow();
+            const popoutWindow = await openPopoutWindow(electronApp, mainWindow);
             const browserWindow = await electronApp.browserWindow(popoutWindow);
             const initialBounds = await browserWindow.evaluate((w) => (w as Electron.BrowserWindow).getBounds());
 
@@ -186,7 +93,7 @@ test.describe('server_management/popout_windows', () => {
         });
 
         test('MM-TXXXX_3 should allow moving the popout window', {tag: ['@P2', '@all']}, async () => {
-            const popoutWindow = await openPopoutWindow();
+            const popoutWindow = await openPopoutWindow(electronApp, mainWindow);
             const browserWindow = await electronApp.browserWindow(popoutWindow);
             const initialBounds = await browserWindow.evaluate((w) => (w as Electron.BrowserWindow).getBounds());
 
@@ -211,8 +118,8 @@ test.describe('server_management/popout_windows', () => {
         });
 
         test('MM-TXXXX_4 should close the popout window using close button', {tag: ['@P2', '@all']}, async () => {
-            const popoutWindow = await openPopoutWindow();
-            await closePopoutWindow(popoutWindow);
+            const popoutWindow = await openPopoutWindow(electronApp, mainWindow);
+            await closePopoutWindow(electronApp, popoutWindow);
         });
 
         // NOTE: there is intentionally no "close popout windows when main window is
@@ -223,7 +130,7 @@ test.describe('server_management/popout_windows', () => {
 
     test.describe('MM-T4411 popout window content functionality', () => {
         test('MM-T4411_1 should display the same server content in popout window', {tag: ['@P2', '@all']}, async () => {
-            const popoutWindow = await openPopoutWindow();
+            const popoutWindow = await openPopoutWindow(electronApp, mainWindow);
 
             const mainWindowTitle = await mainWindow.title();
             const popoutWindowTitle = await popoutWindow.title();
@@ -237,7 +144,7 @@ test.describe('server_management/popout_windows', () => {
             await mainView.waitForSelector('#sidebarItem_off-topic');
             await mainView.click('#sidebarItem_off-topic');
 
-            const popoutWindow = await openPopoutWindow();
+            const popoutWindow = await openPopoutWindow(electronApp, mainWindow);
             expect(popoutWindow).toBeDefined();
 
             const mainTabText = await mainWindow.innerText('.TabBar li.serverTabItem.active');

--- a/e2e/specs/server_management/remove_server_modal.test.ts
+++ b/e2e/specs/server_management/remove_server_modal.test.ts
@@ -44,7 +44,7 @@ async function launchWithRemoveServerModal(testInfo: {outputDir: string}) {
 }
 
 test.describe('RemoveServerModal', () => {
-    test('MM-T4390_1 should remove existing server on click Remove', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
+    test('MM-T1286 MM-T4390 Remove existing server on click Remove', {tag: ['@P2', '@all']}, async ({}, testInfo) => {
         const {app, removeServerView, userDataDir} = await launchWithRemoveServerModal(testInfo);
         try {
             await removeServerView.click('button:has-text("Remove")');

--- a/e2e/specs/server_management/show_tray_icon.test.ts
+++ b/e2e/specs/server_management/show_tray_icon.test.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {ElectronApplication} from 'playwright';
+
+import {test, expect} from '../../fixtures/index';
+import {demoConfig} from '../../helpers/config';
+
+const trayIconConfig = {
+    ...demoConfig,
+    showTrayIcon: true,
+};
+
+async function evaluateTrayExists(app: ElectronApplication): Promise<boolean> {
+    const deadline = Date.now() + 15_000;
+    while (Date.now() < deadline) {
+        try {
+            return await app.evaluate(() => {
+                const refs = (global as any).__e2eTestRefs;
+                const tray = refs?.TrayIcon?.tray;
+                return Boolean(tray && !tray.isDestroyed?.());
+            });
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            if (!message.includes('Execution context was destroyed')) {
+                throw error;
+            }
+            await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+    }
+
+    return false;
+}
+
+test.describe('server_management/show_tray_icon', () => {
+    test.use({appConfig: trayIconConfig});
+
+    test(
+        'MM-T1298 Show Mattermost icon in the menu bar (macOS and Linux)',
+        {tag: ['@P2', '@darwin', '@linux']},
+        async ({electronApp}) => {
+            expect(trayIconConfig.showTrayIcon).toBe(true);
+            expect(await evaluateTrayExists(electronApp)).toBe(true);
+        },
+    );
+});

--- a/e2e/specs/server_management/tab_management.test.ts
+++ b/e2e/specs/server_management/tab_management.test.ts
@@ -91,7 +91,7 @@ test.describe('server_management/tab_management', () => {
     });
 
     test.describe('MM-TXXXX should be able to close server tabs', () => {
-        test('MM-TXXXX_1 should close a server tab when clicking the x button', {tag: ['@P2', '@all']}, async () => {
+        test('MM-T6186 should close a server tab when clicking the x button', {tag: ['@P2', '@all']}, async () => {
             await mainWindow.click('#newTabButton');
 
             await mainWindow.waitForSelector('.TabBar li.serverTabItem:nth-child(2)');
@@ -127,7 +127,7 @@ test.describe('server_management/tab_management', () => {
     });
 
     test.describe('MM-TXXXX main tab for a server cannot be closed', () => {
-        test('MM-TXXXX_2 should not show close button on the main tab when there is only one tab', {tag: ['@P2', '@all']}, async () => {
+        test('MM-T6187 should not show close button on the main tab when there is only one tab', {tag: ['@P2', '@all']}, async () => {
             const firstTab = await mainWindow.waitForSelector('.TabBar li.serverTabItem:nth-child(1)');
             const secondTab = await mainWindow.$('.TabBar li.serverTabItem:nth-child(2)');
             expect(firstTab).toBeDefined();
@@ -137,7 +137,7 @@ test.describe('server_management/tab_management', () => {
             expect(closeButton).toBeNull();
         });
 
-        test('MM-TXXXX_3 should show close button on the main tab when there are multiple tabs', {tag: ['@P2', '@all']}, async () => {
+        test('MM-T6188 should show close button on the main tab when there are multiple tabs', {tag: ['@P2', '@all']}, async () => {
             await mainWindow.click('#newTabButton');
 
             const firstTab = await mainWindow.waitForSelector('.TabBar li.serverTabItem:nth-child(1)');

--- a/e2e/specs/server_management/unread_badge.test.ts
+++ b/e2e/specs/server_management/unread_badge.test.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {test, expect} from '../../fixtures/index';
+import {
+    clearAllBadgesViaAppState,
+    readOsBadge,
+    setUnreadBadgeSetting,
+    updateServerBadgeViaAppState,
+    waitForBadgeInfrastructure,
+} from '../../helpers/badge';
+import {demoConfig} from '../../helpers/config';
+import {acquireExclusiveLock} from '../../helpers/exclusiveLock';
+
+const FIRST_SERVER = demoConfig.servers[0].name;
+
+test.describe('server_management/unread_badge', () => {
+    test.beforeEach(async ({electronApp}) => {
+        if (process.platform === 'linux') {
+            return;
+        }
+        await waitForBadgeInfrastructure(electronApp);
+    });
+
+    test.afterEach(async ({electronApp}) => {
+        if (process.platform === 'linux') {
+            return;
+        }
+        await clearAllBadgesViaAppState(electronApp);
+    });
+
+    test(
+        'MM-T1291 Show red badge on taskbar for unread messages',
+        {tag: ['@P2', '@darwin', '@win32']},
+        async ({electronApp}) => {
+            test.skip(process.platform === 'linux', 'Unread dot badge is not supported on Linux Unity path');
+
+            const releaseLock = await acquireExclusiveLock('notification-badge-state');
+            try {
+                await clearAllBadgesViaAppState(electronApp);
+                await setUnreadBadgeSetting(electronApp, true);
+                await updateServerBadgeViaAppState(electronApp, FIRST_SERVER, 0, true);
+
+                await expect.poll(
+                    () => readOsBadge(electronApp),
+                    {timeout: 10_000, message: 'Badge must show unread state when setting enabled'},
+                ).toMatchObject({symbol: 'unread'});
+
+                await updateServerBadgeViaAppState(electronApp, FIRST_SERVER, 3, false);
+
+                await expect.poll(
+                    () => readOsBadge(electronApp),
+                    {timeout: 10_000, message: 'Badge must show mention count'},
+                ).toMatchObject({symbol: 'mention', count: 3});
+            } finally {
+                await releaseLock();
+            }
+        },
+    );
+
+    test(
+        'MM-T1292 Do not show red badge when setting disabled except mentions',
+        {tag: ['@P2', '@darwin', '@win32']},
+        async ({electronApp}) => {
+            test.skip(process.platform === 'linux', 'Unread dot badge is not supported on Linux Unity path');
+
+            const releaseLock = await acquireExclusiveLock('notification-badge-state');
+            try {
+                await clearAllBadgesViaAppState(electronApp);
+                await setUnreadBadgeSetting(electronApp, false);
+                await updateServerBadgeViaAppState(electronApp, FIRST_SERVER, 0, true);
+
+                await expect.poll(
+                    () => readOsBadge(electronApp),
+                    {timeout: 10_000, message: 'Unread badge must stay hidden when setting disabled'},
+                ).toMatchObject({symbol: 'none'});
+
+                await updateServerBadgeViaAppState(electronApp, FIRST_SERVER, 2, false);
+
+                await expect.poll(
+                    () => readOsBadge(electronApp),
+                    {timeout: 10_000, message: 'Mention badge must still appear when setting disabled'},
+                ).toMatchObject({symbol: 'mention', count: 2});
+            } finally {
+                await releaseLock();
+            }
+        },
+    );
+});

--- a/e2e/specs/server_management/view_state.test.ts
+++ b/e2e/specs/server_management/view_state.test.ts
@@ -4,7 +4,7 @@
 import {test, expect} from '../../fixtures/index';
 
 test(
-    'switching servers preserves view state on return',
+    'MM-T6189 switching servers preserves view state on return',
     {tag: ['@P1', '@all']},
     async ({serverMap, electronApp}) => {
         const serverA = serverMap.example?.[0]?.win;

--- a/e2e/specs/user_attributes/user_attributes.test.ts
+++ b/e2e/specs/user_attributes/user_attributes.test.ts
@@ -1,0 +1,607 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {ElectronApplication} from 'playwright';
+
+import {test, expect} from '../../fixtures/index';
+import {waitForMattermostShellReady} from '../../helpers/mattermostShell';
+import {demoMattermostConfig} from '../../helpers/config';
+import {loginToMattermost} from '../../helpers/login';
+import {
+    activateServerEntry,
+    expectServerViewUrl,
+    getServerEntry,
+} from '../../helpers/serverContext';
+import {buildServerMap, type ServerEntry, type ServerMap} from '../../helpers/serverMap';
+import type {ServerView} from '../../helpers/serverView';
+import {
+    TEST_DEPARTMENT,
+    TEST_INVALID_URL,
+    TEST_PHONE,
+    TEST_UPDATED_PHONE,
+    TEST_UPDATED_URL,
+    TEST_URL,
+    TEST_VALID_URL,
+    cancelCustomAttributeEdit,
+    closeProfilePopover,
+    closeProfileSettings,
+    createCustomProfileAttributeField,
+    deleteCustomProfileAttributeField,
+    dismissBlockingOverlays,
+    editTextCustomAttribute,
+    getCustomAttributeLabelsInSettings,
+    getCustomProfileAttributeFields,
+    isAppResponsive,
+    isUserAttributesFeatureAvailable,
+    postAndOpenProfilePopover,
+    openProfileSettings,
+    patchCustomProfileAttributeField,
+    popoverContainsText,
+    popoverLinkHasHref,
+    recoverFromProfileSettings,
+    updateCustomProfileAttributeValues,
+    type UserPropertyField,
+} from '../../helpers/userAttributes';
+
+const FIELD_PREFIX = 'E2E_UA_';
+
+async function cleanupFields(fieldIds: string[]): Promise<void> {
+    for (const fieldId of fieldIds) {
+        try {
+            await deleteCustomProfileAttributeField(fieldId);
+        } catch {
+            // Best-effort cleanup on shared servers.
+        }
+    }
+}
+
+async function prepareServer(
+    electronApp: ElectronApplication,
+    serverMap?: ServerMap,
+): Promise<{entry: ServerEntry; win: ServerView}> {
+    const map = serverMap ?? await buildServerMap(electronApp);
+    const entry = getServerEntry(map, demoMattermostConfig.servers[0].name);
+    await expectServerViewUrl(electronApp, entry.webContentsId, /mattermost|8065/i, {
+        message: 'Example server view must load the Mattermost URL',
+    });
+    await activateServerEntry(electronApp, entry);
+    await loginToMattermost(entry.win);
+    await waitForMattermostShellReady(entry.win);
+    await dismissBlockingOverlays(entry.win);
+    return {entry, win: entry.win};
+}
+
+test.describe('user_attributes/user_attributes', () => {
+    test.describe.configure({mode: 'serial'});
+    test.use({appConfig: demoMattermostConfig});
+    test.setTimeout(120_000);
+
+    test.beforeAll(async () => {
+        if (!process.env.MM_TEST_SERVER_URL) {
+            test.skip(true, 'MM_TEST_SERVER_URL required');
+            return;
+        }
+
+        if (!process.env.MM_TEST_USER_NAME || !process.env.MM_TEST_PASSWORD) {
+            test.skip(true, 'MM_TEST_USER_NAME and MM_TEST_PASSWORD required');
+            return;
+        }
+
+        const available = await isUserAttributesFeatureAvailable();
+        if (!available) {
+            test.skip(true, 'User Attributes feature not available on this server');
+        }
+
+        const existing = await getCustomProfileAttributeFields();
+        await cleanupFields(existing.filter((field) => field.name.startsWith(FIELD_PREFIX)).map((field) => field.id));
+    });
+
+    test.beforeEach(async ({electronApp, serverMap}) => {
+        if (!process.env.MM_TEST_SERVER_URL) {
+            return;
+        }
+
+        await prepareServer(electronApp, serverMap);
+    });
+
+    test('MM-T5747 Attributes are shown in the user profile settings in the same order that they are listed in the System Console',
+        {tag: ['@P2', '@all']},
+        async ({electronApp, serverMap}) => {
+            const {win} = await prepareServer(electronApp, serverMap);
+            const names = [`${FIELD_PREFIX}Alpha`, `${FIELD_PREFIX}Beta`, `${FIELD_PREFIX}Gamma`];
+            const created: UserPropertyField[] = [];
+
+            try {
+                for (let index = 0; index < names.length; index++) {
+                    created.push(await createCustomProfileAttributeField({name: names[index]}, index));
+                }
+
+                try {
+                    await openProfileSettings(win);
+                } catch {
+                    await recoverFromProfileSettings(win);
+                    test.skip(true, 'Profile settings UI is not available on this server');
+                    return;
+                }
+                const labels = await getCustomAttributeLabelsInSettings(win);
+                await closeProfileSettings(win);
+
+                for (const name of names) {
+                    expect(labels.some((label) => label.includes(name)), `Expected ${name} in profile settings`).toBe(true);
+                }
+
+                const labelIndexes = names.map((name) => labels.findIndex((label) => label.includes(name)));
+                expect(labelIndexes.every((index) => index >= 0)).toBe(true);
+                expect(labelIndexes[0]).toBeLessThan(labelIndexes[1]!);
+                expect(labelIndexes[1]).toBeLessThan(labelIndexes[2]!);
+            } finally {
+                await cleanupFields(created.map((field) => field.id));
+            }
+        },
+    );
+
+    test('MM-T5748 Long attribute names and descriptions are displayed correctly in a user\'s Profile Settings screen',
+        {tag: ['@P2', '@all']},
+        async ({electronApp, serverMap}) => {
+            const {win} = await prepareServer(electronApp, serverMap);
+            const longName = `${FIELD_PREFIX}${'LongAttributeName'.repeat(4)}`;
+            const longDescription = 'This is an intentionally long description for verifying profile settings layout in desktop.';
+            let created: UserPropertyField | undefined;
+
+            try {
+                created = await createCustomProfileAttributeField({
+                    name: longName,
+                    attrs: {description: longDescription},
+                }, 0);
+
+                try {
+                    await openProfileSettings(win);
+                } catch {
+                    await recoverFromProfileSettings(win);
+                    test.skip(true, 'Profile settings UI is not available on this server');
+                    return;
+                }
+                const visible = await win.runInRenderer<{nameVisible: boolean; descriptionVisible: boolean}>(`
+                    const modal = document.querySelector('#accountSettingsModal, .user-settings, #userAccountModal, .AccountModal');
+                    if (!modal) {
+                        return {nameVisible: false, descriptionVisible: false};
+                    }
+                    const text = modal.textContent || '';
+                    return {
+                        nameVisible: text.includes(${JSON.stringify(longName)}),
+                        descriptionVisible: text.includes(${JSON.stringify(longDescription)}),
+                    };
+                `);
+                await closeProfileSettings(win);
+
+                expect(visible.nameVisible, 'Long attribute name should be visible').toBe(true);
+            } finally {
+                if (created) {
+                    await cleanupFields([created.id]);
+                }
+            }
+        },
+    );
+
+    test('MM-T5749 Clicking Cancel does not save the edit in user\'s Profile settings screen',
+        {tag: ['@P2', '@all']},
+        async ({electronApp, serverMap}) => {
+            const {win} = await prepareServer(electronApp, serverMap);
+            const fieldName = `${FIELD_PREFIX}CancelTest`;
+            let created: UserPropertyField | undefined;
+
+            try {
+                created = await createCustomProfileAttributeField({name: fieldName}, 0);
+                await updateCustomProfileAttributeValues({[created.id]: TEST_DEPARTMENT});
+
+                try {
+                    await openProfileSettings(win);
+                } catch {
+                    await recoverFromProfileSettings(win);
+                    test.skip(true, 'Profile settings UI is not available on this server');
+                    return;
+                }
+                await editTextCustomAttribute(win, created.id, 'Changed Value', false);
+                await cancelCustomAttributeEdit(win, created.id);
+                const settingsText = await win.runInRenderer<string>(`
+                    return document.querySelector('.user-settings, #accountSettingsModal')?.textContent || '';
+                `);
+                await closeProfileSettings(win);
+
+                expect(settingsText).toContain(TEST_DEPARTMENT);
+                expect(settingsText).not.toContain('Changed Value');
+            } finally {
+                if (created) {
+                    await cleanupFields([created.id]);
+                }
+            }
+        },
+    );
+
+    test('MM-T5750 No crash if user is editing a user attribute at the same time as the System Admin is deleting it in the System Console',
+        {tag: ['@P2', '@all']},
+        async ({electronApp, serverMap}) => {
+            const {win} = await prepareServer(electronApp, serverMap);
+            const fieldName = `${FIELD_PREFIX}DeleteWhileEditing`;
+            let created: UserPropertyField | undefined;
+
+            try {
+                created = await createCustomProfileAttributeField({name: fieldName}, 0);
+                await updateCustomProfileAttributeValues({[created.id]: TEST_DEPARTMENT});
+
+                try {
+                    await openProfileSettings(win);
+                } catch {
+                    await recoverFromProfileSettings(win);
+                    test.skip(true, 'Profile settings UI is not available on this server');
+                    return;
+                }
+                await win.runInRenderer<void>(`
+                    document.querySelector('#customAttribute_${created!.id}Edit')?.click();
+                `);
+                await win.waitForSelector(`#customAttribute_${created!.id}`, {timeout: 10_000});
+
+                await deleteCustomProfileAttributeField(created!.id);
+                created = undefined;
+
+                expect(await isAppResponsive(win), 'App should remain responsive after field deletion').toBe(true);
+                await closeProfileSettings(win);
+                expect(await isAppResponsive(win), 'App should remain responsive after closing settings').toBe(true);
+            } finally {
+                if (created) {
+                    await cleanupFields([created.id]);
+                }
+            }
+        },
+    );
+
+    test('MM-T5751 Attributes are shown in the user profile pop-over in the same order that they are listed in the System Console',
+        {tag: ['@P2', '@all']},
+        async ({electronApp, serverMap}) => {
+            const {entry, win} = await prepareServer(electronApp, serverMap);
+            const names = [`${FIELD_PREFIX}Pop_A`, `${FIELD_PREFIX}Pop_B`, `${FIELD_PREFIX}Pop_C`];
+            const created: UserPropertyField[] = [];
+
+            try {
+                for (let index = 0; index < names.length; index++) {
+                    const field = await createCustomProfileAttributeField({
+                        name: names[index],
+                        attrs: {visibility: 'always'},
+                    }, index);
+                    created.push(field);
+                    await updateCustomProfileAttributeValues({[field.id]: `Value-${index + 1}`});
+                }
+
+                const message = 'User attributes popover order test';
+                await postAndOpenProfilePopover(electronApp, entry, message);
+
+                await expect.poll(async () => {
+                    const popoverText = await win.runInRenderer<string>(`
+                        const popover = document.querySelector('#user-profile-popover, .user-profile-popover, .profile-popover');
+                        return popover?.textContent || '';
+                    `);
+                    return names.every((name) => popoverText.includes(name));
+                }, {timeout: 30_000, message: 'Custom profile attribute names must appear in the popover'}).toBe(true);
+
+                const popoverText = await win.runInRenderer<string>(`
+                    const popover = document.querySelector('#user-profile-popover, .user-profile-popover, .profile-popover');
+                    return popover?.textContent || '';
+                `);
+
+                const indexes = names.map((name) => popoverText.indexOf(name));
+                expect(indexes.every((index) => index >= 0)).toBe(true);
+                expect(indexes[0]).toBeLessThan(indexes[1]!);
+                expect(indexes[1]).toBeLessThan(indexes[2]!);
+
+                await closeProfilePopover(win);
+            } finally {
+                await cleanupFields(created.map((field) => field.id));
+            }
+        },
+    );
+
+    test('MM-T5752 User profile pop-over is scrollable and bottom bar in pop-over is locked in place',
+        {tag: ['@P2', '@all']},
+        async ({electronApp, serverMap}) => {
+            const {entry, win} = await prepareServer(electronApp, serverMap);
+            const created: UserPropertyField[] = [];
+
+            try {
+                for (let index = 0; index < 6; index++) {
+                    const field = await createCustomProfileAttributeField({
+                        name: `${FIELD_PREFIX}Scroll_${index}`,
+                    }, index);
+                    created.push(field);
+                    await updateCustomProfileAttributeValues({[field.id]: `Scroll value ${index}`});
+                }
+
+                const scrollMessage = 'User attributes scrollable popover test';
+                await postAndOpenProfilePopover(electronApp, entry, scrollMessage);
+
+                const layout = await win.runInRenderer<{scrollable: boolean; bottomLocked: boolean}>(`
+                    const popover = document.querySelector('#user-profile-popover, .user-profile-popover, .profile-popover, [data-testid="userProfilePopover"]');
+                    if (!popover) {
+                        return {scrollable: false, bottomLocked: false};
+                    }
+                    const scrollContainer = popover.querySelector(
+                        '.user-profile-popover__wrapper, .popover-content, .user-popover__content, .profile-popover-content, [data-testid="userProfilePopoverBody"]',
+                    ) || popover;
+                    const bottomBarSelectors = [
+                        '.user-popover__bottom',
+                        '.user-profile-popover__bottom',
+                        '.profile-popover-bottom',
+                        '.popover-footer',
+                        '[data-testid="profilePopoverActions"]',
+                        '[data-testid="userProfilePopoverActions"]',
+                        '.user-profile-popover-actions',
+                    ];
+                    let bottomBar = null;
+                    for (const selector of bottomBarSelectors) {
+                        bottomBar = popover.querySelector(selector);
+                        if (bottomBar) {
+                            break;
+                        }
+                    }
+                    if (!bottomBar) {
+                        bottomBar = Array.from(popover.querySelectorAll('button, a')).find((element) => {
+                            const label = (element.textContent || element.getAttribute('aria-label') || '').toLowerCase();
+                            return label.includes('message') || label.includes('call');
+                        })?.closest('div') || null;
+                    }
+                    const style = window.getComputedStyle(scrollContainer);
+                    const scrollable = scrollContainer.scrollHeight > scrollContainer.clientHeight
+                        || style.overflowY === 'auto'
+                        || style.overflowY === 'scroll';
+                    const bottomLocked = Boolean(bottomBar);
+                    return {scrollable, bottomLocked};
+                `);
+
+                expect(layout.scrollable, 'Popover content should be scrollable when attributes overflow').toBe(true);
+                expect(layout.bottomLocked, 'Popover bottom bar should be present').toBe(true);
+
+                await closeProfilePopover(win);
+            } finally {
+                await cleanupFields(created.map((field) => field.id));
+            }
+        },
+    );
+
+    test('MM-T5771 Editing Phone and URL Type User Attributes',
+        {tag: ['@P2', '@all']},
+        async ({electronApp, serverMap}) => {
+            const {entry, win} = await prepareServer(electronApp, serverMap);
+            const created: UserPropertyField[] = [];
+
+            try {
+                const phoneField = await createCustomProfileAttributeField({
+                    name: `${FIELD_PREFIX}Phone`,
+                    attrs: {value_type: 'phone'},
+                }, 0);
+                const urlField = await createCustomProfileAttributeField({
+                    name: `${FIELD_PREFIX}Website`,
+                    attrs: {value_type: 'url'},
+                }, 1);
+                created.push(phoneField, urlField);
+                await updateCustomProfileAttributeValues({
+                    [phoneField.id]: TEST_PHONE,
+                    [urlField.id]: TEST_URL,
+                });
+
+                try {
+                    await openProfileSettings(win);
+                } catch {
+                    await recoverFromProfileSettings(win);
+                    test.skip(true, 'Profile settings UI is not available on this server');
+                    return;
+                }
+                await editTextCustomAttribute(win, phoneField.id, TEST_UPDATED_PHONE);
+                await editTextCustomAttribute(win, urlField.id, TEST_UPDATED_URL);
+                await closeProfileSettings(win);
+
+                const phoneUrlMessage = 'Phone and URL attribute edit test';
+                await postAndOpenProfilePopover(electronApp, entry, phoneUrlMessage);
+                expect(await popoverContainsText(win, TEST_UPDATED_PHONE)).toBe(true);
+                expect(await popoverContainsText(win, TEST_UPDATED_URL)).toBe(true);
+                await closeProfilePopover(win);
+            } finally {
+                await cleanupFields(created.map((field) => field.id));
+            }
+        },
+    );
+
+    test('MM-T5772 URL Validation in User Attributes',
+        {tag: ['@P2', '@all']},
+        async ({electronApp, serverMap}) => {
+            const {entry, win} = await prepareServer(electronApp, serverMap);
+            let created: UserPropertyField | undefined;
+
+            try {
+                created = await createCustomProfileAttributeField({
+                    name: `${FIELD_PREFIX}WebsiteValidation`,
+                    attrs: {value_type: 'url'},
+                }, 0);
+                await updateCustomProfileAttributeValues({[created.id]: TEST_URL});
+
+                try {
+                    await openProfileSettings(win);
+                } catch {
+                    await recoverFromProfileSettings(win);
+                    test.skip(true, 'Profile settings UI is not available on this server');
+                    return;
+                }
+                await editTextCustomAttribute(win, created.id, TEST_INVALID_URL, false);
+                await win.runInRenderer<void>(`
+                    document.querySelector('#customAttribute_${created!.id}')?.blur();
+                `);
+
+                await expect.poll(async () => win.runInRenderer<boolean>(`
+                    return Boolean(document.querySelector('#error_customAttribute_${created!.id}'));
+                `), {timeout: 10_000}).toBe(true);
+
+                await editTextCustomAttribute(win, created.id, TEST_VALID_URL);
+                await closeProfileSettings(win);
+
+                const urlValidationMessage = 'URL validation attribute test';
+                await postAndOpenProfilePopover(electronApp, entry, urlValidationMessage);
+                expect(await popoverContainsText(win, TEST_VALID_URL)).toBe(true);
+                await closeProfilePopover(win);
+            } finally {
+                if (created) {
+                    await cleanupFields([created.id]);
+                }
+            }
+        },
+    );
+
+    test('MM-T5774 Do Not Display User Attributes If None Exist',
+        {tag: ['@P2', '@all']},
+        async ({electronApp, serverMap}) => {
+            const {entry, win} = await prepareServer(electronApp, serverMap);
+            const created: UserPropertyField[] = [];
+
+            try {
+                const department = await createCustomProfileAttributeField({name: `${FIELD_PREFIX}EmptyDept`}, 0);
+                const location = await createCustomProfileAttributeField({name: `${FIELD_PREFIX}EmptyLoc`}, 1);
+                created.push(department, location);
+
+                const emptyMessage = 'No custom attribute values on this user';
+                await postAndOpenProfilePopover(electronApp, entry, emptyMessage);
+
+                expect(await popoverContainsText(win, department.name)).toBe(false);
+                expect(await popoverContainsText(win, location.name)).toBe(false);
+
+                await closeProfilePopover(win);
+            } finally {
+                await cleanupFields(created.map((field) => field.id));
+            }
+        },
+    );
+
+    test('MM-T5776 Hide User Attributes When Visibility Is Set to Hidden',
+        {tag: ['@P2', '@all']},
+        async ({electronApp, serverMap}) => {
+            const {entry, win} = await prepareServer(electronApp, serverMap);
+            const created: UserPropertyField[] = [];
+
+            try {
+                const hiddenField = await createCustomProfileAttributeField({name: `${FIELD_PREFIX}Hidden`}, 0);
+                const visibleField = await createCustomProfileAttributeField({name: `${FIELD_PREFIX}Visible`}, 1);
+                created.push(hiddenField, visibleField);
+
+                await patchCustomProfileAttributeField(hiddenField.id, {attrs: {visibility: 'hidden'}});
+                await updateCustomProfileAttributeValues({
+                    [hiddenField.id]: TEST_DEPARTMENT,
+                    [visibleField.id]: 'Remote',
+                });
+
+                const hiddenMessage = 'Hidden attribute visibility test';
+                await postAndOpenProfilePopover(electronApp, entry, hiddenMessage);
+
+                expect(await popoverContainsText(win, hiddenField.name)).toBe(false);
+                expect(await popoverContainsText(win, 'Remote')).toBe(true);
+
+                await closeProfilePopover(win);
+            } finally {
+                await cleanupFields(created.map((field) => field.id));
+            }
+        },
+    );
+
+    test('MM-T5777 Always Display User Attributes With Visibility Set to Always',
+        {tag: ['@P2', '@all']},
+        async ({electronApp, serverMap}) => {
+            const {win} = await prepareServer(electronApp, serverMap);
+            let created: UserPropertyField | undefined;
+
+            try {
+                created = await createCustomProfileAttributeField({
+                    name: `${FIELD_PREFIX}AlwaysShow`,
+                    attrs: {visibility: 'always'},
+                }, 0);
+
+                try {
+                    await openProfileSettings(win);
+                } catch {
+                    await recoverFromProfileSettings(win);
+                    test.skip(true, 'Profile settings UI is not available on this server');
+                    return;
+                }
+                const labels = await getCustomAttributeLabelsInSettings(win);
+                expect(labels.some((label) => label.includes(created!.name)), 'Always-visible attribute should appear in profile settings').toBe(true);
+                await closeProfileSettings(win);
+            } finally {
+                if (created) {
+                    await cleanupFields([created.id]);
+                }
+            }
+        },
+    );
+
+    test('MM-T5778 Display Phone and URL Type User Attributes Correctly',
+        {tag: ['@P2', '@all']},
+        async ({electronApp, serverMap}) => {
+            const {entry, win} = await prepareServer(electronApp, serverMap);
+            const created: UserPropertyField[] = [];
+
+            try {
+                const phoneField = await createCustomProfileAttributeField({
+                    name: `${FIELD_PREFIX}DisplayPhone`,
+                    attrs: {value_type: 'phone'},
+                }, 0);
+                const urlField = await createCustomProfileAttributeField({
+                    name: `${FIELD_PREFIX}DisplayURL`,
+                    attrs: {value_type: 'url'},
+                }, 1);
+                created.push(phoneField, urlField);
+                await updateCustomProfileAttributeValues({
+                    [phoneField.id]: TEST_PHONE,
+                    [urlField.id]: TEST_URL,
+                });
+
+                const displayMessage = 'Display phone and URL attributes';
+                await postAndOpenProfilePopover(electronApp, entry, displayMessage);
+
+                expect(await popoverContainsText(win, TEST_PHONE)).toBe(true);
+                expect(await popoverContainsText(win, TEST_URL)).toBe(true);
+
+                await closeProfilePopover(win);
+            } finally {
+                await cleanupFields(created.map((field) => field.id));
+            }
+        },
+    );
+
+    test('MM-T5779 Verify Phone and URL Attributes Are Clickable in Profile Popover',
+        {tag: ['@P2', '@all']},
+        async ({electronApp, serverMap}) => {
+            const {entry, win} = await prepareServer(electronApp, serverMap);
+            const created: UserPropertyField[] = [];
+
+            try {
+                const phoneField = await createCustomProfileAttributeField({
+                    name: `${FIELD_PREFIX}ClickPhone`,
+                    attrs: {value_type: 'phone'},
+                }, 0);
+                const urlField = await createCustomProfileAttributeField({
+                    name: `${FIELD_PREFIX}ClickURL`,
+                    attrs: {value_type: 'url'},
+                }, 1);
+                created.push(phoneField, urlField);
+                await updateCustomProfileAttributeValues({
+                    [phoneField.id]: TEST_PHONE,
+                    [urlField.id]: TEST_URL,
+                });
+
+                const clickableMessage = 'Clickable phone and URL attributes';
+                await postAndOpenProfilePopover(electronApp, entry, clickableMessage);
+
+                expect(await popoverLinkHasHref(win, TEST_PHONE, '^tel:')).toBe(true);
+                expect(await popoverLinkHasHref(win, TEST_URL, '^https:')).toBe(true);
+
+                await closeProfilePopover(win);
+            } finally {
+                await cleanupFields(created.map((field) => field.id));
+            }
+        },
+    );
+});


### PR DESCRIPTION
Adds the remaining Playwright specs from the Rainforest migration: deep linking, downloads, mattermost flows, permissions, server management, and user attributes.

Slice of #3853. E2E coverage validated on #3853. Merge after #3888.

#### Release Note

```release-note
NONE
```