### PR TITLE
test: wire orphaned node --test files into CI, add coverage threshold

### DIFF
--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -28,3 +28,7 @@ runs:
         ELECTRON_DISABLE_SANDBOX: "1"
       run: |
         npm run test:unit
+    - name: ci/run-ci-utils
+      shell: ${{ inputs.shell }}
+      run: |
+        npm run test:ci-utils

--- a/.github/workflows/e2e-functional-template.yml
+++ b/.github/workflows/e2e-functional-template.yml
@@ -170,7 +170,7 @@ jobs:
       - name: e2e/setup-node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           package-manager-cache: false
           # node_modules is cached in e2e/cache-node-modules; disable setup-node's
           # npm cache so actions/cache v5 does not hit legacy entries.

--- a/.github/workflows/e2e-functional.yml
+++ b/.github/workflows/e2e-functional.yml
@@ -372,7 +372,7 @@ jobs:
       - name: e2e/setup-node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           package-manager-cache: false
 
       - name: e2e/use-gnu-tar-macos

--- a/package.json
+++ b/package.json
@@ -56,7 +56,9 @@
     "package:linux:arch-arm64": "cross-env CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ electron-builder --linux",
     "package:linux-tar": "npm run build-prod && npm run package:linux:arch-x64 -- tar.gz --x64 --publish=never && npm run package:linux:arch-arm64 -- tar.gz --arm64 --publish=never",
     "package:linux-pkg": "npm run build-prod && npm run package:linux:arch-x64 -- deb rpm flatpak --x64 --publish=never && npm run package:linux:arch-arm64 -- deb rpm flatpak --arm64 --publish=never",
-    "package:linux-appImage": "npm run build-prod && npm run package:linux:arch-x64 -- tar.gz appimage --x64 --publish=never && npm run package:linux:arch-arm64 -- tar.gz appimage --arm64 --publish=never"
+    "package:linux-appImage": "npm run build-prod && npm run package:linux:arch-x64 -- tar.gz appimage --x64 --publish=never && npm run package:linux:arch-arm64 -- tar.gz appimage --arm64 --publish=never",
+    "test:ci-utils": "node --test e2e/utils/*.test.js",
+    "check-types:e2e": "tsc -p e2e/tsconfig.json --noEmit"
   },
   "jest": {
     "clearMocks": true,
@@ -73,7 +75,9 @@
     ],
     "collectCoverageFrom": [
       "src/common/**/*.ts",
-      "src/main/**/*.ts"
+      "src/main/**/*.ts",
+      "src/app/**/*.ts",
+      "src/renderer/**/*.{ts,tsx}"
     ],
     "testMatch": [
       "**/src/**/*.test.js",
@@ -110,7 +114,15 @@
           "ancestorSeparator": "> "
         }
       ]
-    ]
+    ],
+    "coverageThreshold": {
+      "global": {
+        "statements": 50,
+        "branches": 40,
+        "functions": 40,
+        "lines": 50
+      }
+    }
   },
   "devDependencies": {
     "@babel/preset-env": "7.24.0",


### PR DESCRIPTION
## Summary
Config/CI improvements from a test-automation audit. No test-code rewrites in this PR.

## Changes
- **`test:ci-utils`** — wires the orphaned `node --test` files (`e2e/utils/*.test.js`, 42 tests) into CI via a new `ci/run-ci-utils` step in `.github/actions/test/action.yaml`.
- **`check-types:e2e`** — adds a `tsc -p e2e/tsconfig.json --noEmit` script. **Not wired into CI**: the e2e TypeScript code has 66 pre-existing type errors and has never been type-checked; wiring it would break CI. Tracked as follow-up.
- **Coverage** — extends `collectCoverageFrom` to `src/app/**/*.ts` and `src/renderer/**/*.{ts,tsx}` (the renderer UI was previously excluded), and adds a `coverageThreshold` of 50/40/40/50 (measured 56.61/47.56/44.3/56.67).
- **Node version** — aligns the two e2e workflows from `22.x` to `24.x` to match `.nvmrc` (v24.16.0).

## Verification
- `npx jest --coverage` → exit 0, 80 suites / 1359 tests pass
- `npm run test:ci-utils` → 42 tests, 0 fail
- `npx tsc -p e2e/tsconfig.json --noEmit` → 66 pre-existing errors (why it's not wired)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Changes affect test coverage and CI configuration only. They do not modify production logic or critical user flows.

**QA Recommendation:** Manual QA is not required. Rely on the reported automated test results and CI validation.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->