### PR TITLE
MM-70547: Simplify network request evaluation logic

### DIFF
--- a/src/main/app/initialize.test.js
+++ b/src/main/app/initialize.test.js
@@ -383,11 +383,20 @@ describe('main/app/initialize', () => {
                 expect(callback).toHaveBeenCalledWith({});
             });
 
-            it('does not cancel requests from non-server web contents', async () => {
+            it('cancels requests from non-server web contents to local/private targets', async () => {
                 const handler = await getRegisteredHandler();
                 const callback = jest.fn();
 
                 await handler({url: 'http://127.0.0.1:7777/secret', webContentsId: 999, resourceType: 'xhr'}, callback);
+
+                expect(callback).toHaveBeenCalledWith({cancel: true});
+            });
+
+            it('allows requests from non-server web contents to public targets', async () => {
+                const handler = await getRegisteredHandler();
+                const callback = jest.fn();
+
+                await handler({url: 'https://8.8.8.8/resource', webContentsId: 999, resourceType: 'xhr'}, callback);
 
                 expect(callback).toHaveBeenCalledWith({});
             });
@@ -403,7 +412,7 @@ describe('main/app/initialize', () => {
 
             it('allows the request when the policy check throws', async () => {
                 const handler = await getRegisteredHandler();
-                jest.requireMock('app/views/webContentsManager').getViewByWebContentsId.mockImplementation(() => {
+                jest.requireMock('common/servers/serverManager').getAllServers.mockImplementation(() => {
                     throw new Error('boom');
                 });
                 const callback = jest.fn();

--- a/src/main/security/localNetworkAccess.test.ts
+++ b/src/main/security/localNetworkAccess.test.ts
@@ -22,6 +22,7 @@ describe('main/security/localNetworkAccess', () => {
 
     beforeEach(() => {
         emptyLookup.mockClear();
+        WebContentsManager.getViewByWebContentsId.mockClear();
         WebContentsManager.getViewByWebContentsId.mockImplementation((webContentsId: number) => (webContentsId === 1 ? {id: 1} : undefined));
         ServerManager.getAllServers.mockReturnValue([{url: new URL('http://127.0.0.1:8065')}]);
     });
@@ -123,14 +124,95 @@ describe('main/security/localNetworkAccess', () => {
             )).resolves.toBe(false);
         });
 
-        it('allows requests that belong to a known non-server web contents', async () => {
+        it('blocks local/private requests from web contents that are not registered views', async () => {
             await expect(shouldCancelLocalNetworkRequest(
                 {
                     url: 'http://127.0.0.1:7777/secret',
                     webContentsId: 2,
                 },
                 emptyLookup,
+            )).resolves.toBe(true);
+        });
+
+        it('blocks local/private requests from unregistered web contents across ranges and protocols', async () => {
+            const urls = [
+                'http://10.0.0.5/admin',
+                'http://192.168.1.10/router',
+                'http://172.16.0.1/internal',
+                'http://169.254.169.254/latest/meta-data',
+                'http://localhost:7777/secret',
+                'http://[::1]:7777/secret',
+                'ws://127.0.0.1:9000',
+                'wss://192.168.1.10/socket',
+            ];
+
+            for (const url of urls) {
+                await expect(shouldCancelLocalNetworkRequest({url, webContentsId: 2}, emptyLookup)).resolves.toBe(true);
+            }
+        });
+
+        it('blocks unregistered web contents requests to hostnames that resolve to private addresses', async () => {
+            const lookup = jest.fn().mockResolvedValue([{address: '10.0.0.5'}]);
+
+            await expect(shouldCancelLocalNetworkRequest(
+                {
+                    url: 'http://internal.example.com',
+                    webContentsId: 2,
+                },
+                lookup,
+            )).resolves.toBe(true);
+        });
+
+        it('allows unregistered web contents requests to the configured server origin', async () => {
+            await expect(shouldCancelLocalNetworkRequest(
+                {
+                    url: 'http://127.0.0.1:8065/plugins/com.mattermost.calls/standalone/widget.html',
+                    webContentsId: 2,
+                },
+                emptyLookup,
             )).resolves.toBe(false);
+
+            await expect(shouldCancelLocalNetworkRequest(
+                {
+                    url: 'ws://127.0.0.1:8065/api/v4/websocket',
+                    webContentsId: 2,
+                },
+                emptyLookup,
+            )).resolves.toBe(false);
+        });
+
+        it('allows unregistered web contents requests to public targets', async () => {
+            const lookup = jest.fn().mockResolvedValue([{address: '8.8.8.8'}]);
+
+            await expect(shouldCancelLocalNetworkRequest(
+                {
+                    url: 'https://mattermost.com',
+                    webContentsId: 2,
+                },
+                lookup,
+            )).resolves.toBe(false);
+        });
+
+        it('blocks local/private requests to a different port on the configured server host', async () => {
+            await expect(shouldCancelLocalNetworkRequest(
+                {
+                    url: 'http://127.0.0.1:8066/secret',
+                    webContentsId: 2,
+                },
+                emptyLookup,
+            )).resolves.toBe(true);
+        });
+
+        it('does not consult the web contents registry to make a decision', async () => {
+            await expect(shouldCancelLocalNetworkRequest(
+                {
+                    url: 'http://127.0.0.1:7777/secret',
+                    webContentsId: 2,
+                },
+                emptyLookup,
+            )).resolves.toBe(true);
+
+            expect(WebContentsManager.getViewByWebContentsId).not.toHaveBeenCalled();
         });
 
         it('blocks unowned requests to local/private targets', async () => {

--- a/src/main/security/localNetworkAccess.ts
+++ b/src/main/security/localNetworkAccess.ts
@@ -4,7 +4,6 @@
 import dns from 'dns/promises';
 import {BlockList, isIP} from 'net';
 
-import WebContentsManager from 'app/views/webContentsManager';
 import ServerManager from 'common/servers/serverManager';
 import {parseURL} from 'common/utils/url';
 
@@ -39,10 +38,6 @@ export async function shouldCancelLocalNetworkRequest(
     details: LocalNetworkRequestDetails,
     lookup: LookupFunction = defaultLookup,
 ): Promise<boolean> {
-    if (details.webContentsId && !WebContentsManager.getViewByWebContentsId(details.webContentsId)) {
-        return false;
-    }
-
     const serverURLs = ServerManager.getAllServers().map((server) => server.url);
     return shouldBlockLocalNetworkRequest(details.url, serverURLs, lookup);
 }


### PR DESCRIPTION
See MM-70547.

```release-note
Updated network request evaluation for desktop app windows.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened protection against unauthorized local-network requests.
  * Requests to private IP addresses, localhost, IPv6 local addresses, WebSocket endpoints, and private DNS resolutions are blocked unless explicitly permitted.
  * Configured server origins and public destinations remain accessible, while requests to other ports on the server host are blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->