### PR TITLE
chore(e2e): fix tsio reporting link and Do not post master report to release report channel

### DIFF
--- a/.github/workflows/compatibility-matrix-testing.yml
+++ b/.github/workflows/compatibility-matrix-testing.yml
@@ -203,8 +203,8 @@ jobs:
           TSIO_POLL_DELAY_MS: 5000
           COMMIT_STATUS_CONTEXT: e2e/compatibility-matrix-testing
           # Incoming webhook for the Desktop CMT/RC results channel (separate from
-          # PR/master MM_DESKTOP_E2E_WEBHOOK_URL). Optional — when unset, TSIO
-          # status still flips and channel notify is skipped.
+          # PR MM_DESKTOP_E2E_WEBHOOK_URL and master MM_E2E_MASTER_HEALTH_WEBHOOK_URL).
+          # Optional — when unset, TSIO status still flips and channel notify is skipped.
           MATTERMOST_CMT_WEBHOOK_URL: ${{ secrets.MM_E2E_RELEASE_WEBHOOK_URL }}
           # TSIO only sees test-case-level results — a job-level failure with no
           # matching failed test (hung worker teardown, crashed runner, npm ci

--- a/.github/workflows/compatibility-matrix-testing.yml
+++ b/.github/workflows/compatibility-matrix-testing.yml
@@ -205,7 +205,6 @@ jobs:
           # Incoming webhook for the Desktop CMT/RC results channel (separate from
           # PR/master MM_DESKTOP_E2E_WEBHOOK_URL). Optional — when unset, TSIO
           # status still flips and channel notify is skipped.
-          # RC / CMT channel (same destination as master E2E via resolveWebhookUrl).
           MATTERMOST_CMT_WEBHOOK_URL: ${{ secrets.MM_E2E_RELEASE_WEBHOOK_URL }}
           # TSIO only sees test-case-level results — a job-level failure with no
           # matching failed test (hung worker teardown, crashed runner, npm ci

--- a/.github/workflows/compatibility-matrix-testing.yml
+++ b/.github/workflows/compatibility-matrix-testing.yml
@@ -219,6 +219,7 @@ jobs:
               commitStatusContext: process.env.COMMIT_STATUS_CONTEXT,
               upstreamJobsSucceeded: process.env.UPSTREAM_JOBS_SUCCEEDED === 'true',
               failOnTestFailures: true,
+              useStaging: true,
             });
             core.info(`TSIO report ${reportUrl}: ${status} (${JSON.stringify(stats)})`);
 

--- a/.github/workflows/compatibility-matrix-testing.yml
+++ b/.github/workflows/compatibility-matrix-testing.yml
@@ -219,7 +219,6 @@ jobs:
               commitStatusContext: process.env.COMMIT_STATUS_CONTEXT,
               upstreamJobsSucceeded: process.env.UPSTREAM_JOBS_SUCCEEDED === 'true',
               failOnTestFailures: true,
-              useStaging: true,
             });
             core.info(`TSIO report ${reportUrl}: ${status} (${JSON.stringify(stats)})`);
 

--- a/.github/workflows/e2e-functional-template.yml
+++ b/.github/workflows/e2e-functional-template.yml
@@ -303,8 +303,9 @@ jobs:
       - name: e2e/upload-report-to-tsio
         if: ${{ always() && inputs.tsio-config != '' && hashFiles('e2e/test-results/results.json') != '' }}
         continue-on-error: true
-        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-report-upload@606431efb597481b0857066be8130e86c22d2a03 # release-0.11.0 / 2026-07-21
+        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-report-upload@b5580f407a2776c064c626cc3c42295f2111fdc7 # staging validation — main@b5580f4 (#81 Maestro FilePath + Detox paths)
         with:
+          use-staging: true
           composite-identity: ${{ toJSON(fromJSON(inputs.tsio-config).composite_identity) }}
           total-reports-expected: ${{ fromJSON(inputs.tsio-config).total_reports_expected }}
           framework: playwright

--- a/.github/workflows/e2e-functional-template.yml
+++ b/.github/workflows/e2e-functional-template.yml
@@ -303,9 +303,8 @@ jobs:
       - name: e2e/upload-report-to-tsio
         if: ${{ always() && inputs.tsio-config != '' && hashFiles('e2e/test-results/results.json') != '' }}
         continue-on-error: true
-        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-report-upload@b5580f407a2776c064c626cc3c42295f2111fdc7 # staging validation — main@b5580f4 (#81 Maestro FilePath + Detox paths)
+        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-report-upload@45fb048848edc392f398144f45e2f3e30f43aeaa # release-0.12.0 / main@45fb048 (#81 Maestro FilePath + Detox paths, #82 background finalize)
         with:
