### PR TITLE
Cherry-pick of #3945 to release-6.2

### DIFF
--- a/.github/workflows/compatibility-matrix-testing.yml
+++ b/.github/workflows/compatibility-matrix-testing.yml
@@ -60,6 +60,32 @@ jobs:
           description: "Compatibility Matrix Testing for ${{ inputs.DESKTOP_VERSION }} version"
           status: pending
 
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        continue-on-error: true
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            e2e/utils/github-actions.js
+          sparse-checkout-cone-mode: false
+
+      - name: Post pending e2e/linux|macos|windows
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        continue-on-error: true
+        env:
+          DESKTOP_SHA: ${{ needs.calculate-commit-hash.outputs.DESKTOP_SHA }}
+          CMT_MATRIX: ${{ inputs.CMT_MATRIX }}
+        with:
+          script: |
+            const {updateInitialOsStatuses} = require('./e2e/utils/github-actions.js');
+            const matrix = JSON.parse(process.env.CMT_MATRIX || '{}');
+            const platforms = (matrix.environment || []).map((env) => ({platform: env.os, runner: env.runner}));
+            await updateInitialOsStatuses({
+              github,
+              context,
+              sha: process.env.DESKTOP_SHA,
+              platforms,
+            });
+
   # Input follows the below schema (Matterwick ≥ v0.4.16).
   # {
   #   "environment": [
@@ -123,6 +149,32 @@ jobs:
           description: "Compatibility Matrix Testing for ${{ inputs.DESKTOP_VERSION }} version"
           status: failure
 
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        continue-on-error: true
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            e2e/utils/github-actions.js
+          sparse-checkout-cone-mode: false
+
+      - name: Flip e2e/linux|macos|windows from CMT job results
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        continue-on-error: true
+        env:
+          DESKTOP_SHA: ${{ needs.calculate-commit-hash.outputs.DESKTOP_SHA }}
+          CMT_MATRIX: ${{ inputs.CMT_MATRIX }}
+        with:
+          script: |
+            const {updateCmtOsStatusesFromWorkflowJobs} = require('./e2e/utils/github-actions.js');
+            const matrix = JSON.parse(process.env.CMT_MATRIX || '{}');
+            const platforms = (matrix.environment || []).map((env) => ({platform: env.os, runner: env.runner}));
+            await updateCmtOsStatusesFromWorkflowJobs({
+              github,
+              context,
+              sha: process.env.DESKTOP_SHA,
+              platforms,
+            });
+
   # https://mattermost.atlassian.net/browse/CLD-5815
   update-success-final-status:
     runs-on: ubuntu-22.04
@@ -140,6 +192,32 @@ jobs:
           context: e2e/compatibility-matrix-testing
           description: "Compatibility Matrix Testing for ${{ inputs.DESKTOP_VERSION }} version"
           status: success
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        continue-on-error: true
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            e2e/utils/github-actions.js
+          sparse-checkout-cone-mode: false
+
+      - name: Flip e2e/linux|macos|windows from CMT job results
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        continue-on-error: true
+        env:
+          DESKTOP_SHA: ${{ needs.calculate-commit-hash.outputs.DESKTOP_SHA }}
+          CMT_MATRIX: ${{ inputs.CMT_MATRIX }}
+        with:
+          script: |
+            const {updateCmtOsStatusesFromWorkflowJobs} = require('./e2e/utils/github-actions.js');
+            const matrix = JSON.parse(process.env.CMT_MATRIX || '{}');
+            const platforms = (matrix.environment || []).map((env) => ({platform: env.os, runner: env.runner}));
+            await updateCmtOsStatusesFromWorkflowJobs({
+              github,
+              context,
+              sha: process.env.DESKTOP_SHA,
+              platforms,
+            });
 
   cleanup-cmt-instances:
     runs-on: ubuntu-22.04

--- a/.github/workflows/e2e-functional.yml
+++ b/.github/workflows/e2e-functional.yml
@@ -50,8 +50,36 @@ jobs:
       platforms: ${{ steps.generate.outputs.platforms }}
     steps:
       - id: generate
