### PR TITLE
Fix issue with validation where local HTTP servers will fail to validate

### DIFF
--- a/src/app/serverHub.test.js
+++ b/src/app/serverHub.test.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {session} from 'electron';
+
 import MainWindow from 'app/mainWindow/mainWindow';
 import ModalManager from 'app/mainWindow/modals/modalManager';
 import {MattermostServer} from 'common/servers/MattermostServer';
@@ -26,6 +28,7 @@ jest.mock('electron', () => ({
             allowNTLMCredentialsForDomains: jest.fn(),
             clearData: jest.fn(),
         },
+        fromPartition: jest.fn(),
     },
 }));
 
@@ -282,8 +285,10 @@ describe('app/serverViewState', () => {
 
     describe('handleServerURLValidation', () => {
         const serverViewState = new ServerHub();
+        const validationSession = {id: 'validation-session'};
 
         beforeEach(() => {
+            session.fromPartition.mockReturnValue(validationSession);
             MattermostServer.mockImplementation(({url}) => ({url}));
             ServerInfo.mockImplementation(({url}) => ({
                 pingServer: jest.fn().mockImplementation(() => ({
@@ -315,6 +320,22 @@ describe('app/serverViewState', () => {
             const result = await serverViewState.handleServerURLValidation({}, 'server.com');
             expect(result.status).toBe(URLValidationStatus.OK);
             expect(result.validatedURL).toBe('https://server.com/');
+        });
+
+        it('should test the server on a separate session', async () => {
+            const pingServer = jest.fn();
+            const fetchConfigData = jest.fn().mockReturnValue({
+                serverVersion: '7.8.0',
+                siteName: 'Mattermost',
+                siteURL: 'https://server.com/',
+            });
+            ServerInfo.mockImplementation(() => ({pingServer, fetchConfigData}));
+
+            await serverViewState.handleServerURLValidation({}, 'https://server.com');
+
+            expect(session.fromPartition).toHaveBeenCalledWith('server-validation');
+            expect(pingServer).toHaveBeenCalledWith(validationSession);
+            expect(fetchConfigData).toHaveBeenCalledWith(validationSession);
         });
 
         it('should correct typos in the protocol', async () => {

--- a/src/app/serverHub.ts
+++ b/src/app/serverHub.ts
@@ -455,10 +455,10 @@ export class ServerHub {
         const serverInfo = new ServerInfo(server);
         try {
             // Ping server first for pre-auth - config endpoint might be whitelisted
-            await serverInfo.pingServer();
+            await serverInfo.pingServer(session.fromPartition('server-validation'));
 
             // Only proceed to fetch config if ping is successful
-            const remoteInfo = await serverInfo.fetchConfigData();
+            const remoteInfo = await serverInfo.fetchConfigData(session.fromPartition('server-validation'));
             return {data: remoteInfo};
         } catch (error) {
             return {error: error as Error & { errorReason?: ErrorReason }};

--- a/src/main/app/initialize.test.js
+++ b/src/main/app/initialize.test.js
@@ -74,6 +74,7 @@ jest.mock('electron', () => ({
             on: jest.fn(),
             allowNTLMCredentialsForDomains: jest.fn(),
         },
+        fromPartition: jest.fn(),
     },
     protocol: {
         registerSchemesAsPrivileged: jest.fn(),
@@ -268,6 +269,16 @@ describe('main/app/initialize', () => {
         app.whenReady.mockResolvedValue();
         app.requestSingleInstanceLock.mockReturnValue(true);
         app.getPath.mockImplementation((p) => `/basedir/${p}`);
+        session.fromPartition.mockImplementation((partition) => {
+            if (partition === 'server-validation') {
+                return {
+                    webRequest: {
+                        onHeadersReceived: jest.fn(),
+                    },
+                };
+            }
+            return session.defaultSession;
+        });
     });
 
     afterEach(() => {

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -374,7 +374,13 @@ async function initializeAfterAppReady() {
     });
 
     // Attach this to the server-validation session to handle pre-auth headers for server validation as well
-    session.fromPartition('server-validation').webRequest.onHeadersReceived(PreAuthManager.preAuthHeaderOnHeadersReceivedHander);
+    session.fromPartition('server-validation').webRequest.onHeadersReceived((details, callback) => {
+        if (PreAuthManager.preAuthHeaderOnHeadersReceivedHander(details, callback)) {
+            return;
+        }
+
+        callback({});
+    });
 
     defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
         try {

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -373,6 +373,9 @@ async function initializeAfterAppReady() {
         downloadsManager.webRequestOnHeadersReceivedHandler(details, callback);
     });
 
+    // Attach this to the server-validation session to handle pre-auth headers for server validation as well
+    session.fromPartition('server-validation').webRequest.onHeadersReceived(PreAuthManager.preAuthHeaderOnHeadersReceivedHander);
+
     defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
         try {
             callback({

--- a/src/main/server/serverAPI.ts
+++ b/src/main/server/serverAPI.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {Session} from 'electron';
 import {net, session} from 'electron';
 
 import {COOKIE_NAME_AUTH_TOKEN, COOKIE_NAME_CSRF, COOKIE_NAME_USER_ID} from 'common/constants';
@@ -16,9 +17,10 @@ export async function getServerAPI(
     onSuccess?: (raw: string) => void,
     onAbort?: () => void,
     onError?: (error: Error, errorReason?: ErrorReason) => void,
+    requestSession: Session = session.defaultSession,
 ) {
     if (isAuthenticated) {
-        const cookies = await session.defaultSession.cookies.get({});
+        const cookies = await requestSession.cookies.get({});
         if (!cookies) {
             log.error('Cannot authenticate, no cookies present');
             return;
@@ -40,7 +42,7 @@ export async function getServerAPI(
 
     const req = net.request({
         url: url.toString(),
-        session: session.defaultSession,
+        session: requestSession,
         useSessionCookies: true,
     });
 

--- a/src/main/server/serverInfo.test.js
+++ b/src/main/server/serverInfo.test.js
@@ -30,6 +30,30 @@ describe('main/server/serverInfo', () => {
             expect(callback).toHaveBeenCalledWith(testData);
         });
 
+        it('should pass the provided session along with the request', async () => {
+            const requestSession = {id: 'validation-session'};
+
+            await serverInfo.pingServer(requestSession);
+            expect(getServerAPI).toHaveBeenLastCalledWith(
+                expect.anything(),
+                false,
+                expect.any(Function),
+                expect.any(Function),
+                expect.any(Function),
+                requestSession,
+            );
+
+            await serverInfo.fetchConfigData(requestSession);
+            expect(getServerAPI).toHaveBeenLastCalledWith(
+                expect.anything(),
+                false,
+                expect.any(Function),
+                expect.any(Function),
+                expect.any(Function),
+                requestSession,
+            );
+        });
+
         it('should reject when URL is missing', async () => {
             await expect(serverInfo.getRemoteInfo(callback)).rejects.toThrow();
             expect(callback).not.toHaveBeenCalled();

--- a/src/main/server/serverInfo.ts
+++ b/src/main/server/serverInfo.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {Session} from 'electron';
+
 import type {MattermostServer} from 'common/servers/MattermostServer';
 import {parseURL} from 'common/utils/url';
 
@@ -18,17 +20,19 @@ export class ServerInfo {
         this.remoteInfo = {};
     }
 
-    pingServer = async () => {
+    pingServer = async (session?: Session) => {
         await this.getRemoteInfo<{status: string}>(
             () => {}, // No callback needed for ping, just checking if it responds
             parseURL(`${this.server.url}/api/v4/system/ping`),
+            session,
         );
     };
 
-    fetchConfigData = async () => {
+    fetchConfigData = async (session?: Session) => {
         await this.getRemoteInfo<ClientConfig>(
             this.onGetConfig,
             parseURL(`${this.server.url}/api/v4/config/client?format=old`),
+            session,
         );
 
         return this.remoteInfo;
@@ -57,6 +61,7 @@ export class ServerInfo {
     private getRemoteInfo = <T>(
         callback: (data: T) => void,
         url?: URL,
+        session?: Session,
     ) => {
         if (!url) {
             return Promise.reject(new Error('Malformed URL'));
@@ -79,7 +84,9 @@ export class ServerInfo {
                     const enhancedError = error as Error & { errorReason?: {needsBasicAuth?: boolean; needsPreAuth?: boolean} };
                     enhancedError.errorReason = errorReason;
                     reject(enhancedError);
-                });
+                },
+                session,
+            );
         });
     };
 


### PR DESCRIPTION
#### Summary
The local network request policy on the default session cancels requests to local or private addresses that aren't a configured server, so validating a not-yet-added server on `localhost` or a private IP had its probes blocked and came back as not a Mattermost server.

This PR runs the validation ping and config requests on a dedicated `server-validation` session, which the policy isn't registered on. Server views still use the default session, so the policy continues to apply to server content.

#### Release Note
```release-note
Fixed an issue where adding a Mattermost server on the local network, such as localhost or a private IP address, would fail to validate.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change spans server validation, session management, authentication headers, and shared API code. Automated tests cover the new session flow, but session-related regressions remain possible.

**QA Recommendation:** Manual QA can be skipped because automated coverage is complete and rollback is straightforward.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->