### PR TITLE
Force electron-builder to use desktop name instead of package name

### DIFF
--- a/electron-builder.ts
+++ b/electron-builder.ts
@@ -94,6 +94,11 @@ const config = {
             'flatpak',
         ],
         appId: 'com.Mattermost.Desktop',
+        desktop: {
+            entry: {
+                StartupWMClass: pkg.desktopName,
+            },
+        },
         extraFiles: [
             {
                 filter: [


### PR DESCRIPTION
#### Summary
Fixes https://github.com/mattermost/desktop/issues/3826

#### Release Note
```release-note
Fixed missing icon on GNOME dock
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to Linux packaging configuration. It affects `StartupWMClass` generation and does not modify shared runtime code or critical user flows.

**QA Recommendation:** Skip manual QA. Automated test coverage is sufficient for this low-risk packaging change.
*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->