### PR TITLE
[MM-68968] Guard redirects and subframe navigations alongside will-navigate (#3927)

### DIFF
--- a/src/app/callsWidgetWindow.test.js
+++ b/src/app/callsWidgetWindow.test.js
@@ -593,6 +593,33 @@ describe('main/windows/callsWidgetWindow', () => {
         expect(ev.preventDefault).toHaveBeenCalledTimes(1);
     });
 
+    it('onRedirect', () => {
+        const callsWidgetWindow = new CallsWidgetWindow();
+        callsWidgetWindow.getWidgetURL = () => 'http://localhost:8065';
+
+        const mainFrameEv = {preventDefault: jest.fn(), isMainFrame: true};
+        callsWidgetWindow.onRedirect(mainFrameEv, 'https://www.google.com/');
+        expect(mainFrameEv.preventDefault).toHaveBeenCalled();
+
+        urlUtils.parseURL.mockReturnValue(new URL('https://example.com/embed'));
+        const subFrameEv = {preventDefault: jest.fn(), isMainFrame: false, url: 'https://example.com/embed'};
+        callsWidgetWindow.onRedirect(subFrameEv, subFrameEv.url);
+        expect(subFrameEv.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('onFrameNavigate', () => {
+        const callsWidgetWindow = new CallsWidgetWindow();
+
+        const mainFrameEv = {preventDefault: jest.fn(), isMainFrame: true, url: 'custom://payload'};
+        callsWidgetWindow.onFrameNavigate(mainFrameEv);
+        expect(mainFrameEv.preventDefault).not.toHaveBeenCalled();
+
+        urlUtils.parseURL.mockReturnValue(new URL('custom://payload'));
+        const subFrameEv = {preventDefault: jest.fn(), isMainFrame: false, url: 'custom://payload'};
+        callsWidgetWindow.onFrameNavigate(subFrameEv);
+        expect(subFrameEv.preventDefault).toHaveBeenCalled();
+    });
+
     describe('handleCreateCallsWidgetWindow', () => {
         const callsWidgetWindow = new CallsWidgetWindow();
         callsWidgetWindow.close = jest.fn();

--- a/src/app/callsWidgetWindow.ts
+++ b/src/app/callsWidgetWindow.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {IpcMainEvent, Rectangle, Event, IpcMainInvokeEvent} from 'electron';
+import type {IpcMainEvent, Rectangle, Event, IpcMainInvokeEvent, WebContentsWillRedirectEventParams} from 'electron';
 import {BrowserWindow, desktopCapturer, dialog, ipcMain, systemPreferences} from 'electron';
 import Joi from 'joi';
 
@@ -10,6 +10,7 @@ import NavigationManager from 'app/navigationManager';
 import TabManager from 'app/tabs/tabManager';
 import type {MattermostWebContentsView} from 'app/views/MattermostWebContentsView';
 import webContentsEventManager from 'app/views/webContentEvents';
+import {generateWillFrameNavigate} from 'app/views/webContentEventsCommon';
 import WebContentsManager from 'app/views/webContentsManager';
 import {
     BROWSER_HISTORY_PUSH,
@@ -210,6 +211,8 @@ export class CallsWidgetWindow {
         // Calls widget window is not supposed to navigate anywhere else.
         this.win.webContents.on('will-navigate', this.onNavigate);
         this.win.webContents.on('did-start-navigation', this.onNavigate);
+        this.win.webContents.on('will-redirect', this.onRedirect);
+        this.win.webContents.on('will-frame-navigate', this.onFrameNavigate);
 
         const widgetURL = this.getWidgetURL();
         if (!widgetURL) {
@@ -276,6 +279,18 @@ export class CallsWidgetWindow {
         }
         log.warn('prevented widget window from navigating');
         ev.preventDefault();
+    };
+
+    private onFrameNavigate = generateWillFrameNavigate(log);
+
+    private onRedirect = (ev: Event<WebContentsWillRedirectEventParams>, url: string) => {
+        // Unlike will-navigate, will-redirect fires for subframes as well, so each frame
+        // type needs to be evaluated against its own policy.
+        if (ev.isMainFrame) {
+            this.onNavigate(ev, url);
+        } else {
+            this.onFrameNavigate(ev);
+        }
     };
 
     private setWidgetWindowStacking = ({onTop}: {onTop: boolean}) => {

--- a/src/app/views/pluginsPopUps.test.js
+++ b/src/app/views/pluginsPopUps.test.js
@@ -86,7 +86,8 @@ describe('PluginsPopUpsManager', () => {
 
         expect(win.webContents.on).toHaveBeenNthCalledWith(1, 'will-redirect', handlers['will-redirect']);
         expect(win.webContents.on).toHaveBeenNthCalledWith(2, 'will-navigate', handlers['will-navigate']);
-        expect(win.webContents.on).toHaveBeenNthCalledWith(3, 'did-start-navigation', handlers['did-start-navigation']);
+        expect(win.webContents.on).toHaveBeenNthCalledWith(3, 'will-frame-navigate', handlers['will-frame-navigate']);
+        expect(win.webContents.on).toHaveBeenNthCalledWith(4, 'did-start-navigation', handlers['did-start-navigation']);
         expect(win.webContents.once).toHaveBeenCalledWith('render-process-gone', handlers['render-process-gone']);
         expect(win.webContents.setWindowOpenHandler).toHaveBeenCalledWith(handlers['window-open']);
 
@@ -114,6 +115,18 @@ describe('PluginsPopUpsManager', () => {
         navigateEv.url = 'http://localhost:8065';
         handlers['will-navigate'](navigateEv);
         expect(navigateEv.preventDefault).toHaveBeenCalled();
+
+        // Verify subframes can only navigate to web protocols
+        const frameEv = {
+            preventDefault: jest.fn(),
+            isMainFrame: false,
+            url: 'https://example.com/embed',
+        };
+        handlers['will-frame-navigate'](frameEv);
+        expect(frameEv.preventDefault).not.toHaveBeenCalled();
+        frameEv.url = 'custom://payload';
+        handlers['will-frame-navigate'](frameEv);
+        expect(frameEv.preventDefault).toHaveBeenCalled();
 
         navigateEv.preventDefault = jest.fn();
         navigateEv.url = 'about:blank';

--- a/src/app/views/pluginsPopUps.ts
+++ b/src/app/views/pluginsPopUps.ts
@@ -11,7 +11,7 @@ import {shell} from 'electron';
 
 import MainWindow from 'app/mainWindow/mainWindow';
 import NavigationManager from 'app/navigationManager';
-import {generateHandleConsoleMessage, isCustomProtocol} from 'app/views/webContentEventsCommon';
+import {generateHandleConsoleMessage, generateWillFrameNavigate, isCustomProtocol} from 'app/views/webContentEventsCommon';
 import WebContentsManager from 'app/views/webContentsManager';
 import {Logger} from 'common/log';
 import ServerManager from 'common/servers/serverManager';
@@ -62,6 +62,7 @@ export class PluginsPopUpsManager {
             log.warn('prevented popup window from navigating');
             ev.preventDefault();
         });
+        win.webContents.on('will-frame-navigate', generateWillFrameNavigate(log));
         win.webContents.on('did-start-navigation', (ev: Event<WebContentsDidStartNavigationEventParams>) => {
             if (ev.url === details.url) {
                 return;

--- a/src/app/views/webContentEvents.test.js
+++ b/src/app/views/webContentEvents.test.js
@@ -153,6 +153,7 @@ describe('main/views/webContentsEvents', () => {
 
             expect(contents.on).toHaveBeenCalledWith('will-navigate', expect.any(Function));
             expect(contents.on).toHaveBeenCalledWith('will-frame-navigate', expect.any(Function));
+            expect(contents.on).toHaveBeenCalledWith('will-redirect', expect.any(Function));
 
             // Distinct from will-navigate so a main-frame navigation is not processed twice.
             expect(handlers['will-frame-navigate']).not.toBe(handlers['will-navigate']);
@@ -161,6 +162,40 @@ describe('main/views/webContentsEvents', () => {
 
             expect(contents.removeListener).toHaveBeenCalledWith('will-navigate', handlers['will-navigate']);
             expect(contents.removeListener).toHaveBeenCalledWith('will-frame-navigate', handlers['will-frame-navigate']);
+            expect(contents.removeListener).toHaveBeenCalledWith('will-redirect', handlers['will-redirect']);
+        });
+
+        it('redirect guard applies the main-frame policy to main-frame redirects', () => {
+            const webContentsEventManager = new WebContentsEventManager();
+            webContentsEventManager.getServerURLFromWebContentsId = () => new URL('http://server-1.com');
+            const {handlers, contents} = setupContents();
+            webContentsEventManager.addWebContentsEventListeners(contents);
+            const willRedirect = handlers['will-redirect'];
+
+            const internalEvent = {preventDefault: jest.fn(), isMainFrame: true, url: 'http://server-1.com/subpath'};
+            willRedirect(internalEvent, internalEvent.url);
+            expect(internalEvent.preventDefault).not.toHaveBeenCalled();
+
+            const externalEvent = {preventDefault: jest.fn(), isMainFrame: true, url: 'http://someotherurl.com'};
+            willRedirect(externalEvent, externalEvent.url);
+            expect(externalEvent.preventDefault).toHaveBeenCalled();
+        });
+
+        it('redirect guard applies the subframe policy to subframe redirects', () => {
+            const webContentsEventManager = new WebContentsEventManager();
+            webContentsEventManager.getServerURLFromWebContentsId = () => new URL('http://server-1.com');
+            const {handlers, contents} = setupContents();
+            webContentsEventManager.addWebContentsEventListeners(contents);
+            const willRedirect = handlers['will-redirect'];
+
+            // External redirects are how ordinary embeds work, so they stay allowed for subframes.
+            const embedEvent = {preventDefault: jest.fn(), isMainFrame: false, url: 'https://www.youtube.com/embed/abc'};
+            willRedirect(embedEvent, embedEvent.url);
+            expect(embedEvent.preventDefault).not.toHaveBeenCalled();
+
+            const protocolEvent = {preventDefault: jest.fn(), isMainFrame: false, url: 'custom://payload'};
+            willRedirect(protocolEvent, protocolEvent.url);
+            expect(protocolEvent.preventDefault).toHaveBeenCalled();
         });
 
         it('subframe guard ignores main-frame navigations (handled by will-navigate)', () => {

--- a/src/app/views/webContentEvents.ts
+++ b/src/app/views/webContentEvents.ts
@@ -4,8 +4,8 @@
 import type {
     WebContents,
     Event,
-    WebContentsWillFrameNavigateEventParams,
     WebContentsWillNavigateEventParams,
+    WebContentsWillRedirectEventParams,
 } from 'electron';
 import {BrowserWindow, dialog, shell} from 'electron';
 
@@ -35,7 +35,7 @@ import ViewManager from 'common/views/viewManager';
 import ContextMenu from 'main/contextMenu';
 import {localizeMessage} from 'main/i18nManager';
 
-import {generateHandleConsoleMessage, isAllowedSubframeNavigation, isCustomProtocol, isMattermostProtocol} from './webContentEventsCommon';
+import {generateHandleConsoleMessage, generateWillFrameNavigate, isCustomProtocol, isMattermostProtocol} from './webContentEventsCommon';
 
 import allowProtocolDialog from '../../main/security/allowProtocolDialog';
 import {composeUserAgent} from '../../main/utils';
@@ -130,23 +130,6 @@ export class WebContentsEventManager {
             }
 
             this.log(webContentsId).info('Prevented desktop from navigating to external URL');
-            event.preventDefault();
-        };
-    };
-
-    private generateWillFrameNavigate = (webContentsId: number) => {
-        return (event: Event<WebContentsWillFrameNavigateEventParams>) => {
-            // will-frame-navigate also fires for the main frame; defer that to will-navigate
-            // so the policy (and any protocol dialog) does not run twice.
-            if (event.isMainFrame) {
-                return;
-            }
-
-            if (isAllowedSubframeNavigation(event.url)) {
-                return;
-            }
-
-            this.log(webContentsId).debug('Prevented subframe from navigating to a blocked protocol');
             event.preventDefault();
         };
     };
@@ -273,7 +256,7 @@ export class WebContentsEventManager {
                         }
                     });
                     popup.webContents.on('will-navigate', this.generateWillNavigate(popup.webContents.id));
-                    popup.webContents.on('will-frame-navigate', this.generateWillFrameNavigate(popup.webContents.id));
+                    popup.webContents.on('will-frame-navigate', generateWillFrameNavigate(this.log(popup.webContents.id)));
                     popup.webContents.setWindowOpenHandler(this.denyNewWindow);
                     popup.once('closed', () => {
                         if (this.popupWindow?.contextMenu) {
@@ -329,9 +312,21 @@ export class WebContentsEventManager {
         }
 
         const willNavigate = this.generateWillNavigate(contents.id);
-        const willFrameNavigate = this.generateWillFrameNavigate(contents.id);
+        const willFrameNavigate = generateWillFrameNavigate(this.log(contents.id));
+
+        // Unlike will-navigate, will-redirect fires for subframes as well, so each frame
+        // type needs to be evaluated against its own policy.
+        const willRedirect = (event: Event<WebContentsWillRedirectEventParams>, url?: string) => {
+            if (event.isMainFrame) {
+                willNavigate(event, url);
+            } else {
+                willFrameNavigate(event);
+            }
+        };
+
         contents.on('will-navigate', willNavigate);
         contents.on('will-frame-navigate', willFrameNavigate);
+        contents.on('will-redirect', willRedirect);
 
         const spellcheck = Config.useSpellChecker;
         const newWindow = this.generateNewWindowListener(contents.id, spellcheck);
@@ -350,6 +345,7 @@ export class WebContentsEventManager {
             try {
                 contents.removeListener('will-navigate', willNavigate);
                 contents.removeListener('will-frame-navigate', willFrameNavigate);
+                contents.removeListener('will-redirect', willRedirect);
                 contents.removeListener('console-message', consoleMessage);
                 removeListeners?.(contents);
             } catch (e) {

--- a/src/app/views/webContentEventsCommon.test.ts
+++ b/src/app/views/webContentEventsCommon.test.ts
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {Event, WebContentsConsoleMessageEventParams} from 'electron';
+import type {Event, WebContentsConsoleMessageEventParams, WebContentsWillFrameNavigateEventParams} from 'electron';
 
 import type {Logger} from 'common/log';
 import {getLevel} from 'common/log';
 import {parseURL} from 'common/utils/url';
 
-import {generateHandleConsoleMessage, isAllowedSubframeNavigation, isCustomProtocol, isMattermostProtocol} from './webContentEventsCommon';
+import {generateHandleConsoleMessage, generateWillFrameNavigate, isAllowedSubframeNavigation, isCustomProtocol, isMattermostProtocol} from './webContentEventsCommon';
 
 // Mock the electron-builder.json protocols
 jest.mock('common/constants', () => ({
@@ -47,6 +47,7 @@ describe('webContentEventsCommon', () => {
 
         mockLogger = {
             withPrefix: jest.fn().mockReturnValue(mockWcLog),
+            debug: jest.fn(),
         } as any;
     });
 
@@ -304,6 +305,42 @@ describe('webContentEventsCommon', () => {
         it('blocks unparseable URLs', () => {
             mockParseURL.mockReturnValue(undefined);
             expect(isAllowedSubframeNavigation('::::not a url')).toBe(false);
+        });
+    });
+
+    describe('generateWillFrameNavigate', () => {
+        beforeEach(() => {
+            mockParseURL.mockImplementation((input: string | URL) => {
+                try {
+                    return new URL(input as string);
+                } catch {
+                    return undefined;
+                }
+            });
+        });
+
+        const generateEvent = (url: string, isMainFrame: boolean) => ({
+            preventDefault: jest.fn(),
+            isMainFrame,
+            url,
+        } as unknown as Event<WebContentsWillFrameNavigateEventParams>);
+
+        it('should ignore main frame navigations', () => {
+            const event = generateEvent('custom://payload', true);
+            generateWillFrameNavigate(mockLogger)(event);
+            expect(event.preventDefault).not.toHaveBeenCalled();
+        });
+
+        it('should allow subframes to navigate to web protocols', () => {
+            const event = generateEvent('https://www.youtube.com/embed/abc', false);
+            generateWillFrameNavigate(mockLogger)(event);
+            expect(event.preventDefault).not.toHaveBeenCalled();
+        });
+
+        it('should prevent subframes from navigating to other protocols', () => {
+            const event = generateEvent('custom://payload', false);
+            generateWillFrameNavigate(mockLogger)(event);
+            expect(event.preventDefault).toHaveBeenCalled();
         });
     });
 

--- a/src/app/views/webContentEventsCommon.ts
+++ b/src/app/views/webContentEventsCommon.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 import path from 'path';
 
-import type {Event, WebContentsConsoleMessageEventParams} from 'electron';
+import type {Event, WebContentsConsoleMessageEventParams, WebContentsWillFrameNavigateEventParams} from 'electron';
 
 import {MATTERMOST_PROTOCOL} from 'common/constants';
 import type {Logger} from 'common/log';
@@ -66,3 +66,18 @@ export function isAllowedSubframeNavigation(rawURL?: string): boolean {
 export function isMattermostProtocol(url: URL) {
     return url.protocol === `${MATTERMOST_PROTOCOL}:`;
 }
+
+export const generateWillFrameNavigate = (log: Logger) => (event: Event<WebContentsWillFrameNavigateEventParams>) => {
+    // will-frame-navigate also fires for the main frame; defer that to will-navigate
+    // so the policy (and any protocol dialog) does not run twice.
+    if (event.isMainFrame) {
+        return;
+    }
+
+    if (isAllowedSubframeNavigation(event.url)) {
+        return;
+    }
+
+    log.debug('Prevented subframe from navigating to a blocked protocol');
+    event.preventDefault();
+};


### PR DESCRIPTION
Cherry-pick of #3927 to `release-6.2`

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Navigation behavior changes across multiple web contents and popup modules. Automated tests cover main-frame and subframe redirects, which limits regression risk.

**QA Recommendation:** Skip manual QA. Automated coverage is sufficient for this isolated navigation change.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->