### PR TITLE
fix(e2e): correct stale welcome-screen slide title assertions

### DIFF
--- a/e2e/specs/startup/welcome_screen_modal.test.ts
+++ b/e2e/specs/startup/welcome_screen_modal.test.ts
@@ -185,7 +185,7 @@ test.describe('startup/welcome_screen_modal', () => {
                 await nextBtn.click();
 
                 const lastTitle = await getCurrentSlideTitle(modal);
-                expect(normalizeTitle(lastTitle)).toBe('integrate with tools you love');
+                expect(normalizeTitle(lastTitle)).toBe('integrate with your systems');
 
                 await nextBtn.click();
                 await expect.poll(
@@ -220,7 +220,7 @@ test.describe('startup/welcome_screen_modal', () => {
                 ).not.toBe(firstTitle);
 
                 const wrappedTitle = await getCurrentSlideTitle(modal);
-                expect(normalizeTitle(wrappedTitle)).toBe('integrate with tools you love');
+                expect(normalizeTitle(wrappedTitle)).toBe('integrate with your systems');
             } finally {
                 await closeAppSafely(app, userDataDir);
                 await releaseLock();


### PR DESCRIPTION
#### Summary

Realign two welcome-screen carousel wrap-around assertions (`MM-T4981`, `MM-T4982`) with the slide title #3879 shipped ("Integrate with your systems"). #3879 updated the copy but not these tests, and merged without E2E.

#### Ticket Link

Follow-up to #3879 (MM-69551).

#### Checklist

- [x] executed `npm run lint:js` for proper code formatting
- [x] Run E2E tests by adding label `E2E/Run`

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: Low 🟢

**Regression Risk:** Very low. This is a narrow update to two existing E2E assertions in a single test file, with no production code, shared utilities, or user-facing logic changed.

**QA Recommendation:** Minimal QA is needed. Automated E2E coverage should be sufficient; no manual QA beyond a quick sanity check is recommended.
*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->