### PR TITLE
ci(cmt): backport RC-tag trigger and macOS Bash 3.2 fix to release-6.2

### DIFF
--- a/.github/workflows/cmt-provisioner.yml
+++ b/.github/workflows/cmt-provisioner.yml
@@ -1,29 +1,34 @@
 name: CMT Provisioner
 
-# This is a stub workflow. Its only purpose is to fire a workflow_run webhook
-# to Matterwick, which provisions cloud servers for each server version and
-# then dispatches compatibility-matrix-testing.yml with the CMT_MATRIX input.
+# Lightweight trigger workflow for Compatibility Matrix Testing (CMT).
 #
-# Usage: Go to Actions → CMT Provisioner → Run workflow
-#   server_versions: comma-separated Mattermost server versions
-#   Example: "v11.1.0, v11.2.0, v12.0.0"
+# Matterwick listens for this workflow's workflow_run:requested event, then provisions one
+# Mattermost cloud instance per version in its CMT version set (auto-derived from Mattermost
+# releases, with `CMTServerVersions` in matterwick config as a manual override) and dispatches
+# compatibility-matrix-testing.yml with the CMT_MATRIX input. When that test workflow completes,
+# Matterwick destroys the provisioned instances (cleanup is keyed off the completed
+# workflow_run, matched by commit SHA).
+#
+# Triggers: an RC tag cut (e.g. `v6.2.0-rc.1`), or a manual run from the Actions tab. The tag
+# glob filters out GA tags (`v6.2.0`) and non-RC pre-releases at the GitHub layer; matterwick
+# re-validates with a strict regex (`shouldTriggerCMT` / `isRCTag`) as defense-in-depth.
 
 on:
-  workflow_dispatch:
-    inputs:
-      server_versions:
-        description: "Comma-separated Mattermost server versions (e.g. v11.1.0, v11.2.0)"
-        required: true
-        type: string
+  # RC tag cut. Glob matches the `vX.Y.Z-rc.N` convention; matterwick re-validates strictly.
+  push:
+    tags:
+      - "v[0-9]*.[0-9]*.[0-9]*-rc.[0-9]*"
+  # Manual runs from the Actions tab (any ref).
+  workflow_dispatch: {}
+
+permissions: {}
 
 jobs:
-  notify:
+  trigger-matterwick:
     runs-on: ubuntu-22.04
     steps:
-      - name: Log CMT request
-        env:
-          SERVER_VERSIONS: ${{ inputs.server_versions }}
+      - name: Signal Matterwick to provision CMT servers
         run: |
-          echo "CMT Provisioner triggered"
-          echo "Server versions: ${SERVER_VERSIONS}"
-          echo "Matterwick will provision cloud instances and dispatch compatibility-matrix-testing.yml"
+          echo "CMT trigger started for ref: ${GITHUB_REF}"
+          echo "Matterwick provisions one server per configured version and then"
+          echo "dispatches compatibility-matrix-testing.yml automatically."

--- a/.github/workflows/compatibility-matrix-testing.yml
+++ b/.github/workflows/compatibility-matrix-testing.yml
@@ -60,16 +60,16 @@ jobs:
           description: "Compatibility Matrix Testing for ${{ inputs.DESKTOP_VERSION }} version"
           status: pending
 
-  # Input follows the below schema
+  # Input follows the below schema (Matterwick ≥ v0.4.16).
   # {
   #   "environment": [
   #     {
   #       "os": "linux",
-  #       "runner": "ubuntu-22.04"
+  #       "runner": "ubuntu-latest"
   #     },
   #     {
   #       "os": "macos",
-  #       "runner": "macos-13"
+  #       "runner": "macos-26"
   #     },
   #     {
   #       "os": "windows",
@@ -78,12 +78,12 @@ jobs:
   #   ],
   #   "server": [
   #     {
-  #       "version": "9.6.1",
-  #       "url": "https://delivery-cmt-8467830017-9-6-1.test.mattermost.cloud/"
+  #       "version": "11.9.0",
+  #       "url": "https://delivery-cmt-8467830017-11-9-0.test.mattermost.cloud/"
   #     },
   #     {
-  #       "version": "9.5.2",
-  #       "url": "https://delivery-cmt-8467830017-9-5-2.test.mattermost.cloud/"
+  #       "version": "11.8.4",
+  #       "url": "https://delivery-cmt-8467830017-11-8-4.test.mattermost.cloud/"
   #     }
   #   ]
   # }

--- a/.github/workflows/e2e-functional-template.yml
+++ b/.github/workflows/e2e-functional-template.yml
@@ -166,7 +166,9 @@ jobs:
                 echo "BUILD_SUFFIX=desktop-release-${RUNNER_OS}" >> $GITHUB_OUTPUT
                 echo "TYPE=${INPUT_TYPE:-CMT}" >> $GITHUB_ENV
                 echo "ZEPHYR_ENABLE=true" >> $GITHUB_ENV
-                echo "ZEPHYR_FOLDER_${RUNNER_OS^^}_REPORT=${{
+                # Use tr, not ${var^^} — macOS runners ship Bash 3.2 which rejects ^^.
+                RUNNER_OS_UPPER=$(echo "${RUNNER_OS}" | tr '[:lower:]' '[:upper:]')
+                echo "ZEPHYR_FOLDER_${RUNNER_OS_UPPER}_REPORT=${{
                   runner.os == 'Linux' && '12358649' ||
                   runner.os == 'macOS' && '12358650' ||
                   '12358651'


### PR DESCRIPTION
release-6.2 CMT Provisioner only had workflow_dispatch (no RC tag push), so v6.2.3-rc.* never auto-triggered Matterwick. Port the RC-tag trigger from #3846, the Bash 3.2 Zephyr env fix needed for macos-26 CMT legs, and update matrix schema comments for Matterwick ≥ v0.4.16 (#3920). Automated cherry-picks conflicted; same approach as #3934 on release-6.3.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/desktop/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [ ] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [ ] executed `npm run lint:js` for proper code formatting
- [ ] Run E2E tests by adding label `E2E/Run`

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