-          use-staging: true
           composite-identity: ${{ toJSON(fromJSON(inputs.tsio-config).composite_identity) }}
           total-reports-expected: ${{ fromJSON(inputs.tsio-config).total_reports_expected }}
           framework: playwright

--- a/.github/workflows/e2e-functional.yml
+++ b/.github/workflows/e2e-functional.yml
@@ -200,6 +200,7 @@ jobs:
               upstreamJobsSucceeded: process.env.UPSTREAM_JOBS_SUCCEEDED === 'true',
               commitStatusContext: process.env.COMMIT_STATUS_CONTEXT,
               failOnTestFailures: true,
+              useStaging: true,
             });
             core.info(`TSIO report ${reportUrl}: ${status} (${JSON.stringify(stats)})`);
 
@@ -435,8 +436,9 @@ jobs:
       - name: e2e/upload-report-to-tsio
         if: ${{ always() && needs.prepare-matrix.outputs.tsio-composite-identity != '' && hashFiles('e2e/test-results/results.json') != '' }}
         continue-on-error: true
-        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-report-upload@606431efb597481b0857066be8130e86c22d2a03 # release-0.11.0 / 2026-07-21
+        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-report-upload@b5580f407a2776c064c626cc3c42295f2111fdc7 # staging validation — main@b5580f4 (#81 Maestro FilePath + Detox paths)
         with:
+          use-staging: true
           composite-identity: ${{ needs.prepare-matrix.outputs.tsio-composite-identity }}
           total-reports-expected: ${{ needs.prepare-matrix.outputs.tsio-total-reports-expected }}
           framework: playwright

--- a/.github/workflows/e2e-functional.yml
+++ b/.github/workflows/e2e-functional.yml
@@ -83,6 +83,10 @@ jobs:
           # platform legs (linux/macos/windows) + policy-tests-macos + policy-tests-windows
           TOTAL=$(( $(echo "${PLATFORMS}" | jq -c 'length') + 2 ))
           echo "total-reports-expected=${TOTAL}" >> "$GITHUB_OUTPUT"
