### PR TITLE
e2e: fix tab_management launch on small /dev/shm

### DIFF
--- a/e2e/specs/server_management/tab_management.test.ts
+++ b/e2e/specs/server_management/tab_management.test.ts
@@ -71,7 +71,7 @@ test.describe('server_management/tab_management', () => {
         const {_electron: electron} = await import('playwright');
         electronApp = await electron.launch({
             executablePath: electronBinaryPath,
-            args: [appDir, `--user-data-dir=${userDataDir}`, '--no-sandbox', '--disable-gpu'],
+            args: [appDir, `--user-data-dir=${userDataDir}`, '--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage'],
             env: {...process.env, NODE_ENV: 'test'},
             timeout: 60_000,
         });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`specs/server_management/tab_management.test.ts` self-launches Electron (it does not use the shared Playwright fixture) with a minimal arg set that omitted `--disable-dev-shm-usage`. In containerized environments with a small `/dev/shm` (e.g. 64MB, common in CI/cloud runners), Chromium's renderer crashes on launch, the main window never fires `show`, and `__e2eAppReady` never flips to `true`. The suite then fails in `beforeAll` with:

```
Error: Timed out waiting for __e2eAppReady (30000ms)
```

The shared fixture (`e2e/fixtures/index.ts`) already passes `--disable-dev-shm-usage`; this aligns the custom launch with it so the renderer uses `/tmp` instead of the constrained `/dev/shm`.

## Change

One line — add `--disable-dev-shm-usage` to the `electron.launch` args in the spec's `beforeAll`.

## Verification

Run against a local Mattermost server (Enterprise Edition binary + PostgreSQL, seeded with a `sysadmin` via `mmctl`):

```
env MM_TEST_SERVER_URL=http://localhost:8065 MM_TEST_USER_NAME=sysadmin MM_TEST_PASSWORD=... \
  npx playwright test specs/server_management/tab_management.test.ts --project=linux --reporter=list --workers=1
```

- Before: `1 failed` (`Timed out waiting for __e2eAppReady`), `2 did not run`
- After: `3 passed (5.1s)`

The fixture-based `menu_bar/view_menu.test.ts` (which already carries the flag) passed `8 passed` unchanged, confirming the root cause was the missing flag in the custom launch rather than the server or login path.

Below: the desktop app logged into the local server as `sysadmin` via the E2E harness (`loginToMattermost`), showing the Main Team and default channels.

![Desktop app logged in to local Mattermost server](https://cursor.com/artifacts/c/art-b3b37076-b161-4a31-9d3f-5249e826b2ee)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f2da9f3-2d39-45b0-91a4-04e2520f7442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f2da9f3-2d39-45b0-91a4-04e2520f7442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

