### PR TITLE
fix(e2e): enable fake media + pre-grant Calls permissions for CI

### DIFF
--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -9,7 +9,7 @@ import type {ElectronApplication} from 'playwright';
 import {_electron as electron} from 'playwright';
 
 import {waitForAppReady, waitForMainWindow, waitForMainWindowChrome} from '../helpers/appReadiness';
-import {electronBinaryPath, appDir, demoConfig, writeConfigFile, type AppConfig} from '../helpers/config';
+import {electronBinaryPath, appDir, demoConfig, writeConfigFile, writePermissionsFile, type AppConfig} from '../helpers/config';
 import {
     closeElectronApp,
     FAST_TEARDOWN,
@@ -88,6 +88,7 @@ export const test = base.extend<Fixtures, WorkerFixtures>({
         await fs.mkdir(userDataDir, {recursive: true});
 
         writeConfigFile(userDataDir, appConfig);
+        writePermissionsFile(userDataDir, appConfig);
 
         let launchTimeout: number;
         if (process.platform === 'win32') {
@@ -119,6 +120,8 @@ export const test = base.extend<Fixtures, WorkerFixtures>({
                 '--disable-crash-reporter',
                 '--force-color-profile=srgb',
                 '--mute-audio',
+                '--use-fake-device-for-media-stream',
+                '--use-fake-ui-for-media-stream',
             ],
             env: {
                 ...process.env,

--- a/e2e/helpers/config.ts
+++ b/e2e/helpers/config.ts
@@ -133,3 +133,31 @@ export function localNetworkConfig(serverUrl: string): AppConfig {
 export function writeConfigFile(userDataDir: string, config: AppConfig): void {
     fs.writeFileSync(path.join(userDataDir, 'config.json'), JSON.stringify(config, null, 2));
 }
+
+/**
+ * Pre-grant `media`/`screenShare` permissions for every configured server so the
+ * Calls widget can open a microphone via getUserMedia during E2E.
+ *
+ * The main process PermissionsManager reads userDataDir/permissions.json keyed by
+ * `server.url.origin` and denies `media` in test mode (NODE_ENV=test) unless it is
+ * already allowed here. Without this, the Calls WebRTC peer never establishes even
+ * with `--use-fake-device-for-media-stream`.
+ *
+ * MUST be synchronous — must complete before electron.launch() is called.
+ */
+export function writePermissionsFile(userDataDir: string, config: AppConfig): void {
+    const permissions: Record<string, unknown> = {};
+    for (const server of config.servers) {
+        let origin: string;
+        try {
+            origin = new URL(server.url).origin;
+        } catch {
+            continue;
+        }
+        permissions[origin] = {
+            media: {allowed: true},
+            screenShare: {allowed: true},
+        };
+    }
+    fs.writeFileSync(path.join(userDataDir, 'permissions.json'), JSON.stringify(permissions, null, 2));
+}

--- a/e2e/helpers/directLaunch.ts
+++ b/e2e/helpers/directLaunch.ts
@@ -5,7 +5,7 @@ import type {ElectronApplication} from 'playwright';
 import {_electron as electron} from 'playwright';
 
 import {waitForAppReady} from './appReadiness';
-import {electronBinaryPath, appDir, writeConfigFile, type AppConfig} from './config';
+import {electronBinaryPath, appDir, writeConfigFile, writePermissionsFile, type AppConfig} from './config';
 import {registerElectronMainProcess} from './electronApp';
 
 export const DIRECT_LAUNCH_ARGS = [
@@ -24,6 +24,8 @@ export const DIRECT_LAUNCH_ARGS = [
     '--disable-crash-reporter',
     '--force-color-profile=srgb',
     '--mute-audio',
+    '--use-fake-device-for-media-stream',
+    '--use-fake-ui-for-media-stream',
 ];
 
 export type LaunchDirectTestAppOptions = {
@@ -49,6 +51,7 @@ export async function launchDirectTestApp(
 
     if (writeConfig) {
         writeConfigFile(userDataDir, config as AppConfig);
+        writePermissionsFile(userDataDir, config as AppConfig);
     }
 
     const app = await electron.launch({

--- a/e2e/specs/calls/calls_functionality.test.ts
+++ b/e2e/specs/calls/calls_functionality.test.ts
@@ -67,8 +67,7 @@ test.describe('calls/calls_functionality', () => {
 
             const widgetWindow = await waitForCallsWidgetWindow(electronApp);
             if (!widgetWindow) {
-                test.skip(true, 'Calls plugin/widget not available on this test server');
-                return;
+                throw new Error('Calls widget did not open — is the Calls plugin enabled and media available?');
             }
 
             expect(widgetWindow.url(), 'Widget URL must point to Calls plugin').toContain(
@@ -122,8 +121,7 @@ test.describe('calls/calls_functionality', () => {
 
             const widgetWindow = await waitForCallsWidgetWindow(electronApp, 30_000);
             if (!widgetWindow) {
-                test.skip(true, 'Calls plugin/widget not available on this test server');
-                return;
+                throw new Error('Calls widget did not open — is the Calls plugin enabled and media available?');
             }
 
             // Wait for mute button directly — covers React mount + call connection in one step.


### PR DESCRIPTION
## Summary

Fixes the CI-only failure on #3943 where the Calls E2E tests pass locally but fail in CI. There are **two** independent blockers, and both must be addressed:

### 1. No audio input device in CI

The headless Linux runner has no microphone, so `getUserMedia({audio: true})` returns no track and the Calls WebRTC peer (`callsClient.peer`) never establishes — `startCall()` times out waiting on it.

Fix: add Chromium's `--use-fake-device-for-media-stream` (plus `--use-fake-ui-for-media-stream`) to every Electron launch path:

- `e2e/fixtures/index.ts`
- `e2e/helpers/directLaunch.ts` (`DIRECT_LAUNCH_ARGS`)

This supplies a fake audio/video track — no virtual sound card or pulseaudio needed.

### 2. The app's permission manager denies `media` in test mode

`src/main/security/permissionsManager.ts` has `if (process.env.NODE_ENV === 'test') resolve(false)` — and E2E always launches with `NODE_ENV=test`. So even with a fake device, the `media` permission request is denied unless the origin is already pre-granted. (Confirmed via Electron's `electron_permission_manager.cc`: a registered `setPermissionRequestHandler` always intercepts `media`, so `--use-fake-ui-for-media-stream` alone is not enough.)

Fix: new `writePermissionsFile()` helper in `e2e/helpers/config.ts` that pre-writes `permissions.json` (keyed by `server.url.origin`) into the `userDataDir`, granting `media` + `screenShare`. Wired into the `electronApp` fixture and `launchDirectTestApp()`.

### 3. Stop masking failures as skips

`calls_functionality.test.ts` was `test.skip()`'ing when the widget failed to open, turning a real media/permission failure into a "skipped"/green test. Those two sites now `throw` so a genuine failure surfaces.

## Test plan

- [ ] CI E2E (`E2E/Run` label) — `calls_functionality`, `keyboard_shortcuts`, `slash_commands` pass on linux/macos/windows
- [ ] Local `npm run build-test && cd e2e && npm test -- calls` against a server with the Calls plugin

## Notes

- This is a stacked PR targeting `add-calls-e2e-tests` (base of #3943). The fake-media + permission changes are harness-level and benefit any future `getUserMedia`/Calls E2E.
- I could not run CI locally (requires `MM_TEST_SERVER_URL` + admin creds + a server with the Calls plugin in the marketplace), but `npx tsc --noEmit` and `npx eslint` both pass on the changed files.