+          # Accept MAIN as an alias for MASTER (mobile-style); Matterwick sends MASTER.
+          if [ "${RUN_TYPE}" = "MAIN" ]; then
+            RUN_TYPE=MASTER
+          fi
           NAME="desktop-$(echo "${RUN_TYPE}" | tr '[:upper:]' '[:lower:]')"
           if [ -n "${PR_NUMBER}" ]; then
             COMPOSITE_IDENTITY=$(jq -nc \

--- a/.github/workflows/e2e-functional.yml
+++ b/.github/workflows/e2e-functional.yml
@@ -186,10 +186,11 @@ jobs:
           TSIO_POLL_DELAY_MS: 5000
           COMMIT_STATUS_CONTEXT: e2e-test/desktop-playwright
           UPSTREAM_JOBS_SUCCEEDED: ${{ needs.e2e-tests.result == 'success' && needs.e2e-policy-tests.result == 'success' }}
-          # Master + PR → desktop E2E channel; CMT/RC uses MM_E2E_RELEASE_WEBHOOK_URL
-          # (wired only in compatibility-matrix-testing.yml). Routing is by
-          # compositeIdentity.name in cmt-channel-notify.js.
+          # PR → MM_DESKTOP_E2E_WEBHOOK_URL; master → MM_E2E_MASTER_HEALTH_WEBHOOK_URL;
+          # CMT/RC uses MM_E2E_RELEASE_WEBHOOK_URL (compatibility-matrix-testing.yml).
+          # Routing is by compositeIdentity.name in cmt-channel-notify.js.
           MATTERMOST_E2E_WEBHOOK_URL: ${{ secrets.MM_DESKTOP_E2E_WEBHOOK_URL }}
+          MATTERMOST_MASTER_HEALTH_WEBHOOK_URL: ${{ secrets.MM_E2E_MASTER_HEALTH_WEBHOOK_URL }}
         with:
           script: |
             const {reportUrl, status, stats} = await require('./e2e/utils/tsio-report-status.js')({

--- a/.github/workflows/e2e-functional.yml
+++ b/.github/workflows/e2e-functional.yml
@@ -200,7 +200,6 @@ jobs:
               upstreamJobsSucceeded: process.env.UPSTREAM_JOBS_SUCCEEDED === 'true',
               commitStatusContext: process.env.COMMIT_STATUS_CONTEXT,
               failOnTestFailures: true,
-              useStaging: true,
             });
             core.info(`TSIO report ${reportUrl}: ${status} (${JSON.stringify(stats)})`);
 
@@ -436,9 +435,8 @@ jobs:
       - name: e2e/upload-report-to-tsio
         if: ${{ always() && needs.prepare-matrix.outputs.tsio-composite-identity != '' && hashFiles('e2e/test-results/results.json') != '' }}
         continue-on-error: true
-        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-report-upload@b5580f407a2776c064c626cc3c42295f2111fdc7 # staging validation — main@b5580f4 (#81 Maestro FilePath + Detox paths)
+        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-report-upload@45fb048848edc392f398144f45e2f3e30f43aeaa # release-0.12.0 / main@45fb048 (#81 Maestro FilePath + Detox paths, #82 background finalize)
         with:
-          use-staging: true
           composite-identity: ${{ needs.prepare-matrix.outputs.tsio-composite-identity }}
           total-reports-expected: ${{ needs.prepare-matrix.outputs.tsio-total-reports-expected }}
           framework: playwright

--- a/.github/workflows/e2e-functional.yml
+++ b/.github/workflows/e2e-functional.yml
@@ -83,10 +83,6 @@ jobs:
           # platform legs (linux/macos/windows) + policy-tests-macos + policy-tests-windows
           TOTAL=$(( $(echo "${PLATFORMS}" | jq -c 'length') + 2 ))
           echo "total-reports-expected=${TOTAL}" >> "$GITHUB_OUTPUT"
-          # Accept MAIN as an alias for MASTER (mobile-style); Matterwick sends MASTER.
-          if [ "${RUN_TYPE}" = "MAIN" ]; then
-            RUN_TYPE=MASTER
-          fi
           NAME="desktop-$(echo "${RUN_TYPE}" | tr '[:upper:]' '[:lower:]')"
           if [ -n "${PR_NUMBER}" ]; then
             COMPOSITE_IDENTITY=$(jq -nc \

--- a/.github/workflows/e2e-functional.yml
+++ b/.github/workflows/e2e-functional.yml
@@ -186,9 +186,9 @@ jobs:
           TSIO_POLL_DELAY_MS: 5000
           COMMIT_STATUS_CONTEXT: e2e-test/desktop-playwright
           UPSTREAM_JOBS_SUCCEEDED: ${{ needs.e2e-tests.result == 'success' && needs.e2e-policy-tests.result == 'success' }}
-          # Master shares the CMT/RC channel; PR posts to the E2E QA channel.
-          # Routing is by compositeIdentity.name in cmt-channel-notify.js.
-          MATTERMOST_CMT_WEBHOOK_URL: ${{ secrets.MM_E2E_RELEASE_WEBHOOK_URL }}
+          # Master + PR → desktop E2E channel; CMT/RC uses MM_E2E_RELEASE_WEBHOOK_URL
+          # (wired only in compatibility-matrix-testing.yml). Routing is by
+          # compositeIdentity.name in cmt-channel-notify.js.
           MATTERMOST_E2E_WEBHOOK_URL: ${{ secrets.MM_DESKTOP_E2E_WEBHOOK_URL }}
         with:
           script: |

--- a/e2e/specs/startup/window_position.test.ts
+++ b/e2e/specs/startup/window_position.test.ts
@@ -198,6 +198,7 @@ test.describe('startup/window_position', () => {
             await mainWindow.waitForSelector('#newTabButton', {timeout: 30_000});
 
             const tiledBounds = await tileMainWindowToLeftHalf(electronApp);
+
             // Let MAIN_WINDOW_RESIZED / modal bound handlers settle before opening settings.
             await new Promise((resolve) => setTimeout(resolve, 300));
             await exerciseWindowChrome(electronApp, mainWindow);

--- a/e2e/specs/startup/window_position.test.ts
+++ b/e2e/specs/startup/window_position.test.ts
@@ -152,20 +152,8 @@ async function exerciseWindowChrome(
     }
 
     if (openSettings) {
-        // Open + cancelModal exercises settings chrome while tiled/fullscreen.
-        // Avoid clicking category buttons here: on Linux CI, after parent tiling the
-        // settings WebContentsView can tear down mid-click ("Target page ... closed").
-        // focus.test uses the same cancelModal close path successfully.
         const settingsWindow = await openSettingsWindow(electronApp);
-        await settingsWindow.waitForSelector('.SettingsModal', {timeout: 15_000});
-        if (process.platform === 'linux') {
-            // ModalView defers setBounds by 10ms on Linux; wait for the view to settle
-            // after the parent was tiled before touching the page.
-            await new Promise((resolve) => setTimeout(resolve, 300));
-        }
-        if (settingsWindow.isClosed()) {
-            throw new Error('Settings window closed before cancelModal could run');
-        }
+        await settingsWindow.click('#settingCategoryButton-general');
         await settingsWindow.evaluate(() => {
             const desktop = (window as Window & {desktop?: {modals?: {cancelModal?: () => void}}}).desktop;
             if (!desktop?.modals?.cancelModal) {
@@ -198,9 +186,6 @@ test.describe('startup/window_position', () => {
             await mainWindow.waitForSelector('#newTabButton', {timeout: 30_000});
 
             const tiledBounds = await tileMainWindowToLeftHalf(electronApp);
-
-            // Let MAIN_WINDOW_RESIZED / modal bound handlers settle before opening settings.
-            await new Promise((resolve) => setTimeout(resolve, 300));
             await exerciseWindowChrome(electronApp, mainWindow);
 
             const afterTiled = await getMainWindowState(electronApp);

--- a/e2e/specs/startup/window_position.test.ts
+++ b/e2e/specs/startup/window_position.test.ts
@@ -152,8 +152,20 @@ async function exerciseWindowChrome(
     }
 
     if (openSettings) {
+        // Open + cancelModal exercises settings chrome while tiled/fullscreen.
+        // Avoid clicking category buttons here: on Linux CI, after parent tiling the
+        // settings WebContentsView can tear down mid-click ("Target page ... closed").
+        // focus.test uses the same cancelModal close path successfully.
         const settingsWindow = await openSettingsWindow(electronApp);
-        await settingsWindow.click('#settingCategoryButton-general');
+        await settingsWindow.waitForSelector('.SettingsModal', {timeout: 15_000});
+        if (process.platform === 'linux') {
+            // ModalView defers setBounds by 10ms on Linux; wait for the view to settle
+            // after the parent was tiled before touching the page.
+            await new Promise((resolve) => setTimeout(resolve, 300));
+        }
+        if (settingsWindow.isClosed()) {
+            throw new Error('Settings window closed before cancelModal could run');
+        }
         await settingsWindow.evaluate(() => {
             const desktop = (window as Window & {desktop?: {modals?: {cancelModal?: () => void}}}).desktop;
             if (!desktop?.modals?.cancelModal) {
@@ -186,6 +198,8 @@ test.describe('startup/window_position', () => {
             await mainWindow.waitForSelector('#newTabButton', {timeout: 30_000});
 
             const tiledBounds = await tileMainWindowToLeftHalf(electronApp);
+            // Let MAIN_WINDOW_RESIZED / modal bound handlers settle before opening settings.
+            await new Promise((resolve) => setTimeout(resolve, 300));
             await exerciseWindowChrome(electronApp, mainWindow);
 
             const afterTiled = await getMainWindowState(electronApp);

--- a/e2e/utils/cmt-channel-notify.js
+++ b/e2e/utils/cmt-channel-notify.js
@@ -87,11 +87,13 @@ function parseCmtJobName(jobName) {
 }
 
 /**
- * Webhook routing:
- *   cmt-desktop              → MM_E2E_RELEASE_WEBHOOK_URL (RC / CMT channel)
- *   desktop-master + desktop-pr → MM_DESKTOP_E2E_WEBHOOK_URL (PR / master channel)
+ * Webhook routing (fail closed for named report groups):
+ *   cmt-desktop                 → MATTERMOST_CMT_WEBHOOK_URL only
+ *   desktop-master / desktop-pr → MATTERMOST_E2E_WEBHOOK_URL only
  *
- * MATTERMOST_WEBHOOK_URL remains a fallback for workflows that set only one URL.
+ * Named groups never fall back to MATTERMOST_WEBHOOK_URL (avoids posting
+ * CMT/PR/master to the wrong channel when a dedicated secret is missing).
+ * Unknown names still use MATTERMOST_WEBHOOK_URL as a generic fallback.
  *
  * @param {string} reportName - compositeIdentity.name
  * @param {NodeJS.ProcessEnv} [env]
@@ -99,10 +101,10 @@ function parseCmtJobName(jobName) {
  */
 function resolveWebhookUrl(reportName, env = process.env) {
     if (reportName === 'cmt-desktop') {
-        return env.MATTERMOST_CMT_WEBHOOK_URL || env.MATTERMOST_WEBHOOK_URL || '';
+        return env.MATTERMOST_CMT_WEBHOOK_URL || '';
     }
     if (reportName === 'desktop-master' || reportName === 'desktop-pr') {
-        return env.MATTERMOST_E2E_WEBHOOK_URL || env.MATTERMOST_WEBHOOK_URL || '';
+        return env.MATTERMOST_E2E_WEBHOOK_URL || '';
     }
     return env.MATTERMOST_WEBHOOK_URL || '';
 }
@@ -451,7 +453,7 @@ async function fetchPerJobCountsFromConsolidated(baseUrl, compositeIdentity, gro
  */
 async function postMattermostWebhook({core, webhookUrl, text, username = 'Desktop E2E'}) {
     if (!webhookUrl) {
-        core.info('MATTERMOST_WEBHOOK_URL not set — skipping E2E channel notify');
+        core.info('Mattermost webhook URL not set — skipping E2E channel notify');
         return;
     }
 

--- a/e2e/utils/cmt-channel-notify.js
+++ b/e2e/utils/cmt-channel-notify.js
@@ -88,8 +88,9 @@ function parseCmtJobName(jobName) {
 
 /**
  * Webhook routing (fail closed for named report groups):
- *   cmt-desktop                 → MATTERMOST_CMT_WEBHOOK_URL only
- *   desktop-master / desktop-pr → MATTERMOST_E2E_WEBHOOK_URL only
+ *   cmt-desktop      → MATTERMOST_CMT_WEBHOOK_URL only (MM_E2E_RELEASE_WEBHOOK_URL)
+ *   desktop-master   → MATTERMOST_MASTER_HEALTH_WEBHOOK_URL only (MM_E2E_MASTER_HEALTH_WEBHOOK_URL)
+ *   desktop-pr       → MATTERMOST_E2E_WEBHOOK_URL only (MM_DESKTOP_E2E_WEBHOOK_URL)
  *
  * Named groups never fall back to MATTERMOST_WEBHOOK_URL (avoids posting
  * CMT/PR/master to the wrong channel when a dedicated secret is missing).
@@ -103,7 +104,10 @@ function resolveWebhookUrl(reportName, env = process.env) {
     if (reportName === 'cmt-desktop') {
         return env.MATTERMOST_CMT_WEBHOOK_URL || '';
     }
-    if (reportName === 'desktop-master' || reportName === 'desktop-pr') {
+    if (reportName === 'desktop-master') {
+        return env.MATTERMOST_MASTER_HEALTH_WEBHOOK_URL || '';
+    }
+    if (reportName === 'desktop-pr') {
         return env.MATTERMOST_E2E_WEBHOOK_URL || '';
     }
     return env.MATTERMOST_WEBHOOK_URL || '';

--- a/e2e/utils/cmt-channel-notify.js
+++ b/e2e/utils/cmt-channel-notify.js
@@ -88,9 +88,9 @@ function parseCmtJobName(jobName) {
 
 /**
  * Webhook routing (fail closed for named report groups):
- *   cmt-desktop      → MATTERMOST_CMT_WEBHOOK_URL only (MM_E2E_RELEASE_WEBHOOK_URL)
- *   desktop-master   → MATTERMOST_MASTER_HEALTH_WEBHOOK_URL only (MM_E2E_MASTER_HEALTH_WEBHOOK_URL)
- *   desktop-pr       → MATTERMOST_E2E_WEBHOOK_URL only (MM_DESKTOP_E2E_WEBHOOK_URL)
+ *   cmt-desktop                → MATTERMOST_CMT_WEBHOOK_URL only (MM_E2E_RELEASE_WEBHOOK_URL)
+ *   desktop-master/desktop-main → MATTERMOST_MASTER_HEALTH_WEBHOOK_URL only (MM_E2E_MASTER_HEALTH_WEBHOOK_URL)
+ *   desktop-pr                 → MATTERMOST_E2E_WEBHOOK_URL only (MM_DESKTOP_E2E_WEBHOOK_URL)
  *
  * Named groups never fall back to MATTERMOST_WEBHOOK_URL (avoids posting
  * CMT/PR/master to the wrong channel when a dedicated secret is missing).
@@ -104,7 +104,7 @@ function resolveWebhookUrl(reportName, env = process.env) {
     if (reportName === 'cmt-desktop') {
         return env.MATTERMOST_CMT_WEBHOOK_URL || '';
     }
-    if (reportName === 'desktop-master') {
+    if (reportName === 'desktop-master' || reportName === 'desktop-main') {
         return env.MATTERMOST_MASTER_HEALTH_WEBHOOK_URL || '';
     }
     if (reportName === 'desktop-pr') {
@@ -244,6 +244,7 @@ function reportTitleForIdentity(compositeIdentity) {
     case 'desktop-pr':
         return 'Desktop PR E2E';
     case 'desktop-master':
+    case 'desktop-main':
         return 'Desktop Master E2E';
     default:
         return 'Desktop E2E';

--- a/e2e/utils/cmt-channel-notify.js
+++ b/e2e/utils/cmt-channel-notify.js
@@ -88,8 +88,8 @@ function parseCmtJobName(jobName) {
 
 /**
  * Webhook routing:
- *   cmt-desktop + desktop-master → MM_E2E_RELEASE_WEBHOOK_URL (RC / master channel)
- *   desktop-pr                   → MM_DESKTOP_E2E_WEBHOOK_URL (PR channel)
+ *   cmt-desktop              → MM_E2E_RELEASE_WEBHOOK_URL (RC / CMT channel)
+ *   desktop-master + desktop-pr → MM_DESKTOP_E2E_WEBHOOK_URL (PR / master channel)
  *
  * MATTERMOST_WEBHOOK_URL remains a fallback for workflows that set only one URL.
  *
@@ -98,10 +98,10 @@ function parseCmtJobName(jobName) {
  * @returns {string}
  */
 function resolveWebhookUrl(reportName, env = process.env) {
-    if (reportName === 'cmt-desktop' || reportName === 'desktop-master') {
+    if (reportName === 'cmt-desktop') {
         return env.MATTERMOST_CMT_WEBHOOK_URL || env.MATTERMOST_WEBHOOK_URL || '';
     }
-    if (reportName === 'desktop-pr') {
+    if (reportName === 'desktop-master' || reportName === 'desktop-pr') {
         return env.MATTERMOST_E2E_WEBHOOK_URL || env.MATTERMOST_WEBHOOK_URL || '';
     }
     return env.MATTERMOST_WEBHOOK_URL || '';

--- a/e2e/utils/cmt-channel-notify.js
+++ b/e2e/utils/cmt-channel-notify.js
@@ -88,9 +88,9 @@ function parseCmtJobName(jobName) {
 
 /**
  * Webhook routing (fail closed for named report groups):
- *   cmt-desktop                → MATTERMOST_CMT_WEBHOOK_URL only (MM_E2E_RELEASE_WEBHOOK_URL)
- *   desktop-master/desktop-main → MATTERMOST_MASTER_HEALTH_WEBHOOK_URL only (MM_E2E_MASTER_HEALTH_WEBHOOK_URL)
- *   desktop-pr                 → MATTERMOST_E2E_WEBHOOK_URL only (MM_DESKTOP_E2E_WEBHOOK_URL)
+ *   cmt-desktop      → MATTERMOST_CMT_WEBHOOK_URL only (MM_E2E_RELEASE_WEBHOOK_URL)
+ *   desktop-master   → MATTERMOST_MASTER_HEALTH_WEBHOOK_URL only (MM_E2E_MASTER_HEALTH_WEBHOOK_URL)
+ *   desktop-pr       → MATTERMOST_E2E_WEBHOOK_URL only (MM_DESKTOP_E2E_WEBHOOK_URL)
  *
  * Named groups never fall back to MATTERMOST_WEBHOOK_URL (avoids posting
  * CMT/PR/master to the wrong channel when a dedicated secret is missing).
@@ -104,7 +104,7 @@ function resolveWebhookUrl(reportName, env = process.env) {
     if (reportName === 'cmt-desktop') {
         return env.MATTERMOST_CMT_WEBHOOK_URL || '';
     }
-    if (reportName === 'desktop-master' || reportName === 'desktop-main') {
+    if (reportName === 'desktop-master') {
         return env.MATTERMOST_MASTER_HEALTH_WEBHOOK_URL || '';
     }
     if (reportName === 'desktop-pr') {
@@ -244,7 +244,6 @@ function reportTitleForIdentity(compositeIdentity) {
     case 'desktop-pr':
         return 'Desktop PR E2E';
     case 'desktop-master':
-    case 'desktop-main':
         return 'Desktop Master E2E';
     default:
         return 'Desktop E2E';

--- a/e2e/utils/cmt-channel-notify.test.js
+++ b/e2e/utils/cmt-channel-notify.test.js
@@ -88,6 +88,7 @@ describe('cmt-channel-notify', () => {
 
         it('sends master runs to the master-health webhook', () => {
             assert.equal(resolveWebhookUrl('desktop-master', env), env.MATTERMOST_MASTER_HEALTH_WEBHOOK_URL);
+            assert.equal(resolveWebhookUrl('desktop-main', env), env.MATTERMOST_MASTER_HEALTH_WEBHOOK_URL);
         });
 
         it('sends PR runs to the E2E webhook', () => {

--- a/e2e/utils/cmt-channel-notify.test.js
+++ b/e2e/utils/cmt-channel-notify.test.js
@@ -78,6 +78,7 @@ describe('cmt-channel-notify', () => {
         const env = {
             MATTERMOST_CMT_WEBHOOK_URL: 'https://mm.example/hooks/cmt',
             MATTERMOST_E2E_WEBHOOK_URL: 'https://mm.example/hooks/e2e',
+            MATTERMOST_MASTER_HEALTH_WEBHOOK_URL: 'https://mm.example/hooks/master-health',
             MATTERMOST_WEBHOOK_URL: 'https://mm.example/hooks/fallback',
         };
 
@@ -85,8 +86,11 @@ describe('cmt-channel-notify', () => {
             assert.equal(resolveWebhookUrl('cmt-desktop', env), env.MATTERMOST_CMT_WEBHOOK_URL);
         });
 
-        it('sends master and PR runs to the E2E webhook', () => {
-            assert.equal(resolveWebhookUrl('desktop-master', env), env.MATTERMOST_E2E_WEBHOOK_URL);
+        it('sends master runs to the master-health webhook', () => {
+            assert.equal(resolveWebhookUrl('desktop-master', env), env.MATTERMOST_MASTER_HEALTH_WEBHOOK_URL);
+        });
+
+        it('sends PR runs to the E2E webhook', () => {
             assert.equal(resolveWebhookUrl('desktop-pr', env), env.MATTERMOST_E2E_WEBHOOK_URL);
         });
 
@@ -104,9 +108,12 @@ describe('cmt-channel-notify', () => {
             );
         });
 
-        it('does not use the shared webhook when a dedicated E2E secret is missing for master', () => {
+        it('does not use the shared or PR webhook when master-health secret is missing', () => {
             assert.equal(
-                resolveWebhookUrl('desktop-master', {MATTERMOST_WEBHOOK_URL: env.MATTERMOST_WEBHOOK_URL}),
+                resolveWebhookUrl('desktop-master', {
+                    MATTERMOST_WEBHOOK_URL: env.MATTERMOST_WEBHOOK_URL,
+                    MATTERMOST_E2E_WEBHOOK_URL: env.MATTERMOST_E2E_WEBHOOK_URL,
+                }),
                 '',
             );
         });

--- a/e2e/utils/cmt-channel-notify.test.js
+++ b/e2e/utils/cmt-channel-notify.test.js
@@ -96,6 +96,31 @@ describe('cmt-channel-notify', () => {
                 '',
             );
         });
+
+        it('does not use the shared webhook when a dedicated CMT secret is missing', () => {
+            assert.equal(
+                resolveWebhookUrl('cmt-desktop', {MATTERMOST_WEBHOOK_URL: env.MATTERMOST_WEBHOOK_URL}),
+                '',
+            );
+        });
+
+        it('does not use the shared webhook when a dedicated E2E secret is missing for master', () => {
+            assert.equal(
+                resolveWebhookUrl('desktop-master', {MATTERMOST_WEBHOOK_URL: env.MATTERMOST_WEBHOOK_URL}),
+                '',
+            );
+        });
+
+        it('does not use the shared webhook when a dedicated E2E secret is missing for PR', () => {
+            assert.equal(
+                resolveWebhookUrl('desktop-pr', {MATTERMOST_WEBHOOK_URL: env.MATTERMOST_WEBHOOK_URL}),
+                '',
+            );
+        });
+
+        it('still uses the shared webhook for unknown report names', () => {
+            assert.equal(resolveWebhookUrl('unknown-report', env), env.MATTERMOST_WEBHOOK_URL);
+        });
     });
 
     describe('formatCmtChannelMessage', () => {

--- a/e2e/utils/cmt-channel-notify.test.js
+++ b/e2e/utils/cmt-channel-notify.test.js
@@ -81,18 +81,18 @@ describe('cmt-channel-notify', () => {
             MATTERMOST_WEBHOOK_URL: 'https://mm.example/hooks/fallback',
         };
 
-        it('sends CMT and master to the CMT webhook', () => {
+        it('sends CMT to the release webhook', () => {
             assert.equal(resolveWebhookUrl('cmt-desktop', env), env.MATTERMOST_CMT_WEBHOOK_URL);
-            assert.equal(resolveWebhookUrl('desktop-master', env), env.MATTERMOST_CMT_WEBHOOK_URL);
         });
 
-        it('sends PR runs to the E2E webhook', () => {
+        it('sends master and PR runs to the E2E webhook', () => {
+            assert.equal(resolveWebhookUrl('desktop-master', env), env.MATTERMOST_E2E_WEBHOOK_URL);
             assert.equal(resolveWebhookUrl('desktop-pr', env), env.MATTERMOST_E2E_WEBHOOK_URL);
         });
 
-        it('does not fall back master to the PR webhook when CMT secret is missing', () => {
+        it('does not fall back CMT to the E2E webhook when release secret is missing', () => {
             assert.equal(
-                resolveWebhookUrl('desktop-master', {MATTERMOST_E2E_WEBHOOK_URL: env.MATTERMOST_E2E_WEBHOOK_URL}),
+                resolveWebhookUrl('cmt-desktop', {MATTERMOST_E2E_WEBHOOK_URL: env.MATTERMOST_E2E_WEBHOOK_URL}),
                 '',
             );
         });

--- a/e2e/utils/cmt-channel-notify.test.js
+++ b/e2e/utils/cmt-channel-notify.test.js
@@ -88,7 +88,6 @@ describe('cmt-channel-notify', () => {
 
         it('sends master runs to the master-health webhook', () => {
             assert.equal(resolveWebhookUrl('desktop-master', env), env.MATTERMOST_MASTER_HEALTH_WEBHOOK_URL);
-            assert.equal(resolveWebhookUrl('desktop-main', env), env.MATTERMOST_MASTER_HEALTH_WEBHOOK_URL);
         });
 
         it('sends PR runs to the E2E webhook', () => {

--- a/e2e/utils/tsio-report-status.js
+++ b/e2e/utils/tsio-report-status.js
@@ -267,8 +267,9 @@ async function reportTsioStatus({
     });
 
     // Channel notify (best-effort). Routing (see resolveWebhookUrl):
-    //   cmt-desktop                    → MM_E2E_RELEASE_WEBHOOK_URL
-    //   desktop-master / desktop-pr    → MM_DESKTOP_E2E_WEBHOOK_URL
+    //   cmt-desktop      → MM_E2E_RELEASE_WEBHOOK_URL
+    //   desktop-master   → MM_E2E_MASTER_HEALTH_WEBHOOK_URL
+    //   desktop-pr       → MM_DESKTOP_E2E_WEBHOOK_URL
     // Failures here must not undo a successfully written commit status.
     try {
         const notifyNames = new Set(['cmt-desktop', 'desktop-pr', 'desktop-master']);

--- a/e2e/utils/tsio-report-status.js
+++ b/e2e/utils/tsio-report-status.js
@@ -268,11 +268,11 @@ async function reportTsioStatus({
 
     // Channel notify (best-effort). Routing (see resolveWebhookUrl):
     //   cmt-desktop      → MM_E2E_RELEASE_WEBHOOK_URL
-    //   desktop-master   → MM_E2E_MASTER_HEALTH_WEBHOOK_URL
-    //   desktop-pr       → MM_DESKTOP_E2E_WEBHOOK_URL
+    //   desktop-master / desktop-main → MM_E2E_MASTER_HEALTH_WEBHOOK_URL
+    //   desktop-pr                    → MM_DESKTOP_E2E_WEBHOOK_URL
     // Failures here must not undo a successfully written commit status.
     try {
-        const notifyNames = new Set(['cmt-desktop', 'desktop-pr', 'desktop-master']);
+        const notifyNames = new Set(['cmt-desktop', 'desktop-pr', 'desktop-master', 'desktop-main']);
         if (notifyNames.has(compositeIdentity.name)) {
             const {notifyCmtChannel, resolveWebhookUrl} = require('./cmt-channel-notify.js');
             const webhookUrl = resolveWebhookUrl(compositeIdentity.name);

--- a/e2e/utils/tsio-report-status.js
+++ b/e2e/utils/tsio-report-status.js
@@ -268,11 +268,11 @@ async function reportTsioStatus({
 
     // Channel notify (best-effort). Routing (see resolveWebhookUrl):
     //   cmt-desktop      → MM_E2E_RELEASE_WEBHOOK_URL
-    //   desktop-master / desktop-main → MM_E2E_MASTER_HEALTH_WEBHOOK_URL
-    //   desktop-pr                    → MM_DESKTOP_E2E_WEBHOOK_URL
+    //   desktop-master   → MM_E2E_MASTER_HEALTH_WEBHOOK_URL
+    //   desktop-pr       → MM_DESKTOP_E2E_WEBHOOK_URL
     // Failures here must not undo a successfully written commit status.
     try {
-        const notifyNames = new Set(['cmt-desktop', 'desktop-pr', 'desktop-master', 'desktop-main']);
+        const notifyNames = new Set(['cmt-desktop', 'desktop-pr', 'desktop-master']);
         if (notifyNames.has(compositeIdentity.name)) {
             const {notifyCmtChannel, resolveWebhookUrl} = require('./cmt-channel-notify.js');
             const webhookUrl = resolveWebhookUrl(compositeIdentity.name);

--- a/e2e/utils/tsio-report-status.js
+++ b/e2e/utils/tsio-report-status.js
@@ -267,8 +267,8 @@ async function reportTsioStatus({
     });
 
     // Channel notify (best-effort). Routing (see resolveWebhookUrl):
-    //   cmt-desktop / desktop-master → MM_E2E_RELEASE_WEBHOOK_URL
-    //   desktop-pr                   → MM_DESKTOP_E2E_WEBHOOK_URL
+    //   cmt-desktop                    → MM_E2E_RELEASE_WEBHOOK_URL
+    //   desktop-master / desktop-pr    → MM_DESKTOP_E2E_WEBHOOK_URL
     // Failures here must not undo a successfully written commit status.
     try {
         const notifyNames = new Set(['cmt-desktop', 'desktop-pr', 'desktop-master']);


### PR DESCRIPTION
fix tsio reporting link and Do not post master report to release report channel


```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Changes update shared Mattermost webhook routing/skip behavior across E2E/TSIO/CMT/master reporting, including a fail-closed path when dedicated webhook secrets are missing. This is limited to notifications/report publishing (not core product logic), but misrouting could affect multiple workflows and external channel updates. Unit tests were updated to match the new routing rules.  
**QA Recommendation:** Skip full manual QA; spot-check at least one e2e run per report group (`desktop-pr`, `desktop-master`, `cmt-desktop`) to verify the correct webhook/channel receives (or omits) notifications when relevant webhook secrets are set vs unset.  
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->