### PR TITLE
Suppress CodeRabbit review status comments

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,3 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  review_status: false


### PR DESCRIPTION
#### Summary

Adds a `.coderabbit.yaml` with `reviews.review_status: false` so CodeRabbit stops posting "Review skipped" status comments (e.g. the "Draft detected" notice on every draft PR). All other CodeRabbit settings remain at their defaults.

#### Checklist
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)

#### Release Note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration with YAML schema metadata.
  * Disabled review status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->