+        env:
+          INSTANCE_DETAILS: ${{ inputs.instance_details }}
         run: |
-          echo "platforms=$(echo '${{ inputs.instance_details }}' | jq -c)" >> $GITHUB_OUTPUT
+          # Matterwick still dispatches macos-latest; pin explicitly so the job
+          # does not drift when GitHub retargets that label to macOS 26.
+          # Normalize platform to canonical linux|macos|windows (derive from runner
+          # when needed) so job names and e2e/<os> statuses stay consistent.
+          platforms=$(echo "${INSTANCE_DETAILS}" | jq -c '
+            map(
+              (if .runner == "macos-latest" then .runner = "macos-26" else . end) |
+              . as $row |
+              ($row.platform // $row.os // "") as $raw |
+              (
+                if $raw == "linux" or $raw == "macos" or $raw == "windows" then $raw
+                elif (($row.runner // "") | test("^(ubuntu|linux)")) then "linux"
+                elif (($row.runner // "") | test("^(macos|darwin)")) then "macos"
+                elif (($row.runner // "") | test("^windows")) then "windows"
+                else null
+                end
+              ) as $canon |
+              if $canon == null then empty
+              else ($row | .platform = $canon | del(.os))
+              end
+            )
+          ')
+          if [ "$(echo "${platforms}" | jq 'length')" -eq 0 ]; then
+            echo "No supported platforms in instance_details (need linux|macos|windows)" >&2
+            exit 1
+          fi
+          echo "platforms=${platforms}" >> "$GITHUB_OUTPUT"
 
   update-initial-status:
     name: Update initial status

--- a/e2e/utils/github-actions.js
+++ b/e2e/utils/github-actions.js
@@ -67,6 +67,37 @@ function summarizeCmtJobsByOs(jobs, expectedOs) {
 }
 
 /**
+ * Commit-status payload for one CMT OS bucket.
+ *
+ * @param {{failed: boolean, seen: boolean}} row
+ * @param {string} os
+ * @returns {{state: 'success'|'failure', description: string}}
+ */
+function cmtOsCommitStatus(row, os) {
+    if (row.seen === false) {
+        return {state: 'failure', description: `E2E incomplete — no ${os} CMT jobs`};
+    }
+    if (row.failed) {
+        return {state: 'failure', description: `E2E failed on ${os}`};
+    }
+    return {state: 'success', description: `E2E passed on ${os}`};
+}
+
+const PLAYWRIGHT_PROJECT_BY_OS = {
+    linux: 'linux',
+    macos: 'darwin',
+    windows: 'win32',
+};
+
+/**
+ * @param {'linux'|'macos'|'windows'|null} os
+ * @returns {string}
+ */
+function playwrightProjectForOs(os) {
+    return PLAYWRIGHT_PROJECT_BY_OS[os] || 'linux';
+}
+
+/**
  * Post pending e2e/<os> statuses for this run.
  *
  * @param {Object} params
@@ -145,13 +176,7 @@ async function updateCmtOsStatusesFromWorkflowJobs({github, context, sha, platfo
 
     const byOs = summarizeCmtJobsByOs(jobs, expectedOs);
     await Promise.all(expectedOs.map((os) => {
-        const row = byOs[os];
-        const state = !row.seen || row.failed ? 'failure' : 'success';
-        const description = !row.seen ?
-            `E2E incomplete — no ${os} CMT jobs` :
-            row.failed ?
-                `E2E failed on ${os}` :
-                `E2E passed on ${os}`;
+        const {state, description} = cmtOsCommitStatus(byOs[os], os);
         return github.rest.repos.createCommitStatus({
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -197,7 +222,7 @@ async function updateFinalStatus({github, context, platforms, outputs, mergedRep
     await Promise.all(platforms.map((platform) => {
         const os = canonicalizeOs(platform.platform || platform.os, platform.runner);
         const osKey = os ? os.toUpperCase() : 'WINDOWS';
-        const playwrightProject = os === 'macos' ? 'darwin' : os === 'windows' ? 'win32' : 'linux';
+        const playwrightProject = playwrightProjectForOs(os);
 
         const failures = outputs[`NEW_FAILURES_${osKey}`] || 0;
         const status = outputs[`STATUS_${osKey}`] || 'failure';
@@ -303,6 +328,8 @@ module.exports = {
     canonicalizeOs,
     osFromCmtJobName,
     summarizeCmtJobsByOs,
+    cmtOsCommitStatus,
+    playwrightProjectForOs,
     osStatusContext,
     E2E_OS_LIST,
 };

--- a/e2e/utils/github-actions.js
+++ b/e2e/utils/github-actions.js
@@ -2,6 +2,170 @@
 // See LICENSE.txt for license information.
 /* eslint-disable no-console -- Logging is intentional in CI utility scripts */
 
+/** Canonical OS identifiers for e2e/<os> commit statuses. */
+const E2E_OS_LIST = ['linux', 'macos', 'windows'];
+
+/**
+ * @param {string} [value] - platform / os field from matrix
+ * @param {string} [runner] - GitHub runner label
+ * @returns {'linux'|'macos'|'windows'|null}
+ */
+function canonicalizeOs(value, runner) {
+    const raw = String(value || '').toLowerCase();
+    if (E2E_OS_LIST.includes(raw)) {
+        return raw;
+    }
+    const r = String(runner || '').toLowerCase();
+    if (r.startsWith('ubuntu') || r.startsWith('linux')) {
+        return 'linux';
+    }
+    if (r.startsWith('macos') || r.startsWith('darwin')) {
+        return 'macos';
+    }
+    if (r.startsWith('windows')) {
+        return 'windows';
+    }
+    return null;
+}
+
+/**
+ * @param {string} os
+ * @returns {string}
+ */
+function osStatusContext(os) {
+    return `e2e/${os}`;
+}
+
+/**
+ * CMT reusable-workflow jobs are named `{os}-{serverVersion}` (e.g. linux-11.9.0).
+ *
+ * @param {string} [jobName]
+ * @returns {'linux'|'macos'|'windows'|null}
+ */
+function osFromCmtJobName(jobName) {
+    return canonicalizeOs(String(jobName || '').split('-')[0]);
+}
+
+/**
+ * @param {Array<{name?: string, conclusion?: string}>} jobs
+ * @param {string[]} expectedOs
+ * @returns {Record<string, {failed: boolean, seen: boolean}>}
+ */
+function summarizeCmtJobsByOs(jobs, expectedOs) {
+    const byOs = Object.fromEntries((expectedOs || []).map((os) => [os, {failed: false, seen: false}]));
+    for (const job of jobs || []) {
+        const os = osFromCmtJobName(job.name);
+        if (!os || !byOs[os]) {
+            continue;
+        }
+        byOs[os].seen = true;
+        if (['failure', 'cancelled', 'timed_out'].includes(job.conclusion)) {
+            byOs[os].failed = true;
+        }
+    }
+    return byOs;
+}
+
+/**
+ * Post pending e2e/<os> statuses for this run.
+ *
+ * @param {Object} params
+ * @param {Object} params.github
+ * @param {Object} params.context
+ * @param {string} params.sha
+ * @param {Array<{platform?: string, os?: string, runner?: string}>} params.platforms
+ */
+async function updateInitialOsStatuses({github, context, sha, platforms}) {
+    const workflowUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+    const seen = new Set();
+    const targets = [];
+
+    for (const platform of platforms || []) {
+        const os = canonicalizeOs(platform.platform || platform.os, platform.runner);
+        if (!os || seen.has(os)) {
+            continue;
+        }
+        seen.add(os);
+        targets.push(os);
+    }
+
+    if (targets.length === 0) {
+        console.log('No canonical OS platforms — skipping pending e2e/<os> statuses');
+        return;
+    }
+
+    await Promise.all(targets.map((os) =>
+        github.rest.repos.createCommitStatus({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            sha,
+            state: 'pending',
+            context: osStatusContext(os),
+            description: `E2E tests on ${os} have started...`,
+            target_url: workflowUrl,
+        }).catch((error) => {
+            console.log(`Could not set pending ${osStatusContext(os)} on ${sha}: ${error.message}`);
+        }),
+    ));
+}
+
+/**
+ * Flip e2e/<os> from CMT matrix job conclusions (release-6.2 has no TSIO reporter).
+ *
+ * @param {Object} params
+ * @param {Object} params.github
+ * @param {Object} params.context
+ * @param {string} params.sha
+ * @param {Array<{platform?: string, os?: string, runner?: string}>} params.platforms
+ */
+async function updateCmtOsStatusesFromWorkflowJobs({github, context, sha, platforms}) {
+    const workflowUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+    const expectedOs = [...new Set(
+        (platforms || []).map((p) => canonicalizeOs(p.platform || p.os, p.runner)).filter(Boolean),
+    )];
+    if (expectedOs.length === 0) {
+        console.log('No canonical OS platforms — skipping final e2e/<os> statuses');
+        return;
+    }
+
+    const jobs = [];
+    for (let page = 1; page <= 10; page++) {
+        const {data} = await github.rest.actions.listJobsForWorkflowRun({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: context.runId,
+            per_page: 100,
+            page,
+        });
+        jobs.push(...(data.jobs || []));
+        if (!data.jobs || data.jobs.length < 100) {
+            break;
+        }
+    }
+
+    const byOs = summarizeCmtJobsByOs(jobs, expectedOs);
+    await Promise.all(expectedOs.map((os) => {
+        const row = byOs[os];
+        const state = !row.seen || row.failed ? 'failure' : 'success';
+        const description = !row.seen ?
+            `E2E incomplete — no ${os} CMT jobs` :
+            row.failed ?
+                `E2E failed on ${os}` :
+                `E2E passed on ${os}`;
+        return github.rest.repos.createCommitStatus({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            sha,
+            state,
+            context: osStatusContext(os),
+            description,
+            target_url: workflowUrl,
+        }).catch((error) => {
+            console.log(`Could not set ${osStatusContext(os)} on ${sha}: ${error.message}`);
+        });
+    }));
+}
+
 /**
  * Update initial pending status for all platforms
  * @param {Object} params - Parameters object
@@ -10,19 +174,12 @@
  * @param {Array} params.platforms - Array of platform objects from matrix
  */
 async function updateInitialStatus({github, context, platforms}) {
-    const workflowUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-
-    await Promise.all(platforms.map((platform) =>
-        github.rest.repos.createCommitStatus({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            sha: context.sha,
-            state: 'pending',
-            context: `e2e/${platform.platform}`,
-            description: `E2E tests for Mattermost desktop app on ${platform.platform} have started...`,
-            target_url: workflowUrl,
-        }),
-    ));
+    await updateInitialOsStatuses({
+        github,
+        context,
+        sha: context.sha,
+        platforms,
+    });
 }
 
 /**
@@ -38,19 +195,9 @@ async function updateFinalStatus({github, context, platforms, outputs, mergedRep
     const workflowUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
     await Promise.all(platforms.map((platform) => {
-        // Determine OS key and Playwright project name based on runner
-        let osKey;
-        let playwrightProject;
-        if (platform.runner.includes('ubuntu')) {
-            osKey = 'LINUX';
-            playwrightProject = 'linux';
-        } else if (platform.runner.includes('macos')) {
-            osKey = 'MACOS';
-            playwrightProject = 'darwin';
-        } else {
-            osKey = 'WINDOWS';
-            playwrightProject = 'win32';
-        }
+        const os = canonicalizeOs(platform.platform || platform.os, platform.runner);
+        const osKey = os ? os.toUpperCase() : 'WINDOWS';
+        const playwrightProject = os === 'macos' ? 'darwin' : os === 'windows' ? 'win32' : 'linux';
 
         const failures = outputs[`NEW_FAILURES_${osKey}`] || 0;
         const status = outputs[`STATUS_${osKey}`] || 'failure';
@@ -66,8 +213,8 @@ async function updateFinalStatus({github, context, platforms, outputs, mergedRep
             repo: context.repo.repo,
             sha: context.payload.pull_request?.head?.sha || context.sha,
             state: status,
-            context: `e2e/${platform.platform}`,
-            description: `${platform.platform} E2E completed with ${failures} failures`,
+            context: os ? osStatusContext(os) : `e2e/${platform.platform}`,
+            description: `${os || platform.platform} E2E completed with ${failures} failures`,
             target_url: reportLink,
         });
     }));
@@ -151,4 +298,11 @@ module.exports = {
     updateInitialStatus,
     updateFinalStatus,
     removeE2ELabel,
+    updateInitialOsStatuses,
+    updateCmtOsStatusesFromWorkflowJobs,
+    canonicalizeOs,
+    osFromCmtJobName,
+    summarizeCmtJobsByOs,
+    osStatusContext,
+    E2E_OS_LIST,
 };

--- a/e2e/utils/github-actions.test.js
+++ b/e2e/utils/github-actions.test.js
@@ -10,6 +10,8 @@ const {
     canonicalizeOs,
     osFromCmtJobName,
     summarizeCmtJobsByOs,
+    cmtOsCommitStatus,
+    playwrightProjectForOs,
 } = require('./github-actions');
 
 describe('canonicalizeOs', () => {
@@ -55,5 +57,37 @@ describe('summarizeCmtJobsByOs', () => {
         assert.deepEqual(byOs.linux, {failed: true, seen: true});
         assert.deepEqual(byOs.macos, {failed: false, seen: true});
         assert.deepEqual(byOs.windows, {failed: false, seen: false});
+    });
+});
+
+describe('cmtOsCommitStatus', () => {
+    it('fails incomplete OS buckets', () => {
+        assert.deepEqual(
+            cmtOsCommitStatus({failed: false, seen: false}, 'windows'),
+            {state: 'failure', description: 'E2E incomplete — no windows CMT jobs'},
+        );
+    });
+
+    it('fails when any matrix cell failed', () => {
+        assert.deepEqual(
+            cmtOsCommitStatus({failed: true, seen: true}, 'linux'),
+            {state: 'failure', description: 'E2E failed on linux'},
+        );
+    });
+
+    it('succeeds when every seen cell passed', () => {
+        assert.deepEqual(
+            cmtOsCommitStatus({failed: false, seen: true}, 'macos'),
+            {state: 'success', description: 'E2E passed on macos'},
+        );
+    });
+});
+
+describe('playwrightProjectForOs', () => {
+    it('maps canonical OS ids to Playwright project names', () => {
+        assert.equal(playwrightProjectForOs('linux'), 'linux');
+        assert.equal(playwrightProjectForOs('macos'), 'darwin');
+        assert.equal(playwrightProjectForOs('windows'), 'win32');
+        assert.equal(playwrightProjectForOs(null), 'linux');
     });
 });

--- a/e2e/utils/github-actions.test.js
+++ b/e2e/utils/github-actions.test.js
@@ -1,0 +1,59 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// CI util unit tests: run with `node --test e2e/utils/github-actions.test.js`.
+
+const {describe, it} = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    canonicalizeOs,
+    osFromCmtJobName,
+    summarizeCmtJobsByOs,
+} = require('./github-actions');
+
+describe('canonicalizeOs', () => {
+    it('keeps linux|macos|windows', () => {
+        assert.equal(canonicalizeOs('linux'), 'linux');
+        assert.equal(canonicalizeOs('macos'), 'macos');
+        assert.equal(canonicalizeOs('windows'), 'windows');
+    });
+
+    it('derives OS from runner labels', () => {
+        assert.equal(canonicalizeOs('', 'ubuntu-latest'), 'linux');
+        assert.equal(canonicalizeOs(undefined, 'macos-26'), 'macos');
+        assert.equal(canonicalizeOs('darwin', 'windows-2022'), 'windows');
+    });
+
+    it('returns null when neither platform nor runner is recognized', () => {
+        assert.equal(canonicalizeOs('freebsd', 'custom-runner'), null);
+    });
+});
+
+describe('osFromCmtJobName', () => {
+    it('parses CMT job names of the form os-version', () => {
+        assert.equal(osFromCmtJobName('linux-11.9.0'), 'linux');
+        assert.equal(osFromCmtJobName('macos-11.8.4'), 'macos');
+        assert.equal(osFromCmtJobName('windows-10.5.14'), 'windows');
+    });
+
+    it('ignores unrelated jobs', () => {
+        assert.equal(osFromCmtJobName('calculate-commit-hash'), null);
+        assert.equal(osFromCmtJobName(''), null);
+    });
+});
+
+describe('summarizeCmtJobsByOs', () => {
+    it('marks an OS failed when any matrix cell failed', () => {
+        const byOs = summarizeCmtJobsByOs([
+            {name: 'linux-11.9.0', conclusion: 'success'},
+            {name: 'linux-11.8.4', conclusion: 'failure'},
+            {name: 'macos-11.9.0', conclusion: 'success'},
+            {name: 'calculate-commit-hash', conclusion: 'success'},
+        ], ['linux', 'macos', 'windows']);
+
+        assert.deepEqual(byOs.linux, {failed: true, seen: true});
+        assert.deepEqual(byOs.macos, {failed: false, seen: true});
+        assert.deepEqual(byOs.windows, {failed: false, seen: false});
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cherry pick of #3945 on release-6.2.

Restores per-OS GitHub commit statuses (`e2e/linux`, `e2e/macos`, `e2e/windows`) for CMT, alongside the existing `e2e/compatibility-matrix-testing` umbrella. PR/master E2E already posted per-OS checks on this branch; those now use canonical `linux|macos|windows` names.

#### Summary
- Normalize `instance_details` platforms to `linux|macos|windows` (and pin `macos-latest` → `macos-26`) so `e2e/<os>` statuses stay consistent.
- Post pending `e2e/linux|macos|windows` on CMT start, then flip them from CMT matrix job conclusions (this branch has no TSIO reporter).
- Keep the CMT umbrella check `e2e/compatibility-matrix-testing`.
- Restructure the 6.2-only status helpers so `no-nested-ternary` / `no-negated-condition` pass (`cmtOsCommitStatus`, `playwrightProjectForOs`).

#### Ticket Link
Cherry-pick of https://github.com/mattermost/desktop/pull/3945

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [ ] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [x] executed `npm run lint:js` for proper code formatting
- [ ] Run E2E tests by adding label `E2E/Run`

#### Device Information
This PR was tested on: unit tests via `node --test e2e/utils/github-actions.test.js` (10 passed); `npx eslint e2e/utils/github-actions.js e2e/utils/github-actions.test.js --quiet` clean

#### Release Note
```release-note
NONE
```

#### Backport notes
Automated cherry-pick conflicted because `release-6.2` does not have TSIO reporting (`tsio-report-status.js`) or channel notify (`cmt-channel-notify.js`).

What this PR includes:
- Per-OS CMT commit statuses from #3945, implemented without TSIO by aggregating CMT job names (`linux-11.9.0`, …)
- Platform canonicalization for PR E2E statuses (already per-OS on this branch)

What this PR does not include:
- Unique CMT channel-notify failure counts (no Mattermost webhook notify on this branch)
- TSIO per-leg report links / `e2e/<os>-policy` status rename (`policy-test/<os>` remains)
- #3923 / `media_preview.test.ts` — that spec does not exist on `release-6.2`

**Merge gate:** wait for `ci` (`build-linux`, `build-mac-no-dmg`, `build-win-no-installer`, `report-test-results`) on HEAD `393ae8bb`. Playwright `E2E/Run` is not required for this CI-only change; latest `release-6.2` CMT is already green. Needs a review (currently none).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f74bd6b-be81-444f-8b5a-38971e1d45d5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f74bd6b-be81-444f-8b5a-38971e1d45d5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

