### PR TITLE
Automated cherry pick of #3951

### DIFF
--- a/src/app/serverHub.test.js
+++ b/src/app/serverHub.test.js
@@ -460,6 +460,25 @@ describe('app/serverViewState', () => {
             expect(result.validatedURL).toBe('https://mainserver.com/');
         });
 
+        it('should not update the users URL when the Site URL cannot be parsed', async () => {
+            ServerInfo.mockImplementation(() => ({
+                pingServer: jest.fn().mockImplementation(() => ({
+                    status: 'OK',
+                })),
+                fetchConfigData: jest.fn().mockImplementation(() => {
+                    return {
+                        serverVersion: '7.8.0',
+                        siteName: 'Mattermost',
+                        siteURL: 'not-a-url',
+                    };
+                }),
+            }));
+
+            const result = await serverViewState.handleServerURLValidation({}, 'https://server.com');
+            expect(result.status).toBe(URLValidationStatus.OK);
+            expect(result.validatedURL).toBe('https://server.com/');
+        });
+
         it('should not update the users URL when the Site URL is blank', async () => {
             ServerInfo.mockImplementation(() => ({
                 pingServer: jest.fn().mockImplementation(() => ({

--- a/src/app/serverHub.ts
+++ b/src/app/serverHub.ts
@@ -392,32 +392,31 @@ export class ServerHub {
         }
 
         // If the URL doesn't match the Site URL, set the URL to the correct one
-        if (remoteInfo.siteURL && remoteURL.toString() !== new URL(remoteInfo.siteURL).toString()) {
+        const parsedSiteURL = remoteInfo.siteURL ? parseURL(remoteInfo.siteURL) : undefined;
+        if (parsedSiteURL && remoteURL.toString() !== parsedSiteURL.toString()) {
             log.verbose('handleServerURLValidation: Remote URL does not match Site URL, checking Site URL');
-            const parsedSiteURL = parseURL(remoteInfo.siteURL);
-            if (parsedSiteURL) {
-                // Check the Site URL as well to see if it's already pre-configured
-                const existingServer = ServerManager.lookupServerByURL(parsedSiteURL, true);
-                if (existingServer && existingServer.id !== currentId) {
-                    log.info('handleServerURLValidation: Site URL already exists, returning URLExists');
-                    return {
-                        status: URLValidationStatus.URLExists,
-                        existingServerName: existingServer.name,
-                        validatedURL: existingServer.url.toString(),
-                    };
-                }
 
-                // If we can't reach the remote Site URL, there's probably a configuration issue
-                const remoteSiteURLResult = await this.testRemoteServer(parsedSiteURL);
-                if ('error' in remoteSiteURLResult) {
-                    log.debug('handleServerURLValidation: Site URL not reachable, returning URLNotMatched');
-                    return {
-                        status: URLValidationStatus.URLNotMatched,
-                        serverVersion: remoteInfo.serverVersion,
-                        serverName: remoteServerName,
-                        validatedURL: remoteURL.toString(),
-                    };
-                }
+            // Check the Site URL as well to see if it's already pre-configured
+            const existingServer = ServerManager.lookupServerByURL(parsedSiteURL, true);
+            if (existingServer && existingServer.id !== currentId) {
+                log.info('handleServerURLValidation: Site URL already exists, returning URLExists');
+                return {
+                    status: URLValidationStatus.URLExists,
+                    existingServerName: existingServer.name,
+                    validatedURL: existingServer.url.toString(),
+                };
+            }
+
+            // If we can't reach the remote Site URL, there's probably a configuration issue
+            const remoteSiteURLResult = await this.testRemoteServer(parsedSiteURL);
+            if ('error' in remoteSiteURLResult) {
+                log.debug('handleServerURLValidation: Site URL not reachable, returning URLNotMatched');
+                return {
+                    status: URLValidationStatus.URLNotMatched,
+                    serverVersion: remoteInfo.serverVersion,
+                    serverName: remoteServerName,
+                    validatedURL: remoteURL.toString(),
+                };
             }
 
             // Otherwise fix it for them and return
@@ -426,7 +425,7 @@ export class ServerHub {
                 status: URLValidationStatus.URLUpdated,
                 serverVersion: remoteInfo.serverVersion,
                 serverName: remoteServerName,
-                validatedURL: remoteInfo.siteURL,
+                validatedURL: parsedSiteURL.toString(),
             };
         }
 

--- a/src/common/servers/MattermostServer.ts
+++ b/src/common/servers/MattermostServer.ts
@@ -31,11 +31,12 @@ export class MattermostServer {
         this.preAuthSecret = preAuthSecret;
     }
 
-    updateURL = (url: string) => {
-        this.url = parseURL(url)!;
-        if (!this.url) {
+    updateURL = (url: string | URL) => {
+        const parsedURL = parseURL(url);
+        if (!parsedURL) {
             throw new Error('Invalid url for creating a server');
         }
+        this.url = parsedURL;
     };
 
     toUniqueServer = (): UniqueServer => {

--- a/src/common/servers/serverManager.test.js
+++ b/src/common/servers/serverManager.test.js
@@ -45,6 +45,13 @@ describe('common/servers/serverManager', () => {
             serverManager.servers = new Map([['server-1', server]]);
             serverManager.persistServers = jest.fn();
             Utils.isVersionGreaterThanOrEqualTo.mockImplementation((version) => version === '6.0.0');
+            parseURL.mockImplementation((url) => {
+                try {
+                    return new URL(url);
+                } catch (e) {
+                    return undefined;
+                }
+            });
         });
 
         it('should not save when there is nothing to update', () => {
@@ -76,6 +83,18 @@ describe('common/servers/serverManager', () => {
                 hasPlaybooks: true,
                 hasFocalboard: true,
             }, false);
+
+            expect(serverManager.servers.get('server-1').url.toString()).toBe('http://server-1.com/');
+            expect(serverManager.persistServers).not.toHaveBeenCalled();
+        });
+
+        it('should not throw or update server URL when the site URL cannot be parsed', () => {
+            expect(() => serverManager.updateRemoteInfo('server-1', {
+                siteURL: 'not-a-url',
+                serverVersion: '6.0.0',
+                hasPlaybooks: true,
+                hasFocalboard: true,
+            }, true)).not.toThrow();
 
             expect(serverManager.servers.get('server-1').url.toString()).toBe('http://server-1.com/');
             expect(serverManager.persistServers).not.toHaveBeenCalled();

--- a/src/common/servers/serverManager.ts
+++ b/src/common/servers/serverManager.ts
@@ -177,8 +177,9 @@ export class ServerManager extends EventEmitter {
 
         this.remoteInfo.set(serverId, remoteInfo);
 
-        if (remoteInfo.siteURL && server.url.toString() !== new URL(remoteInfo.siteURL).toString() && isSiteURLValidated) {
-            server.updateURL(remoteInfo.siteURL);
+        const siteURL = remoteInfo.siteURL ? parseURL(remoteInfo.siteURL) : undefined;
+        if (siteURL && server.url.toString() !== siteURL.toString() && isSiteURLValidated) {
+            server.updateURL(siteURL);
             this.servers.set(serverId, server);
             this.emit(SERVER_URL_CHANGED, serverId);
             this.persistServers();

--- a/src/main/app/utils.test.js
+++ b/src/main/app/utils.test.js
@@ -229,5 +229,36 @@ describe('main/app/utils', () => {
             expect(mockServerInfoInstance.fetchRemoteInfo).toHaveBeenCalled();
             expect(ServerManager.updateRemoteInfo).not.toHaveBeenCalled();
         });
+
+        it('should record the server as unvalidated when the site URL cannot be parsed', async () => {
+            const mockServer = new MattermostServer({id: 'server-1', name: 'Test Server', url: 'http://localhost:8065'});
+            const data = {siteURL: 'not-a-url'};
+            const mockServerInfoInstance = {
+                fetchRemoteInfo: jest.fn().mockResolvedValue(data),
+                fetchConfigData: jest.fn(),
+            };
+            ServerInfo.mockImplementation(() => mockServerInfoInstance);
+
+            await updateServerInfos([mockServer]);
+
+            expect(MattermostServer).not.toHaveBeenCalledWith({name: 'temp', url: 'not-a-url'}, false);
+            expect(mockServerInfoInstance.fetchConfigData).not.toHaveBeenCalled();
+            expect(ServerManager.updateRemoteInfo).toHaveBeenCalledWith('server-1', data, false);
+        });
+
+        it('should record the server as validated when the site URL matches', async () => {
+            const mockServer = new MattermostServer({id: 'server-1', name: 'Test Server', url: 'http://localhost:8065'});
+            const data = {siteURL: 'http://localhost:8065'};
+            const mockServerInfoInstance = {
+                fetchRemoteInfo: jest.fn().mockResolvedValue(data),
+                fetchConfigData: jest.fn().mockResolvedValue(data),
+            };
+            ServerInfo.mockImplementation(() => mockServerInfoInstance);
+
+            await updateServerInfos([mockServer]);
+
+            expect(MattermostServer).toHaveBeenCalledWith({name: 'temp', url: 'http://localhost:8065/'}, false);
+            expect(ServerManager.updateRemoteInfo).toHaveBeenCalledWith('server-1', data, true);
+        });
     });
 });

--- a/src/main/app/utils.ts
+++ b/src/main/app/utils.ts
@@ -14,7 +14,7 @@ import {MATTERMOST_PROTOCOL} from 'common/constants';
 import {Logger} from 'common/log';
 import {MattermostServer} from 'common/servers/MattermostServer';
 import ServerManager from 'common/servers/serverManager';
-import {isValidURI} from 'common/utils/url';
+import {isValidURI, parseURL} from 'common/utils/url';
 import {localizeMessage} from 'main/i18nManager';
 import {ServerInfo} from 'main/server/serverInfo';
 
@@ -169,8 +169,16 @@ export async function updateServerInfos(servers: MattermostServer[]) {
         }
 
         if (data.siteURL) {
+            // The site URL comes from the server's client configuration, so it cannot be trusted to be a valid URL
+            const siteURL = parseURL(data.siteURL);
+            if (!siteURL) {
+                log.warn('updateServerInfos: Received an invalid site URL from the server', {serverId: srv.id});
+                ServerManager.updateRemoteInfo(srv.id, data, false);
+                return;
+            }
+
             // We need to validate the site URL is reachable by pinging the server
-            const tempServer = new MattermostServer({name: 'temp', url: data.siteURL}, false);
+            const tempServer = new MattermostServer({name: 'temp', url: siteURL.toString()}, false);
             const tempServerInfo = new ServerInfo(tempServer);
             try {
                 const tempRemoteInfo = await tempServerInfo.fetchConfigData();


### PR DESCRIPTION
Cherry pick of #3951 on release-6.3.

/cc  @lieut-data

```release-note
NONE
```