### PR TITLE
Automated cherry pick of #3930

### DIFF
--- a/e2e/helpers/config.ts
+++ b/e2e/helpers/config.ts
@@ -39,7 +39,7 @@ export const appDir = path.join(sourceRootDir, 'e2e/dist');
 
 export const mattermostURL = process.env.MM_TEST_SERVER_URL ?? 'http://localhost:8065/';
 
-export const exampleURL = 'http://example.com/';
+export const exampleURL = 'https://example.com/';
 
 export const cmdOrCtrl = process.platform === 'darwin' ? 'command' : 'control';
 

--- a/e2e/specs/server_management/bad_servers.test.ts
+++ b/e2e/specs/server_management/bad_servers.test.ts
@@ -17,7 +17,7 @@ import {buildServerMap} from '../../helpers/serverMap';
 const UNREACHABLE_SERVER_URL = 'https://jhsgefhjsaeiuofhseifuphoauifdhjauiowijdfcpohuawoiudfjpdhauwodjahwdpojaoiwdhawhdiuawd.com';
 const EXPIRED_CERT_URL = 'https://expired.badssl.com';
 const TLS_1_0_URL = 'https://tls-v1-0.badssl.com:1010';
-const TLS_1_1_URL = 'https://tls-v1-1.badssl.com';
+const TLS_1_1_URL = 'https://tls-v1-1.badssl.com:1011';
 const RC4_CIPHER_URL = 'https://rc4.badssl.com';
 const INSECURE_TLS_ERROR_PATTERN = /ERR_SSL_(VERSION_OR_CIPHER_MISMATCH|PROTOCOL_ERROR|OBSOLETE_CIPHER)|ERR_CONNECTION_RESET|ERR_ABORTED/;
 

--- a/e2e/specs/server_management/drag_and_drop.test.ts
+++ b/e2e/specs/server_management/drag_and_drop.test.ts
@@ -26,7 +26,7 @@ const config = {
         ...demoMattermostConfig.servers,
         {
             name: 'google',
-            url: 'https://google.com/',
+            url: 'https://www.google.com/',
             order: 2,
         },
     ],


### PR DESCRIPTION
Cherry pick of #3930 on release-6.3.

/cc  @cursor[bot]

```release-note
NONE
```