### PR TITLE
[MM-70566] Enforce local network access restrictions on all web contents

### DIFF
--- a/src/app/callsWidgetWindow.test.js
+++ b/src/app/callsWidgetWindow.test.js
@@ -25,6 +25,7 @@ import {
 import urlUtils from 'common/utils/url';
 import ViewManager from 'common/views/viewManager';
 import PermissionsManager from 'main/security/permissionsManager';
+import LocalNetworkAccessManager from 'main/security/localNetworkAccess';
 import {
     resetScreensharePermissionsMacOS,
     openScreensharePermissionsSettingsMacOS,
@@ -80,6 +81,13 @@ jest.mock('app/serverHub', () => ({
 jest.mock('main/performanceMonitor', () => ({
     registerView: jest.fn(),
     unregisterView: jest.fn(),
+}));
+jest.mock('main/security/localNetworkAccess', () => ({
+    __esModule: true,
+    default: {
+        registerWebContents: jest.fn(),
+        unregisterWebContents: jest.fn(),
+    },
 }));
 jest.mock('common/views/viewManager', () => ({
     getView: jest.fn(),
@@ -514,7 +522,9 @@ describe('main/windows/callsWidgetWindow', () => {
         let frameFinishedLoadListener;
         const popOut = {
             on: (event, listener) => {
-                closedListener = listener;
+                if (event === 'closed') {
+                    closedListener = listener;
+                }
             },
             webContents: {
                 on: (event, listener) => {
@@ -554,6 +564,7 @@ describe('main/windows/callsWidgetWindow', () => {
 
         expect(callsWidgetWindow.popOut).toBe(popOut);
         expect(WebContentsEventManager.addWebContentsEventListeners).toHaveBeenCalledWith(popOut.webContents);
+        expect(jest.mocked(LocalNetworkAccessManager.registerWebContents)).toHaveBeenCalledWith(popOut.webContents);
         expect(redirectListener).toBeDefined();
         expect(frameFinishedLoadListener).toBeDefined();
         expect(mockContextMenuReload).toHaveBeenCalledTimes(1);
@@ -567,6 +578,7 @@ describe('main/windows/callsWidgetWindow', () => {
 
         closedListener();
         expect(callsWidgetWindow.popOut).not.toBeDefined();
+        expect(jest.mocked(LocalNetworkAccessManager.unregisterWebContents)).toHaveBeenCalledWith('webContentsId');
         expect(mockContextMenuDispose).toHaveBeenCalled();
 
         // Verify widget visibility has been toggled

--- a/src/app/callsWidgetWindow.ts
+++ b/src/app/callsWidgetWindow.ts
@@ -42,6 +42,7 @@ import ViewManager from 'common/views/viewManager';
 import ContextMenu from 'main/contextMenu';
 import {localizeMessage} from 'main/i18nManager';
 import performanceMonitor from 'main/performanceMonitor';
+import LocalNetworkAccessManager from 'main/security/localNetworkAccess';
 import PermissionsManager from 'main/security/permissionsManager';
 import {
     composeUserAgent,
@@ -63,6 +64,7 @@ export class CallsWidgetWindow {
     private options?: CallsWidgetWindowConfig;
     private missingScreensharePermissions?: boolean;
     private seenErrorMessage?: boolean;
+    private webContentsId?: number;
 
     private popOut?: BrowserWindow;
     private boundsErr: Rectangle = {
@@ -221,6 +223,8 @@ export class CallsWidgetWindow {
             return;
         }
         performanceMonitor.registerView('CallsWidgetWindow', this.win.webContents);
+        this.webContentsId = this.win.webContents.id;
+        LocalNetworkAccessManager.registerWebContents(this.win.webContents);
         this.win?.loadURL(widgetURL, {
             userAgent: composeUserAgent(),
         }).catch((reason) => {
@@ -272,6 +276,10 @@ export class CallsWidgetWindow {
 
     private onClosed = () => {
         ipcMain.emit(UPDATE_SHORTCUT_MENU);
+        if (this.webContentsId) {
+            LocalNetworkAccessManager.unregisterWebContents(this.webContentsId);
+            delete this.webContentsId;
+        }
         delete this.win;
         delete this.mainView;
         delete this.options;
@@ -378,6 +386,7 @@ export class CallsWidgetWindow {
 
         // Let the webContentsEventManager handle links that try to open a new window.
         webContentsEventManager.addWebContentsEventListeners(this.popOut.webContents);
+        LocalNetworkAccessManager.registerWebContents(this.popOut.webContents);
 
         // Need to capture and handle redirects for security.
         this.popOut.webContents.on('will-redirect', (event: Event) => {
@@ -394,8 +403,10 @@ export class CallsWidgetWindow {
         this.popOut.webContents.on('devtools-focused', this.emitShortcutMenuUpdate);
         this.popOut.webContents.on('devtools-closed', this.emitShortcutMenuUpdate);
 
+        const popOutWebContentsId = win.webContents.id;
         this.popOut.on('closed', () => {
             ipcMain.emit(UPDATE_SHORTCUT_MENU);
+            LocalNetworkAccessManager.unregisterWebContents(popOutWebContentsId);
             delete this.popOut;
             contextMenu.dispose();
             this.setWidgetWindowStacking({onTop: true});

--- a/src/app/views/MattermostWebContentsView.test.js
+++ b/src/app/views/MattermostWebContentsView.test.js
@@ -12,6 +12,7 @@ import ServerManager from 'common/servers/serverManager';
 import {MattermostView, ViewType} from 'common/views/MattermostView';
 import ViewManager from 'common/views/viewManager';
 import {updateServerInfos} from 'main/app/utils';
+import LocalNetworkAccessManager from 'main/security/localNetworkAccess';
 import {getServerAPI} from 'main/server/serverAPI';
 
 import {MattermostWebContentsView} from './MattermostWebContentsView';
@@ -92,6 +93,13 @@ jest.mock('main/performanceMonitor', () => ({
     registerView: jest.fn(),
     registerServerView: jest.fn(),
     unregisterView: jest.fn(),
+}));
+jest.mock('main/security/localNetworkAccess', () => ({
+    __esModule: true,
+    default: {
+        registerWebContents: jest.fn(),
+        unregisterWebContents: jest.fn(),
+    },
 }));
 jest.mock('common/servers/serverManager', () => ({
     getRemoteInfo: jest.fn(),
@@ -359,8 +367,10 @@ describe('main/views/MattermostWebContentsView', () => {
 
         it('should remove browser view from window', () => {
             const mattermostView = new MattermostWebContentsView(view, {}, window);
+            expect(jest.mocked(LocalNetworkAccessManager.registerWebContents)).toHaveBeenCalledWith(mattermostView.webContentsView.webContents);
             mattermostView.webContentsView.webContents.close = jest.fn();
             mattermostView.destroy();
+            expect(jest.mocked(LocalNetworkAccessManager.unregisterWebContents)).toHaveBeenCalledWith(mattermostView.webContentsId);
             expect(window.contentView.removeChildView).toBeCalledWith(mattermostView.webContentsView);
         });
 

--- a/src/app/views/MattermostWebContentsView.ts
+++ b/src/app/views/MattermostWebContentsView.ts
@@ -34,6 +34,7 @@ import {updateServerInfos} from 'main/app/utils';
 import DeveloperMode from 'main/developerMode';
 import {localizeMessage} from 'main/i18nManager';
 import performanceMonitor from 'main/performanceMonitor';
+import LocalNetworkAccessManager from 'main/security/localNetworkAccess';
 import {getServerAPI} from 'main/server/serverAPI';
 
 import WebContentsEventManager from './webContentEvents';
@@ -82,6 +83,7 @@ export class MattermostWebContentsView extends EventEmitter {
         this.atRoot = true;
         this.webContentsView = new WebContentsView(this.options);
         this.cachedWebContentsId = this.webContentsView.webContents.id;
+        LocalNetworkAccessManager.registerWebContents(this.webContentsView.webContents);
         this.resetLoadingStatus();
 
         this.log = ViewManager.getViewLog(this.id, 'MattermostWebContentsView');
@@ -249,6 +251,7 @@ export class MattermostWebContentsView extends EventEmitter {
         AppState.clear(this.id);
         WebContentsEventManager.removeWebContentsListeners(this.webContentsId);
         performanceMonitor.unregisterView(this.webContentsId);
+        LocalNetworkAccessManager.unregisterWebContents(this.webContentsId);
         if (this.parentWindow && !this.parentWindow.isDestroyed()) {
             this.parentWindow.contentView.removeChildView(this.webContentsView);
         }

--- a/src/app/views/pluginsPopUps.test.js
+++ b/src/app/views/pluginsPopUps.test.js
@@ -8,6 +8,8 @@ import WebContentsManager from 'app/views/webContentsManager';
 import ServerManager from 'common/servers/serverManager';
 import {parseURL} from 'common/utils/url';
 
+import LocalNetworkAccessManager from 'main/security/localNetworkAccess';
+
 import PluginsPopUpsManager from './pluginsPopUps';
 
 import allowProtocolDialog from '../../main/security/allowProtocolDialog';
@@ -54,6 +56,14 @@ jest.mock('main/security/allowProtocolDialog', () => ({
     handleDialogEvent: jest.fn(),
 }));
 
+jest.mock('main/security/localNetworkAccess', () => ({
+    __esModule: true,
+    default: {
+        registerWebContents: jest.fn(),
+        unregisterWebContents: jest.fn(),
+    },
+}));
+
 describe('PluginsPopUpsManager', () => {
     afterEach(() => {
         jest.resetAllMocks();
@@ -92,6 +102,7 @@ describe('PluginsPopUpsManager', () => {
         expect(win.webContents.setWindowOpenHandler).toHaveBeenCalledWith(handlers['window-open']);
 
         expect(win.once).toHaveBeenCalledWith('closed', handlers.closed);
+        expect(jest.mocked(LocalNetworkAccessManager.registerWebContents)).toHaveBeenCalledWith(win.webContents);
 
         expect(mockContextMenuReload).toHaveBeenCalledTimes(1);
 
@@ -169,6 +180,7 @@ describe('PluginsPopUpsManager', () => {
 
         // Close
         handlers.closed();
+        expect(jest.mocked(LocalNetworkAccessManager.unregisterWebContents)).toHaveBeenCalledWith(45);
         expect(mockContextMenuDispose).toHaveBeenCalledTimes(1);
 
         // Verify the popout reference has been deleted

--- a/src/app/views/pluginsPopUps.ts
+++ b/src/app/views/pluginsPopUps.ts
@@ -20,8 +20,8 @@ import {
     parseURL,
 } from 'common/utils/url';
 import ContextMenu from 'main/contextMenu';
-
-import allowProtocolDialog from '../../main/security/allowProtocolDialog';
+import allowProtocolDialog from 'main/security/allowProtocolDialog';
+import LocalNetworkAccessManager from 'main/security/localNetworkAccess';
 
 const log = new Logger('PluginsPopUpsManager');
 
@@ -45,6 +45,7 @@ export class PluginsPopUpsManager {
             parentId,
             win,
         };
+        LocalNetworkAccessManager.registerWebContents(win.webContents);
 
         // We take a conservative approach for the time being and disallow most events coming from popups:
         // - Redirects
@@ -110,6 +111,7 @@ export class PluginsPopUpsManager {
         win.once('closed', () => {
             log.debug('removing popup window', details.url, webContentsId);
             Reflect.deleteProperty(this.popups, webContentsId);
+            LocalNetworkAccessManager.unregisterWebContents(webContentsId);
             contextMenu.dispose();
         });
 

--- a/src/app/views/webContentEvents.test.js
+++ b/src/app/views/webContentEvents.test.js
@@ -9,6 +9,7 @@ import NavigationManager from 'app/navigationManager';
 import WebContentsManager from 'app/views/webContentsManager';
 import {getLevel} from 'common/log';
 import ContextMenu from 'main/contextMenu';
+import LocalNetworkAccessManager from 'main/security/localNetworkAccess';
 
 import PluginsPopUpsManager from './pluginsPopUps';
 import {WebContentsEventManager} from './webContentEvents';
@@ -41,6 +42,14 @@ jest.mock('common/views/viewManager', () => ({
 jest.mock('app/views/pluginsPopUps', () => ({
     handleNewWindow: jest.fn(() => ({action: 'allow'})),
     generateHandleCreateWindow: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('main/security/localNetworkAccess', () => ({
+    __esModule: true,
+    default: {
+        registerWebContents: jest.fn(),
+        unregisterWebContents: jest.fn(),
+    },
 }));
 
 jest.mock('main/utils', () => ({
@@ -440,6 +449,7 @@ describe('main/views/webContentsEvents', () => {
         it('should open popup window for plugins', () => {
             expect(newWindow({url: 'http://server-1.com/plugins/myplugin/login'})).toStrictEqual({action: 'deny'});
             expect(webContentsEventManager.popupWindow).toBeTruthy();
+            expect(jest.mocked(LocalNetworkAccessManager.registerWebContents)).toHaveBeenCalled();
         });
 
         it('should open popup window for managed resources', () => {
@@ -463,6 +473,7 @@ describe('main/views/webContentsEvents', () => {
                 show: jest.fn(),
                 loadURL: jest.fn(),
                 webContents: {
+                    id: 99,
                     on: jest.fn(),
                     setWindowOpenHandler: jest.fn(),
                 },
@@ -476,6 +487,7 @@ describe('main/views/webContentsEvents', () => {
             expect(closedCallback).toBeDefined();
 
             closedCallback();
+            expect(jest.mocked(LocalNetworkAccessManager.unregisterWebContents)).toHaveBeenCalledWith(99);
             expect(mockContextMenu.dispose).toHaveBeenCalled();
         });
     });

--- a/src/app/views/webContentEvents.ts
+++ b/src/app/views/webContentEvents.ts
@@ -34,11 +34,11 @@ import {
 import ViewManager from 'common/views/viewManager';
 import ContextMenu from 'main/contextMenu';
 import {localizeMessage} from 'main/i18nManager';
+import allowProtocolDialog from 'main/security/allowProtocolDialog';
+import LocalNetworkAccessManager from 'main/security/localNetworkAccess';
+import {composeUserAgent} from 'main/utils';
 
 import {generateHandleConsoleMessage, generateWillFrameNavigate, isCustomProtocol, isMattermostProtocol} from './webContentEventsCommon';
-
-import allowProtocolDialog from '../../main/security/allowProtocolDialog';
-import {composeUserAgent} from '../../main/utils';
 
 const log = new Logger('WebContentsEventManager');
 
@@ -244,6 +244,7 @@ export class WebContentsEventManager {
                     };
 
                     popup = this.popupWindow.win;
+                    LocalNetworkAccessManager.registerWebContents(popup.webContents);
                     popup.webContents.on('will-redirect', (event, url) => {
                         const parsedURL = parseURL(url);
                         if (!parsedURL) {
@@ -258,7 +259,9 @@ export class WebContentsEventManager {
                     popup.webContents.on('will-navigate', this.generateWillNavigate(popup.webContents.id));
                     popup.webContents.on('will-frame-navigate', generateWillFrameNavigate(this.log(popup.webContents.id)));
                     popup.webContents.setWindowOpenHandler(this.denyNewWindow);
+                    const popupWebContentsId = popup.webContents.id;
                     popup.once('closed', () => {
+                        LocalNetworkAccessManager.unregisterWebContents(popupWebContentsId);
                         if (this.popupWindow?.contextMenu) {
                             this.popupWindow.contextMenu.dispose();
                         }

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -67,3 +67,9 @@ export const ModalConstants = {
     PROXY_LOGIN_MODAL: 'proxyLoginModal',
     PRE_AUTH_MODAL: 'preAuthModal',
 };
+
+export const FILTERED_PROTOCOLS = new Set(['http:', 'https:', 'ws:', 'wss:']);
+export const WEBSOCKET_PROTOCOL_EQUIVALENTS: {[protocol: string]: string} = {
+    'ws:': 'http:',
+    'wss:': 'https:',
+};

--- a/src/main/app/initialize.test.js
+++ b/src/main/app/initialize.test.js
@@ -8,6 +8,7 @@ import {app, session} from 'electron';
 import NavigationManager from 'app/navigationManager';
 import Config from 'common/config';
 import parseArgs from 'main/ParseArgs';
+import LocalNetworkAccessManager from 'main/security/localNetworkAccess';
 
 import {initialize} from './initialize';
 import {clearAppCache, getDeeplinkingURL, wasUpdated} from './utils';
@@ -105,9 +106,13 @@ jest.mock('electron-devtools-installer', () => {
 const isDev = false;
 jest.mock('electron-is-dev', () => isDev);
 
-jest.mock('common/constants', () => ({
-    MATTERMOST_PROTOCOL: 'mattermost',
-}));
+jest.mock('common/constants', () => {
+    const original = jest.requireActual('common/constants');
+    return {
+        ...original,
+        MATTERMOST_PROTOCOL: 'mattermost',
+    };
+});
 
 jest.mock('app/serverHub', () => ({
     init: jest.fn(),
@@ -122,6 +127,14 @@ jest.mock('common/config', () => ({
 jest.mock('main/security/allowProtocolDialog', () => ({
     init: jest.fn(),
 }));
+jest.mock('main/security/localNetworkAccess', () => {
+    const actual = jest.requireActual('main/security/localNetworkAccess');
+    return {
+        __esModule: true,
+        ...actual,
+        default: actual.default,
+    };
+});
 jest.mock('main/app/app', () => ({}));
 jest.mock('main/app/config', () => ({
     handleConfigUpdate: jest.fn(),
@@ -164,11 +177,6 @@ jest.mock('main/notifications', () => ({
     getDoNotDisturb: jest.fn(),
 }));
 jest.mock('main/ParseArgs', () => jest.fn());
-jest.mock('common/servers/serverManager', () => ({
-    reloadFromConfig: jest.fn(),
-    getAllServers: jest.fn(),
-    on: jest.fn(),
-}));
 jest.mock('app/system/tray/tray', () => ({
     refreshImages: jest.fn(),
     setup: jest.fn(),
@@ -178,10 +186,6 @@ jest.mock('main/UserActivityMonitor', () => ({
     startMonitoring: jest.fn(),
 }));
 jest.mock('app/callsWidgetWindow', () => ({}));
-jest.mock('app/views/webContentsManager', () => ({
-    getViewByWebContentsId: jest.fn(),
-    handleDeepLink: jest.fn(),
-}));
 jest.mock('app/mainWindow/mainWindow', () => ({
     get: jest.fn(),
     show: jest.fn(),
@@ -357,9 +361,10 @@ describe('main/app/initialize', () => {
 
             const getRegisteredHandler = async () => {
                 const ServerManager = jest.requireMock('common/servers/serverManager');
-                const WebContentsManager = jest.requireMock('app/views/webContentsManager');
+                const mockedLocalNetworkAccessManager = jest.mocked(LocalNetworkAccessManager);
                 ServerManager.getAllServers.mockReturnValue([{url: new URL('http://127.0.0.1:8065')}]);
-                WebContentsManager.getViewByWebContentsId.mockImplementation((id) => (id === SERVER_WEBCONTENTS_ID ? {id} : undefined));
+                mockedLocalNetworkAccessManager.clear();
+                mockedLocalNetworkAccessManager.registerWebContents({id: SERVER_WEBCONTENTS_ID});
                 await initialize();
                 const calls = session.defaultSession.webRequest.onBeforeRequest.mock.calls;
                 return calls[calls.length - 1][0];
@@ -403,9 +408,7 @@ describe('main/app/initialize', () => {
 
             it('allows the request when the policy check throws', async () => {
                 const handler = await getRegisteredHandler();
-                jest.requireMock('app/views/webContentsManager').getViewByWebContentsId.mockImplementation(() => {
-                    throw new Error('boom');
-                });
+                jest.spyOn(jest.mocked(LocalNetworkAccessManager), 'shouldCancelLocalNetworkRequest').mockRejectedValueOnce(new Error('boom'));
                 const callback = jest.fn();
 
                 await handler({url: 'http://127.0.0.1:7777/secret', webContentsId: SERVER_WEBCONTENTS_ID, resourceType: 'xhr'}, callback);

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -57,7 +57,7 @@ import parseArgs from 'main/ParseArgs';
 import PerformanceMonitor from 'main/performanceMonitor';
 import secureStorage from 'main/secureStorage';
 import AllowProtocolDialog from 'main/security/allowProtocolDialog';
-import {shouldCancelLocalNetworkRequest} from 'main/security/localNetworkAccess';
+import LocalNetworkAccessManager from 'main/security/localNetworkAccess';
 import PermissionsManager from 'main/security/permissionsManager';
 import PreAuthManager from 'main/security/preAuthManager';
 import sentryHandler from 'main/sentryHandler';
@@ -335,7 +335,7 @@ async function initializeAfterAppReady() {
     const defaultSession = session.defaultSession;
     defaultSession.webRequest.onBeforeRequest(async (details, callback) => {
         try {
-            const shouldCancel = await shouldCancelLocalNetworkRequest(details);
+            const shouldCancel = await LocalNetworkAccessManager.shouldCancelLocalNetworkRequest(details);
 
             if (shouldCancel) {
                 log.warn('Blocked server content from accessing local or private network URL', {

--- a/src/main/security/localNetworkAccess.test.ts
+++ b/src/main/security/localNetworkAccess.test.ts
@@ -1,15 +1,12 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {
-    isLocalOrPrivateIPAddress,
-    shouldCancelLocalNetworkRequest,
-    shouldBlockLocalNetworkRequest,
-} from './localNetworkAccess';
+import type {WebContents} from 'electron';
 
-jest.mock('app/views/webContentsManager', () => ({
-    getViewByWebContentsId: jest.fn(),
-}));
+import type {MattermostServer} from 'common/servers/MattermostServer';
+import ServerManager from 'common/servers/serverManager';
+
+import localNetworkAccessManager, {LocalNetworkAccessManager} from './localNetworkAccess';
 
 jest.mock('common/servers/serverManager', () => ({
     getAllServers: jest.fn(),
@@ -17,94 +14,143 @@ jest.mock('common/servers/serverManager', () => ({
 
 describe('main/security/localNetworkAccess', () => {
     const emptyLookup = jest.fn().mockResolvedValue([]);
-    const WebContentsManager = jest.requireMock('app/views/webContentsManager');
-    const ServerManager = jest.requireMock('common/servers/serverManager');
+    const mockServerManager = jest.mocked(ServerManager);
 
     beforeEach(() => {
         emptyLookup.mockClear();
-        WebContentsManager.getViewByWebContentsId.mockImplementation((webContentsId: number) => (webContentsId === 1 ? {id: 1} : undefined));
-        ServerManager.getAllServers.mockReturnValue([{url: new URL('http://127.0.0.1:8065')}]);
+        localNetworkAccessManager.clear();
+        mockServerManager.getAllServers.mockReturnValue([{url: new URL('http://127.0.0.1:8065')} as unknown as MattermostServer]);
+    });
+
+    describe('LocalNetworkAccessManager', () => {
+        it('registers webContents and tracks monitored status', () => {
+            const manager = new LocalNetworkAccessManager();
+            const mockWebContents = {
+                id: 10,
+                isDestroyed: () => false,
+            } as unknown as WebContents;
+
+            manager.registerWebContents(mockWebContents);
+            expect(manager.isMonitored(10)).toBe(true);
+            expect(manager.isMonitored(20)).toBe(false);
+        });
+
+        it('does not register if webContents is already destroyed', () => {
+            const manager = new LocalNetworkAccessManager();
+            const mockWebContents = {
+                id: 10,
+                isDestroyed: () => true,
+            } as unknown as WebContents;
+
+            manager.registerWebContents(mockWebContents);
+            expect(manager.isMonitored(10)).toBe(false);
+        });
+
+        it('unregisters webContents by id directly', () => {
+            const manager = new LocalNetworkAccessManager();
+            const mockWebContents = {
+                id: 10,
+                isDestroyed: () => false,
+            } as unknown as WebContents;
+
+            manager.registerWebContents(mockWebContents);
+            expect(manager.isMonitored(10)).toBe(true);
+
+            manager.unregisterWebContents(10);
+            expect(manager.isMonitored(10)).toBe(false);
+        });
     });
 
     describe('isLocalOrPrivateIPAddress', () => {
         it('detects IPv4 local and private ranges', () => {
-            expect(isLocalOrPrivateIPAddress('127.0.0.1')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('10.0.0.1')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('172.16.0.1')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('172.31.255.255')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('192.168.1.1')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('169.254.169.254')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('8.8.8.8')).toBe(false);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('127.0.0.1')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('10.0.0.1')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('172.16.0.1')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('172.31.255.255')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('192.168.1.1')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('169.254.169.254')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('8.8.8.8')).toBe(false);
         });
 
         it('detects IPv6 local and private ranges', () => {
-            expect(isLocalOrPrivateIPAddress('::1')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('fc00::1')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('fd00::1')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('fec0::1')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('fe80::1')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('::ffff:127.0.0.1')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('2606:4700:4700::1111')).toBe(false);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('::1')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('fc00::1')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('fd00::1')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('fec0::1')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('fe80::1')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('::ffff:127.0.0.1')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('2606:4700:4700::1111')).toBe(false);
         });
     });
 
     describe('shouldBlockLocalNetworkRequest', () => {
         it('blocks local hostnames and private IP literals', async () => {
-            await expect(shouldBlockLocalNetworkRequest('http://localhost:3000', [], emptyLookup)).resolves.toBe(true);
-            await expect(shouldBlockLocalNetworkRequest('http://127.0.0.1:3000', [], emptyLookup)).resolves.toBe(true);
-            await expect(shouldBlockLocalNetworkRequest('http://192.168.1.10', [], emptyLookup)).resolves.toBe(true);
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest('http://localhost:3000', [], emptyLookup)).resolves.toBe(true);
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest('http://127.0.0.1:3000', [], emptyLookup)).resolves.toBe(true);
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest('http://192.168.1.10', [], emptyLookup)).resolves.toBe(true);
         });
 
         it('allows configured server origins even when they are local', async () => {
-            await expect(shouldBlockLocalNetworkRequest(
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest(
                 'http://127.0.0.1:8065/api/v4/system/ping',
                 [new URL('http://127.0.0.1:8065')],
+                emptyLookup,
+            )).resolves.toBe(false);
+
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest(
+                'http://localhost:8065/api/v4/system/ping',
+                [new URL('http://localhost:8065/team')],
                 emptyLookup,
             )).resolves.toBe(false);
         });
 
         it('blocks hostnames that resolve to private addresses', async () => {
             const lookup = jest.fn().mockResolvedValue([{address: '10.0.0.5'}]);
-
-            await expect(shouldBlockLocalNetworkRequest('http://internal.example.com', [], lookup)).resolves.toBe(true);
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest('http://printer.corp', [], lookup)).resolves.toBe(true);
         });
 
         it('allows public http targets and non-filtered protocols', async () => {
             const lookup = jest.fn().mockResolvedValue([{address: '8.8.8.8'}]);
-
-            await expect(shouldBlockLocalNetworkRequest('https://mattermost.com', [], lookup)).resolves.toBe(false);
-            await expect(shouldBlockLocalNetworkRequest('mattermost-desktop://renderer/index.html', [], lookup)).resolves.toBe(false);
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest('https://mattermost.com', [], lookup)).resolves.toBe(false);
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest('file:///etc/hosts', [], lookup)).resolves.toBe(false);
         });
 
         it('blocks WebSocket connections to local/private targets', async () => {
-            await expect(shouldBlockLocalNetworkRequest('ws://127.0.0.1:9000', [], emptyLookup)).resolves.toBe(true);
-            await expect(shouldBlockLocalNetworkRequest('wss://192.168.1.10/socket', [], emptyLookup)).resolves.toBe(true);
-            await expect(shouldBlockLocalNetworkRequest('ws://localhost:8080', [], emptyLookup)).resolves.toBe(true);
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest('ws://127.0.0.1:8065/websocket', [], emptyLookup)).resolves.toBe(true);
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest('wss://10.0.0.5/websocket', [], emptyLookup)).resolves.toBe(true);
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest('ws://localhost:3000', [], emptyLookup)).resolves.toBe(true);
         });
 
         it('allows WebSocket connections to the configured server origin', async () => {
-            await expect(shouldBlockLocalNetworkRequest(
-                'wss://127.0.0.1:8065/api/v4/websocket',
-                [new URL('https://127.0.0.1:8065')],
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest(
+                'ws://127.0.0.1:8065/api/v4/websocket',
+                [new URL('http://127.0.0.1:8065')],
                 emptyLookup,
             )).resolves.toBe(false);
 
-            await expect(shouldBlockLocalNetworkRequest(
-                'ws://127.0.0.1:8065/api/v4/websocket',
-                [new URL('http://127.0.0.1:8065')],
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest(
+                'wss://127.0.0.1:8065/api/v4/websocket',
+                [new URL('https://127.0.0.1:8065')],
                 emptyLookup,
             )).resolves.toBe(false);
         });
 
         it('allows public WebSocket targets', async () => {
             const lookup = jest.fn().mockResolvedValue([{address: '8.8.8.8'}]);
-            await expect(shouldBlockLocalNetworkRequest('wss://realtime.example.com', [], lookup)).resolves.toBe(false);
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest('wss://realtime.example.com', [], lookup)).resolves.toBe(false);
         });
     });
 
     describe('shouldCancelLocalNetworkRequest', () => {
+        beforeEach(() => {
+            localNetworkAccessManager.registerWebContents({
+                id: 1,
+                isDestroyed: () => false,
+            } as unknown as WebContents);
+        });
+
         it('blocks server view requests using webContentsId', async () => {
-            await expect(shouldCancelLocalNetworkRequest(
+            await expect(localNetworkAccessManager.shouldCancelLocalNetworkRequest(
                 {
                     url: 'http://127.0.0.1:7777/secret',
                     webContentsId: 1,
@@ -114,7 +160,7 @@ describe('main/security/localNetworkAccess', () => {
         });
 
         it('allows configured server origins', async () => {
-            await expect(shouldCancelLocalNetworkRequest(
+            await expect(localNetworkAccessManager.shouldCancelLocalNetworkRequest(
                 {
                     url: 'http://127.0.0.1:8065/api/v4/system/ping',
                     webContentsId: 1,
@@ -124,7 +170,7 @@ describe('main/security/localNetworkAccess', () => {
         });
 
         it('allows requests that belong to a known non-server web contents', async () => {
-            await expect(shouldCancelLocalNetworkRequest(
+            await expect(localNetworkAccessManager.shouldCancelLocalNetworkRequest(
                 {
                     url: 'http://127.0.0.1:7777/secret',
                     webContentsId: 2,
@@ -134,7 +180,7 @@ describe('main/security/localNetworkAccess', () => {
         });
 
         it('blocks unowned requests to local/private targets', async () => {
-            await expect(shouldCancelLocalNetworkRequest(
+            await expect(localNetworkAccessManager.shouldCancelLocalNetworkRequest(
                 {
                     url: 'http://127.0.0.1:7777/secret',
                 },
@@ -143,7 +189,7 @@ describe('main/security/localNetworkAccess', () => {
         });
 
         it('allows unowned requests to the configured server origin', async () => {
-            await expect(shouldCancelLocalNetworkRequest(
+            await expect(localNetworkAccessManager.shouldCancelLocalNetworkRequest(
                 {
                     url: 'http://127.0.0.1:8065/api/v4/websocket',
                 },
@@ -153,7 +199,7 @@ describe('main/security/localNetworkAccess', () => {
 
         it('allows unowned requests to public targets', async () => {
             const lookup = jest.fn().mockResolvedValue([{address: '8.8.8.8'}]);
-            await expect(shouldCancelLocalNetworkRequest(
+            await expect(localNetworkAccessManager.shouldCancelLocalNetworkRequest(
                 {
                     url: 'https://mattermost.com',
                 },

--- a/src/main/security/localNetworkAccess.ts
+++ b/src/main/security/localNetworkAccess.ts
@@ -4,123 +4,147 @@
 import dns from 'dns/promises';
 import {BlockList, isIP} from 'net';
 
-import WebContentsManager from 'app/views/webContentsManager';
+import type {WebContents} from 'electron';
+
+import {FILTERED_PROTOCOLS, WEBSOCKET_PROTOCOL_EQUIVALENTS} from 'common/constants';
 import ServerManager from 'common/servers/serverManager';
 import {parseURL} from 'common/utils/url';
 
-type LookupAddress = {
-    address: string;
-}
-
-type LookupFunction = (hostname: string) => Promise<LookupAddress[]>;
-
-export type LocalNetworkRequestDetails = {
+type LookupFunction = (hostname: string) => Promise<Array<{address: string}>>;
+type LocalNetworkRequestDetails = {
     url: string;
     webContentsId?: number;
-}
+};
 
 const defaultLookup: LookupFunction = (hostname: string) => dns.lookup(hostname, {all: true, verbatim: true});
 
-// Address ranges handled by the request policy.
-const LOCAL_NETWORK_BLOCKLIST = new BlockList();
+export class LocalNetworkAccessManager {
+    private monitoredWebContents: Set<number>;
+    private blockList: BlockList;
 
-LOCAL_NETWORK_BLOCKLIST.addSubnet('0.0.0.0', 8, 'ipv4');
-LOCAL_NETWORK_BLOCKLIST.addSubnet('10.0.0.0', 8, 'ipv4');
-LOCAL_NETWORK_BLOCKLIST.addSubnet('127.0.0.0', 8, 'ipv4');
-LOCAL_NETWORK_BLOCKLIST.addSubnet('169.254.0.0', 16, 'ipv4');
-LOCAL_NETWORK_BLOCKLIST.addSubnet('172.16.0.0', 12, 'ipv4');
-LOCAL_NETWORK_BLOCKLIST.addSubnet('192.168.0.0', 16, 'ipv4');
-LOCAL_NETWORK_BLOCKLIST.addSubnet('::1', 128, 'ipv6');
-LOCAL_NETWORK_BLOCKLIST.addSubnet('fc00::', 7, 'ipv6');
-LOCAL_NETWORK_BLOCKLIST.addSubnet('fec0::', 10, 'ipv6');
-LOCAL_NETWORK_BLOCKLIST.addSubnet('fe80::', 10, 'ipv6');
+    constructor() {
+        this.monitoredWebContents = new Set();
+        this.blockList = new BlockList();
+        this.blockList.addSubnet('0.0.0.0', 8, 'ipv4');
+        this.blockList.addSubnet('10.0.0.0', 8, 'ipv4');
+        this.blockList.addSubnet('127.0.0.0', 8, 'ipv4');
+        this.blockList.addSubnet('169.254.0.0', 16, 'ipv4');
+        this.blockList.addSubnet('172.16.0.0', 12, 'ipv4');
+        this.blockList.addSubnet('192.168.0.0', 16, 'ipv4');
+        this.blockList.addSubnet('::1', 128, 'ipv6');
+        this.blockList.addSubnet('fc00::', 7, 'ipv6');
+        this.blockList.addSubnet('fec0::', 10, 'ipv6');
+        this.blockList.addSubnet('fe80::', 10, 'ipv6');
+    }
 
-export async function shouldCancelLocalNetworkRequest(
-    details: LocalNetworkRequestDetails,
-    lookup: LookupFunction = defaultLookup,
-): Promise<boolean> {
-    if (details.webContentsId && !WebContentsManager.getViewByWebContentsId(details.webContentsId)) {
+    registerWebContents = (webContents: WebContents) => {
+        if (!webContents || webContents.isDestroyed?.()) {
+            return;
+        }
+        this.monitoredWebContents.add(webContents.id);
+    };
+
+    unregisterWebContents = (webContentsId: number) => {
+        this.monitoredWebContents.delete(webContentsId);
+    };
+
+    isMonitored = (webContentsId?: number): boolean => {
+        if (!webContentsId) {
+            return false;
+        }
+        return this.monitoredWebContents.has(webContentsId);
+    };
+
+    clear = () => {
+        this.monitoredWebContents.clear();
+    };
+
+    shouldCancelLocalNetworkRequest = async (
+        details: LocalNetworkRequestDetails,
+        lookup: LookupFunction = defaultLookup,
+    ): Promise<boolean> => {
+        if (details.webContentsId && !this.isMonitored(details.webContentsId)) {
+            return false;
+        }
+
+        const serverURLs = ServerManager.getAllServers().map((server) => server.url);
+        return this.shouldBlockLocalNetworkRequest(details.url, serverURLs, lookup);
+    };
+
+    shouldBlockLocalNetworkRequest = async (
+        rawURL: string,
+        serverURLs: URL[],
+        lookup: LookupFunction = defaultLookup,
+    ): Promise<boolean> => {
+        const url = parseURL(rawURL);
+        if (!url) {
+            return false;
+        }
+
+        if (!FILTERED_PROTOCOLS.has(url.protocol)) {
+            return false;
+        }
+
+        if (this.isAllowedServerOrigin(url, serverURLs)) {
+            return false;
+        }
+
+        return this.isLocalOrPrivateHostname(url.hostname, lookup);
+    };
+
+    isLocalOrPrivateIPAddress = (address: string): boolean => {
+        const family = isIP(address);
+        if (family === 4) {
+            return this.blockList.check(address, 'ipv4');
+        }
+
+        if (family === 6) {
+            return this.blockList.check(address, 'ipv6');
+        }
+
         return false;
-    }
+    };
 
-    const serverURLs = ServerManager.getAllServers().map((server) => server.url);
-    return shouldBlockLocalNetworkRequest(details.url, serverURLs, lookup);
+    private isAllowedServerOrigin = (url: URL, serverURLs: URL[]): boolean => {
+        const targetOrigin = this.getComparableOrigin(url);
+        return serverURLs.some((serverURL) => this.getComparableOrigin(serverURL) === targetOrigin);
+    };
+
+    private isLocalOrPrivateHostname = async (
+        hostname: string,
+        lookup: LookupFunction = defaultLookup,
+    ): Promise<boolean> => {
+        const normalizedHostname = this.normalizeHostname(hostname);
+
+        if (this.isLocalhostHostname(normalizedHostname)) {
+            return true;
+        }
+
+        if (this.isLocalOrPrivateIPAddress(normalizedHostname)) {
+            return true;
+        }
+
+        try {
+            const addresses = await lookup(normalizedHostname);
+            return addresses.some(({address}) => this.isLocalOrPrivateIPAddress(this.normalizeHostname(address)));
+        } catch {
+            return false;
+        }
+    };
+
+    private normalizeHostname = (hostname: string): string => {
+        return hostname.toLowerCase().replace(/^\[/, '').replace(/\]$/, '').split('%')[0];
+    };
+
+    private isLocalhostHostname = (hostname: string): boolean => {
+        return hostname === 'localhost' || hostname.endsWith('.localhost');
+    };
+
+    private getComparableOrigin = (url: URL): string => {
+        const protocol = WEBSOCKET_PROTOCOL_EQUIVALENTS[url.protocol] ?? url.protocol;
+        return `${protocol}//${url.host}`;
+    };
 }
 
-const FILTERED_PROTOCOLS = new Set(['http:', 'https:', 'ws:', 'wss:']);
-
-const WEBSOCKET_PROTOCOL_EQUIVALENTS: {[protocol: string]: string} = {
-    'ws:': 'http:',
-    'wss:': 'https:',
-};
-
-function getComparableOrigin(url: URL): string {
-    const protocol = WEBSOCKET_PROTOCOL_EQUIVALENTS[url.protocol] ?? url.protocol;
-    return `${protocol}//${url.host}`;
-}
-
-export function isAllowedServerOrigin(url: URL, serverURLs: URL[]): boolean {
-    const targetOrigin = getComparableOrigin(url);
-    return serverURLs.some((serverURL) => getComparableOrigin(serverURL) === targetOrigin);
-}
-
-export async function shouldBlockLocalNetworkRequest(
-    rawURL: string,
-    serverURLs: URL[],
-    lookup: LookupFunction = defaultLookup,
-): Promise<boolean> {
-    const url = parseURL(rawURL);
-    if (!url) {
-        return false;
-    }
-
-    if (!FILTERED_PROTOCOLS.has(url.protocol)) {
-        return false;
-    }
-
-    if (isAllowedServerOrigin(url, serverURLs)) {
-        return false;
-    }
-
-    return isLocalOrPrivateHostname(url.hostname, lookup);
-}
-
-export async function isLocalOrPrivateHostname(hostname: string, lookup: LookupFunction = defaultLookup): Promise<boolean> {
-    const normalizedHostname = normalizeHostname(hostname);
-
-    if (isLocalhostHostname(normalizedHostname)) {
-        return true;
-    }
-
-    if (isLocalOrPrivateIPAddress(normalizedHostname)) {
-        return true;
-    }
-
-    try {
-        const addresses = await lookup(normalizedHostname);
-        return addresses.some(({address}) => isLocalOrPrivateIPAddress(normalizeHostname(address)));
-    } catch {
-        return false;
-    }
-}
-
-function normalizeHostname(hostname: string): string {
-    return hostname.toLowerCase().replace(/^\[/, '').replace(/\]$/, '').split('%')[0];
-}
-
-function isLocalhostHostname(hostname: string): boolean {
-    return hostname === 'localhost' || hostname.endsWith('.localhost');
-}
-
-export function isLocalOrPrivateIPAddress(address: string): boolean {
-    const family = isIP(address);
-    if (family === 4) {
-        return LOCAL_NETWORK_BLOCKLIST.check(address, 'ipv4');
-    }
-
-    if (family === 6) {
-        return LOCAL_NETWORK_BLOCKLIST.check(address, 'ipv6');
-    }
-
-    return false;
-}
+const localNetworkAccessManager = new LocalNetworkAccessManager();
+export default localNetworkAccessManager;


### PR DESCRIPTION
#### Summary
Certain secondary windows, such as plugin pop-outs and calls widget views, were not subject to local network access restrictions.

This PR refactors `LocalNetworkAccessManager` into a class that explicitly registers web contents upon creation and unregisters them when closed, ensuring all relevant views are consistently monitored for local network requests.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-70566

#### Release Note
```release-note
Fixed an issue with some local network access checks.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved protection against requests to local and private network addresses across pop-up windows, calls widgets, and embedded content.
  * Added coverage for localhost, WebSocket, HTTP, and HTTPS request scenarios.
  * Web content access permissions are now cleaned up when windows and views close, helping prevent stale access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->