### PR TITLE
Redact pre-auth secret in diagnostics file obfuscator

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -36,6 +36,7 @@ export const REGEX_LOG_FILE_LINE = /\[(\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}.\d{3
 export const MASK_EMAIL = 'EMAIL';
 export const MASK_IPV4 = 'IPV4';
 export const MASK_PATH = 'PATH';
+export const MASK_SECRET = 'SECRET';
 export const MASK_URL = 'URL';
 
 export const LOGS_MAX_STRING_LENGTH = 63;

--- a/src/main/diagnostics/steps/internal/loggerHooks.test.js
+++ b/src/main/diagnostics/steps/internal/loggerHooks.test.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {MASK_EMAIL, MASK_PATH} from 'common/constants';
+import {MASK_EMAIL, MASK_PATH, MASK_SECRET} from 'common/constants';
 
 import {maskMessageDataHook} from './loggerHooks';
 import {obfuscateByType} from './obfuscators';
@@ -58,6 +58,15 @@ describe('main/diagnostics/loggerHooks', () => {
         };
         const result = maskMessageDataHook(loggerMock)(message, 'file').data[0];
         expect(URLs.some((url) => result.includes(url))).toBe(false);
+    });
+
+    it('should mask sensitive object keys containing "preauth" or "secret"', () => {
+        const message = {
+            data: [{preAuthSecret: 'some-secret-value', serverId: '123'}],
+        };
+        const result = maskMessageDataHook(loggerMock)(message, 'file');
+        expect(result.data[0].preAuthSecret).toBe(MASK_SECRET);
+        expect(result.data[0].serverId).toBe('123');
     });
 
     it('should not allow local prototype pollution', () => {

--- a/src/main/diagnostics/steps/internal/obfuscators.ts
+++ b/src/main/diagnostics/steps/internal/obfuscators.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {MASK_EMAIL, MASK_IPV4, MASK_PATH, MASK_URL, REGEX_EMAIL, REGEX_IPV4, REGEX_PATH_DARWIN, REGEX_PATH_LINUX, REGEX_PATH_WIN32, REGEX_URL} from 'common/constants';
+import {MASK_EMAIL, MASK_IPV4, MASK_PATH, MASK_SECRET, MASK_URL, REGEX_EMAIL, REGEX_IPV4, REGEX_PATH_DARWIN, REGEX_PATH_LINUX, REGEX_PATH_WIN32, REGEX_URL} from 'common/constants';
 
 import {truncateString} from './utils';
 
@@ -58,11 +58,18 @@ function maskDataInArray(arr: unknown[]): unknown[] {
     });
 }
 
+const SENSITIVE_OBJECT_KEYS = ['preauth', 'secret'];
+
 function maskDataInObject(obj: Record<string, unknown>): Record<string, unknown> {
     return Object.keys(obj).reduce<Record<string, unknown>>((acc, key) => {
         // Avoid local prototype pollution
         if (key !== '__proto__') {
-            acc[key] = obfuscateByType(obj[key]);
+            const lowerKey = key.toLowerCase();
+            if (SENSITIVE_OBJECT_KEYS.some((pattern) => lowerKey.includes(pattern))) {
+                acc[key] = MASK_SECRET;
+            } else {
+                acc[key] = obfuscateByType(obj[key]);
+            }
         }
         return acc;
     }, {});


### PR DESCRIPTION

## Summary
The diagnostics file obfuscator was not masking the `preAuthSecret` field on `MattermostServer` objects. This PR fixes that.

## Ticket Link



