### PR TITLE
Fix three flaky E2E tests (MM-T2949, MM-T4054, MM-T6150)

### DIFF
--- a/e2e/specs/macos_only/cmd_enter.test.ts
+++ b/e2e/specs/macos_only/cmd_enter.test.ts
@@ -4,7 +4,7 @@
 import {test, expect} from '../../fixtures/index';
 import {demoMattermostConfig} from '../../helpers/config';
 import {loginToMattermost} from '../../helpers/login';
-import {POST_TEXTBOX_SELECTOR, typeIntoPostTextbox} from '../../helpers/mattermostShell';
+import {POST_TEXTBOX_SELECTOR, typeIntoPostTextbox, waitForMattermostShellReady} from '../../helpers/mattermostShell';
 
 test.describe('macos_only/cmd_enter', () => {
     test.use({appConfig: demoMattermostConfig});
@@ -17,7 +17,7 @@ test.describe('macos_only/cmd_enter', () => {
 
             const serverWin = serverMap[demoMattermostConfig.servers[0].name][0].win;
             await loginToMattermost(serverWin);
-            await serverWin.waitForSelector('#sidebarItem_off-topic', {timeout: 15_000});
+            await waitForMattermostShellReady(serverWin, {channelItem: '#sidebarItem_off-topic'});
             await serverWin.click('#sidebarItem_off-topic');
             await serverWin.waitForSelector(POST_TEXTBOX_SELECTOR, {timeout: 15_000});
             await typeIntoPostTextbox(serverWin, 'mac line');

--- a/e2e/specs/macos_only/cmd_enter.test.ts
+++ b/e2e/specs/macos_only/cmd_enter.test.ts
@@ -17,6 +17,7 @@ test.describe('macos_only/cmd_enter', () => {
 
             const serverWin = serverMap[demoMattermostConfig.servers[0].name][0].win;
             await loginToMattermost(serverWin);
+            await serverWin.waitForSelector('#sidebarItem_off-topic', {timeout: 15_000});
             await serverWin.click('#sidebarItem_off-topic');
             await serverWin.waitForSelector(POST_TEXTBOX_SELECTOR, {timeout: 15_000});
             await typeIntoPostTextbox(serverWin, 'mac line');

--- a/e2e/specs/mattermost/media_preview.test.ts
+++ b/e2e/specs/mattermost/media_preview.test.ts
@@ -63,7 +63,7 @@ const findVisibleLoadedPreviewTarget = (root) => {
             continue;
         }
         const loadedImg = button.querySelector('img:not(.image-loading__placeholder)');
-        if (loadedImg instanceof HTMLImageElement && loadedImg.complete && loadedImg.naturalWidth > 0) {
+        if (isLoadedPreviewImage(loadedImg)) {
             return loadedImg;
         }
     }

--- a/e2e/specs/mattermost/media_preview.test.ts
+++ b/e2e/specs/mattermost/media_preview.test.ts
@@ -57,14 +57,14 @@ const findPreviewFixturePost = () => {
     }
     return null;
 };
-const findVisibleLoadedPreviewButton = (root) => {
+const findVisibleLoadedPreviewTarget = (root) => {
     for (const button of root.querySelectorAll('.file-preview__button')) {
         if (!isPreviewControlVisible(button)) {
             continue;
         }
         const loadedImg = button.querySelector('img:not(.image-loading__placeholder)');
         if (loadedImg instanceof HTMLImageElement && loadedImg.complete && loadedImg.naturalWidth > 0) {
-            return button;
+            return loadedImg;
         }
     }
     return null;
@@ -84,9 +84,9 @@ async function waitForLoadedImagePreviewControl(serverWin: ServerView): Promise<
             return false;
         }
 
-        const previewButton = findVisibleLoadedPreviewButton(post);
-        if (previewButton) {
-            previewButton.scrollIntoView({block: 'center'});
+        const previewTarget = findVisibleLoadedPreviewTarget(post);
+        if (previewTarget) {
+            previewTarget.scrollIntoView({block: 'center'});
             return true;
         }
 
@@ -202,12 +202,10 @@ async function openImagePreview(serverWin: ServerView): Promise<boolean> {
             return false;
         }
 
-        // Prefer the visible SizeAwareImage control (11.10+/MM-69174); clicks on the
-        // placeholder button are intentionally ignored until the real image loads.
-        const previewButton = findVisibleLoadedPreviewButton(root);
-        if (previewButton) {
-            previewButton.scrollIntoView({block: 'center', inline: 'center'});
-            previewButton.click();
+        const previewTarget = findVisibleLoadedPreviewTarget(root);
+        if (previewTarget) {
+            previewTarget.scrollIntoView({block: 'center', inline: 'center'});
+            previewTarget.click();
             return true;
         }
 

--- a/e2e/specs/menu_bar/help_menu.test.ts
+++ b/e2e/specs/menu_bar/help_menu.test.ts
@@ -12,6 +12,8 @@ test.describe('menu_bar/help_menu', () => {
         'MM-T6150 Check for Updates menu item invokes the update manager',
         {tag: ['@P1', '@all']},
         async ({electronApp}) => {
+            await waitForAppReady(electronApp);
+
             const canUpgrade = await electronApp.evaluate(() => {
                 const refs = (global as any).__e2eTestRefs;
                 return Boolean(refs?.Config?.canUpgrade);


### PR DESCRIPTION
#### Summary

Fixes three flaky E2E tests:

- **MM-T2949** (`cmd_enter`): Added `waitForSelector('#sidebarItem_off-topic')` before clicking it, so the test doesn't race against the sidebar loading after login.
- **MM-T4054** (`media_preview`): Changed click target from the `.file-preview__button` wrapper div to the `img` child element, since clicks on the wrapper are ignored until the real image loads.
- **MM-T6150** (`help_menu`): Added `waitForAppReady` before the first `electronApp.evaluate` call, ensuring the app's `__e2eTestRefs` are populated before the test reads them.

#### Ticket Link

N/A

#### Checklist

- [ ] Added or updated unit tests (required for all new features)
- [x] read and understood our [Contributing Guidelines](https://github.com/mattermost/desktop/blob/master/CONTRIBUTING.md)
- [x] completed [Mattermost Contributor Agreement](https://mattermost.com/contribute/)
- [x] executed `npm run lint:js` for proper code formatting

#### Release Note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved automated coverage reliability for macOS keyboard shortcuts.
  - Updated media preview testing to interact with the loaded image in the visible preview.
  - Added initialization checks to improve update-check menu test stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->