### PR TITLE
[MM-68740] Guard loading screen fade against undefined webContents

### DIFF
--- a/src/app/views/loadingScreen.test.js
+++ b/src/app/views/loadingScreen.test.js
@@ -92,4 +92,58 @@ describe('main/views/loadingScreen', () => {
             expect(mainWindow.contentView.addChildView).not.toHaveBeenCalled();
         });
     });
+
+    describe('fade', () => {
+        const mainWindow = {
+            contentView: {
+                addChildView: jest.fn(),
+                on: jest.fn(),
+            },
+            webContents: {
+                id: 123,
+            },
+            isDestroyed: jest.fn(() => false),
+        };
+        let loadingScreen;
+
+        beforeEach(() => {
+            jest.clearAllMocks();
+            loadingScreen = new LoadingScreen(mainWindow);
+            loadingScreen.view.webContents.isLoading.mockReturnValue(false);
+            loadingScreen.show();
+            loadingScreen.view.webContents.send.mockClear();
+        });
+
+        it('should send the fade event when webContents is alive', () => {
+            loadingScreen.fade();
+
+            expect(loadingScreen.view.webContents.send).toHaveBeenCalledWith(TOGGLE_LOADING_SCREEN_VISIBILITY, false);
+        });
+
+        it('should not send the fade event when webContents is destroyed', () => {
+            loadingScreen.view.webContents.isDestroyed.mockReturnValue(true);
+
+            loadingScreen.fade();
+
+            expect(loadingScreen.view.webContents.send).not.toHaveBeenCalled();
+        });
+
+        it('should not throw when webContents is undefined during teardown', () => {
+            loadingScreen.view.webContents = undefined;
+
+            expect(() => loadingScreen.fade()).not.toThrow();
+        });
+
+        it('should still leave the visible state when webContents is undefined', () => {
+            const webContents = loadingScreen.view.webContents;
+            loadingScreen.view.webContents = undefined;
+            loadingScreen.fade();
+
+            loadingScreen.view.webContents = webContents;
+            loadingScreen.fade();
+
+            // The second fade is only a no-op if the first one advanced out of VISIBLE.
+            expect(webContents.send).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/src/app/views/loadingScreen.ts
+++ b/src/app/views/loadingScreen.ts
@@ -89,8 +89,9 @@ export class LoadingScreen {
         if (this.state === LoadingScreenState.VISIBLE) {
             log.debug('fade: fading loading screen');
             this.state = LoadingScreenState.FADING;
-            if (!this.view.webContents.isDestroyed()) {
-                this.view.webContents.send(TOGGLE_LOADING_SCREEN_VISIBILITY, false);
+            const webContents = this.view.webContents;
+            if (webContents && !webContents.isDestroyed()) {
+                webContents.send(TOGGLE_LOADING_SCREEN_VISIBILITY, false);
             }
         }
     };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Fixes an unhandled `TypeError` thrown from `LoadingScreen.fade()` when Electron has already torn down the loading screen's `webContents`.

Electron can leave `WebContentsView.webContents` undefined during teardown. `fade()` called `isDestroyed()` directly on it, so a fade triggered by `setInitialized` after teardown threw. The change caches the `webContents` and guards on existence as well as destroyed-ness before sending:

```ts
const webContents = this.view.webContents;
if (webContents && !webContents.isDestroyed()) {
    webContents.send(TOGGLE_LOADING_SCREEN_VISIBILITY, false);
}
```

The `this.state = LoadingScreenState.FADING` transition is deliberately left where it was, ahead of the guard, so `handleAnimationFinished` and the state machine behave exactly as before. Scope is confined to `fade()`.

<details>
<summary>Why the reported signature differs from what reproduces today</summary>

Sentry `MATTERMOST-DESKTOP-1S` reports `Cannot read properties of undefined (reading 'send')`, with culprit `m.fade` reached via `IpcMainImpl → setInitialized → fadeLoadingScreen → fade`. Every one of its 2,009 events comes from released 6.1.1–6.2.2 builds, where `fade()` called `send()` with no guard at all.

`e6994098` ([MM-68749], #3822) later wrapped that `send()` in an `isDestroyed()` check, which fixed the `send` variant but still assumed `webContents` exists. So on `master` the same teardown race now throws `Cannot read properties of undefined (reading 'isDestroyed')` instead — the signature tracked as MM-68927. Reverting `loadingScreen.ts` and running the new tests reproduces exactly that:

```
✕ should not throw when webContents is undefined during teardown
✕ should still leave the visible state when webContents is undefined
  TypeError: Cannot read properties of undefined (reading 'isDestroyed')
Tests: 2 failed, 5 passed, 7 total
```

Both pass with the fix applied.
</details>

Sibling `this.view.webContents` dereferences in `show()`, `destroy()`, and `registerThemeManager()` carry the same latent hazard but are intentionally left alone to keep this change minimal.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-68740

#### Checklist

- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [x] executed `npm run lint:js` for proper code formatting

#### Device Information

Verified on Linux (x64) via the unit suite only. `npm run check` is green: ESLint and `tsc` clean, `Test Suites: 79 passed, 79 total`, `Tests: 1317 passed, 1317 total`.

This is a teardown race with no practical manual reproduction, so correctness is demonstrated by the two new regression tests, which fail against the pre-fix code with the exact production crash and pass after it, rather than by manual GUI testing.

#### Release Note

```release-note
Fixed a crash that could occur when the loading screen faded after its web contents had already been torn down.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5bf357b-9ebb-42ab-81da-ca4fe52626e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5bf357b-9ebb-42ab-81da-ca4fe52626e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[MM-68749]: https://mattermost.atlassian.net/browse/MM-68749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Low; the change is isolated to loading-screen teardown handling and is covered by regression tests.
**QA Recommendation:** Manual QA can be skipped; automated coverage is sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->