### PR TITLE
[MM-69724] Allow WS updates to update session attribute manifest rather than rely on refetch every time

### DIFF
--- a/api-types/index.ts
+++ b/api-types/index.ts
@@ -43,6 +43,16 @@ export type PopoutViewProps = {
     titleTemplate?: string;
     isRHS?: boolean;
 };
+export type SessionAttributeField = {
+    name: string;
+    type: string;
+    attrs: {
+        enabled: boolean;
+        ttl_seconds: number;
+        grace_period_seconds: number;
+        platforms: string[];
+    };
+};
 
 export type DesktopAPI = {
 
@@ -62,6 +72,7 @@ export type DesktopAPI = {
     onLogout: () => void;
     invalidateSessionAttributeManifest: () => void;
     resendSessionAttributes: () => void;
+    updateSessionAttribute: (field: SessionAttributeField) => void;
 
     // Unreads/mentions/notifications
     sendNotification: (title: string, body: string, channelId: string, teamId: string, url: string, silent: boolean, soundName: string) => Promise<{status: string; reason?: string; data?: string}>;

--- a/api-types/lib/index.d.ts
+++ b/api-types/lib/index.d.ts
@@ -42,6 +42,16 @@ export type PopoutViewProps = {
     titleTemplate?: string;
     isRHS?: boolean;
 };
+export type SessionAttributeField = {
+    name: string;
+    type: string;
+    attrs: {
+        enabled: boolean;
+        ttl_seconds: number;
+        grace_period_seconds: number;
+        platforms: string[];
+    };
+};
 export type DesktopAPI = {
     isDev: () => Promise<boolean>;
     getAppInfo: () => Promise<{
@@ -55,6 +65,7 @@ export type DesktopAPI = {
     onLogout: () => void;
     invalidateSessionAttributeManifest: () => void;
     resendSessionAttributes: () => void;
+    updateSessionAttribute: (field: SessionAttributeField) => void;
     sendNotification: (title: string, body: string, channelId: string, teamId: string, url: string, silent: boolean, soundName: string) => Promise<{
         status: string;
         reason?: string;

--- a/api-types/package-lock.json
+++ b/api-types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mattermost/desktop-api",
-  "version": "6.3.0-1",
+  "version": "6.3.0-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mattermost/desktop-api",
-      "version": "6.3.0-1",
+      "version": "6.3.0-2",
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^4.3.0 || ^5.0.0"

--- a/api-types/package.json
+++ b/api-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/desktop-api",
-  "version": "6.3.0-1",
+  "version": "6.3.0-2",
   "description": "Shared types for the Desktop App API provided to the Web App",
   "keywords": [
     "mattermost"

--- a/src/app/preload/externalAPI.ts
+++ b/src/app/preload/externalAPI.ts
@@ -37,6 +37,7 @@ import {
     TAB_LOGIN_CHANGED,
     SESSION_ATTRIBUTES_MANIFEST_INVALIDATED,
     SESSION_ATTRIBUTES_RESEND_REQUESTED,
+    SESSION_ATTRIBUTES_FIELD_UPDATED,
     METRICS_SEND,
     METRICS_REQUEST,
     METRICS_RECEIVE,
@@ -85,6 +86,7 @@ const desktopAPI: DesktopAPI = {
     onLogout: () => ipcRenderer.send(TAB_LOGIN_CHANGED, false),
     invalidateSessionAttributeManifest: () => ipcRenderer.send(SESSION_ATTRIBUTES_MANIFEST_INVALIDATED),
     resendSessionAttributes: () => ipcRenderer.send(SESSION_ATTRIBUTES_RESEND_REQUESTED),
+    updateSessionAttribute: (field) => ipcRenderer.send(SESSION_ATTRIBUTES_FIELD_UPDATED, field),
 
     // Unreads/mentions/notifications
     sendNotification: (title, body, channelId, teamId, url, silent, soundName) =>

--- a/src/common/Validator.ts
+++ b/src/common/Validator.ts
@@ -418,3 +418,14 @@ export const desktopSourcesOptsSchema = Joi.object({
     }),
     fetchWindowIcons: Joi.boolean(),
 });
+
+export const sessionAttributeFieldSchema = Joi.object({
+    name: Joi.string().required(),
+    type: Joi.string().required(),
+    attrs: Joi.object({
+        enabled: Joi.boolean().required(),
+        ttl_seconds: Joi.number().required(),
+        grace_period_seconds: Joi.number().required(),
+        platforms: Joi.array().items(Joi.string()).required(),
+    }).unknown(true).required(),
+}).unknown(true);

--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -263,3 +263,4 @@ export const RESET_THEME = 'reset-theme';
 // Session attributes events
 export const SESSION_ATTRIBUTES_MANIFEST_INVALIDATED = 'session-attributes-manifest-invalidated';
 export const SESSION_ATTRIBUTES_RESEND_REQUESTED = 'session-attributes-resend-requested';
+export const SESSION_ATTRIBUTES_FIELD_UPDATED = 'session-attributes-field-updated';

--- a/src/main/sessionAttributes/sessionAttributesManager.test.ts
+++ b/src/main/sessionAttributes/sessionAttributesManager.test.ts
@@ -7,6 +7,7 @@ import {ipcMain} from 'electron';
 import WebContentsManager from 'app/views/webContentsManager';
 import {
     SERVER_REMOVED,
+    SESSION_ATTRIBUTES_FIELD_UPDATED,
     SESSION_ATTRIBUTES_MANIFEST_INVALIDATED,
     SESSION_ATTRIBUTES_RESEND_REQUESTED,
 } from 'common/communication';
@@ -47,6 +48,7 @@ jest.mock('common/servers/serverManager', () => ({
         getServer: jest.fn(),
         lookupServerByURL: jest.fn(),
         getRemoteInfo: jest.fn(),
+        updateRemoteInfo: jest.fn(),
     },
 }));
 
@@ -84,6 +86,7 @@ describe('main/sessionAttributes/sessionAttributesManager', () => {
     let serverRemovedHandler: (srv: typeof server) => void;
     let manifestInvalidatedHandler: (event: IpcMainEvent) => void;
     let resendRequestedHandler: (event: IpcMainEvent) => void;
+    let fieldUpdatedHandler: (event: IpcMainEvent, field: unknown) => void;
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -100,6 +103,9 @@ describe('main/sessionAttributes/sessionAttributesManager', () => {
             }
             if (channel === SESSION_ATTRIBUTES_RESEND_REQUESTED) {
                 resendRequestedHandler = handler;
+            }
+            if (channel === SESSION_ATTRIBUTES_FIELD_UPDATED) {
+                fieldUpdatedHandler = handler;
             }
             return ipcMainMock;
         });
@@ -230,5 +236,117 @@ describe('main/sessionAttributes/sessionAttributesManager', () => {
 
         expect(updateServerInfos).not.toHaveBeenCalled();
         expect((manager as unknown as {lastSentAt: Map<string, Map<string, number>>}).lastSentAt.has(server.id)).toBe(true);
+    });
+
+    it('appends a new field to the manifest on SESSION_ATTRIBUTES_FIELD_UPDATED', () => {
+        ServerManagerMock.getRemoteInfo.mockReturnValue({
+            sessionAttributesManifest: [
+                {name: 'os_platform', type: 'text', ttl_seconds: 0, grace_period_seconds: 0, platforms: ['desktop']},
+            ],
+        });
+        WebContentsManagerMock.getViewByWebContentsId.mockReturnValue({serverId: server.id} as never);
+
+        fieldUpdatedHandler({sender: {id: 42}} as IpcMainEvent, {
+            name: 'hardware_id',
+            type: 'text',
+            attrs: {enabled: true, ttl_seconds: 300, grace_period_seconds: 300, platforms: ['desktop']},
+        });
+
+        expect(ServerManagerMock.updateRemoteInfo).toHaveBeenCalledWith(server.id, {
+            sessionAttributesManifest: [
+                {name: 'os_platform', type: 'text', ttl_seconds: 0, grace_period_seconds: 0, platforms: ['desktop']},
+                {name: 'hardware_id', type: 'text', ttl_seconds: 300, grace_period_seconds: 300, platforms: ['desktop']},
+            ],
+        });
+    });
+
+    it('replaces an existing field in the manifest on SESSION_ATTRIBUTES_FIELD_UPDATED', () => {
+        ServerManagerMock.getRemoteInfo.mockReturnValue({
+            sessionAttributesManifest: [
+                {name: 'hardware_id', type: 'text', ttl_seconds: 60, grace_period_seconds: 60, platforms: ['desktop']},
+            ],
+        });
+        WebContentsManagerMock.getViewByWebContentsId.mockReturnValue({serverId: server.id} as never);
+
+        fieldUpdatedHandler({sender: {id: 42}} as IpcMainEvent, {
+            name: 'hardware_id',
+            type: 'text',
+            attrs: {enabled: true, ttl_seconds: 300, grace_period_seconds: 300, platforms: ['desktop']},
+        });
+
+        expect(ServerManagerMock.updateRemoteInfo).toHaveBeenCalledWith(server.id, {
+            sessionAttributesManifest: [
+                {name: 'hardware_id', type: 'text', ttl_seconds: 300, grace_period_seconds: 300, platforms: ['desktop']},
+            ],
+        });
+    });
+
+    it('removes a field from the manifest when it is disabled', () => {
+        ServerManagerMock.getRemoteInfo.mockReturnValue({
+            sessionAttributesManifest: [
+                {name: 'hardware_id', type: 'text', ttl_seconds: 300, grace_period_seconds: 300, platforms: ['desktop']},
+            ],
+        });
+        WebContentsManagerMock.getViewByWebContentsId.mockReturnValue({serverId: server.id} as never);
+
+        fieldUpdatedHandler({sender: {id: 42}} as IpcMainEvent, {
+            name: 'hardware_id',
+            type: 'text',
+            attrs: {enabled: false, ttl_seconds: 300, grace_period_seconds: 300, platforms: ['desktop']},
+        });
+
+        expect(ServerManagerMock.updateRemoteInfo).toHaveBeenCalledWith(server.id, {
+            sessionAttributesManifest: [],
+        });
+    });
+
+    it('does not track a field that no longer targets the desktop', () => {
+        ServerManagerMock.getRemoteInfo.mockReturnValue({
+            sessionAttributesManifest: [
+                {name: 'hardware_id', type: 'text', ttl_seconds: 300, grace_period_seconds: 300, platforms: ['desktop']},
+            ],
+        });
+        WebContentsManagerMock.getViewByWebContentsId.mockReturnValue({serverId: server.id} as never);
+
+        fieldUpdatedHandler({sender: {id: 42}} as IpcMainEvent, {
+            name: 'hardware_id',
+            type: 'text',
+            attrs: {enabled: true, ttl_seconds: 300, grace_period_seconds: 300, platforms: ['mobile']},
+        });
+
+        expect(ServerManagerMock.updateRemoteInfo).toHaveBeenCalledWith(server.id, {
+            sessionAttributesManifest: [],
+        });
+    });
+
+    it('clears the lastSentAt entry for the updated field so it is resent', () => {
+        ServerManagerMock.getRemoteInfo.mockReturnValue({
+            sessionAttributesManifest: [
+                {name: 'hardware_id', type: 'text', ttl_seconds: 300, grace_period_seconds: 300, platforms: ['desktop']},
+            ],
+        });
+        (manager as unknown as {lastSentAt: Map<string, Map<string, number>>}).lastSentAt.set(server.id, new Map([['hardware_id', Date.now()]]));
+        WebContentsManagerMock.getViewByWebContentsId.mockReturnValue({serverId: server.id} as never);
+
+        fieldUpdatedHandler({sender: {id: 42}} as IpcMainEvent, {
+            name: 'hardware_id',
+            type: 'text',
+            attrs: {enabled: true, ttl_seconds: 600, grace_period_seconds: 300, platforms: ['desktop']},
+        });
+
+        expect((manager as unknown as {lastSentAt: Map<string, Map<string, number>>}).lastSentAt.get(server.id)?.has('hardware_id')).toBe(false);
+    });
+
+    it('ignores an invalid field payload on SESSION_ATTRIBUTES_FIELD_UPDATED', () => {
+        ServerManagerMock.getRemoteInfo.mockReturnValue({
+            sessionAttributesManifest: [
+                {name: 'hardware_id', type: 'text', ttl_seconds: 300, grace_period_seconds: 300, platforms: ['desktop']},
+            ],
+        });
+        WebContentsManagerMock.getViewByWebContentsId.mockReturnValue({serverId: server.id} as never);
+
+        fieldUpdatedHandler({sender: {id: 42}} as IpcMainEvent, {name: 'hardware_id'});
+
+        expect(ServerManagerMock.updateRemoteInfo).not.toHaveBeenCalled();
     });
 });

--- a/src/main/sessionAttributes/sessionAttributesManager.ts
+++ b/src/main/sessionAttributes/sessionAttributesManager.ts
@@ -9,6 +9,7 @@ import {
     SERVER_PRE_AUTH_SECRET_CHANGED,
     SERVER_REMOVED,
     SERVER_URL_CHANGED,
+    SESSION_ATTRIBUTES_FIELD_UPDATED,
     SESSION_ATTRIBUTES_MANIFEST_INVALIDATED,
     SESSION_ATTRIBUTES_RESEND_REQUESTED,
 } from 'common/communication';
@@ -18,9 +19,10 @@ import {Logger} from 'common/log';
 import type {MattermostServer} from 'common/servers/MattermostServer';
 import ServerManager from 'common/servers/serverManager';
 import {parseURL} from 'common/utils/url';
+import {ipcValidate, sessionAttributeFieldSchema} from 'common/Validator';
 import {updateServerInfos} from 'main/app/utils';
 
-import type {SAField} from 'types/sessionAttributes';
+import type {SAField, SAPropertyField} from 'types/sessionAttributes';
 
 import SessionAttributeCollector from './collector';
 
@@ -36,6 +38,7 @@ export class SessionAttributesManager {
 
         ipcMain.on(SESSION_ATTRIBUTES_MANIFEST_INVALIDATED, this.handleManifestInvalidated);
         ipcMain.on(SESSION_ATTRIBUTES_RESEND_REQUESTED, this.handleResendRequested);
+        ipcMain.on(SESSION_ATTRIBUTES_FIELD_UPDATED, ipcValidate(this.handleFieldUpdated, [sessionAttributeFieldSchema]));
     }
 
     getHeaderForRequest = (
@@ -97,6 +100,8 @@ export class SessionAttributesManager {
         if (!Object.keys(payload).length) {
             return undefined;
         }
+
+        log.info('Sending session attributes', {serverId: server.id, payload});
 
         return Buffer.from(JSON.stringify(payload)).toString('base64');
     };
@@ -196,6 +201,38 @@ export class SessionAttributesManager {
             return;
         }
         this.lastSentAt.delete(serverId);
+    };
+
+    private handleFieldUpdated = (event: IpcMainEvent, field: SAPropertyField) => {
+        log.debug('handleFieldUpdated', {name: field.name});
+
+        const serverId = WebContentsManager.getViewByWebContentsId(event.sender.id)?.serverId;
+        if (!serverId) {
+            return;
+        }
+
+        const remoteInfo = ServerManager.getRemoteInfo(serverId);
+        if (!remoteInfo || !remoteInfo.sessionAttributesManifest) {
+            return;
+        }
+
+        const manifest = remoteInfo.sessionAttributesManifest.filter((f) => f.name !== field.name);
+
+        // Only track enabled fields that target the desktop; disabled fields are dropped entirely
+        if (field.attrs.enabled && field.attrs.platforms.includes('desktop')) {
+            manifest.push({
+                name: field.name,
+                type: field.type,
+                ttl_seconds: field.attrs.ttl_seconds,
+                grace_period_seconds: field.attrs.grace_period_seconds,
+                platforms: field.attrs.platforms,
+            });
+        }
+
+        ServerManager.updateRemoteInfo(serverId, {...remoteInfo, sessionAttributesManifest: manifest});
+
+        // Force the changed field to be re-sent on the next request
+        this.lastSentAt.get(serverId)?.delete(field.name);
     };
 }
 

--- a/src/main/sessionAttributes/sessionAttributesManager.ts
+++ b/src/main/sessionAttributes/sessionAttributesManager.ts
@@ -101,8 +101,6 @@ export class SessionAttributesManager {
             return undefined;
         }
 
-        log.info('Sending session attributes', {serverId: server.id, payload});
-
         return Buffer.from(JSON.stringify(payload)).toString('base64');
     };
 

--- a/src/types/sessionAttributes.ts
+++ b/src/types/sessionAttributes.ts
@@ -9,4 +9,15 @@ export type SAField = {
     platforms: string[];
 };
 
+export type SAPropertyField = {
+    name: string;
+    type: string;
+    attrs: {
+        enabled: boolean;
+        ttl_seconds: number;
+        grace_period_seconds: number;
+        platforms: string[];
+    };
+};
+
 export type InterfaceType = 'wifi' | 'ethernet' | 'cellular' | 'vpn' | 'other';


### PR DESCRIPTION
#### Summary
The current session attribute implementation reacts to a websocket event by having the Desktop App refetch the entire manifest. This works, but as session attribute configuration can change while a server is live, repeatedly refetching the whole manifest is unnecessary work and could become a performance concern over time.

This PR adds an `updateSessionAttribute` bridge on the external API so the web app can forward a single changed property field over IPC. The `SessionAttributesManager` maps that payload into a manifest field and upserts it in place.

Web App PR: https://github.com/mattermost/mattermost/pull/37392

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69724

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Medium risk. The change spans the public Desktop API type surface, IPC contract (new channel + payload), validation, and main-process session-attribute manifest upsert logic. While behavior is well-scoped to session-attribute updates and covered by new Jest cases (add/replace/remove/disabled-platform behavior and ignoring invalid payloads), malformed payloads or platform/enabled filtering mistakes could affect request header generation.

**QA Recommendation:** Limited manual QA is recommended—verify end-to-end session attribute updates via the Desktop App (IPC delivery, enable/disable behavior, and desktop-platform targeting) and confirm subsequent request headers reflect the updated manifest. *Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->