### PR TITLE
ci(cmt): backport macos Bash 3.2 fix + drop legacy runner remap

### DIFF
--- a/.github/workflows/compatibility-matrix-testing.yml
+++ b/.github/workflows/compatibility-matrix-testing.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       DESKTOP_SHA: ${{ steps.repo.outputs.DESKTOP_SHA }}
-      CMT_MATRIX: ${{ steps.normalize-matrix.outputs.matrix }}
+      CMT_MATRIX: ${{ steps.matrix.outputs.matrix }}
       TSIO_COMPOSITE_IDENTITY: ${{ steps.tsio-identity.outputs.composite-identity-json }}
       TSIO_TOTAL_REPORTS_EXPECTED: ${{ steps.tsio-identity.outputs.total-reports-expected }}
     steps:
@@ -55,20 +55,13 @@ jobs:
         id: repo
         run: echo "DESKTOP_SHA=$(git rev-parse HEAD)" >> ${GITHUB_OUTPUT}
 
-      # Matterwick still dispatches ubuntu-22.04 for Linux; pin to ubuntu-latest so
-      # CMT matches PR E2E (24.04) and install-os-dependencies can resolve
-      # libasound2t64. Same idea as e2e-functional.yml remapping macos-latest → macos-26.
-      - name: cmt/normalize-matrix-runners
-        id: normalize-matrix
+      # Matterwick (≥ v0.4.16) sends the runners we run on: ubuntu-latest,
+      # macos-26, windows-2022. Pass the matrix through as-is.
+      - name: cmt/set-matrix
+        id: matrix
         env:
           CMT_MATRIX: ${{ inputs.CMT_MATRIX }}
-        run: |
-          NORMALIZED=$(echo "${CMT_MATRIX}" | jq -c '
-            .environment |= map(
-              if .runner == "ubuntu-22.04" then .runner = "ubuntu-latest" else . end
-            )
-          ')
-          echo "matrix=${NORMALIZED}" >> "$GITHUB_OUTPUT"
+        run: echo "matrix=${CMT_MATRIX}" >> "$GITHUB_OUTPUT"
 
       # One composite identity + total-reports-expected for the WHOLE CMT run
       # (every OS x server-version leg), computed once here and threaded into
@@ -79,7 +72,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           MM_SHA: ${{ steps.repo.outputs.DESKTOP_SHA }}
           MM_BRANCH: ${{ inputs.DESKTOP_VERSION }}
-          CMT_MATRIX: ${{ steps.normalize-matrix.outputs.matrix }}
+          CMT_MATRIX: ${{ steps.matrix.outputs.matrix }}
         run: |
           TOTAL=$(echo "${CMT_MATRIX}" | jq -c '(.environment | length) * (.server | length)')
           echo "total-reports-expected=${TOTAL}" >> "$GITHUB_OUTPUT"
@@ -114,17 +107,16 @@ jobs:
           description: "Compatibility Matrix Testing for ${{ inputs.DESKTOP_VERSION }} version"
           status: pending
 
-  # Input follows the below schema (Matterwick may still send ubuntu-22.04;
-  # calculate-commit-hash remaps Linux to ubuntu-latest before the e2e matrix).
+  # Input follows the below schema (Matterwick ≥ v0.4.16).
   # {
   #   "environment": [
   #     {
   #       "os": "linux",
-  #       "runner": "ubuntu-22.04"
+  #       "runner": "ubuntu-latest"
   #     },
   #     {
   #       "os": "macos",
-  #       "runner": "macos-13"
+  #       "runner": "macos-26"
   #     },
   #     {
   #       "os": "windows",

--- a/.github/workflows/e2e-functional-template.yml
+++ b/.github/workflows/e2e-functional-template.yml
@@ -103,8 +103,8 @@ env:
 jobs:
   e2e:
     # Includes MM_SERVER_VERSION, not just runs-on: CMT tests multiple server
-    # versions against the same runner (e.g. macos-13 x 9.6.1 and macos-13 x
-    # 9.5.2)
+    # versions against the same runner (e.g. macos-26 x 11.9.0 and macos-26 x
+    # 11.8.4).
     name: e2e-on-${{ inputs.runs-on }}-${{ inputs.MM_SERVER_VERSION }}
     runs-on: ${{ inputs.runs-on }}
     permissions:
@@ -137,7 +137,9 @@ jobs:
                 echo "BUILD_SUFFIX=desktop-release-${RUNNER_OS}" >> $GITHUB_OUTPUT
                 echo "TYPE=${INPUT_TYPE:-CMT}" >> $GITHUB_ENV
                 echo "ZEPHYR_ENABLE=true" >> $GITHUB_ENV
-                echo "ZEPHYR_FOLDER_${RUNNER_OS^^}_REPORT=${{
+                # Use tr, not ${var^^} — macOS runners ship Bash 3.2 which rejects ^^.
+                RUNNER_OS_UPPER=$(echo "${RUNNER_OS}" | tr '[:lower:]' '[:upper:]')
+                echo "ZEPHYR_FOLDER_${RUNNER_OS_UPPER}_REPORT=${{
                   runner.os == 'Linux' && '12358649' ||
                   runner.os == 'macOS' && '12358650' ||
                   '12358651'


### PR DESCRIPTION
## Summary
Manual backport to `release-6.3` after automated `/cherry-pick` of #3920 conflicted.

CMT on `v6.3.0-rc.3` ([run 30788534920](https://github.com/mattermost/desktop/actions/runs/30788534920)) put every macOS leg on `macos-26` (Matterwick `v0.4.16+` is fine) but all five failed immediately in `e2e/set-required-variables`:

```text
ZEPHYR_FOLDER_${RUNNER_OS^^}_REPORT=...: bad substitution
```

macOS runners ship Bash 3.2, which rejects `${var^^}`.

### What this PR includes
| Source | What | Why |
|---|---|---|
| **#3902** (partial) | `RUNNER_OS_UPPER=$(… \| tr …)` instead of `${RUNNER_OS^^}` | **Required** — unblocks CMT macOS legs |
| **#3920** | Drop `cmt/normalize-matrix-runners`; pass Matterwick matrix through; update schema comments to `ubuntu-latest` / `macos-26` | Aligns with Matterwick ≥ `v0.4.16` (already sends those runners) |

### What this PR deliberately does **not** cherry-pick
Full **#3902** (release-channel notify, TSIO pin bumps, BUILD_SUFFIX renames, e2e helper/test changes) — not needed to fix this CMT failure and would widen conflict/risk on `release-6.3`.

## Test plan
- [ ] Merge to `release-6.3`
- [ ] Manually run **CMT Provisioner** on `release-6.3` (or re-cut / re-dispatch CMT for the 6.3 RC line)
- [ ] Confirm macOS jobs get past `e2e/set-required-variables` (no `bad substitution`)
- [ ] Confirm matrix legs use `macos-26` / `ubuntu-latest` / `windows-2022`

```release-note
NONE
```

Made with [Cursor](https://cursor.com)