### PR TITLE
e2e: fix MM-T4054 media preview failure on Mattermost 11.10.0-rc2

### DIFF
--- a/e2e/specs/mattermost/media_preview.test.ts
+++ b/e2e/specs/mattermost/media_preview.test.ts
@@ -9,8 +9,10 @@ import {prepareMattermostServerView} from '../../helpers/prepareServerView';
 import {getFilePublicLink, isPublicLinkEnabled} from '../../helpers/server_api/publicLinks';
 import type {ServerView} from '../../helpers/serverView';
 
-// 64x64 PNG — above Mattermost's 48px inline-image minimum so thumbnails render visibly.
-const PREVIEW_PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAf0lEQVR4nNXOQREAIAzAsFJJ8y8FMYjgsWsU5NwZyiRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4iRO4twO/HqSogHAzFmDswAAAABJRU5ErkJggg==';
+// Valid 128x128 PNG. The previous fixture was rejected by the server decoder
+// ("png: invalid format: too much pixel data"), so no preview was generated and
+// SizeAwareImage (MM-69174 / 11.10+) ignored clicks until load forever.
+const PREVIEW_PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAIAAABMXPacAAACx0lEQVR4nO3dsVEbQRhH8ZWHOuyAHogcEVAClTgmcGpX4hIIlNgRPRC4EjnYmRuNYARrab/3P/R+kQMh43333Z1kFm12u10b8eXnn6HH//321ec/4tPQo3V2BoAZAGYAmAFgBoAZAGYAmAFgBoAZAGYAmAFgBoAZAHaV9v74pT2/EwAzAMwAMAPADAAzAMwAMAPADAAzAMwAMAPADAAzAMwAsM3q9gdsf30//oDrp8dTnv/A7P8/uBp6NOXNRd/3fHO3/Pl4jATRAYbW/VVLjNgSoQFOX/oDvURghrgAZ1/6fc83d9vWbu8f5v0Vo7LugvZP3/NMbTwqZQJqln7RGySMQsQEFK/+ImEU+ADU6nd4AzgAu/od24AMkLD6HdgAC5Cz+h3VgAmQtvod0gAIkLn6XX0D/i7owlUHSD78u+Ih2Hz+8XvoC055fxy/6X6/5W079wd8cHUBVnT4t8JTpRMAKwqwrsO/qxkCJwBmAFhFgDWef7qCs5ATADMAzACw6QHWewHoZn//TgDMADADwAwAm74/YO0X4Tb4I71+fsDKGABmAJgBYAaATQ8QuCtoyOzv3wmAGQBmAFhFgPVeBgo2kTkBMAPAigKs8SxUs4nVCYDVBVjXEJTt4S79/IDt0Feiln/mh9ofkPCrAd6jclirrwH5DYpPlV6EYUCA5CGov1NgJiCzAXKfhp2C0hpQd8nkNSCnAfgaBb4IJzRgXyHyd0FsA/z1OR+gcQ3w1W85v7SvNyj7OcaEpe8iJmBRMwo5q9/SArTWrp8e5y3Q7f1D1Oq3nFPQgb5MZ9wlmnC79arQAN1ytP53idh1X/j5AW/w8wMOHRzUowuUJu4ifGkMADMAzAAwA8AMADMAzAAwA8AMADMAzAAwA8AMACvdH+Dzv+QEwAwAMwDMADADwAwAMwDMADADwAwAMwDMADADwAwAMwDsH5fw4xGXqkx/AAAAAElFTkSuQmCC';
 
 const PREVIEW_MODAL_SELECTOR = [
     '.file-preview-modal',

--- a/e2e/specs/mattermost/media_preview.test.ts
+++ b/e2e/specs/mattermost/media_preview.test.ts
@@ -27,25 +27,36 @@ const LOADED_IMAGE_SELECTOR = [
     'img[src*="/api/v4/files/"]:not(.image-loading__placeholder)',
 ].join(', ');
 
-const POSTED_IMAGE_SELECTOR = [
-    '.file-preview__button',
-    '.post-image .small-image__container',
-    '.post-image .image-loaded-container',
-    '.post-image__image',
-    LOADED_IMAGE_SELECTOR,
-    '.file-viewer-touch',
-    '.file-attachment',
-].join(', ');
+const PREVIEW_FILE_NAME = 'e2e-preview.png';
 
 // Shared helpers injected into renderer scripts (same pattern as DOM_UTILS in serverView.ts).
 const PREVIEW_IMAGE_UTILS = `
 const LOADED_IMAGE_SELECTOR = ${JSON.stringify(LOADED_IMAGE_SELECTOR)};
+const PREVIEW_FILE_NAME = ${JSON.stringify(PREVIEW_FILE_NAME)};
 const isPreviewControlVisible = (el) => el instanceof HTMLElement && window.getComputedStyle(el).display !== 'none';
 const isLoadedPreviewImage = (el) => el instanceof HTMLImageElement &&
     !el.classList.contains('image-loading__placeholder') &&
     el.complete &&
     el.naturalWidth > 0 &&
     isPreviewControlVisible(el);
+const postHasPreviewFixture = (post) => {
+    if (post.querySelector('[aria-label*="' + PREVIEW_FILE_NAME + '" i]')) {
+        return true;
+    }
+    // Filename can also appear in attachment headers before the image aria-label mounts.
+    const attachment = post.querySelector('.post-image, .post--attachment, .file-attachment, .file-preview__button');
+    return Boolean(attachment && (attachment.textContent || '').toLowerCase().includes(PREVIEW_FILE_NAME));
+};
+const findPreviewFixturePost = () => {
+    const posts = Array.from(document.querySelectorAll('.post'));
+    for (let index = posts.length - 1; index >= 0; index--) {
+        const post = posts[index];
+        if (postHasPreviewFixture(post)) {
+            return post;
+        }
+    }
+    return null;
+};
 const findVisibleLoadedPreviewButton = (root) => {
     for (const button of root.querySelectorAll('.file-preview__button')) {
         if (!isPreviewControlVisible(button)) {
@@ -68,26 +79,27 @@ const findVisibleLoadedPreviewButton = (root) => {
 async function waitForLoadedImagePreviewControl(serverWin: ServerView): Promise<void> {
     await expect.poll(async () => serverWin.runInRenderer<boolean>(`
         ${PREVIEW_IMAGE_UTILS}
-        const posts = Array.from(document.querySelectorAll('.post'));
-        for (let index = posts.length - 1; index >= 0; index--) {
-            const post = posts[index];
-            const previewButton = findVisibleLoadedPreviewButton(post);
-            if (previewButton) {
-                previewButton.scrollIntoView({block: 'center'});
-                return true;
-            }
+        const post = findPreviewFixturePost();
+        if (!post) {
+            return false;
+        }
 
-            // Legacy servers without .file-preview__button
-            const legacyImg = post.querySelector(LOADED_IMAGE_SELECTOR);
-            if (isLoadedPreviewImage(legacyImg)) {
-                legacyImg.scrollIntoView({block: 'center'});
-                return true;
-            }
+        const previewButton = findVisibleLoadedPreviewButton(post);
+        if (previewButton) {
+            previewButton.scrollIntoView({block: 'center'});
+            return true;
+        }
+
+        // Legacy servers without .file-preview__button
+        const legacyImg = post.querySelector(LOADED_IMAGE_SELECTOR);
+        if (isLoadedPreviewImage(legacyImg)) {
+            legacyImg.scrollIntoView({block: 'center'});
+            return true;
         }
         return false;
     `, true), {
         timeout: 60_000,
-        message: 'Uploaded image must finish loading into a visible file-preview control before it can be opened',
+        message: 'Uploaded e2e-preview.png must finish loading into a visible file-preview control before it can be opened',
     }).toBe(true);
 }
 
@@ -110,24 +122,20 @@ async function submitComposerPost(serverWin: ServerView): Promise<void> {
 
 async function waitForPostedAttachment(serverWin: ServerView): Promise<void> {
     await expect.poll(async () => serverWin.runInRenderer<boolean>(`
-        const attachmentSelector = ${JSON.stringify(POSTED_IMAGE_SELECTOR)};
+        ${PREVIEW_IMAGE_UTILS}
         const composer = document.querySelector('#post-create, .AdvancedTextEditor, .post-create, [data-testid="post-create"]');
         const draftAttachment = composer?.querySelector('.file-preview, .file-preview__container, .attachment-preview');
         if (draftAttachment) {
             return false;
         }
 
-        const posts = Array.from(document.querySelectorAll('.post'));
-        for (let index = posts.length - 1; index >= 0; index--) {
-            const post = posts[index];
-            if (post.querySelector(attachmentSelector) ||
-                post.querySelector('[aria-label*="e2e-preview.png" i], [aria-label*="file thumbnail" i]')) {
-                post.scrollIntoView({block: 'center'});
-                return true;
-            }
+        const post = findPreviewFixturePost();
+        if (!post) {
+            return false;
         }
-        return false;
-    `, true), {timeout: 60_000, message: 'Uploaded image must appear in the channel post list'}).toBe(true);
+        post.scrollIntoView({block: 'center'});
+        return true;
+    `, true), {timeout: 60_000, message: 'Uploaded e2e-preview.png must appear in the channel post list'}).toBe(true);
 }
 
 async function uploadAndPostPng(serverWin: ServerView): Promise<void> {
@@ -138,7 +146,7 @@ async function uploadAndPostPng(serverWin: ServerView): Promise<void> {
         for (let i = 0; i < binary.length; i++) {
             bytes[i] = binary.charCodeAt(i);
         }
-        const file = new File([bytes], 'e2e-preview.png', {type: 'image/png'});
+        const file = new File([bytes], ${JSON.stringify(PREVIEW_FILE_NAME)}, {type: 'image/png'});
 
         const input = document.querySelector('#fileUploadInput, input[type="file"]');
         if (!(input instanceof HTMLInputElement)) {
@@ -189,16 +197,7 @@ async function isImagePreviewOpen(serverWin: ServerView): Promise<boolean> {
 async function openImagePreview(serverWin: ServerView): Promise<boolean> {
     return serverWin.runInRenderer<boolean>(`
         ${PREVIEW_IMAGE_UTILS}
-        const posts = Array.from(document.querySelectorAll('.post'));
-        let root = null;
-        for (let index = posts.length - 1; index >= 0; index--) {
-            const post = posts[index];
-            if (post.querySelector('.file-preview__button, .post-image, .post--attachment, .file-attachment') ||
-                post.querySelector('[aria-label*="e2e-preview.png" i], [aria-label*="file thumbnail" i]')) {
-                root = post;
-                break;
-            }
-        }
+        const root = findPreviewFixturePost();
         if (!root) {
             return false;
         }
@@ -213,8 +212,7 @@ async function openImagePreview(serverWin: ServerView): Promise<boolean> {
         }
 
         const clickTargets = [
-            ...Array.from(root.querySelectorAll('[aria-label*="e2e-preview.png" i]')),
-            ...Array.from(root.querySelectorAll('[aria-label*="file thumbnail" i]')),
+            ...Array.from(root.querySelectorAll('[aria-label*="' + PREVIEW_FILE_NAME + '" i]')),
             ...Array.from(root.querySelectorAll(LOADED_IMAGE_SELECTOR)),
             root.querySelector('.post-image .image-loaded-container'),
             root.querySelector('.post-image .small-image__container'),

--- a/e2e/specs/mattermost/media_preview.test.ts
+++ b/e2e/specs/mattermost/media_preview.test.ts
@@ -20,15 +20,63 @@ const PREVIEW_MODAL_SELECTOR = [
 ].join(', ');
 
 const POSTED_IMAGE_SELECTOR = [
+    '.file-preview__button',
     '.post-image .small-image__container',
     '.post-image .image-loaded-container',
     '.post-image__image',
-    '.post-image img',
+    '.post-image img:not(.image-loading__placeholder)',
     '.file-viewer-touch',
     '.file-attachment',
-    '.post--attachment img',
-    'img[src*="/api/v4/files/"]',
+    '.post--attachment img:not(.image-loading__placeholder)',
+    'img[src*="/api/v4/files/"]:not(.image-loading__placeholder)',
 ].join(', ');
+
+/**
+ * Mattermost 11.10+ (MM-69174) SizeAwareImage ignores clicks until the real image has
+ * loaded, and keeps a visible placeholder button while the clickable control is
+ * display:none. Wait for a visible, loaded non-placeholder control before opening.
+ */
+async function waitForLoadedImagePreviewControl(serverWin: ServerView): Promise<void> {
+    await expect.poll(async () => serverWin.runInRenderer<boolean>(`
+        const posts = Array.from(document.querySelectorAll('.post'));
+        for (let index = posts.length - 1; index >= 0; index--) {
+            const post = posts[index];
+            const buttons = Array.from(post.querySelectorAll('.file-preview__button'));
+            for (const button of buttons) {
+                if (!(button instanceof HTMLElement)) {
+                    continue;
+                }
+                if (window.getComputedStyle(button).display === 'none') {
+                    continue;
+                }
+                const loadedImg = button.querySelector('img:not(.image-loading__placeholder)');
+                if (!(loadedImg instanceof HTMLImageElement)) {
+                    continue;
+                }
+                if (loadedImg.complete && loadedImg.naturalWidth > 0) {
+                    button.scrollIntoView({block: 'center'});
+                    return true;
+                }
+            }
+
+            // Legacy servers without .file-preview__button
+            const legacyImg = post.querySelector(
+                '.post-image img:not(.image-loading__placeholder), .post--attachment img:not(.image-loading__placeholder), img[src*="/api/v4/files/"]:not(.image-loading__placeholder)',
+            );
+            if (legacyImg instanceof HTMLImageElement &&
+                legacyImg.complete &&
+                legacyImg.naturalWidth > 0 &&
+                window.getComputedStyle(legacyImg).display !== 'none') {
+                legacyImg.scrollIntoView({block: 'center'});
+                return true;
+            }
+        }
+        return false;
+    `, true), {
+        timeout: 60_000,
+        message: 'Uploaded image must finish loading into a visible file-preview control before it can be opened',
+    }).toBe(true);
+}
 
 async function submitComposerPost(serverWin: ServerView): Promise<void> {
     const sent = await serverWin.runInRenderer<boolean>(`
@@ -109,6 +157,7 @@ async function uploadAndPostPng(serverWin: ServerView): Promise<void> {
     await recoverInteractiveChannel(serverWin, {channelItem: '#sidebarItem_town-square'});
 
     await waitForPostedAttachment(serverWin);
+    await waitForLoadedImagePreviewControl(serverWin);
 }
 
 async function isImagePreviewOpen(serverWin: ServerView): Promise<boolean> {
@@ -126,12 +175,11 @@ async function isImagePreviewOpen(serverWin: ServerView): Promise<boolean> {
 
 async function openImagePreview(serverWin: ServerView): Promise<boolean> {
     return serverWin.runInRenderer<boolean>(`
-        const attachmentSelector = ${JSON.stringify(POSTED_IMAGE_SELECTOR)};
         const posts = Array.from(document.querySelectorAll('.post'));
         let root = null;
         for (let index = posts.length - 1; index >= 0; index--) {
             const post = posts[index];
-            if (post.querySelector(attachmentSelector) ||
+            if (post.querySelector('.file-preview__button, .post-image, .post--attachment, .file-attachment') ||
                 post.querySelector('[aria-label*="e2e-preview.png" i], [aria-label*="file thumbnail" i]')) {
                 root = post;
                 break;
@@ -141,30 +189,52 @@ async function openImagePreview(serverWin: ServerView): Promise<boolean> {
             return false;
         }
 
+        const isVisible = (el) => el instanceof HTMLElement && window.getComputedStyle(el).display !== 'none';
+        const isLoadedImg = (el) => el instanceof HTMLImageElement &&
+            !el.classList.contains('image-loading__placeholder') &&
+            el.complete &&
+            el.naturalWidth > 0 &&
+            isVisible(el);
+
+        // Prefer the visible SizeAwareImage control (11.10+/MM-69174); clicks on the
+        // placeholder button are intentionally ignored until the real image loads.
+        const previewButtons = Array.from(root.querySelectorAll('.file-preview__button')).filter(isVisible);
+        for (const button of previewButtons) {
+            const loadedImg = button.querySelector('img:not(.image-loading__placeholder)');
+            if (loadedImg instanceof HTMLImageElement && loadedImg.complete && loadedImg.naturalWidth > 0) {
+                button.scrollIntoView({block: 'center', inline: 'center'});
+                button.click();
+                return true;
+            }
+        }
+
         const clickTargets = [
-            root.querySelector('[aria-label*="e2e-preview.png" i]'),
-            root.querySelector('[aria-label*="file thumbnail" i]'),
-            root.querySelector('.post-image .small-image__container'),
+            ...Array.from(root.querySelectorAll('[aria-label*="e2e-preview.png" i]')),
+            ...Array.from(root.querySelectorAll('[aria-label*="file thumbnail" i]')),
+            ...Array.from(root.querySelectorAll('.post-image img:not(.image-loading__placeholder)')),
+            ...Array.from(root.querySelectorAll('.post--attachment img:not(.image-loading__placeholder)')),
+            ...Array.from(root.querySelectorAll('img[src*="/api/v4/files/"]:not(.image-loading__placeholder)')),
             root.querySelector('.post-image .image-loaded-container'),
+            root.querySelector('.post-image .small-image__container'),
             root.querySelector('.post-image__image'),
-            root.querySelector('.post-image img'),
             root.querySelector('.file-viewer-touch'),
-            root.querySelector('.file-attachment'),
-            root.querySelector('.post--attachment img'),
-            root.querySelector('img[src*="/api/v4/files/"]'),
-            root.querySelector('.post-image'),
-            root.querySelector('.post--attachment'),
-        ].filter(Boolean);
+        ].filter((target) => {
+            if (!target) {
+                return false;
+            }
+            if (target instanceof HTMLImageElement) {
+                return isLoadedImg(target);
+            }
+            return isVisible(target) && Boolean(target.querySelector?.('img:not(.image-loading__placeholder)'));
+        });
 
         const target = clickTargets[0];
-        if (!target) {
+        if (!(target instanceof HTMLElement)) {
             return false;
         }
 
         target.scrollIntoView({block: 'center', inline: 'center'});
-        if (target instanceof HTMLElement) {
-            target.click();
-        }
+        target.click();
         return true;
     `, true);
 }
@@ -185,8 +255,8 @@ async function getPreviewFileId(serverWin: ServerView): Promise<string | null> {
         const sources = [
             document.querySelector('[data-testid="imagePreview"]')?.getAttribute('src'),
             document.querySelector('.file-preview-modal img')?.getAttribute('src'),
-            document.querySelector('.post-image img[src*="/files/"]')?.getAttribute('src'),
-            document.querySelector('img[src*="/api/v4/files/"]')?.getAttribute('src'),
+            document.querySelector('.post-image img[src*="/files/"]:not(.image-loading__placeholder)')?.getAttribute('src'),
+            document.querySelector('img[src*="/api/v4/files/"]:not(.image-loading__placeholder)')?.getAttribute('src'),
         ].filter(Boolean);
 
         for (const source of sources) {

--- a/e2e/specs/mattermost/media_preview.test.ts
+++ b/e2e/specs/mattermost/media_preview.test.ts
@@ -21,17 +21,44 @@ const PREVIEW_MODAL_SELECTOR = [
     '#viewImageModalLabel',
 ].join(', ');
 
+const LOADED_IMAGE_SELECTOR = [
+    '.post-image img:not(.image-loading__placeholder)',
+    '.post--attachment img:not(.image-loading__placeholder)',
+    'img[src*="/api/v4/files/"]:not(.image-loading__placeholder)',
+].join(', ');
+
 const POSTED_IMAGE_SELECTOR = [
     '.file-preview__button',
     '.post-image .small-image__container',
     '.post-image .image-loaded-container',
     '.post-image__image',
-    '.post-image img:not(.image-loading__placeholder)',
+    LOADED_IMAGE_SELECTOR,
     '.file-viewer-touch',
     '.file-attachment',
-    '.post--attachment img:not(.image-loading__placeholder)',
-    'img[src*="/api/v4/files/"]:not(.image-loading__placeholder)',
 ].join(', ');
+
+// Shared helpers injected into renderer scripts (same pattern as DOM_UTILS in serverView.ts).
+const PREVIEW_IMAGE_UTILS = `
+const LOADED_IMAGE_SELECTOR = ${JSON.stringify(LOADED_IMAGE_SELECTOR)};
+const isPreviewControlVisible = (el) => el instanceof HTMLElement && window.getComputedStyle(el).display !== 'none';
+const isLoadedPreviewImage = (el) => el instanceof HTMLImageElement &&
+    !el.classList.contains('image-loading__placeholder') &&
+    el.complete &&
+    el.naturalWidth > 0 &&
+    isPreviewControlVisible(el);
+const findVisibleLoadedPreviewButton = (root) => {
+    for (const button of root.querySelectorAll('.file-preview__button')) {
+        if (!isPreviewControlVisible(button)) {
+            continue;
+        }
+        const loadedImg = button.querySelector('img:not(.image-loading__placeholder)');
+        if (loadedImg instanceof HTMLImageElement && loadedImg.complete && loadedImg.naturalWidth > 0) {
+            return button;
+        }
+    }
+    return null;
+};
+`;
 
 /**
  * Mattermost 11.10+ (MM-69174) SizeAwareImage ignores clicks until the real image has
@@ -40,35 +67,19 @@ const POSTED_IMAGE_SELECTOR = [
  */
 async function waitForLoadedImagePreviewControl(serverWin: ServerView): Promise<void> {
     await expect.poll(async () => serverWin.runInRenderer<boolean>(`
+        ${PREVIEW_IMAGE_UTILS}
         const posts = Array.from(document.querySelectorAll('.post'));
         for (let index = posts.length - 1; index >= 0; index--) {
             const post = posts[index];
-            const buttons = Array.from(post.querySelectorAll('.file-preview__button'));
-            for (const button of buttons) {
-                if (!(button instanceof HTMLElement)) {
-                    continue;
-                }
-                if (window.getComputedStyle(button).display === 'none') {
-                    continue;
-                }
-                const loadedImg = button.querySelector('img:not(.image-loading__placeholder)');
-                if (!(loadedImg instanceof HTMLImageElement)) {
-                    continue;
-                }
-                if (loadedImg.complete && loadedImg.naturalWidth > 0) {
-                    button.scrollIntoView({block: 'center'});
-                    return true;
-                }
+            const previewButton = findVisibleLoadedPreviewButton(post);
+            if (previewButton) {
+                previewButton.scrollIntoView({block: 'center'});
+                return true;
             }
 
             // Legacy servers without .file-preview__button
-            const legacyImg = post.querySelector(
-                '.post-image img:not(.image-loading__placeholder), .post--attachment img:not(.image-loading__placeholder), img[src*="/api/v4/files/"]:not(.image-loading__placeholder)',
-            );
-            if (legacyImg instanceof HTMLImageElement &&
-                legacyImg.complete &&
-                legacyImg.naturalWidth > 0 &&
-                window.getComputedStyle(legacyImg).display !== 'none') {
+            const legacyImg = post.querySelector(LOADED_IMAGE_SELECTOR);
+            if (isLoadedPreviewImage(legacyImg)) {
                 legacyImg.scrollIntoView({block: 'center'});
                 return true;
             }
@@ -177,6 +188,7 @@ async function isImagePreviewOpen(serverWin: ServerView): Promise<boolean> {
 
 async function openImagePreview(serverWin: ServerView): Promise<boolean> {
     return serverWin.runInRenderer<boolean>(`
+        ${PREVIEW_IMAGE_UTILS}
         const posts = Array.from(document.querySelectorAll('.post'));
         let root = null;
         for (let index = posts.length - 1; index >= 0; index--) {
@@ -191,31 +203,19 @@ async function openImagePreview(serverWin: ServerView): Promise<boolean> {
             return false;
         }
 
-        const isVisible = (el) => el instanceof HTMLElement && window.getComputedStyle(el).display !== 'none';
-        const isLoadedImg = (el) => el instanceof HTMLImageElement &&
-            !el.classList.contains('image-loading__placeholder') &&
-            el.complete &&
-            el.naturalWidth > 0 &&
-            isVisible(el);
-
         // Prefer the visible SizeAwareImage control (11.10+/MM-69174); clicks on the
         // placeholder button are intentionally ignored until the real image loads.
-        const previewButtons = Array.from(root.querySelectorAll('.file-preview__button')).filter(isVisible);
-        for (const button of previewButtons) {
-            const loadedImg = button.querySelector('img:not(.image-loading__placeholder)');
-            if (loadedImg instanceof HTMLImageElement && loadedImg.complete && loadedImg.naturalWidth > 0) {
-                button.scrollIntoView({block: 'center', inline: 'center'});
-                button.click();
-                return true;
-            }
+        const previewButton = findVisibleLoadedPreviewButton(root);
+        if (previewButton) {
+            previewButton.scrollIntoView({block: 'center', inline: 'center'});
+            previewButton.click();
+            return true;
         }
 
         const clickTargets = [
             ...Array.from(root.querySelectorAll('[aria-label*="e2e-preview.png" i]')),
             ...Array.from(root.querySelectorAll('[aria-label*="file thumbnail" i]')),
-            ...Array.from(root.querySelectorAll('.post-image img:not(.image-loading__placeholder)')),
-            ...Array.from(root.querySelectorAll('.post--attachment img:not(.image-loading__placeholder)')),
-            ...Array.from(root.querySelectorAll('img[src*="/api/v4/files/"]:not(.image-loading__placeholder)')),
+            ...Array.from(root.querySelectorAll(LOADED_IMAGE_SELECTOR)),
             root.querySelector('.post-image .image-loaded-container'),
             root.querySelector('.post-image .small-image__container'),
             root.querySelector('.post-image__image'),
@@ -225,9 +225,10 @@ async function openImagePreview(serverWin: ServerView): Promise<boolean> {
                 return false;
             }
             if (target instanceof HTMLImageElement) {
-                return isLoadedImg(target);
+                return isLoadedPreviewImage(target);
             }
-            return isVisible(target) && Boolean(target.querySelector?.('img:not(.image-loading__placeholder)'));
+            return isPreviewControlVisible(target) &&
+                Boolean(target.querySelector?.('img:not(.image-loading__placeholder)'));
         });
 
         const target = clickTargets[0];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Fixes the hard E2E failure of **MM-T4054** (`mattermost/media_preview`) that started failing on master after CI moved from Mattermost **`11.10.0-rc1` → `11.10.0-rc2`**.

This is **not** a regression from [#3921](https://github.com/mattermost/desktop/pull/3921) (destroyed-object guards). Evidence:

| Run | Server | MM-T4054 |
|---|---|---|
| Master green (`5e585bb6`) | `11.10.0-rc1` | passed |
| PR #3921 / master after merge / unrelated #3922 | `11.10.0-rc2` | failed on all OSes |

Root causes (both required):

1. **Invalid fixture PNG** — the previous base64 PNG was rejected by Mattermost’s decoder (`png: invalid format: too much pixel data`), so no preview/thumbnail was generated.
2. **Webapp click gating in rc2** — [MM-69174 / mattermost#37420](https://github.com/mattermost/mattermost/pull/37420) makes `SizeAwareImage` ignore clicks until `state.loaded`. On rc1, clicking still opened the modal even when the image failed to decode; on rc2 it does not.

Changes in `e2e/specs/mattermost/media_preview.test.ts`:
- Replace the fixture with a valid 128×128 PNG that the server accepts (`has_preview_image: true`).
- Wait for a visible, loaded non-placeholder `.file-preview__button` before opening.
- Prefer clicking that control; never click `.image-loading__placeholder`.
- Share loaded-image selectors / visibility helpers across wait and open paths (CodeRabbit feedback).

**MM-T5891** (Windows-only on the master run) passed on #3921’s own E2E and is treated as an unrelated flake; not changed here.

#### Ticket Link
N/A — follow-up to master E2E health after #3921 / server rc2 bump.

#### Checklist
- [x] Added or updated unit tests (required for all new features) — E2E helper/fixture update only
- [ ] Has UI changes
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [ ] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [ ] executed `npm run lint:js` for proper code formatting
- [ ] Run E2E tests by adding label `E2E/Run`

#### Device Information
This PR was tested on: Linux (Cloud VM), Mattermost `11.10.0-rc2` local server, Playwright `--project=linux`

#### Screenshots
N/A (E2E-only). Local verification:

```
npx playwright test specs/mattermost/media_preview.test.ts --project=linux --workers=1 --retries=0
✓ MM-T4054 Open/Close permanent link media preview (3.4s)
1 passed
```

#### Release Note

```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e5aa7e1-81f8-4780-853f-7da671eb56c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e5aa7e1-81f8-4780-853f-7da671eb56c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Limited to a single E2E test file, adjusting only test-side fixture validity and renderer DOM synchronization/click logic for the media preview modal; no production/shared modules are modified.
**QA Recommendation:** Rely on the existing automated E2E coverage; manual QA can be skipped.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->