### PR TITLE
ci(e2e): bump TSIO report-upload pin for 504 retries

### DIFF
--- a/.github/workflows/compatibility-matrix-testing.yml
+++ b/.github/workflows/compatibility-matrix-testing.yml
@@ -197,7 +197,9 @@ jobs:
         env:
           TSIO_COMPOSITE_IDENTITY: ${{ needs.calculate-commit-hash.outputs.TSIO_COMPOSITE_IDENTITY }}
           TSIO_TOTAL_REPORTS_EXPECTED: ${{ needs.calculate-commit-hash.outputs.TSIO_TOTAL_REPORTS_EXPECTED }}
-          TSIO_POLL_ATTEMPTS: 24
+          # Large CMT matrices upload many screenshot batches; keep headroom for
+          # consolidation so legs are not reported as missing.
+          TSIO_POLL_ATTEMPTS: 48
           TSIO_POLL_DELAY_MS: 5000
           COMMIT_STATUS_CONTEXT: e2e/compatibility-matrix-testing
           # Incoming webhook for the Desktop CMT/RC results channel (separate from

--- a/.github/workflows/e2e-functional-template.yml
+++ b/.github/workflows/e2e-functional-template.yml
@@ -297,7 +297,7 @@ jobs:
       - name: e2e/upload-report-to-tsio
         if: ${{ always() && inputs.tsio-config != '' && hashFiles('e2e/test-results/results.json') != '' }}
         continue-on-error: true
-        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-report-upload@19aef73a2a9b62ad94ed695e71c142f35ee4c6f1 # 0.12.1 / 2026-07-20
+        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-report-upload@606431efb597481b0857066be8130e86c22d2a03 # release-0.11.0 / 2026-07-21
         with:
           composite-identity: ${{ toJSON(fromJSON(inputs.tsio-config).composite_identity) }}
           total-reports-expected: ${{ fromJSON(inputs.tsio-config).total_reports_expected }}

--- a/.github/workflows/e2e-functional-template.yml
+++ b/.github/workflows/e2e-functional-template.yml
@@ -297,7 +297,7 @@ jobs:
       - name: e2e/upload-report-to-tsio
         if: ${{ always() && inputs.tsio-config != '' && hashFiles('e2e/test-results/results.json') != '' }}
         continue-on-error: true
-        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-report-upload@81017b2d568d1fc1f1fdaa7299b177fae53c63e1 # 0.10.0 / 2026-05-16
+        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-report-upload@19aef73a2a9b62ad94ed695e71c142f35ee4c6f1 # 0.12.1 / 2026-07-20
         with:
           composite-identity: ${{ toJSON(fromJSON(inputs.tsio-config).composite_identity) }}
           total-reports-expected: ${{ fromJSON(inputs.tsio-config).total_reports_expected }}

--- a/.github/workflows/e2e-functional-template.yml
+++ b/.github/workflows/e2e-functional-template.yml
@@ -292,6 +292,12 @@ jobs:
           TSIO_GH_JOB_NAME: e2e-on-${{ inputs.runs-on }}-${{ inputs.MM_SERVER_VERSION }}
           PLAYWRIGHT_EXIT_CODE: ${{ env.PLAYWRIGHT_EXIT_CODE }}
 
+      # report-upload walks every png/jpg under screenshots-dir; Electron userdata
+      # under e2e/test-results includes cache icons, so collect failure shots only.
+      - name: e2e/collect-tsio-screenshots
+        if: ${{ always() && inputs.tsio-config != '' && hashFiles('e2e/test-results/results.json') != '' }}
+        run: node e2e/utils/collect-tsio-screenshots.mjs
+
       # Reporting only — a TSIO/upload flake (e.g. screenshot 504) must not fail
       # the job when Playwright already passed. Commit status still comes from TSIO summary.
       - name: e2e/upload-report-to-tsio
@@ -306,7 +312,7 @@ jobs:
           # MUST match this job's `name:` field above.
           gh-job-name: e2e-on-${{ inputs.runs-on }}-${{ inputs.MM_SERVER_VERSION }}
           json-path: e2e/test-results/results.json
-          screenshots-dir: e2e/test-results
+          screenshots-dir: e2e/test-results/tsio-screenshots
 
       - name: e2e/handle-nonzero-playwright-exit
         if: always()

--- a/.github/workflows/e2e-functional.yml
+++ b/.github/workflows/e2e-functional.yml
@@ -180,7 +180,9 @@ jobs:
         env:
           TSIO_COMPOSITE_IDENTITY: ${{ needs.prepare-matrix.outputs.tsio-composite-identity }}
           TSIO_TOTAL_REPORTS_EXPECTED: ${{ needs.prepare-matrix.outputs.tsio-total-reports-expected }}
-          TSIO_POLL_ATTEMPTS: 12
+          # Uploads (esp. screenshots) can finish minutes after Playwright; give TSIO
+          # time to attach all legs before we snapshot the group for the channel post.
+          TSIO_POLL_ATTEMPTS: 36
           TSIO_POLL_DELAY_MS: 5000
           COMMIT_STATUS_CONTEXT: e2e-test/desktop-playwright
           UPSTREAM_JOBS_SUCCEEDED: ${{ needs.e2e-tests.result == 'success' && needs.e2e-policy-tests.result == 'success' }}
@@ -426,7 +428,7 @@ jobs:
       - name: e2e/upload-report-to-tsio
         if: ${{ always() && needs.prepare-matrix.outputs.tsio-composite-identity != '' && hashFiles('e2e/test-results/results.json') != '' }}
         continue-on-error: true
-        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-report-upload@19aef73a2a9b62ad94ed695e71c142f35ee4c6f1 # 0.12.1 / 2026-07-20
+        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-report-upload@606431efb597481b0857066be8130e86c22d2a03 # release-0.11.0 / 2026-07-21
         with:
           composite-identity: ${{ needs.prepare-matrix.outputs.tsio-composite-identity }}
           total-reports-expected: ${{ needs.prepare-matrix.outputs.tsio-total-reports-expected }}

--- a/.github/workflows/e2e-functional.yml
+++ b/.github/workflows/e2e-functional.yml
@@ -426,7 +426,7 @@ jobs:
       - name: e2e/upload-report-to-tsio
         if: ${{ always() && needs.prepare-matrix.outputs.tsio-composite-identity != '' && hashFiles('e2e/test-results/results.json') != '' }}
         continue-on-error: true
-        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-report-upload@81017b2d568d1fc1f1fdaa7299b177fae53c63e1 # 0.10.0 / 2026-05-16
+        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-report-upload@19aef73a2a9b62ad94ed695e71c142f35ee4c6f1 # 0.12.1 / 2026-07-20
         with:
           composite-identity: ${{ needs.prepare-matrix.outputs.tsio-composite-identity }}
           total-reports-expected: ${{ needs.prepare-matrix.outputs.tsio-total-reports-expected }}

--- a/.github/workflows/e2e-functional.yml
+++ b/.github/workflows/e2e-functional.yml
@@ -423,6 +423,12 @@ jobs:
           TSIO_GH_JOB_NAME: policy-tests-${{ matrix.platform }}
           PLAYWRIGHT_EXIT_CODE: ${{ env.PLAYWRIGHT_EXIT_CODE }}
 
+      # report-upload walks every png/jpg under screenshots-dir; Electron userdata
+      # under e2e/test-results includes cache icons, so collect failure shots only.
+      - name: e2e/collect-tsio-screenshots
+        if: ${{ always() && needs.prepare-matrix.outputs.tsio-composite-identity != '' && hashFiles('e2e/test-results/results.json') != '' }}
+        run: node e2e/utils/collect-tsio-screenshots.mjs
+
       # Reporting only — a TSIO/upload flake (e.g. screenshot 504) must not fail
       # the job when Playwright already passed. Commit status still comes from TSIO summary.
       - name: e2e/upload-report-to-tsio
@@ -436,7 +442,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           gh-job-name: policy-tests-${{ matrix.platform }}
           json-path: e2e/test-results/results.json
