### PR TITLE
ci(cmt): drop legacy runner remapping after Matterwick v0.4.16

### DIFF
--- a/.github/workflows/compatibility-matrix-testing.yml
+++ b/.github/workflows/compatibility-matrix-testing.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       DESKTOP_SHA: ${{ steps.repo.outputs.DESKTOP_SHA }}
-      CMT_MATRIX: ${{ steps.normalize-matrix.outputs.matrix }}
+      CMT_MATRIX: ${{ steps.matrix.outputs.matrix }}
       TSIO_COMPOSITE_IDENTITY: ${{ steps.tsio-identity.outputs.composite-identity-json }}
       TSIO_TOTAL_REPORTS_EXPECTED: ${{ steps.tsio-identity.outputs.total-reports-expected }}
     steps:
@@ -55,23 +55,13 @@ jobs:
         id: repo
         run: echo "DESKTOP_SHA=$(git rev-parse HEAD)" >> ${GITHUB_OUTPUT}
 
-      # Matterwick still dispatches ubuntu-22.04 for Linux and macos-13/macos-14 for
-      # macOS. Remap so CMT matches PR E2E: Linux → ubuntu-latest (libasound2t64 on
-      # 24.04), macOS → macos-26 (macos-13/14 are unavailable / queue for ~24h).
-      # Same idea as e2e-functional.yml remapping macos-latest → macos-26.
-      - name: cmt/normalize-matrix-runners
-        id: normalize-matrix
+      # Matterwick (≥ v0.4.16) sends the runners we run on: ubuntu-latest,
+      # macos-26, windows-2022. Pass the matrix through as-is.
+      - name: cmt/set-matrix
+        id: matrix
         env:
           CMT_MATRIX: ${{ inputs.CMT_MATRIX }}
-        run: |
-          NORMALIZED=$(echo "${CMT_MATRIX}" | jq -c '
-            .environment |= map(
-              if .runner == "ubuntu-22.04" then .runner = "ubuntu-latest"
-              elif .runner == "macos-13" or .runner == "macos-14" or .runner == "macos-latest" then .runner = "macos-26"
-              else . end
-            )
-          ')
-          echo "matrix=${NORMALIZED}" >> "$GITHUB_OUTPUT"
+        run: echo "matrix=${CMT_MATRIX}" >> "$GITHUB_OUTPUT"
 
       # One composite identity + total-reports-expected for the WHOLE CMT run
       # (every OS x server-version leg), computed once here and threaded into
@@ -82,7 +72,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           MM_SHA: ${{ steps.repo.outputs.DESKTOP_SHA }}
           MM_BRANCH: ${{ inputs.DESKTOP_VERSION }}
-          CMT_MATRIX: ${{ steps.normalize-matrix.outputs.matrix }}
+          CMT_MATRIX: ${{ steps.matrix.outputs.matrix }}
         run: |
           TOTAL=$(echo "${CMT_MATRIX}" | jq -c '(.environment | length) * (.server | length)')
           echo "total-reports-expected=${TOTAL}" >> "$GITHUB_OUTPUT"
@@ -117,17 +107,16 @@ jobs:
           description: "Compatibility Matrix Testing for ${{ inputs.DESKTOP_VERSION }} version"
           status: pending
 
-  # Input follows the below schema (Matterwick may still send ubuntu-22.04 /
-  # macos-13 / macos-14; calculate-commit-hash remaps those before the e2e matrix).
+  # Input follows the below schema (Matterwick ≥ v0.4.16).
   # {
   #   "environment": [
   #     {
   #       "os": "linux",
-  #       "runner": "ubuntu-22.04"
+  #       "runner": "ubuntu-latest"
   #     },
   #     {
   #       "os": "macos",
-  #       "runner": "macos-13"
+  #       "runner": "macos-26"
   #     },
   #     {
   #       "os": "windows",

--- a/.github/workflows/e2e-functional-template.yml
+++ b/.github/workflows/e2e-functional-template.yml
@@ -103,8 +103,8 @@ env:
 jobs:
   e2e:
     # Includes MM_SERVER_VERSION, not just runs-on: CMT tests multiple server
-    # versions against the same runner (e.g. macos-13 x 9.6.1 and macos-13 x
-    # 9.5.2)
+    # versions against the same runner (e.g. macos-26 x 11.9.0 and macos-26 x
+    # 11.8.4).
     name: e2e-on-${{ inputs.runs-on }}-${{ inputs.MM_SERVER_VERSION }}
     runs-on: ${{ inputs.runs-on }}
     permissions:


### PR DESCRIPTION
## Summary
- Matterwick [#93](https://github.com/mattermost/matterwick/pull/93) / `v0.4.16` now emits `ubuntu-latest` + `macos-26` for desktop CMT
- Remove the CMT workflow's legacy label remapping (`macos-13`/`14`/`ubuntu-22.04`) — pass the matrix through as-is
- Update schema/comments to match current runners
- Leave PR E2E `macos-latest` → `macos-26` pin in `e2e-functional.yml` (Matterwick PR path still sends `macos-latest`)

## Test plan
- [ ] Confirm [gitops#78](https://github.com/mattermost/gitops-platform/pull/78) is merged and Matterwick rolled to `v0.4.16`
- [ ] Manually run CMT Provisioner and confirm matrix legs use `macos-26` / `ubuntu-latest` with no remapping step
- [ ] Confirm PR E2E still remaps `macos-latest` → `macos-26`


#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Changes CI runner-matrix handling and may affect CMT or PR E2E execution if runner availability or matrix inputs are incompatible.
**QA Recommendation:** Manual verification of CMT matrix runners and PR E2E remapping is recommended.
*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->