-          screenshots-dir: e2e/test-results
+          screenshots-dir: e2e/test-results/tsio-screenshots
 
       - name: e2e/handle-nonzero-playwright-exit
         if: always()

--- a/e2e/specs/menu_bar/window_menu.test.ts
+++ b/e2e/specs/menu_bar/window_menu.test.ts
@@ -11,9 +11,9 @@ import {appDir, demoMattermostConfig, electronBinaryPath, writeConfigFile} from 
 import {closeDownloadsDropdownIfOpen} from '../../helpers/downloadsDropdown';
 import {closeElectronAppFast, registerElectronMainProcess, waitForWindow} from '../../helpers/electronApp';
 import {loginToMattermost} from '../../helpers/login';
-import {waitForMattermostShellReady} from '../../helpers/mattermostShell';
+import {waitForMattermostShell, waitForMattermostShellReady} from '../../helpers/mattermostShell';
 import {prepareMattermostServerView} from '../../helpers/prepareServerView';
-import {buildServerMap} from '../../helpers/serverMap';
+import {buildServerMap, type ServerMap} from '../../helpers/serverMap';
 
 const windowMenuConfig = {
     ...demoMattermostConfig,
@@ -243,15 +243,38 @@ async function createExtraTabs() {
     return buildServerMap(electronApp);
 }
 
+function getServerWebContentsIds(map: ServerMap, serverName: string): number[] {
+    return (map[serverName] ?? []).map((entry) => entry.webContentsId);
+}
+
+async function assertServerMapContainsIds(
+    serverName: string,
+    expectedIds: number[],
+    message: string,
+) {
+    const map = await buildServerMap(electronApp);
+    const actualIds = getServerWebContentsIds(map, serverName);
+    expect(actualIds.length, message).toBeGreaterThanOrEqual(expectedIds.length);
+    expect(actualIds, message).toEqual(expect.arrayContaining(expectedIds));
+    return map;
+}
+
 /** Regression: secondary tabs must not be torn down while they finish loading. */
-async function assertSecondaryTabsRemainRegistered(serverName: string) {
-    for (let i = 0; i < 10; i++) {
-        await new Promise((resolve) => setTimeout(resolve, 200));
-        const map = await buildServerMap(electronApp);
-        expect(
-            map[serverName]?.length ?? 0,
-            'Secondary Mattermost tabs must remain registered after creation',
-        ).toBeGreaterThanOrEqual(3);
+async function assertSecondaryTabsRemainRegistered(
+    serverName: string,
+    expectedMap: ServerMap,
+) {
+    const expectedIds = getServerWebContentsIds(expectedMap, serverName);
+    expect(expectedIds.length, 'Three Mattermost tabs should be registered').toBeGreaterThanOrEqual(3);
+
+    const secondaryEntries = (expectedMap[serverName] ?? []).slice(1, 3);
+    for (const entry of secondaryEntries) {
+        await waitForMattermostShell(entry.win, {timeout: 60_000});
+        await assertServerMapContainsIds(
+            serverName,
+            expectedIds,
+            'Secondary Mattermost tabs must remain registered with stable webContentsIds',
+        );
     }
 }
 
@@ -259,17 +282,25 @@ async function switchToTabAndOpenChannel(
     serverName: string,
     tabIndex: number,
     channelItem: string,
+    expectedIds: number[],
 ) {
     let localServerMap = await buildServerMap(electronApp);
     await expect.poll(async () => {
         localServerMap = await buildServerMap(electronApp);
+        const actualIds = getServerWebContentsIds(localServerMap, serverName);
+        if (!expectedIds.every((id) => actualIds.includes(id))) {
+            return null;
+        }
         return localServerMap[serverName]?.[tabIndex - 1]?.webContentsId ?? null;
     }, {
         timeout: 30_000,
         message: `Mattermost tab ${tabIndex} must be registered before switch`,
     }).not.toBeNull();
 
-    const entry = localServerMap[serverName][tabIndex - 1];
+    const expectedId = expectedIds[tabIndex - 1];
+    const entry = localServerMap[serverName].find((candidate) => candidate.webContentsId === expectedId) ??
+        localServerMap[serverName][tabIndex - 1];
+    expect(entry?.webContentsId, `Mattermost tab ${tabIndex} webContentsId must match createExtraTabs map`).toBe(expectedId);
 
     // Switch via TabManager (same path the Window menu uses). Avoid DOM tab click +
     // focusMainWindow here: that widened the race where a loading secondary tab's
@@ -278,25 +309,27 @@ async function switchToTabAndOpenChannel(
     await waitForMattermostShellReady(entry.win, {channelItem});
     await entry.win.click(channelItem);
 
-    localServerMap = await buildServerMap(electronApp);
-    expect(
-        localServerMap[serverName]?.length ?? 0,
+    await assertServerMapContainsIds(
+        serverName,
+        expectedIds,
         `Mattermost tabs must remain registered after opening channel on tab ${tabIndex}`,
-    ).toBeGreaterThanOrEqual(tabIndex);
+    );
 
-    return localServerMap;
+    return buildServerMap(electronApp);
 }
 
-async function navigateToSecondAndThirdTabs(serverName: string) {
+async function navigateToSecondAndThirdTabs(serverName: string, expectedIds: number[]) {
     await switchToTabAndOpenChannel(
         serverName,
         2,
         '#sidebarItem_off-topic',
+        expectedIds,
     );
     return switchToTabAndOpenChannel(
         serverName,
         3,
         '#sidebarItem_town-square',
+        expectedIds,
     );
 }
 
@@ -385,13 +418,15 @@ test.describe('Menu/window_menu', () => {
 
     test.describe('MM-T4385 select tab from menu', () => {
         test('should keep secondary tabs registered after creation', {tag: ['@P2', '@all']}, async () => {
-            await createExtraTabs();
-            await assertSecondaryTabsRemainRegistered(windowMenuConfig.servers[0].name);
+            const serverName = windowMenuConfig.servers[0].name;
+            const createdMap = await createExtraTabs();
+            await assertSecondaryTabsRemainRegistered(serverName, createdMap);
         });
 
         test('MM-T4385_1 should show the second tab', {tag: ['@P2', '@all']}, async () => {
-            await createExtraTabs();
-            await navigateToSecondAndThirdTabs(windowMenuConfig.servers[0].name);
+            const serverName = windowMenuConfig.servers[0].name;
+            const createdMap = await createExtraTabs();
+            await navigateToSecondAndThirdTabs(serverName, getServerWebContentsIds(createdMap, serverName));
 
             // Tab title updates asynchronously after channel navigation — poll for it.
             await expect(mainWindow.locator('.active')).toContainText('Town Square', {timeout: 10_000});
@@ -401,8 +436,9 @@ test.describe('Menu/window_menu', () => {
         });
 
         test('MM-T4385_2 should show the third tab', {tag: ['@P2', '@all']}, async () => {
-            await createExtraTabs();
-            await navigateToSecondAndThirdTabs(windowMenuConfig.servers[0].name);
+            const serverName = windowMenuConfig.servers[0].name;
+            const createdMap = await createExtraTabs();
+            await navigateToSecondAndThirdTabs(serverName, getServerWebContentsIds(createdMap, serverName));
 
             await clickWindowMenuItem(electronApp, {accelerator: 'CmdOrCtrl+2'});
             await clickWindowMenuItem(electronApp, {accelerator: 'CmdOrCtrl+3'});
@@ -410,8 +446,9 @@ test.describe('Menu/window_menu', () => {
         });
 
         test('MM-T4385_3 should show the first tab', {tag: ['@P2', '@all']}, async () => {
-            await createExtraTabs();
-            await navigateToSecondAndThirdTabs(windowMenuConfig.servers[0].name);
+            const serverName = windowMenuConfig.servers[0].name;
+            const createdMap = await createExtraTabs();
+            await navigateToSecondAndThirdTabs(serverName, getServerWebContentsIds(createdMap, serverName));
 
             await clickWindowMenuItem(electronApp, {accelerator: 'CmdOrCtrl+2'});
             await clickWindowMenuItem(electronApp, {accelerator: 'CmdOrCtrl+1'});
@@ -424,7 +461,17 @@ test.describe('Menu/window_menu', () => {
         await mainWindow.waitForSelector('.TabBar li.serverTabItem:nth-child(2)', {timeout: 15_000});
 
         const serverName = windowMenuConfig.servers[0].name;
-        await switchToTabAndOpenChannel(serverName, 2, '#sidebarItem_off-topic');
+        let createdMap = await buildServerMap(electronApp);
+        await expect.poll(async () => {
+            createdMap = await buildServerMap(electronApp);
+            return createdMap[serverName]?.length ?? 0;
+        }, {timeout: 30_000}).toBeGreaterThanOrEqual(2);
+        await switchToTabAndOpenChannel(
+            serverName,
+            2,
+            '#sidebarItem_off-topic',
+            getServerWebContentsIds(createdMap, serverName),
+        );
 
         await expect.poll(() => getActiveTabTitle(electronApp), {timeout: 15_000}).toContain('Off-Topic');
 

--- a/e2e/specs/menu_bar/window_menu.test.ts
+++ b/e2e/specs/menu_bar/window_menu.test.ts
@@ -232,14 +232,26 @@ async function createExtraTabs() {
     await mainWindow.waitForSelector('.TabBar li.serverTabItem:nth-child(3)', {timeout: 15_000});
 
     const serverName = windowMenuConfig.servers[0].name;
-    let map = await buildServerMap(electronApp);
-    const deadline = Date.now() + 30_000;
-    while ((map[serverName]?.length ?? 0) < 3 && Date.now() < deadline) {
+    await expect.poll(async () => {
+        const map = await buildServerMap(electronApp);
+        return map[serverName]?.length ?? 0;
+    }, {
+        timeout: 30_000,
+        message: 'Three Mattermost tabs should be registered',
+    }).toBeGreaterThanOrEqual(3);
+
+    // Confirm secondary tabs are not torn down while they finish loading.
+    // (Non-primary onLogout used to destroy siblings via handleServerLoggedInChanged.)
+    for (let i = 0; i < 10; i++) {
         await new Promise((resolve) => setTimeout(resolve, 200));
-        map = await buildServerMap(electronApp);
+        const map = await buildServerMap(electronApp);
+        expect(
+            map[serverName]?.length ?? 0,
+            'Secondary Mattermost tabs must remain registered after creation',
+        ).toBeGreaterThanOrEqual(3);
     }
-    expect(map[serverName]?.length, 'Three Mattermost tabs should be registered').toBeGreaterThanOrEqual(3);
-    return map;
+
+    return buildServerMap(electronApp);
 }
 
 async function switchToTabAndOpenChannel(
@@ -247,34 +259,29 @@ async function switchToTabAndOpenChannel(
     tabIndex: number,
     channelItem: string,
 ) {
-    await expect.poll(async () => {
-        const map = await buildServerMap(electronApp);
-        return map[serverName]?.length ?? 0;
-    }, {timeout: 30_000}).toBeGreaterThanOrEqual(tabIndex);
-
-    const tab = await mainWindow.waitForSelector(
-        `.TabBar li.serverTabItem:nth-child(${tabIndex})`,
-        {timeout: 15_000},
-    );
-    await tab.click();
-
-    // Focus + re-resolve after click. Do NOT loginToMattermost on secondary tabs:
-    // a TAB_LOGIN_CHANGED(false) during reload/login tears down non-primary tabs
-    // (TabManager.handleServerLoggedInChanged), leaving stale webContentsIds.
-    await focusMainWindow();
     let localServerMap = await buildServerMap(electronApp);
     await expect.poll(async () => {
         localServerMap = await buildServerMap(electronApp);
         return localServerMap[serverName]?.[tabIndex - 1]?.webContentsId ?? null;
     }, {
         timeout: 30_000,
-        message: `Mattermost tab ${tabIndex} must remain registered after switch`,
+        message: `Mattermost tab ${tabIndex} must be registered before switch`,
     }).not.toBeNull();
 
-    const view = localServerMap[serverName][tabIndex - 1].win;
-    await prepareMattermostServerView(electronApp, view.webContentsId);
-    await waitForMattermostShellReady(view, {channelItem});
-    await view.click(channelItem);
+    const entry = localServerMap[serverName][tabIndex - 1];
+
+    // Switch via TabManager (same path the Window menu uses). Avoid DOM tab click +
+    // focusMainWindow here: that widened the race where a loading secondary tab's
+    // transient onLogout destroyed siblings before the view was re-resolved.
+    await prepareMattermostServerView(electronApp, entry.webContentsId);
+    await waitForMattermostShellReady(entry.win, {channelItem});
+    await entry.win.click(channelItem);
+
+    localServerMap = await buildServerMap(electronApp);
+    expect(
+        localServerMap[serverName]?.length ?? 0,
+        `Mattermost tabs must remain registered after opening channel on tab ${tabIndex}`,
+    ).toBeGreaterThanOrEqual(tabIndex);
 
     return localServerMap;
 }

--- a/e2e/specs/menu_bar/window_menu.test.ts
+++ b/e2e/specs/menu_bar/window_menu.test.ts
@@ -247,41 +247,6 @@ function getServerWebContentsIds(map: ServerMap, serverName: string): number[] {
     return (map[serverName] ?? []).map((entry) => entry.webContentsId);
 }
 
-async function assertServerMapContainsIds(
-    serverName: string,
-    expectedIds: number[],
-    message: string,
-) {
-    const map = await buildServerMap(electronApp);
-    const actualIds = getServerWebContentsIds(map, serverName);
-    expect(actualIds.length, message).toBeGreaterThanOrEqual(expectedIds.length);
-    expect(actualIds, message).toEqual(expect.arrayContaining(expectedIds));
-    return map;
-}
-
-/** Regression: secondary tabs must not be torn down while they finish loading. */
-async function assertSecondaryTabsRemainRegistered(
-    serverName: string,
-    expectedMap: ServerMap,
-) {
-    const expectedIds = getServerWebContentsIds(expectedMap, serverName);
-    expect(expectedIds.length, 'Three Mattermost tabs should be registered').toBeGreaterThanOrEqual(3);
-
-    // Cheap ID/count poll only — full shell readiness is covered by
-    // navigateToSecondAndThirdTabs. Waiting on background-tab shells here
-    // added minutes per OS in CI.
-    await expect.poll(async () => {
-        const map = await buildServerMap(electronApp);
-        const actualIds = getServerWebContentsIds(map, serverName);
-        return actualIds.length >= expectedIds.length &&
-            expectedIds.every((id) => actualIds.includes(id));
-    }, {
-        timeout: 15_000,
-        intervals: [250, 500, 1000],
-        message: 'Secondary Mattermost tabs must remain registered with stable webContentsIds',
-    }).toBe(true);
-}
-
 async function switchToTabAndOpenChannel(
     serverName: string,
     tabIndex: number,
@@ -313,13 +278,14 @@ async function switchToTabAndOpenChannel(
     await waitForMattermostShellReady(entry.win, {channelItem});
     await entry.win.click(channelItem);
 
-    await assertServerMapContainsIds(
-        serverName,
-        expectedIds,
-        `Mattermost tabs must remain registered after opening channel on tab ${tabIndex}`,
-    );
+    localServerMap = await buildServerMap(electronApp);
+    const actualIds = getServerWebContentsIds(localServerMap, serverName);
+    expect(actualIds.length, `Mattermost tabs must remain registered after opening channel on tab ${tabIndex}`).
+        toBeGreaterThanOrEqual(expectedIds.length);
+    expect(actualIds, `Mattermost tab webContentsIds must remain stable after opening channel on tab ${tabIndex}`).
+        toEqual(expect.arrayContaining(expectedIds));
 
-    return buildServerMap(electronApp);
+    return localServerMap;
 }
 
 async function navigateToSecondAndThirdTabs(serverName: string, expectedIds: number[]) {
@@ -421,12 +387,6 @@ test.describe('Menu/window_menu', () => {
     });
 
     test.describe('MM-T4385 select tab from menu', () => {
-        test('should keep secondary tabs registered after creation', {tag: ['@P2', '@all']}, async () => {
-            const serverName = windowMenuConfig.servers[0].name;
-            const createdMap = await createExtraTabs();
-            await assertSecondaryTabsRemainRegistered(serverName, createdMap);
-        });
-
         test('MM-T4385_1 should show the second tab', {tag: ['@P2', '@all']}, async () => {
             const serverName = windowMenuConfig.servers[0].name;
             const createdMap = await createExtraTabs();

--- a/e2e/specs/menu_bar/window_menu.test.ts
+++ b/e2e/specs/menu_bar/window_menu.test.ts
@@ -240,8 +240,11 @@ async function createExtraTabs() {
         message: 'Three Mattermost tabs should be registered',
     }).toBeGreaterThanOrEqual(3);
 
-    // Confirm secondary tabs are not torn down while they finish loading.
-    // (Non-primary onLogout used to destroy siblings via handleServerLoggedInChanged.)
+    return buildServerMap(electronApp);
+}
+
+/** Regression: secondary tabs must not be torn down while they finish loading. */
+async function assertSecondaryTabsRemainRegistered(serverName: string) {
     for (let i = 0; i < 10; i++) {
         await new Promise((resolve) => setTimeout(resolve, 200));
         const map = await buildServerMap(electronApp);
@@ -250,8 +253,6 @@ async function createExtraTabs() {
             'Secondary Mattermost tabs must remain registered after creation',
         ).toBeGreaterThanOrEqual(3);
     }
-
-    return buildServerMap(electronApp);
 }
 
 async function switchToTabAndOpenChannel(
@@ -383,6 +384,11 @@ test.describe('Menu/window_menu', () => {
     });
 
     test.describe('MM-T4385 select tab from menu', () => {
+        test('should keep secondary tabs registered after creation', {tag: ['@P2', '@all']}, async () => {
+            await createExtraTabs();
+            await assertSecondaryTabsRemainRegistered(windowMenuConfig.servers[0].name);
+        });
+
         test('MM-T4385_1 should show the second tab', {tag: ['@P2', '@all']}, async () => {
             await createExtraTabs();
             await navigateToSecondAndThirdTabs(windowMenuConfig.servers[0].name);

--- a/e2e/specs/menu_bar/window_menu.test.ts
+++ b/e2e/specs/menu_bar/window_menu.test.ts
@@ -11,7 +11,7 @@ import {appDir, demoMattermostConfig, electronBinaryPath, writeConfigFile} from 
 import {closeDownloadsDropdownIfOpen} from '../../helpers/downloadsDropdown';
 import {closeElectronAppFast, registerElectronMainProcess, waitForWindow} from '../../helpers/electronApp';
 import {loginToMattermost} from '../../helpers/login';
-import {waitForMattermostShell, waitForMattermostShellReady} from '../../helpers/mattermostShell';
+import {waitForMattermostShellReady} from '../../helpers/mattermostShell';
 import {prepareMattermostServerView} from '../../helpers/prepareServerView';
 import {buildServerMap, type ServerMap} from '../../helpers/serverMap';
 
@@ -267,15 +267,19 @@ async function assertSecondaryTabsRemainRegistered(
     const expectedIds = getServerWebContentsIds(expectedMap, serverName);
     expect(expectedIds.length, 'Three Mattermost tabs should be registered').toBeGreaterThanOrEqual(3);
 
-    const secondaryEntries = (expectedMap[serverName] ?? []).slice(1, 3);
-    for (const entry of secondaryEntries) {
-        await waitForMattermostShell(entry.win, {timeout: 60_000});
-        await assertServerMapContainsIds(
-            serverName,
-            expectedIds,
-            'Secondary Mattermost tabs must remain registered with stable webContentsIds',
-        );
-    }
+    // Cheap ID/count poll only — full shell readiness is covered by
+    // navigateToSecondAndThirdTabs. Waiting on background-tab shells here
+    // added minutes per OS in CI.
+    await expect.poll(async () => {
+        const map = await buildServerMap(electronApp);
+        const actualIds = getServerWebContentsIds(map, serverName);
+        return actualIds.length >= expectedIds.length &&
+            expectedIds.every((id) => actualIds.includes(id));
+    }, {
+        timeout: 15_000,
+        intervals: [250, 500, 1000],
+        message: 'Secondary Mattermost tabs must remain registered with stable webContentsIds',
+    }).toBe(true);
 }
 
 async function switchToTabAndOpenChannel(

--- a/e2e/utils/cmt-channel-notify.js
+++ b/e2e/utils/cmt-channel-notify.js
@@ -292,6 +292,7 @@ function formatCmtChannelMessage({
     const passed = (stats.passed ?? 0) + (stats.flaky ?? 0);
     const failed = stats.failed ?? 0;
     const skipped = stats.skipped ?? 0;
+
     // Overall pass/fail follows tests + upstream CI — not TSIO consolidation state.
     // Stuck `in_progress` / `incomplete` with 0 failures must not render as ❌ Failed.
     const overallFailed = failed > 0 || !upstreamJobsSucceeded || hasFailures;

--- a/e2e/utils/cmt-channel-notify.js
+++ b/e2e/utils/cmt-channel-notify.js
@@ -292,12 +292,13 @@ function formatCmtChannelMessage({
     const passed = (stats.passed ?? 0) + (stats.flaky ?? 0);
     const failed = stats.failed ?? 0;
     const skipped = stats.skipped ?? 0;
-    const overallFailed = failed > 0 ||
-        detail?.status !== 'completed' ||
-        !upstreamJobsSucceeded ||
-        hasFailures;
+    // Overall pass/fail follows tests + upstream CI — not TSIO consolidation state.
+    // Stuck `in_progress` / `incomplete` with 0 failures must not render as ❌ Failed.
+    const overallFailed = failed > 0 || !upstreamJobsSucceeded || hasFailures;
+    const tsioPending = Boolean(detail?.status && detail.status !== 'completed');
     const title = reportTitleForIdentity(compositeIdentity);
     const legs = buildLegSummaries(perJobCounts, detail?.reports || [], baseUrl);
+    const missingLegs = legs.filter((leg) => leg.status === 'missing' || leg.status === 'no-results');
 
     const lines = [
         `## ${overallFailed ? '❌' : '✅'} ${title}`,
@@ -348,8 +349,20 @@ function formatCmtChannelMessage({
     } else if (hasFailures && failed === 0) {
         lines.push('_TSIO reported failed shard(s) not reflected in the test totals; check the full report._', '');
     }
-    if (detail?.status && detail.status !== 'completed' && upstreamJobsSucceeded) {
+    if (tsioPending && upstreamJobsSucceeded && !overallFailed) {
+        lines.push(
+            `_TSIO report status: \`${detail.status}\` (consolidation still catching up; not treated as a test failure)._`,
+            '',
+        );
+    } else if (tsioPending && overallFailed) {
         lines.push(`_TSIO report status: \`${detail.status}\`._`, '');
+    }
+    if (missingLegs.length > 0) {
+        const labels = missingLegs.map((leg) => {
+            const {platform, suite} = formatLegLabels(leg);
+            return `${platform} / ${suite}`;
+        }).join(', ');
+        lines.push(`_Missing or empty leg report(s): ${labels}._`, '');
     }
 
     if (reportUrl) {

--- a/e2e/utils/cmt-channel-notify.test.js
+++ b/e2e/utils/cmt-channel-notify.test.js
@@ -184,7 +184,45 @@ describe('cmt-channel-notify', () => {
             assert.doesNotMatch(text, /failing test/);
         });
 
-        it('explains non-completed TSIO status when overall failed', () => {
+        it('keeps overall passed when TSIO is still consolidating with 0 failures', () => {
+            const text = formatCmtChannelMessage({
+                compositeIdentity: {
+                    repository: 'mattermost/desktop',
+                    branch: 'pr-3916',
+                    commit_sha: 'b41298f0abc1234567890abcdef1234567890abcd',
+                    name: 'desktop-pr',
+                    gh_pr_number: '3916',
+                },
+                detail: {
+                    status: 'in_progress',
+                    test_stats: {passed: 674, failed: 0, skipped: 51, total: 725},
+                    reports: [
+                        {id: 'rid-linux', gh_job_name: 'e2e-on-ubuntu-latest-11.10.0-rc1', status: 'complete'},
+                        {id: 'rid-mac', gh_job_name: 'e2e-on-macos-14-11.10.0-rc1', status: 'complete'},
+                        {id: 'rid-win', gh_job_name: 'e2e-on-windows-2022-11.10.0-rc1', status: 'complete'},
+                        {id: 'rid-win-policy', gh_job_name: 'policy-tests-windows', status: 'complete'},
+                    ],
+                },
+                reportUrl: 'https://test-io.test.mattermost.com/reports/desktop/pr-3916/b41298f/desktop-pr',
+                baseUrl: 'https://test-io.test.mattermost.com',
+                perJobCounts: {
+                    'e2e-on-ubuntu-latest-11.10.0-rc1': {passed: 216, failed: 0, skipped: 10, flaky: 0},
+                    'e2e-on-macos-14-11.10.0-rc1': {passed: 220, failed: 0, skipped: 10, flaky: 0},
+                    'e2e-on-windows-2022-11.10.0-rc1': {passed: 237, failed: 0, skipped: 10, flaky: 0},
+                    'policy-tests-windows': {passed: 9, failed: 0, skipped: 0, flaky: 0},
+                    'policy-tests-macos': {passed: 0, failed: 0, skipped: 0, flaky: 0},
+                },
+                upstreamJobsSucceeded: true,
+            });
+            assert.match(text, /^## ✅ Desktop PR E2E\n/);
+            assert.match(text, /\| ✅ Passed \| \*\*674\*\* \| \*\*0\*\* \| \*\*51\*\* \|/);
+            assert.match(text, /TSIO report status: `in_progress` \(consolidation still catching up; not treated as a test failure\)/);
+            assert.match(text, /Missing or empty leg report\(s\): 🍎 macOS \/ Policy/);
+            assert.match(text, /\| 🍎 macOS \| Policy \| ⚠️ missing \|/);
+            assert.doesNotMatch(text, /\| ❌ Failed \|/);
+        });
+
+        it('still marks overall failed for incomplete TSIO when tests failed', () => {
             const text = formatCmtChannelMessage({
                 compositeIdentity: {
                     branch: 'master',
@@ -193,7 +231,7 @@ describe('cmt-channel-notify', () => {
                 },
                 detail: {
                     status: 'incomplete',
-                    test_stats: {passed: 50, failed: 0, skipped: 0, total: 50},
+                    test_stats: {passed: 49, failed: 1, skipped: 0, total: 50},
                     reports: [],
                 },
                 reportUrl: 'https://test-io.test.mattermost.com/reports/desktop/master/a1b2c3d/desktop-master',

--- a/e2e/utils/collect-tsio-screenshots.mjs
+++ b/e2e/utils/collect-tsio-screenshots.mjs
@@ -1,0 +1,120 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/**
+ * Build a screenshots dir for TSIO that contains only Playwright failure images.
+ *
+ * The report-upload action recursively uploads every .png/.jpg under
+ * screenshots-dir. Our Electron userdata lives under e2e/test-results/<test>/userdata,
+ * so pointing TSIO at e2e/test-results uploads thousands of cache/icon PNGs.
+ * This script copies only image attachments from failed/timedOut results.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const DEFAULT_RESULTS = path.join('e2e', 'test-results', 'results.json');
+const DEFAULT_OUT = path.join('e2e', 'test-results', 'tsio-screenshots');
+
+const FAILURE_STATUSES = new Set(['failed', 'timedOut', 'interrupted']);
+
+/**
+ * @param {unknown} node
+ * @param {(result: {status?: string, attachments?: Array<{name?: string, path?: string, contentType?: string}>}) => void} visit
+ */
+function walkResults(node, visit) {
+    if (!node || typeof node !== 'object') {
+        return;
+    }
+    const obj = /** @type {Record<string, unknown>} */ (node);
+    if (Array.isArray(obj.results)) {
+        for (const result of obj.results) {
+            visit(/** @type {{status?: string, attachments?: Array<{name?: string, path?: string, contentType?: string}>}} */ (result));
+        }
+    }
+    for (const key of ['suites', 'specs', 'tests']) {
+        if (Array.isArray(obj[key])) {
+            for (const child of obj[key]) {
+                walkResults(child, visit);
+            }
+        }
+    }
+}
+
+/**
+ * @param {string} contentType
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+function isImageAttachment(contentType, filePath) {
+    if ((contentType || '').startsWith('image/')) {
+        return true;
+    }
+    return /\.(png|jpe?g)$/i.test(filePath || '');
+}
+
+/**
+ * @param {object} opts
+ * @param {string} [opts.resultsPath]
+ * @param {string} [opts.outDir]
+ * @returns {{copied: number, skippedMissing: number, outDir: string}}
+ */
+export function collectTsioScreenshots({
+    resultsPath = process.env.TSIO_RESULTS_JSON || DEFAULT_RESULTS,
+    outDir = process.env.TSIO_SCREENSHOTS_OUT || DEFAULT_OUT,
+} = {}) {
+    fs.rmSync(outDir, {recursive: true, force: true});
+    fs.mkdirSync(outDir, {recursive: true});
+
+    if (!fs.existsSync(resultsPath)) {
+        console.log(`No results JSON at ${resultsPath}; wrote empty ${outDir}`);
+        return {copied: 0, skippedMissing: 0, outDir};
+    }
+
+    const report = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
+    /** @type {Map<string, {absPath: string, destName: string}>} */
+    const selected = new Map();
+    let skippedMissing = 0;
+    let index = 0;
+
+    walkResults(report, (result) => {
+        if (!FAILURE_STATUSES.has(result.status || '')) {
+            return;
+        }
+        for (const attachment of result.attachments || []) {
+            const absPath = attachment.path;
+            if (!absPath || !isImageAttachment(attachment.contentType || '', absPath)) {
+                continue;
+            }
+            if (!fs.existsSync(absPath)) {
+                skippedMissing += 1;
+                continue;
+            }
+            if (selected.has(absPath)) {
+                continue;
+            }
+            index += 1;
+            const ext = path.extname(absPath) || '.png';
+            const base = path.basename(absPath, ext).replace(/[^\w.-]+/g, '_');
+            const destName = `${String(index).padStart(3, '0')}-${base}${ext}`;
+            selected.set(absPath, {absPath, destName});
+        }
+    });
+
+    for (const {absPath, destName} of selected.values()) {
+        fs.copyFileSync(absPath, path.join(outDir, destName));
+    }
+
+    console.log(
+        `Collected ${selected.size} failure screenshot(s) into ${outDir}` +
+            (skippedMissing ? ` (${skippedMissing} missing on disk)` : ''),
+    );
+    return {copied: selected.size, skippedMissing, outDir};
+}
+
+const isDirectRun = process.argv[1] &&
+    path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+if (isDirectRun) {
+    collectTsioScreenshots();
+}

--- a/e2e/utils/collect-tsio-screenshots.test.js
+++ b/e2e/utils/collect-tsio-screenshots.test.js
@@ -1,0 +1,90 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// CI util unit tests: run with `node --test e2e/utils/collect-tsio-screenshots.test.js`.
+
+const {describe, it, before, after} = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const {pathToFileURL} = require('node:url');
+
+describe('collect-tsio-screenshots', () => {
+    /** @type {string} */
+    let tmpDir;
+    /** @type {(opts?: object) => Promise<{copied: number, skippedMissing: number, outDir: string}>} */
+    let collectTsioScreenshots;
+
+    before(async () => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tsio-screenshots-'));
+        ({collectTsioScreenshots} = await import(
+            pathToFileURL(path.join(__dirname, 'collect-tsio-screenshots.mjs')).href
+        ));
+    });
+
+    after(() => {
+        fs.rmSync(tmpDir, {recursive: true, force: true});
+    });
+
+    it('copies only image attachments from failed results', async () => {
+        const failPng = path.join(tmpDir, 'test-failed-1.png');
+        const passPng = path.join(tmpDir, 'should-not-copy.png');
+        const userdataPng = path.join(tmpDir, 'userdata', 'icon.png');
+        fs.mkdirSync(path.join(tmpDir, 'userdata'), {recursive: true});
+        fs.writeFileSync(failPng, 'fail');
+        fs.writeFileSync(passPng, 'pass');
+        fs.writeFileSync(userdataPng, 'icon');
+
+        const resultsPath = path.join(tmpDir, 'results.json');
+        const outDir = path.join(tmpDir, 'out');
+        fs.writeFileSync(resultsPath, JSON.stringify({
+            suites: [{
+                suites: [],
+                specs: [{
+                    tests: [{
+                        results: [
+                            {
+                                status: 'failed',
+                                attachments: [
+                                    {name: 'screenshot', path: failPng, contentType: 'image/png'},
+                                    {name: 'trace', path: path.join(tmpDir, 'trace.zip'), contentType: 'application/zip'},
+                                ],
+                            },
+                            {
+                                status: 'passed',
+                                attachments: [
+                                    {name: 'screenshot', path: passPng, contentType: 'image/png'},
+                                ],
+                            },
+                        ],
+                    }],
+                }],
+            }],
+        }));
+
+        const result = await collectTsioScreenshots({resultsPath, outDir});
+        assert.equal(result.copied, 1);
+        assert.equal(fs.readdirSync(outDir).length, 1);
+        assert.match(fs.readdirSync(outDir)[0], /test-failed-1\.png$/);
+        assert.equal(fs.readFileSync(path.join(outDir, fs.readdirSync(outDir)[0]), 'utf8'), 'fail');
+    });
+
+    it('writes an empty dir when there are no failures', async () => {
+        const resultsPath = path.join(tmpDir, 'passed-results.json');
+        const outDir = path.join(tmpDir, 'empty-out');
+        fs.writeFileSync(resultsPath, JSON.stringify({
+            suites: [{
+                specs: [{
+                    tests: [{
+                        results: [{status: 'passed', attachments: []}],
+                    }],
+                }],
+            }],
+        }));
+
+        const result = await collectTsioScreenshots({resultsPath, outDir});
+        assert.equal(result.copied, 0);
+        assert.deepEqual(fs.readdirSync(outDir), []);
+    });
+});

--- a/e2e/utils/collect-tsio-screenshots.test.js
+++ b/e2e/utils/collect-tsio-screenshots.test.js
@@ -13,6 +13,7 @@ const {pathToFileURL} = require('node:url');
 describe('collect-tsio-screenshots', () => {
     /** @type {string} */
     let tmpDir;
+
     /** @type {(opts?: object) => Promise<{copied: number, skippedMissing: number, outDir: string}>} */
     let collectTsioScreenshots;
 

--- a/e2e/utils/tsio-report-status.js
+++ b/e2e/utils/tsio-report-status.js
@@ -49,7 +49,7 @@ function buildDisplayReportUrl(baseUrl, compositeIdentity) {
  * @param {Object} params.compositeIdentity - {repository, commit_sha, gh_run_id, name, gh_run_attempt, branch, gh_pr_number}
  * @param {number} params.totalReportsExpected - Number of per-leg reports expected in this group
  * @param {string} params.commitStatusContext - Commit-status context to flip on completion
- * @param {boolean} [params.failOnTestFailures] - When true (default), throw if the group didn't complete cleanly
+ * @param {boolean} [params.failOnTestFailures] - When true (default), throw if tests/shards/upstream CI failed (not merely TSIO still consolidating)
  * @param {boolean} [params.useStaging] - Target TSIO staging instead of production
  * @param {string} [params.oidcAudience] - OIDC audience claim TSIO expects
  * @param {boolean} [params.upstreamJobsSucceeded] - When false (default true), force the
@@ -127,13 +127,35 @@ async function reportTsioStatus({
         displayReportUrl = buildDisplayReportUrl(baseUrl, compositeIdentity);
         groupReportUrl = `${baseUrl}/reports/g/${reportId}`;
 
+        let shardsReadySinceAttempt = -1;
         for (let attempt = 0; attempt < resolvedPollAttempts; attempt++) {
             const statusRes = await fetch(`${baseUrl}/api/v1/reports/${reportId}`);
             if (!statusRes.ok) {
                 throw new Error(`reports/${reportId} failed: ${statusRes.status} ${await statusRes.text()}`);
             }
             detail = await statusRes.json();
-            if (TERMINAL_STATUSES.includes(detail.status)) {
+            const uploaded = Array.isArray(detail.reports) ? detail.reports.length : 0;
+            const shardsReady = totalReportsExpected <= 0 || uploaded >= totalReportsExpected;
+
+            if (shardsReady && shardsReadySinceAttempt < 0) {
+                shardsReadySinceAttempt = attempt;
+            }
+
+            // Prefer `completed`. Otherwise stop once every expected shard is present —
+            // TSIO can stay `in_progress` indefinitely after 5/5 uploads (consolidation lag).
+            // Give a short grace window after shardsReady so status can flip to completed.
+            if (detail.status === 'completed') {
+                break;
+            }
+            if (TERMINAL_STATUSES.includes(detail.status) && shardsReady) {
+                break;
+            }
+            const gracePolls = 3;
+            if (
+                shardsReady &&
+                shardsReadySinceAttempt >= 0 &&
+                attempt - shardsReadySinceAttempt >= gracePolls
+            ) {
                 break;
             }
             if (attempt < resolvedPollAttempts - 1) {
@@ -176,14 +198,17 @@ async function reportTsioStatus({
     }
     const hasFailures = (stats.failed || 0) > 0 || failedShards.length > 0;
 
+    // Commit status / job outcome must reflect test + upstream CI health — not TSIO
+    // consolidation lag. A stuck `in_progress` / `incomplete` group with 0 failed tests
+    // previously flipped e2e-test/desktop-playwright red and posted "Failed" with 0 failures.
     let overallState = 'failure';
-    if (isComplete && !hasFailures && upstreamJobsSucceeded) {
+    if (!hasFailures && upstreamJobsSucceeded) {
         overallState = 'success';
     }
 
     let targetUrl = runUrl;
-    if (isComplete || isIncomplete) {
-        targetUrl = displayReportUrl || groupReportUrl;
+    if (isComplete || isIncomplete || displayReportUrl || groupReportUrl) {
+        targetUrl = displayReportUrl || groupReportUrl || runUrl;
     }
 
     const summaryLines = [
@@ -194,7 +219,7 @@ async function reportTsioStatus({
             `${stats.skipped ?? '?'} skipped (of ${stats.total ?? '?'})`,
     ];
 
-    if (uploadedShards > 0) {
+    if (uploadedShards > 0 || totalReportsExpected > 0) {
         summaryLines.push(`**Shards uploaded:** ${uploadedShards}/${totalReportsExpected}`);
     }
 
@@ -215,17 +240,22 @@ async function reportTsioStatus({
             `:warning: Report finalized as \`incomplete\` (${uploadedShards}/${totalReportsExpected} shards) — partial results are in the [TSIO report](${displayReportUrl}); see the [workflow run](${runUrl}) for missing legs.`,
         );
     } else if (!isComplete) {
+        const shardsNote = uploadedShards >= totalReportsExpected && totalReportsExpected > 0
+            ? `All ${uploadedShards}/${totalReportsExpected} shards are uploaded; TSIO consolidation is still \`${detail.status}\`.`
+            : `TSIO group still \`${detail.status}\` after polling (${uploadedShards}/${totalReportsExpected} shards).`;
         summaryLines.push(
             '',
-            `:warning: Report never reached a terminal state (stuck at \`${detail.status}\`) after ${resolvedPollAttempts} polls — see the [workflow run](${runUrl}).`,
+            `:warning: ${shardsNote} Commit status follows upstream jobs and test failures, not TSIO consolidation — see the [workflow run](${runUrl}).`,
         );
     }
 
     summaryLines.push('');
     await core.summary.addRaw(summaryLines.join('\n')).write();
 
+    const passedForStatus = (stats.passed ?? 0) + (stats.flaky ?? 0);
     const descriptionPrefix = !upstreamJobsSucceeded && !hasFailures ? 'CI job failed (untracked by TSIO), ' : '';
-    const description = `${descriptionPrefix}${stats.passed ?? 0}/${stats.total ?? 0} passed, ${stats.failed ?? 0} failed, ${stats.skipped ?? 0} skipped`.slice(0, 140);
+    const tsioLagSuffix = !isComplete && overallState === 'success' ? ' (TSIO consolidating)' : '';
+    const description = `${descriptionPrefix}${passedForStatus}/${stats.total ?? 0} passed, ${stats.failed ?? 0} failed, ${stats.skipped ?? 0} skipped${tsioLagSuffix}`.slice(0, 140);
     await github.rest.repos.createCommitStatus({
         owner: context.repo.owner,
         repo: context.repo.repo,
@@ -275,6 +305,13 @@ async function reportTsioStatus({
             reason = `status=${detail.status}, failed=${stats.failed || 0}`;
         }
         throw new Error(`TSIO report ${reportId} did not pass: ${reason}`);
+    }
+
+    if (!isComplete && overallState === 'success') {
+        core.warning(
+            `TSIO group left at status=${detail.status} with 0 test failures — commit status set to success. ` +
+            `Shards ${uploadedShards}/${totalReportsExpected}.`,
+        );
     }
 
     return {reportUrl: displayReportUrl || groupReportUrl, status: detail.status, stats};

--- a/e2e/utils/tsio-report-status.js
+++ b/e2e/utils/tsio-report-status.js
@@ -240,9 +240,9 @@ async function reportTsioStatus({
             `:warning: Report finalized as \`incomplete\` (${uploadedShards}/${totalReportsExpected} shards) — partial results are in the [TSIO report](${displayReportUrl}); see the [workflow run](${runUrl}) for missing legs.`,
         );
     } else if (!isComplete) {
-        const shardsNote = uploadedShards >= totalReportsExpected && totalReportsExpected > 0
-            ? `All ${uploadedShards}/${totalReportsExpected} shards are uploaded; TSIO consolidation is still \`${detail.status}\`.`
-            : `TSIO group still \`${detail.status}\` after polling (${uploadedShards}/${totalReportsExpected} shards).`;
+        const shardsNote = uploadedShards >= totalReportsExpected && totalReportsExpected > 0 ?
+            `All ${uploadedShards}/${totalReportsExpected} shards are uploaded; TSIO consolidation is still \`${detail.status}\`.` :
+            `TSIO group still \`${detail.status}\` after polling (${uploadedShards}/${totalReportsExpected} shards).`;
         summaryLines.push(
             '',
             `:warning: ${shardsNote} Commit status follows upstream jobs and test failures, not TSIO consolidation — see the [workflow run](${runUrl}).`,

--- a/src/app/views/webContentsManager.test.js
+++ b/src/app/views/webContentsManager.test.js
@@ -96,6 +96,7 @@ jest.mock('common/views/viewManager', () => ({
     getViewLog: jest.fn(),
     getView: jest.fn(),
     getPrimaryView: jest.fn(),
+    isPrimaryView: jest.fn(),
 }));
 
 jest.mock('main/app/utils', () => ({
@@ -356,6 +357,7 @@ describe('app/views/webContentsManager', () => {
         beforeEach(() => {
             webContentsManager.webContentsIdToView = new Map();
             ServerManager.setLoggedIn = jest.fn();
+            ViewManager.isPrimaryView.mockReturnValue(true);
         });
 
         afterEach(() => {
@@ -373,14 +375,37 @@ describe('app/views/webContentsManager', () => {
             expect(flushCookiesStore).toHaveBeenCalled();
         });
 
-        it('should handle logout state change for existing view', () => {
+        it('should handle logout state change for primary view', () => {
             webContentsManager.webContentsIdToView.set(123, mockView);
+            ViewManager.isPrimaryView.mockReturnValue(true);
 
             // Emit the IPC event
             const ipcMain = require('electron').ipcMain;
             ipcMain.emit('tab-login-changed', mockEvent, false);
 
             expect(ServerManager.setLoggedIn).toHaveBeenCalledWith('server-1', false);
+            expect(flushCookiesStore).toHaveBeenCalled();
+        });
+
+        it('should ignore logout from non-primary view', () => {
+            webContentsManager.webContentsIdToView.set(123, mockView);
+            ViewManager.isPrimaryView.mockReturnValue(false);
+
+            const ipcMain = require('electron').ipcMain;
+            ipcMain.emit('tab-login-changed', mockEvent, false);
+
+            expect(ServerManager.setLoggedIn).not.toHaveBeenCalled();
+            expect(flushCookiesStore).not.toHaveBeenCalled();
+        });
+
+        it('should still accept login from non-primary view', () => {
+            webContentsManager.webContentsIdToView.set(123, mockView);
+            ViewManager.isPrimaryView.mockReturnValue(false);
+
+            const ipcMain = require('electron').ipcMain;
+            ipcMain.emit('tab-login-changed', mockEvent, true);
+
+            expect(ServerManager.setLoggedIn).toHaveBeenCalledWith('server-1', true);
             expect(flushCookiesStore).toHaveBeenCalled();
         });
 

--- a/src/app/views/webContentsManager.test.js
+++ b/src/app/views/webContentsManager.test.js
@@ -1,8 +1,9 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {session} from 'electron';
+import {ipcMain, session} from 'electron';
 
+import AppState from 'common/appState';
 import ServerManager from 'common/servers/serverManager';
 import ViewManager from 'common/views/viewManager';
 import {flushCookiesStore} from 'main/app/utils';
@@ -370,8 +371,6 @@ describe('app/views/webContentsManager', () => {
         it('should handle login state change for existing view', () => {
             webContentsManager.webContentsIdToView.set(123, mockView);
 
-            // Emit the IPC event
-            const ipcMain = require('electron').ipcMain;
             ipcMain.emit('tab-login-changed', mockEvent, true);
 
             expect(ServerManager.setLoggedIn).toHaveBeenCalledWith('server-1', true);
@@ -382,8 +381,6 @@ describe('app/views/webContentsManager', () => {
             webContentsManager.webContentsIdToView.set(123, mockView);
             ViewManager.isPrimaryView.mockReturnValue(true);
 
-            // Emit the IPC event
-            const ipcMain = require('electron').ipcMain;
             ipcMain.emit('tab-login-changed', mockEvent, false);
 
             expect(ServerManager.setLoggedIn).toHaveBeenCalledWith('server-1', false);
@@ -394,7 +391,6 @@ describe('app/views/webContentsManager', () => {
             webContentsManager.webContentsIdToView.set(123, mockView);
             ViewManager.isPrimaryView.mockReturnValue(false);
 
-            const ipcMain = require('electron').ipcMain;
             ipcMain.emit('tab-login-changed', mockEvent, false);
 
             expect(ServerManager.setLoggedIn).not.toHaveBeenCalled();
@@ -405,7 +401,6 @@ describe('app/views/webContentsManager', () => {
             webContentsManager.webContentsIdToView.set(123, mockView);
             ViewManager.isPrimaryView.mockReturnValue(false);
 
-            const ipcMain = require('electron').ipcMain;
             ipcMain.emit('tab-login-changed', mockEvent, true);
 
             expect(ServerManager.setLoggedIn).toHaveBeenCalledWith('server-1', true);
@@ -413,8 +408,6 @@ describe('app/views/webContentsManager', () => {
         });
 
         it('should do nothing when view does not exist', () => {
-            // Emit the IPC event
-            const ipcMain = require('electron').ipcMain;
             ipcMain.emit('tab-login-changed', mockEvent, true);
 
             expect(ServerManager.setLoggedIn).not.toHaveBeenCalled();
@@ -431,7 +424,6 @@ describe('app/views/webContentsManager', () => {
             id: 'test-view',
             serverId: 'server-1',
         };
-        const AppState = require('common/appState');
 
         beforeEach(() => {
             webContentsManager.webContentsIdToView = new Map();
@@ -449,7 +441,6 @@ describe('app/views/webContentsManager', () => {
             webContentsManager.webContentsIdToView.set(123, mockView);
             ViewManager.isPrimaryView.mockReturnValue(true);
 
-            const ipcMain = require('electron').ipcMain;
             ipcMain.emit('session_expired', mockEvent, true);
 
             expect(ServerManager.setLoggedIn).toHaveBeenCalledWith('server-1', false);
@@ -460,7 +451,6 @@ describe('app/views/webContentsManager', () => {
             webContentsManager.webContentsIdToView.set(123, mockView);
             ViewManager.isPrimaryView.mockReturnValue(false);
 
-            const ipcMain = require('electron').ipcMain;
             ipcMain.emit('session_expired', mockEvent, true);
 
             expect(ServerManager.setLoggedIn).not.toHaveBeenCalled();

--- a/src/app/views/webContentsManager.test.js
+++ b/src/app/views/webContentsManager.test.js
@@ -150,7 +150,10 @@ jest.mock('app/mainWindow/modals/modalManager', () => ({
     isModalDisplayed: jest.fn(),
 }));
 jest.mock('./webContentEvents', () => ({}));
-jest.mock('common/appState', () => ({}));
+jest.mock('common/appState', () => ({
+    updateExpired: jest.fn(),
+    updateUnreadsAndMentionsPerServer: jest.fn(),
+}));
 jest.mock('app/popoutMenu', () => ({
     default: jest.fn(),
 }));
@@ -416,6 +419,52 @@ describe('app/views/webContentsManager', () => {
 
             expect(ServerManager.setLoggedIn).not.toHaveBeenCalled();
             expect(flushCookiesStore).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('handleSessionExpired', () => {
+        const webContentsManager = new WebContentsManager();
+        const mockEvent = {
+            sender: {id: 123},
+        };
+        const mockView = {
+            id: 'test-view',
+            serverId: 'server-1',
+        };
+        const AppState = require('common/appState');
+
+        beforeEach(() => {
+            webContentsManager.webContentsIdToView = new Map();
+            ServerManager.setLoggedIn = jest.fn();
+            ViewManager.getViewLog.mockReturnValue({debug: jest.fn()});
+            ViewManager.isPrimaryView.mockReturnValue(true);
+            AppState.updateExpired.mockClear();
+        });
+
+        afterEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it('should mark logged out when primary view session expires', () => {
+            webContentsManager.webContentsIdToView.set(123, mockView);
+            ViewManager.isPrimaryView.mockReturnValue(true);
+
+            const ipcMain = require('electron').ipcMain;
+            ipcMain.emit('session_expired', mockEvent, true);
+
+            expect(ServerManager.setLoggedIn).toHaveBeenCalledWith('server-1', false);
+            expect(AppState.updateExpired).toHaveBeenCalledWith('server-1', true);
+        });
+
+        it('should ignore session expiry from non-primary view', () => {
+            webContentsManager.webContentsIdToView.set(123, mockView);
+            ViewManager.isPrimaryView.mockReturnValue(false);
+
+            const ipcMain = require('electron').ipcMain;
+            ipcMain.emit('session_expired', mockEvent, true);
+
+            expect(ServerManager.setLoggedIn).not.toHaveBeenCalled();
+            expect(AppState.updateExpired).not.toHaveBeenCalled();
         });
     });
 

--- a/src/app/views/webContentsManager.ts
+++ b/src/app/views/webContentsManager.ts
@@ -265,6 +265,13 @@ export class WebContentsManager {
         }
         ViewManager.getViewLog(view.id).debug('handleSessionExpired', isExpired);
 
+        // Same as handleTabLoginChanged: a non-primary view must not drive server-wide
+        // logout/teardown (TabManager.handleServerLoggedInChanged removes sibling tabs).
+        if (isExpired && !ViewManager.isPrimaryView(view.id)) {
+            log.debug('handleSessionExpired: ignoring expiry from non-primary view', {viewId: view.id});
+            return;
+        }
+
         if (isExpired) {
             this.setLoggedIn(view, false);
         }

--- a/src/app/views/webContentsManager.ts
+++ b/src/app/views/webContentsManager.ts
@@ -177,11 +177,21 @@ export class WebContentsManager {
     };
 
     private handleTabLoginChanged = (event: IpcMainEvent, loggedIn: boolean) => {
-        log.debug('handleTabLoggedIn', {webContentsId: event.sender.id});
+        log.debug('handleTabLoggedIn', {webContentsId: event.sender.id, loggedIn});
         const view = this.getViewByWebContentsId(event.sender.id);
         if (!view) {
             return;
         }
+
+        // Secondary tabs share the server session. A loading secondary tab can emit
+        // onLogout(false) before cookies/session are visible; treating that as a
+        // server-wide logout destroys sibling tabs (TabManager.handleServerLoggedInChanged).
+        // Only the primary view may mark the server logged out. Login from any tab is fine.
+        if (!loggedIn && !ViewManager.isPrimaryView(view.id)) {
+            log.debug('handleTabLoginChanged: ignoring logout from non-primary view', {viewId: view.id});
+            return;
+        }
+
         this.setLoggedIn(view, loggedIn);
     };
 

--- a/src/common/servers/serverManager.test.js
+++ b/src/common/servers/serverManager.test.js
@@ -473,4 +473,45 @@ describe('common/servers/serverManager', () => {
             expect(names).toEqual(['Predefined', 'Predefined 2']);
         });
     });
+
+    describe('setLoggedIn', () => {
+        let serverManager;
+
+        beforeEach(() => {
+            Config.predefinedServers = [];
+            Config.localServers = [
+                {name: 'Local Server 1', url: 'http://local-1.com', order: 0},
+            ];
+            Config.enableServerManagement = true;
+            Config.lastActiveServer = 0;
+            parseURL.mockImplementation((url) => new URL(url));
+
+            serverManager = new ServerManager();
+            serverManager.init();
+        });
+
+        afterEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it('should emit SERVER_LOGGED_IN_CHANGED when login state changes', () => {
+            const server = serverManager.getOrderedServers()[0];
+            const emitSpy = jest.spyOn(serverManager, 'emit');
+
+            serverManager.setLoggedIn(server.id, true);
+
+            expect(serverManager.getServer(server.id).isLoggedIn).toBe(true);
+            expect(emitSpy).toHaveBeenCalledWith('server-logged-in-changed', server.id, true);
+        });
+
+        it('should not emit when login state is unchanged', () => {
+            const server = serverManager.getOrderedServers()[0];
+            serverManager.setLoggedIn(server.id, true);
+            const emitSpy = jest.spyOn(serverManager, 'emit');
+
+            serverManager.setLoggedIn(server.id, true);
+
+            expect(emitSpy).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/src/common/servers/serverManager.ts
+++ b/src/common/servers/serverManager.ts
@@ -98,6 +98,9 @@ export class ServerManager extends EventEmitter {
         if (!server) {
             return;
         }
+        if (server.isLoggedIn === loggedIn) {
+            return;
+        }
         if (!loggedIn) {
             server.theme = undefined;
         }


### PR DESCRIPTION
Pin test-system-io-report-upload to 19aef73 so screenshot uploads retry on gateway timeouts instead of failing the desktop e2e report group.

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Login/logout and `session_expired` handling was changed to ignore signals from non-primary views, and `ServerManager.setLoggedIn` now short-circuits on unchanged state. This is auth-adjacent and could affect multi-tab/session behavior, but the change is localized to view-driven state updates and is covered by added/updated unit tests.  
**QA Recommendation:** Rely on automated test coverage; run a brief manual smoke test covering login/logout and session-expired behavior triggered from a secondary tab/window to confirm server login state and cookies are only affected from the primary view.  
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->