### PR TITLE
Add Desktop theme protocol V1

### DIFF
--- a/api-types/index.ts
+++ b/api-types/index.ts
@@ -39,6 +39,129 @@ export type Theme = {
 
     isUsingSystemTheme: boolean;
 }
+export type DesktopThemeProtocolCapabilities = {
+    protocolVersion: 1;
+}
+export type SystemAppearanceUnknownReason =
+    | 'unsupported'
+    | 'unavailable'
+    | 'invalid'
+    | 'error'
+    | 'unstable';
+export type SystemAppearanceSnapshot =
+    | {
+        revision: number;
+        status: 'known';
+        value: 'light' | 'dark';
+    }
+    | {
+        revision: number;
+        status: 'unknown';
+        reason: SystemAppearanceUnknownReason;
+    };
+export type SystemAppearanceInvalidation = {
+    revision: number;
+    previousValueStatus: 'stale' | 'invalid';
+}
+export type DesktopThemeMainStandbyReason =
+    | 'not-current'
+    | 'desktop-sync-disabled'
+    | 'screen-locked'
+    | 'system-suspended'
+    | 'apply-failed'
+    | 'theme-reset-failed';
+export type DesktopThemeSurfaceState =
+    | {
+        revision: number;
+        scope: 'main-tab';
+        status: 'standby';
+        reason: DesktopThemeMainStandbyReason;
+    }
+    | {
+        revision: number;
+        scope: 'main-tab';
+        status: 'granted';
+        leaseId: string;
+    }
+    | {
+        revision: number;
+        scope: 'popout';
+        status: 'ineligible';
+        reason: 'not-main-tab';
+    };
+export type DesktopThemeSurfaceRegistration = {
+    surfaceId: string;
+    state: DesktopThemeSurfaceState;
+}
+export type DesktopThemeSurfaceStateEvent = {
+    surfaceId: string;
+    state: DesktopThemeSurfaceState;
+}
+export type DesktopShellTheme = Omit<Theme, 'isUsingSystemTheme'>;
+export type DesktopThemeDirective = {
+    mode: 'fixed' | 'system';
+    shellTheme: DesktopShellTheme;
+}
+export type DesktopThemeApplyRequest = {
+    surfaceId: string;
+    leaseId: string;
+    sequence: number;
+    directive: DesktopThemeDirective;
+}
+export type DesktopThemeRejectReason =
+    | 'unknown-surface'
+    | 'not-owner'
+    | 'stale-lease'
+    | 'stale-sequence'
+    | 'invalid-document'
+    | 'desktop-sync-disabled'
+    | 'screen-locked'
+    | 'system-suspended';
+export type DesktopThemeFailureReason =
+    | 'native-theme-update'
+    | 'desktop-shell-update'
+    | 'theme-reset';
+export type DesktopThemeApplyResult =
+    | {
+        status: 'applied';
+        surfaceId: string;
+        leaseId: string;
+        sequence: number;
+    }
+    | {
+        status: 'rejected';
+        surfaceId: string;
+        leaseId: string;
+        sequence: number;
+        reason: DesktopThemeRejectReason;
+    }
+    | {
+        status: 'failed';
+        surfaceId: string;
+        leaseId: string;
+        sequence: number;
+        reason: DesktopThemeFailureReason;
+    };
+export type DesktopThemeReleaseResult =
+    | {status: 'released'}
+    | {status: 'stale'};
+export type DesktopThemeProtocolV1 = {
+    getDesktopThemeCapabilities: () => Promise<DesktopThemeProtocolCapabilities | undefined>;
+    getSystemAppearance: () => Promise<SystemAppearanceSnapshot | undefined>;
+    onSystemAppearanceInvalidated: (
+        listener: (event: SystemAppearanceInvalidation) => void,
+    ) => () => void;
+    registerDesktopThemeSurface: () => Promise<DesktopThemeSurfaceRegistration | undefined>;
+    onDesktopThemeSurfaceStateChanged: (
+        listener: (event: DesktopThemeSurfaceStateEvent) => void,
+    ) => () => void;
+    applyDesktopTheme: (
+        request: DesktopThemeApplyRequest,
+    ) => Promise<DesktopThemeApplyResult>;
+    releaseDesktopThemeSurface: (
+        surfaceId: string,
+    ) => Promise<DesktopThemeReleaseResult>;
+}
 export type PopoutViewProps = {
     titleTemplate?: string;
     isRHS?: boolean;
@@ -54,7 +177,7 @@ export type SessionAttributeField = {
     };
 };
 
-export type DesktopAPI = {
+export type DesktopAPI = DesktopThemeProtocolV1 & {
 
     // Initialization
     isDev: () => Promise<boolean>;

--- a/api-types/lib/index.d.ts
+++ b/api-types/lib/index.d.ts
@@ -38,6 +38,93 @@ export type Theme = {
     codeTheme: string;
     isUsingSystemTheme: boolean;
 };
+export type DesktopThemeProtocolCapabilities = {
+    protocolVersion: 1;
+};
+export type SystemAppearanceUnknownReason = 'unsupported' | 'unavailable' | 'invalid' | 'error' | 'unstable';
+export type SystemAppearanceSnapshot = {
+    revision: number;
+    status: 'known';
+    value: 'light' | 'dark';
+} | {
+    revision: number;
+    status: 'unknown';
+    reason: SystemAppearanceUnknownReason;
+};
+export type SystemAppearanceInvalidation = {
+    revision: number;
+    previousValueStatus: 'stale' | 'invalid';
+};
+export type DesktopThemeMainStandbyReason = 'not-current' | 'desktop-sync-disabled' | 'screen-locked' | 'system-suspended' | 'apply-failed' | 'theme-reset-failed';
+export type DesktopThemeSurfaceState = {
+    revision: number;
+    scope: 'main-tab';
+    status: 'standby';
+    reason: DesktopThemeMainStandbyReason;
+} | {
+    revision: number;
+    scope: 'main-tab';
+    status: 'granted';
+    leaseId: string;
+} | {
+    revision: number;
+    scope: 'popout';
+    status: 'ineligible';
+    reason: 'not-main-tab';
+};
+export type DesktopThemeSurfaceRegistration = {
+    surfaceId: string;
+    state: DesktopThemeSurfaceState;
+};
+export type DesktopThemeSurfaceStateEvent = {
+    surfaceId: string;
+    state: DesktopThemeSurfaceState;
+};
+export type DesktopShellTheme = Omit<Theme, 'isUsingSystemTheme'>;
+export type DesktopThemeDirective = {
+    mode: 'fixed' | 'system';
+    shellTheme: DesktopShellTheme;
+};
+export type DesktopThemeApplyRequest = {
+    surfaceId: string;
+    leaseId: string;
+    sequence: number;
+    directive: DesktopThemeDirective;
+};
+export type DesktopThemeRejectReason = 'unknown-surface' | 'not-owner' | 'stale-lease' | 'stale-sequence' | 'invalid-document' | 'desktop-sync-disabled' | 'screen-locked' | 'system-suspended';
+export type DesktopThemeFailureReason = 'native-theme-update' | 'desktop-shell-update' | 'theme-reset';
+export type DesktopThemeApplyResult = {
+    status: 'applied';
+    surfaceId: string;
+    leaseId: string;
+    sequence: number;
+} | {
+    status: 'rejected';
+    surfaceId: string;
+    leaseId: string;
+    sequence: number;
+    reason: DesktopThemeRejectReason;
+} | {
+    status: 'failed';
+    surfaceId: string;
+    leaseId: string;
+    sequence: number;
+    reason: DesktopThemeFailureReason;
+};
+export type DesktopThemeReleaseResult = {
+    status: 'released';
+} | {
+    status: 'stale';
+};
+export type DesktopThemeProtocolV1 = {
+    getDesktopThemeCapabilities: () => Promise<DesktopThemeProtocolCapabilities | undefined>;
+    getSystemAppearance: () => Promise<SystemAppearanceSnapshot | undefined>;
+    onSystemAppearanceInvalidated: (listener: (event: SystemAppearanceInvalidation) => void) => () => void;
+    registerDesktopThemeSurface: () => Promise<DesktopThemeSurfaceRegistration | undefined>;
+    onDesktopThemeSurfaceStateChanged: (listener: (event: DesktopThemeSurfaceStateEvent) => void) => () => void;
+    applyDesktopTheme: (request: DesktopThemeApplyRequest) => Promise<DesktopThemeApplyResult>;
+    releaseDesktopThemeSurface: (surfaceId: string) => Promise<DesktopThemeReleaseResult>;
+};
 export type PopoutViewProps = {
     titleTemplate?: string;
     isRHS?: boolean;
@@ -52,7 +139,7 @@ export type SessionAttributeField = {
         platforms: string[];
     };
 };
-export type DesktopAPI = {
+export type DesktopAPI = DesktopThemeProtocolV1 & {
     isDev: () => Promise<boolean>;
     getAppInfo: () => Promise<{
         name: string;

--- a/api-types/package-lock.json
+++ b/api-types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mattermost/desktop-api",
-  "version": "6.3.0-2",
+  "version": "6.3.0-4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mattermost/desktop-api",
-      "version": "6.3.0-2",
+      "version": "6.3.0-4",
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^4.3.0 || ^5.0.0"

--- a/api-types/package.json
+++ b/api-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/desktop-api",
-  "version": "6.3.0-2",
+  "version": "6.3.0-4",
   "description": "Shared types for the Desktop App API provided to the Web App",
   "keywords": [
     "mattermost"

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
     },
     "api-types": {
       "name": "@mattermost/desktop-api",
-      "version": "6.3.0-2",
+      "version": "6.3.0-4",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/src/app/preload/externalAPI.ts
+++ b/src/app/preload/externalAPI.ts
@@ -55,6 +55,13 @@ import {
     POPOUT_CLOSED,
     WINDOW_CLOSE,
     UPDATE_POPOUT_TITLE_TEMPLATE,
+    GET_DESKTOP_THEME_CAPABILITIES,
+    GET_SYSTEM_APPEARANCE,
+    SYSTEM_APPEARANCE_INVALIDATED,
+    REGISTER_DESKTOP_THEME_SURFACE,
+    DESKTOP_THEME_SURFACE_STATE_CHANGED,
+    APPLY_DESKTOP_THEME,
+    RELEASE_DESKTOP_THEME_SURFACE,
 } from 'common/communication';
 
 import type {ExternalAPI} from 'types/externalAPI';
@@ -103,6 +110,13 @@ const desktopAPI: DesktopAPI = {
     updateTheme: (theme) => ipcRenderer.send(UPDATE_THEME, theme),
     getDarkMode: () => ipcRenderer.invoke(GET_DARK_MODE),
     onDarkModeChanged: (listener) => createListener(DARK_MODE_CHANGE, listener),
+    getDesktopThemeCapabilities: () => ipcRenderer.invoke(GET_DESKTOP_THEME_CAPABILITIES),
+    getSystemAppearance: () => ipcRenderer.invoke(GET_SYSTEM_APPEARANCE),
+    onSystemAppearanceInvalidated: (listener) => createListener(SYSTEM_APPEARANCE_INVALIDATED, listener),
+    registerDesktopThemeSurface: () => ipcRenderer.invoke(REGISTER_DESKTOP_THEME_SURFACE),
+    onDesktopThemeSurfaceStateChanged: (listener) => createListener(DESKTOP_THEME_SURFACE_STATE_CHANGED, listener),
+    applyDesktopTheme: (request) => ipcRenderer.invoke(APPLY_DESKTOP_THEME, request),
+    releaseDesktopThemeSurface: (surfaceId) => ipcRenderer.invoke(RELEASE_DESKTOP_THEME_SURFACE, surfaceId),
 
     // Calls
     joinCall: (opts) => ipcRenderer.invoke(CALLS_JOIN_CALL, opts),
@@ -228,31 +242,36 @@ contextBridge.executeInMainWorld({
 });
 
 function getThemeValues() {
+    ipcRenderer.send(UPDATE_SERVER_THEME, readThemeValues());
+}
+
+function readThemeValues() {
     const style = window.getComputedStyle(document.body);
-    ipcRenderer.send(UPDATE_SERVER_THEME, {
-        sidebarBg: style.getPropertyValue('--sidebar-bg'),
-        sidebarText: style.getPropertyValue('--sidebar-text'),
-        sidebarUnreadText: style.getPropertyValue('--sidebar-unread-text'),
-        sidebarTextHoverBg: style.getPropertyValue('--sidebar-text-hover-bg'),
-        sidebarTextActiveBorder: style.getPropertyValue('--sidebar-text-active-border'),
-        sidebarTextActiveColor: style.getPropertyValue('--sidebar-text-active-color'),
-        sidebarHeaderBg: style.getPropertyValue('--sidebar-header-bg'),
-        sidebarTeamBarBg: style.getPropertyValue('--sidebar-team-bar-bg'),
-        sidebarHeaderTextColor: style.getPropertyValue('--sidebar-header-text-color'),
-        onlineIndicator: style.getPropertyValue('--online-indicator'),
-        awayIndicator: style.getPropertyValue('--away-indicator'),
-        dndIndicator: style.getPropertyValue('--dnd-indicator'),
-        mentionBg: style.getPropertyValue('--mention-bg'),
-        mentionColor: style.getPropertyValue('--mention-color'),
-        centerChannelBg: style.getPropertyValue('--center-channel-bg'),
-        centerChannelColor: style.getPropertyValue('--center-channel-color'),
-        newMessageSeparator: style.getPropertyValue('--new-message-separator'),
-        linkColor: style.getPropertyValue('--link-color'),
-        buttonBg: style.getPropertyValue('--button-bg'),
-        buttonColor: style.getPropertyValue('--button-color'),
-        errorTextColor: style.getPropertyValue('--error-text'),
-        mentionHighlightBg: style.getPropertyValue('--mention-highlight-bg'),
-        mentionHighlightLink: style.getPropertyValue('--mention-highlight-link'),
-        codeTheme: style.getPropertyValue('--code-theme'),
-    });
+    const readProperty = (name: string) => style.getPropertyValue(name).trim();
+    return {
+        sidebarBg: readProperty('--sidebar-bg'),
+        sidebarText: readProperty('--sidebar-text'),
+        sidebarUnreadText: readProperty('--sidebar-unread-text'),
+        sidebarTextHoverBg: readProperty('--sidebar-text-hover-bg'),
+        sidebarTextActiveBorder: readProperty('--sidebar-text-active-border'),
+        sidebarTextActiveColor: readProperty('--sidebar-text-active-color'),
+        sidebarHeaderBg: readProperty('--sidebar-header-bg'),
+        sidebarTeamBarBg: readProperty('--sidebar-team-bar-bg'),
+        sidebarHeaderTextColor: readProperty('--sidebar-header-text-color'),
+        onlineIndicator: readProperty('--online-indicator'),
+        awayIndicator: readProperty('--away-indicator'),
+        dndIndicator: readProperty('--dnd-indicator'),
+        mentionBg: readProperty('--mention-bg'),
+        mentionColor: readProperty('--mention-color'),
+        centerChannelBg: readProperty('--center-channel-bg'),
+        centerChannelColor: readProperty('--center-channel-color'),
+        newMessageSeparator: readProperty('--new-message-separator'),
+        linkColor: readProperty('--link-color'),
+        buttonBg: readProperty('--button-bg'),
+        buttonColor: readProperty('--button-color'),
+        errorTextColor: readProperty('--error-text'),
+        mentionHighlightBg: readProperty('--mention-highlight-bg'),
+        mentionHighlightLink: readProperty('--mention-highlight-link'),
+        codeTheme: readProperty('--code-theme'),
+    };
 }

--- a/src/app/tabs/tabManager.test.js
+++ b/src/app/tabs/tabManager.test.js
@@ -223,6 +223,17 @@ describe('TabManager', () => {
 
             expect(observedOwners).toEqual([undefined, 'test-view-id']);
         });
+
+        it('clears the committed owner when its tab fails to load', () => {
+            const tabManager = new TabManager();
+            tabManager.activeTabs.set('test-server-id', 'test-view-id');
+            tabManager.currentVisibleTab = 'test-view-id';
+
+            tabManager.failLoading('test-view-id');
+
+            expect(tabManager.currentVisibleTab).toBeUndefined();
+            expect(ThemeManager.handleCommittedMainViewChanged).toHaveBeenCalled();
+        });
     });
 
     describe('getOrderedTabsForServer', () => {
@@ -904,7 +915,6 @@ describe('TabManager', () => {
 
             // Verify switchToNextTabIfNecessary was called
             expect(switchToNextTabSpy).toHaveBeenCalledWith('test-tab-id', 'test-server-id');
-            expect(ThemeManager.handleDesktopThemeViewInvalidated).not.toHaveBeenCalled();
         });
 
         it('should not handle non-TAB type removal', () => {
@@ -1158,6 +1168,7 @@ describe('TabManager', () => {
             };
 
             ViewManager.getView.mockReturnValue(mockView);
+            tabManager.currentVisibleTab = 'new-window-id';
 
             // Emit the event for WINDOW type
             ViewManager.mockViewManager.emit(VIEW_TYPE_ADDED, 'new-window-id', ViewType.WINDOW);
@@ -1166,14 +1177,6 @@ describe('TabManager', () => {
             expect(tabManager.tabOrder.get('test-server-id')).toBeUndefined();
             expect(emitSpy).not.toHaveBeenCalledWith(TAB_ADDED, expect.any(String), expect.any(String));
             expect(ThemeManager.handleDesktopThemeViewTypeChanged).toHaveBeenCalledWith('new-window-id', ViewType.WINDOW);
-        });
-
-        it('clears a committed view after it becomes a window', () => {
-            const tabManager = new TabManager();
-            tabManager.currentVisibleTab = 'converted-view-id';
-
-            ViewManager.mockViewManager.emit(VIEW_TYPE_ADDED, 'converted-view-id', ViewType.WINDOW);
-
             expect(tabManager.currentVisibleTab).toBeUndefined();
             expect(ThemeManager.handleCommittedMainViewChanged).toHaveBeenCalled();
         });

--- a/src/app/tabs/tabManager.test.js
+++ b/src/app/tabs/tabManager.test.js
@@ -31,6 +31,7 @@ import {
 import ServerManager from 'common/servers/serverManager';
 import {ViewType} from 'common/views/MattermostView';
 import ViewManager from 'common/views/viewManager';
+import ThemeManager from 'main/themeManager';
 
 import {TabManager} from './tabManager';
 
@@ -112,6 +113,13 @@ jest.mock('common/config', () => ({
     viewLimit: 15,
 }));
 
+jest.mock('main/themeManager', () => ({
+    setCommittedMainViewResolver: jest.fn(),
+    handleCommittedMainViewChanged: jest.fn(),
+    handleDesktopThemeViewInvalidated: jest.fn(),
+    handleDesktopThemeViewTypeChanged: jest.fn(),
+}));
+
 describe('TabManager', () => {
     const mockWebContentsView = {
         on: jest.fn(),
@@ -127,6 +135,7 @@ describe('TabManager', () => {
         reload: jest.fn(),
         currentURL: 'https://test.com',
         serverId: 'test-server-id',
+        isDestroyed: jest.fn(() => false),
         isErrored: jest.fn(() => false),
         needsLoadingScreen: jest.fn(() => false),
     };
@@ -173,6 +182,47 @@ describe('TabManager', () => {
 
         ServerManager.getCurrentServerId.mockReturnValue('test-server-id');
         ServerManager.getServer.mockReturnValue(mockServer);
+    });
+
+    describe('committed main view', () => {
+        it('injects a resolver for the committed visible tab', () => {
+            const tabManager = new TabManager();
+            const resolver = ThemeManager.setCommittedMainViewResolver.mock.calls.at(-1)[0];
+            tabManager.currentVisibleTab = 'test-view-id';
+
+            const committedMainView = resolver();
+
+            expect(committedMainView.viewId).toBe('test-view-id');
+            expect(committedMainView.webContents).toBeDefined();
+        });
+
+        it('does not resolve an absent, invalid, or destroyed tab', () => {
+            const tabManager = new TabManager();
+            const resolver = ThemeManager.setCommittedMainViewResolver.mock.calls.at(-1)[0];
+
+            expect(resolver()).toBeUndefined();
+
+            tabManager.currentVisibleTab = 'test-view-id';
+            ViewManager.getView.mockReturnValue({...mockView, type: ViewType.WINDOW});
+            expect(resolver()).toBeUndefined();
+
+            ViewManager.getView.mockReturnValue(mockView);
+            WebContentsManager.getView.mockReturnValue({...mockWebContentsView, isDestroyed: () => true});
+            expect(resolver()).toBeUndefined();
+        });
+
+        it('publishes the owner gap before committing a replacement', () => {
+            const tabManager = new TabManager();
+            const observedOwners = [];
+            tabManager.currentVisibleTab = 'old-view-id';
+            ThemeManager.handleCommittedMainViewChanged.
+                mockImplementationOnce(() => observedOwners.push(tabManager.currentVisibleTab)).
+                mockImplementationOnce(() => observedOwners.push(tabManager.currentVisibleTab));
+
+            tabManager.setActiveTab('test-view-id');
+
+            expect(observedOwners).toEqual([undefined, 'test-view-id']);
+        });
     });
 
     describe('getOrderedTabsForServer', () => {
@@ -579,6 +629,18 @@ describe('TabManager', () => {
             expect(tabManager.tabOrder.get('test-server-id')).toEqual(['tab2', 'tab3']);
             expect(emitSpy).toHaveBeenCalledWith(TAB_REMOVED, 'test-server-id', 'tab1');
         });
+
+        it('clears the committed view when its removal has no replacement', () => {
+            const tabManager = new TabManager();
+            tabManager.tabOrder.set('test-server-id', ['only-tab-id']);
+            tabManager.activeTabs.set('test-server-id', 'only-tab-id');
+            tabManager.currentVisibleTab = 'only-tab-id';
+
+            ViewManager.mockViewManager.emit(VIEW_REMOVED, 'only-tab-id', 'test-server-id');
+
+            expect(tabManager.currentVisibleTab).toBeUndefined();
+            expect(ThemeManager.handleCommittedMainViewChanged).toHaveBeenCalled();
+        });
     });
 
     describe('handleViewUpdated', () => {
@@ -780,6 +842,7 @@ describe('TabManager', () => {
 
             expect(mockMainWindow.contentView.removeChildView).toHaveBeenCalledWith(mockView.getWebContentsView());
             expect(tabManager.currentVisibleTab).toBeUndefined();
+            expect(ThemeManager.handleCommittedMainViewChanged).toHaveBeenCalled();
         });
 
         it('should do nothing if no current visible tab', () => {
@@ -841,6 +904,7 @@ describe('TabManager', () => {
 
             // Verify switchToNextTabIfNecessary was called
             expect(switchToNextTabSpy).toHaveBeenCalledWith('test-tab-id', 'test-server-id');
+            expect(ThemeManager.handleDesktopThemeViewInvalidated).not.toHaveBeenCalled();
         });
 
         it('should not handle non-TAB type removal', () => {
@@ -1081,6 +1145,7 @@ describe('TabManager', () => {
 
             // Verify switchToTab was called
             expect(switchToTabSpy).toHaveBeenCalledWith('new-tab-id');
+            expect(ThemeManager.handleDesktopThemeViewTypeChanged).toHaveBeenCalledWith('new-tab-id', ViewType.TAB);
         });
 
         it('should not handle non-TAB type addition', () => {
@@ -1100,6 +1165,17 @@ describe('TabManager', () => {
             // Verify no tab-related actions were taken
             expect(tabManager.tabOrder.get('test-server-id')).toBeUndefined();
             expect(emitSpy).not.toHaveBeenCalledWith(TAB_ADDED, expect.any(String), expect.any(String));
+            expect(ThemeManager.handleDesktopThemeViewTypeChanged).toHaveBeenCalledWith('new-window-id', ViewType.WINDOW);
+        });
+
+        it('clears a committed view after it becomes a window', () => {
+            const tabManager = new TabManager();
+            tabManager.currentVisibleTab = 'converted-view-id';
+
+            ViewManager.mockViewManager.emit(VIEW_TYPE_ADDED, 'converted-view-id', ViewType.WINDOW);
+
+            expect(tabManager.currentVisibleTab).toBeUndefined();
+            expect(ThemeManager.handleCommittedMainViewChanged).toHaveBeenCalled();
         });
 
         it('should handle addition when view does not exist', () => {

--- a/src/app/tabs/tabManager.ts
+++ b/src/app/tabs/tabManager.ts
@@ -45,6 +45,7 @@ import ServerManager from 'common/servers/serverManager';
 import type {MattermostView} from 'common/views/MattermostView';
 import {ViewType} from 'common/views/MattermostView';
 import ViewManager from 'common/views/viewManager';
+import ThemeManager, {type CommittedMainView} from 'main/themeManager';
 import {getAdjustedWindowBoundaries, getWindowBoundaries} from 'main/utils';
 
 import type {UniqueView} from 'types/config';
@@ -62,6 +63,8 @@ export class TabManager extends EventEmitter {
         this.activeTabs = new Map();
         this.tabOrder = new Map();
         this.tabListeners = new Map();
+
+        ThemeManager.setCommittedMainViewResolver(this.resolveCommittedMainView);
 
         MainWindow.on(MAIN_WINDOW_RESIZED, this.handleSetCurrentTabViewBounds);
         MainWindow.on(MAIN_WINDOW_FOCUSED, this.focusCurrentTab);
@@ -268,6 +271,9 @@ export class TabManager extends EventEmitter {
 
     private handleViewRemoved = (viewId: string, serverId: string) => {
         this.switchToNextTabIfNecessary(viewId, serverId);
+        if (this.currentVisibleTab === viewId) {
+            this.removeCurrentVisibleTab();
+        }
         this.unregisterTab(viewId, serverId);
         WebContentsManager.removeView(viewId);
     };
@@ -300,6 +306,7 @@ export class TabManager extends EventEmitter {
     };
 
     private handleViewTypeAdded = (viewId: string, type: ViewType) => {
+        ThemeManager.handleDesktopThemeViewTypeChanged(viewId, type);
         if (type === ViewType.TAB) {
             const view = ViewManager.getView(viewId);
             const webContentsView = WebContentsManager.getView(viewId);
@@ -311,6 +318,9 @@ export class TabManager extends EventEmitter {
                 this.setupTab(view, webContentsView);
                 this.switchToTab(viewId);
             }
+        } else if (this.currentVisibleTab === viewId) {
+            this.currentVisibleTab = undefined;
+            ThemeManager.handleCommittedMainViewChanged();
         }
     };
 
@@ -398,6 +408,7 @@ export class TabManager extends EventEmitter {
         view.getWebContentsView().setBounds(getWindowBoundaries(mainWindow));
         this.removeCurrentVisibleTab();
         this.currentVisibleTab = viewId;
+        ThemeManager.handleCommittedMainViewChanged();
 
         if (view.needsLoadingScreen()) {
             MainWindow.window?.showLoadingScreen(() => ModalManager.isModalDisplayed());
@@ -416,6 +427,7 @@ export class TabManager extends EventEmitter {
                 mainWindow.contentView.removeChildView(view.getWebContentsView());
             }
             this.currentVisibleTab = undefined;
+            ThemeManager.handleCommittedMainViewChanged();
         }
     };
 
@@ -437,6 +449,7 @@ export class TabManager extends EventEmitter {
             }
             if (this.currentVisibleTab === viewId) {
                 this.currentVisibleTab = undefined;
+                ThemeManager.handleCommittedMainViewChanged();
             }
             MainWindow.window?.fadeLoadingScreen();
         }
@@ -538,6 +551,27 @@ export class TabManager extends EventEmitter {
         }
         const title = `${ViewManager.getViewTitle(currentActiveTab.id)}${server.isLoggedIn ? ` - ${server.name}` : ''} - ${app.name}`;
         MainWindow.get()?.setTitle(title);
+    };
+
+    private resolveCommittedMainView = (): CommittedMainView | undefined => {
+        if (!this.currentVisibleTab) {
+            return undefined;
+        }
+
+        const view = ViewManager.getView(this.currentVisibleTab);
+        if (!view || view.type !== ViewType.TAB || !ServerManager.getServer(view.serverId)) {
+            return undefined;
+        }
+
+        const webContentsView = WebContentsManager.getView(view.id);
+        if (!webContentsView || webContentsView.isDestroyed()) {
+            return undefined;
+        }
+
+        return {
+            viewId: view.id,
+            webContents: webContentsView.getWebContentsView().webContents,
+        };
     };
 }
 

--- a/src/app/views/webContentsManager.test.js
+++ b/src/app/views/webContentsManager.test.js
@@ -5,8 +5,11 @@ import {ipcMain, session} from 'electron';
 
 import AppState from 'common/appState';
 import ServerManager from 'common/servers/serverManager';
+import {ViewType} from 'common/views/MattermostView';
 import ViewManager from 'common/views/viewManager';
 import {flushCookiesStore} from 'main/app/utils';
+import SystemAppearanceMonitor from 'main/systemAppearanceMonitor';
+import ThemeManager from 'main/themeManager';
 
 import {WebContentsManager} from './webContentsManager';
 
@@ -57,7 +60,8 @@ jest.mock('common/utils/url', () => ({
             return null;
         }
     },
-    getFormattedPathName: (pathname) => (pathname.length ? pathname : '/'),
+    getFormattedPathName: (pathname) => (pathname.endsWith('/') ? pathname : `${pathname}/`),
+    isInternalURL: (targetURL, currentURL) => targetURL.host === currentURL.host && targetURL.protocol === currentURL.protocol,
     equalUrlsIgnoringSubpath: jest.fn(),
 }));
 
@@ -93,6 +97,21 @@ jest.mock('main/performanceMonitor', () => ({
     registerView: jest.fn(),
 }));
 
+jest.mock('main/systemAppearanceMonitor', () => ({
+    getSystemAppearance: jest.fn(),
+    subscribeInvalidation: jest.fn(),
+}));
+
+jest.mock('main/themeManager', () => ({
+    applyDesktopTheme: jest.fn(),
+    handleDesktopThemeDocumentInvalidated: jest.fn(),
+    handleDesktopThemeViewInvalidated: jest.fn(),
+    isDesktopThemeDocumentCutover: jest.fn(() => false),
+    registerDesktopThemeSurface: jest.fn(),
+    releaseDesktopThemeSurface: jest.fn(),
+    updatePopoutTheme: jest.fn(),
+}));
+
 jest.mock('common/views/viewManager', () => ({
     getViewLog: jest.fn(),
     getView: jest.fn(),
@@ -118,6 +137,7 @@ jest.mock('common/servers/serverManager', () => {
         lookupServerByURL: jest.fn(),
         getRemoteInfo: jest.fn(),
         getServer: jest.fn(),
+        updateTheme: jest.fn(),
         on: jest.fn((event, handler) => mockServerManager.on(event, handler)),
         emit: jest.fn((event, ...args) => mockServerManager.emit(event, ...args)),
         setLoggedIn: jest.fn(),
@@ -205,6 +225,164 @@ describe('app/views/webContentsManager', () => {
         it('should return undefined when webContentsId does not exist', () => {
             const result = webContentsManager.getViewByWebContentsId(999);
             expect(result).toBeUndefined();
+        });
+    });
+
+    describe('getAuthenticatedDesktopThemeDocument', () => {
+        const webContentsManager = new WebContentsManager();
+        const frame = {
+            detached: false,
+            isDestroyed: jest.fn().mockReturnValue(false),
+            origin: 'https://mattermost.example.com',
+            url: 'https://mattermost.example.com/workspace/channels/town-square',
+        };
+        const webContents = {id: 123, mainFrame: frame};
+        const mockView = {
+            id: 'test-view',
+            serverId: 'server-1',
+            isDestroyed: jest.fn().mockReturnValue(false),
+            getWebContentsView: jest.fn(() => ({webContents})),
+        };
+        const mattermostView = {
+            id: 'test-view',
+            serverId: 'server-1',
+            type: ViewType.TAB,
+        };
+        const server = {
+            id: 'server-1',
+            url: new URL('https://mattermost.example.com/workspace'),
+        };
+
+        beforeEach(() => {
+            webContentsManager.webContentsIdToView = new Map([[123, mockView]]);
+            frame.detached = false;
+            frame.isDestroyed.mockReturnValue(false);
+            frame.origin = 'https://mattermost.example.com';
+            frame.url = 'https://mattermost.example.com/workspace/channels/town-square';
+            webContents.mainFrame = frame;
+            mockView.isDestroyed.mockReturnValue(false);
+            mockView.getWebContentsView.mockReturnValue({webContents});
+            ViewManager.getView.mockReturnValue(mattermostView);
+            ServerManager.getServer.mockReturnValue(server);
+            ThemeManager.isDesktopThemeDocumentCutover.mockReturnValue(false);
+        });
+
+        afterEach(() => {
+            webContentsManager.webContentsIdToView = new Map();
+            jest.clearAllMocks();
+        });
+
+        it('authenticates the mapped live main-frame document', () => {
+            const result = webContentsManager.getAuthenticatedDesktopThemeDocument({sender: webContents, senderFrame: frame});
+
+            expect(result).toEqual({
+                viewId: 'test-view',
+                serverId: 'server-1',
+                viewType: ViewType.TAB,
+                webContents,
+                frame,
+                scope: 'main-tab',
+            });
+        });
+
+        it('rejects a sender whose mapped view is stale', () => {
+            mockView.isDestroyed.mockReturnValue(true);
+
+            expect(webContentsManager.getAuthenticatedDesktopThemeDocument({sender: webContents, senderFrame: frame})).toBeUndefined();
+
+            mockView.isDestroyed.mockReturnValue(false);
+            mockView.getWebContentsView.mockReturnValue({webContents: {id: 123, mainFrame: frame}});
+
+            expect(webContentsManager.getAuthenticatedDesktopThemeDocument({sender: webContents, senderFrame: frame})).toBeUndefined();
+        });
+
+        it('rejects a missing, destroyed, detached, or non-main frame', () => {
+            expect(webContentsManager.getAuthenticatedDesktopThemeDocument({sender: webContents, senderFrame: null})).toBeUndefined();
+
+            frame.isDestroyed.mockReturnValue(true);
+            expect(webContentsManager.getAuthenticatedDesktopThemeDocument({sender: webContents, senderFrame: frame})).toBeUndefined();
+
+            frame.isDestroyed.mockReturnValue(false);
+            frame.detached = true;
+            expect(webContentsManager.getAuthenticatedDesktopThemeDocument({sender: webContents, senderFrame: frame})).toBeUndefined();
+
+            frame.detached = false;
+            expect(webContentsManager.getAuthenticatedDesktopThemeDocument({
+                sender: webContents,
+                senderFrame: {...frame},
+            })).toBeUndefined();
+        });
+
+        it('rejects a view whose current metadata no longer matches', () => {
+            ViewManager.getView.mockReturnValue(undefined);
+            expect(webContentsManager.getAuthenticatedDesktopThemeDocument({sender: webContents, senderFrame: frame})).toBeUndefined();
+
+            ViewManager.getView.mockReturnValue({...mattermostView, serverId: 'server-2'});
+            expect(webContentsManager.getAuthenticatedDesktopThemeDocument({sender: webContents, senderFrame: frame})).toBeUndefined();
+        });
+
+        it('rejects a document outside the configured origin or server subpath', () => {
+            frame.origin = 'https://attacker.example.com';
+            expect(webContentsManager.getAuthenticatedDesktopThemeDocument({sender: webContents, senderFrame: frame})).toBeUndefined();
+
+            frame.origin = 'https://mattermost.example.com';
+            frame.url = 'https://mattermost.example.com/workspace-other/channels/town-square';
+            expect(webContentsManager.getAuthenticatedDesktopThemeDocument({sender: webContents, senderFrame: frame})).toBeUndefined();
+
+            frame.url = 'https://attacker.example.com/workspace/channels/town-square';
+            frame.origin = 'https://attacker.example.com';
+            expect(webContentsManager.getAuthenticatedDesktopThemeDocument({sender: webContents, senderFrame: frame})).toBeUndefined();
+        });
+
+        it('delegates v1 operations only after document authentication', async () => {
+            const event = {sender: webContents, senderFrame: frame};
+            const request = {
+                surfaceId: 'surface-id',
+                leaseId: 'lease-id',
+                sequence: 1,
+                directive: {mode: 'system', shellTheme: {}},
+            };
+            ThemeManager.registerDesktopThemeSurface.mockResolvedValue({surfaceId: 'surface-id'});
+            ThemeManager.applyDesktopTheme.mockResolvedValue({status: 'applied'});
+            ThemeManager.releaseDesktopThemeSurface.mockResolvedValue({status: 'released'});
+            SystemAppearanceMonitor.getSystemAppearance.mockResolvedValue({revision: 1, status: 'known', value: 'light'});
+
+            await expect(webContentsManager.handleGetSystemAppearance(event)).resolves.toMatchObject({status: 'known', value: 'light'});
+            await webContentsManager.handleRegisterDesktopThemeSurface(event);
+            await webContentsManager.handleApplyDesktopTheme(event, request);
+            await webContentsManager.handleReleaseDesktopThemeSurface(event, 'surface-id');
+
+            expect(ThemeManager.registerDesktopThemeSurface).toHaveBeenCalledWith(expect.objectContaining({viewId: 'test-view', frame}));
+            expect(ThemeManager.applyDesktopTheme).toHaveBeenCalledWith(expect.objectContaining({viewId: 'test-view', frame}), request);
+            expect(ThemeManager.releaseDesktopThemeSurface).toHaveBeenCalledWith(expect.objectContaining({viewId: 'test-view', frame}), 'surface-id');
+        });
+
+        it('returns a frame rejection without delegating an unauthenticated apply', async () => {
+            const request = {
+                surfaceId: 'surface-id',
+                leaseId: 'lease-id',
+                sequence: 1,
+                directive: {mode: 'system', shellTheme: {}},
+            };
+
+            expect(webContentsManager.handleApplyDesktopTheme({sender: webContents, senderFrame: null}, request)).toMatchObject({
+                status: 'rejected',
+                reason: 'invalid-document',
+            });
+            expect(ThemeManager.applyDesktopTheme).not.toHaveBeenCalled();
+        });
+
+        it('stores legacy updates only while the frame remains legacy', () => {
+            const event = {sender: webContents, senderFrame: frame};
+            const theme = {centerChannelBg: '#111111'};
+
+            webContentsManager.handleUpdateTheme(event, theme);
+            expect(ServerManager.updateTheme).toHaveBeenCalled();
+
+            ThemeManager.isDesktopThemeDocumentCutover.mockReturnValue(true);
+            ServerManager.updateTheme.mockClear();
+            webContentsManager.handleUpdateTheme(event, theme);
+            expect(ServerManager.updateTheme).not.toHaveBeenCalled();
         });
     });
 

--- a/src/app/views/webContentsManager.test.js
+++ b/src/app/views/webContentsManager.test.js
@@ -414,7 +414,8 @@ describe('app/views/webContentsManager', () => {
             expect(ThemeManager.handleDesktopThemeDocumentInvalidated).toHaveBeenCalledWith(webContents, undefined);
         });
 
-        it('retains the current document when navigation is cancelled', () => {
+        it('does not observe pre-commit navigation attempts', () => {
+            expect(handlers['did-start-navigation']).toBeUndefined();
             expect(webContentsManager.appearanceConsumers.has(frame)).toBe(true);
             expect(ThemeManager.handleDesktopThemeDocumentInvalidated).not.toHaveBeenCalled();
         });

--- a/src/app/views/webContentsManager.test.js
+++ b/src/app/views/webContentsManager.test.js
@@ -105,6 +105,8 @@ jest.mock('main/systemAppearanceMonitor', () => ({
 jest.mock('main/themeManager', () => ({
     applyDesktopTheme: jest.fn(),
     handleDesktopThemeDocumentInvalidated: jest.fn(),
+    handleDesktopThemeDocumentNavigationCompleted: jest.fn(),
+    handleDesktopThemeDocumentNavigationStarted: jest.fn(),
     handleDesktopThemeViewInvalidated: jest.fn(),
     isDesktopThemeDocumentCutover: jest.fn(() => false),
     registerDesktopThemeSurface: jest.fn(),
@@ -383,6 +385,47 @@ describe('app/views/webContentsManager', () => {
             ServerManager.updateTheme.mockClear();
             webContentsManager.handleUpdateTheme(event, theme);
             expect(ServerManager.updateTheme).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('desktop theme document lifecycle', () => {
+        const webContentsManager = new WebContentsManager();
+        const handlers = {};
+        const frame = {};
+        const webContents = {
+            on: jest.fn((event, handler) => {
+                handlers[event] = handler;
+            }),
+        };
+
+        beforeEach(() => {
+            webContentsManager.appearanceConsumers = new Map([[frame, {webContents}]]);
+            webContentsManager.addDesktopThemeLifecycleListeners(webContents);
+        });
+
+        afterEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it('retains cutover through navigation until the replacement document commits', () => {
+            handlers['did-start-navigation']({isMainFrame: true, isSameDocument: false, frame});
+
+            expect(webContentsManager.appearanceConsumers.has(frame)).toBe(false);
+            expect(ThemeManager.handleDesktopThemeDocumentNavigationStarted).toHaveBeenCalledWith(webContents, frame);
+            expect(ThemeManager.handleDesktopThemeDocumentNavigationCompleted).not.toHaveBeenCalled();
+
+            handlers['did-frame-navigate']({}, 'https://mattermost.example.com', 200, 'OK', true);
+
+            expect(ThemeManager.handleDesktopThemeDocumentNavigationCompleted).toHaveBeenCalledWith(webContents);
+        });
+
+        it('ignores same-document and subframe navigations', () => {
+            handlers['did-start-navigation']({isMainFrame: true, isSameDocument: true, frame});
+            handlers['did-start-navigation']({isMainFrame: false, isSameDocument: false, frame});
+            handlers['did-frame-navigate']({}, 'https://mattermost.example.com', 200, 'OK', false);
+
+            expect(ThemeManager.handleDesktopThemeDocumentNavigationStarted).not.toHaveBeenCalled();
+            expect(ThemeManager.handleDesktopThemeDocumentNavigationCompleted).not.toHaveBeenCalled();
         });
     });
 

--- a/src/app/views/webContentsManager.test.js
+++ b/src/app/views/webContentsManager.test.js
@@ -105,8 +105,6 @@ jest.mock('main/systemAppearanceMonitor', () => ({
 jest.mock('main/themeManager', () => ({
     applyDesktopTheme: jest.fn(),
     handleDesktopThemeDocumentInvalidated: jest.fn(),
-    handleDesktopThemeDocumentNavigationCompleted: jest.fn(),
-    handleDesktopThemeDocumentNavigationStarted: jest.fn(),
     handleDesktopThemeViewInvalidated: jest.fn(),
     isDesktopThemeDocumentCutover: jest.fn(() => false),
     registerDesktopThemeSurface: jest.fn(),
@@ -407,25 +405,24 @@ describe('app/views/webContentsManager', () => {
             jest.clearAllMocks();
         });
 
-        it('retains cutover through navigation until the replacement document commits', () => {
-            handlers['did-start-navigation']({isMainFrame: true, isSameDocument: false, frame});
-
-            expect(webContentsManager.appearanceConsumers.has(frame)).toBe(false);
-            expect(ThemeManager.handleDesktopThemeDocumentNavigationStarted).toHaveBeenCalledWith(webContents, frame);
-            expect(ThemeManager.handleDesktopThemeDocumentNavigationCompleted).not.toHaveBeenCalled();
+        it('retires the current document when its replacement commits', () => {
+            expect(webContentsManager.appearanceConsumers.has(frame)).toBe(true);
 
             handlers['did-frame-navigate']({}, 'https://mattermost.example.com', 200, 'OK', true);
 
-            expect(ThemeManager.handleDesktopThemeDocumentNavigationCompleted).toHaveBeenCalledWith(webContents);
+            expect(webContentsManager.appearanceConsumers.has(frame)).toBe(false);
+            expect(ThemeManager.handleDesktopThemeDocumentInvalidated).toHaveBeenCalledWith(webContents, undefined);
         });
 
-        it('ignores same-document and subframe navigations', () => {
-            handlers['did-start-navigation']({isMainFrame: true, isSameDocument: true, frame});
-            handlers['did-start-navigation']({isMainFrame: false, isSameDocument: false, frame});
+        it('retains the current document when navigation is cancelled', () => {
+            expect(webContentsManager.appearanceConsumers.has(frame)).toBe(true);
+            expect(ThemeManager.handleDesktopThemeDocumentInvalidated).not.toHaveBeenCalled();
+        });
+
+        it('ignores subframe navigations', () => {
             handlers['did-frame-navigate']({}, 'https://mattermost.example.com', 200, 'OK', false);
 
-            expect(ThemeManager.handleDesktopThemeDocumentNavigationStarted).not.toHaveBeenCalled();
-            expect(ThemeManager.handleDesktopThemeDocumentNavigationCompleted).not.toHaveBeenCalled();
+            expect(ThemeManager.handleDesktopThemeDocumentInvalidated).not.toHaveBeenCalled();
         });
     });
 

--- a/src/app/views/webContentsManager.test.js
+++ b/src/app/views/webContentsManager.test.js
@@ -4,6 +4,11 @@
 import {ipcMain, session} from 'electron';
 
 import AppState from 'common/appState';
+import {
+    APPLY_DESKTOP_THEME,
+    RELEASE_DESKTOP_THEME_SURFACE,
+    SYSTEM_APPEARANCE_INVALIDATED,
+} from 'common/communication';
 import ServerManager from 'common/servers/serverManager';
 import {ViewType} from 'common/views/MattermostView';
 import ViewManager from 'common/views/viewManager';
@@ -347,11 +352,13 @@ describe('app/views/webContentsManager', () => {
             ThemeManager.releaseDesktopThemeSurface.mockResolvedValue({status: 'released'});
             SystemAppearanceMonitor.getSystemAppearance.mockResolvedValue({revision: 1, status: 'known', value: 'light'});
 
+            expect(webContentsManager.handleGetDesktopThemeCapabilities(event)).toEqual({protocolVersion: 1});
             await expect(webContentsManager.handleGetSystemAppearance(event)).resolves.toMatchObject({status: 'known', value: 'light'});
             await webContentsManager.handleRegisterDesktopThemeSurface(event);
             await webContentsManager.handleApplyDesktopTheme(event, request);
             await webContentsManager.handleReleaseDesktopThemeSurface(event, 'surface-id');
 
+            expect(webContentsManager.appearanceConsumers.get(frame)).toMatchObject({viewId: 'test-view', frame});
             expect(ThemeManager.registerDesktopThemeSurface).toHaveBeenCalledWith(expect.objectContaining({viewId: 'test-view', frame}));
             expect(ThemeManager.applyDesktopTheme).toHaveBeenCalledWith(expect.objectContaining({viewId: 'test-view', frame}), request);
             expect(ThemeManager.releaseDesktopThemeSurface).toHaveBeenCalledWith(expect.objectContaining({viewId: 'test-view', frame}), 'surface-id');
@@ -383,6 +390,28 @@ describe('app/views/webContentsManager', () => {
             ServerManager.updateTheme.mockClear();
             webContentsManager.handleUpdateTheme(event, theme);
             expect(ServerManager.updateTheme).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('desktop theme IPC validation', () => {
+        beforeEach(() => {
+            ipcMain.handle.mockClear();
+        });
+
+        afterEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it('rejects malformed mutation requests before delegation', () => {
+            const webContentsManager = new WebContentsManager();
+            const applyHandler = ipcMain.handle.mock.calls.find(([channel]) => channel === APPLY_DESKTOP_THEME)[1];
+            const releaseHandler = ipcMain.handle.mock.calls.find(([channel]) => channel === RELEASE_DESKTOP_THEME_SURFACE)[1];
+
+            expect(() => applyHandler({}, {})).toThrow('Invalid IPC arguments');
+            expect(() => releaseHandler({}, '')).toThrow('Invalid IPC arguments');
+            expect(SystemAppearanceMonitor.subscribeInvalidation).toHaveBeenLastCalledWith(webContentsManager.handleSystemAppearanceInvalidated);
+            expect(ThemeManager.applyDesktopTheme).not.toHaveBeenCalled();
+            expect(ThemeManager.releaseDesktopThemeSurface).not.toHaveBeenCalled();
         });
     });
 
@@ -424,6 +453,34 @@ describe('app/views/webContentsManager', () => {
             handlers['did-frame-navigate']({}, 'https://mattermost.example.com', 200, 'OK', false);
 
             expect(ThemeManager.handleDesktopThemeDocumentInvalidated).not.toHaveBeenCalled();
+        });
+
+        it('notifies live appearance consumers and retires stale ones', () => {
+            const liveFrame = {detached: false, isDestroyed: jest.fn(() => false), send: jest.fn()};
+            const liveWebContents = {isDestroyed: jest.fn(() => false), mainFrame: liveFrame};
+            const staleFrame = {detached: true, isDestroyed: jest.fn(() => false), send: jest.fn()};
+            const staleWebContents = {isDestroyed: jest.fn(() => false), mainFrame: staleFrame};
+            const throwingFrame = {
+                detached: false,
+                isDestroyed: jest.fn(() => false),
+                send: jest.fn(() => {
+                    throw new Error('send failed');
+                }),
+            };
+            const throwingWebContents = {isDestroyed: jest.fn(() => false), mainFrame: throwingFrame};
+            const invalidation = {revision: 2, previousValueStatus: 'stale'};
+            webContentsManager.appearanceConsumers = new Map([
+                [liveFrame, {webContents: liveWebContents, frame: liveFrame}],
+                [staleFrame, {webContents: staleWebContents, frame: staleFrame}],
+                [throwingFrame, {webContents: throwingWebContents, frame: throwingFrame}],
+            ]);
+
+            webContentsManager.handleSystemAppearanceInvalidated(invalidation);
+
+            expect(liveFrame.send).toHaveBeenCalledWith(SYSTEM_APPEARANCE_INVALIDATED, invalidation);
+            expect(webContentsManager.appearanceConsumers.has(liveFrame)).toBe(true);
+            expect(webContentsManager.appearanceConsumers.has(staleFrame)).toBe(false);
+            expect(webContentsManager.appearanceConsumers.has(throwingFrame)).toBe(false);
         });
     });
 
@@ -524,6 +581,7 @@ describe('app/views/webContentsManager', () => {
             expect(mockView.destroy).toHaveBeenCalled();
             expect(webContentsManager.webContentsViews.has('test-view')).toBe(false);
             expect(webContentsManager.webContentsIdToView.has(123)).toBe(false);
+            expect(ThemeManager.handleDesktopThemeViewInvalidated).toHaveBeenCalledWith('test-view');
         });
 
         it('should do nothing when view does not exist', () => {

--- a/src/app/views/webContentsManager.ts
+++ b/src/app/views/webContentsManager.ts
@@ -1,12 +1,16 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {IpcMainEvent, IpcMainInvokeEvent} from 'electron';
+import type {IpcMainEvent, IpcMainInvokeEvent, WebContents, WebFrameMain} from 'electron';
 import {ipcMain, nativeTheme, session, shell} from 'electron';
 import isDev from 'electron-is-dev';
 import Joi from 'joi';
 
-import type {Theme} from '@mattermost/desktop-api';
+import type {
+    DesktopThemeApplyRequest,
+    SystemAppearanceInvalidation,
+    Theme,
+} from '@mattermost/desktop-api';
 
 import popoutMenu from 'app/popoutMenu';
 import WebContentsEventManager from 'app/views/webContentEvents';
@@ -26,31 +30,55 @@ import {
     OPEN_POPOUT_MENU,
     UPDATE_SERVER_THEME,
     DARK_MODE_CHANGE,
+    GET_DESKTOP_THEME_CAPABILITIES,
+    GET_SYSTEM_APPEARANCE,
+    REGISTER_DESKTOP_THEME_SURFACE,
+    APPLY_DESKTOP_THEME,
+    RELEASE_DESKTOP_THEME_SURFACE,
+    SYSTEM_APPEARANCE_INVALIDATED,
     UPDATE_THEME,
 } from 'common/communication';
 import Config from 'common/config';
 import {DEFAULT_CHANGELOG_LINK} from 'common/constants';
 import {Logger} from 'common/log';
 import ServerManager from 'common/servers/serverManager';
-import {ipcValidate, themeSchema} from 'common/Validator';
+import {getFormattedPathName, isInternalURL, parseURL} from 'common/utils/url';
+import {
+    desktopThemeApplyRequestSchema,
+    desktopThemeSurfaceIdSchema,
+    ipcValidate,
+    themeSchema,
+} from 'common/Validator';
 import {ViewType, type MattermostView} from 'common/views/MattermostView';
 import ViewManager from 'common/views/viewManager';
 import {flushCookiesStore} from 'main/app/utils';
 import PermissionsManager from 'main/security/permissionsManager';
+import SystemAppearanceMonitor from 'main/systemAppearanceMonitor';
+import type {DesktopThemeDocument} from 'main/themeManager';
 import ThemeManager from 'main/themeManager';
 
 import {MattermostWebContentsView} from './MattermostWebContentsView';
 
 const log = new Logger('WebContentsManager');
 
+type DesktopThemeDocumentEvent = Pick<IpcMainEvent | IpcMainInvokeEvent, 'sender' | 'senderFrame'>;
+
+export type AuthenticatedDesktopThemeDocument = DesktopThemeDocument & {
+    viewId: string;
+    serverId: string;
+    viewType: ViewType;
+};
+
 export class WebContentsManager {
     private webContentsViews: Map<string, MattermostWebContentsView>;
     private webContentsIdToView: Map<number, MattermostWebContentsView>;
     private focusedWebContentsView?: string;
+    private appearanceConsumers: Map<WebFrameMain, DesktopThemeDocument>;
 
     constructor() {
         this.webContentsViews = new Map();
         this.webContentsIdToView = new Map();
+        this.appearanceConsumers = new Map();
 
         ipcMain.handle(GET_VIEW_INFO_FOR_TEST, this.handleGetViewInfoForTest);
         ipcMain.handle(GET_IS_DEV_MODE, () => isDev);
@@ -68,6 +96,13 @@ export class WebContentsManager {
         ipcMain.on(OPEN_POPOUT_MENU, this.handleOpenPopoutMenu);
         ipcMain.on(UPDATE_SERVER_THEME, ipcValidate(this.handleUpdateServerTheme, [themeSchema.required()]));
         ipcMain.on(UPDATE_THEME, ipcValidate(this.handleUpdateTheme, [themeSchema.required()]));
+        ipcMain.handle(GET_DESKTOP_THEME_CAPABILITIES, this.handleGetDesktopThemeCapabilities);
+        ipcMain.handle(GET_SYSTEM_APPEARANCE, this.handleGetSystemAppearance);
+        ipcMain.handle(REGISTER_DESKTOP_THEME_SURFACE, this.handleRegisterDesktopThemeSurface);
+        ipcMain.handle(APPLY_DESKTOP_THEME, ipcValidate(this.handleApplyDesktopTheme, [desktopThemeApplyRequestSchema], {throwOnError: true}));
+        ipcMain.handle(RELEASE_DESKTOP_THEME_SURFACE, ipcValidate(this.handleReleaseDesktopThemeSurface, [desktopThemeSurfaceIdSchema], {throwOnError: true}));
+
+        SystemAppearanceMonitor.subscribeInvalidation(this.handleSystemAppearanceInvalidated);
 
         if (process.platform !== 'linux') {
             nativeTheme.on('updated', this.handleDarkModeChanged);
@@ -89,6 +124,45 @@ export class WebContentsManager {
 
     getViewByWebContentsId = (webContentsId: number) => {
         return this.webContentsIdToView.get(webContentsId);
+    };
+
+    getAuthenticatedDesktopThemeDocument = (event: DesktopThemeDocumentEvent): AuthenticatedDesktopThemeDocument | undefined => {
+        const view = this.getViewByWebContentsId(event.sender.id);
+        if (!view || view.isDestroyed()) {
+            return undefined;
+        }
+
+        const webContents = view.getWebContentsView().webContents;
+        const frame = event.senderFrame;
+        if (webContents !== event.sender || !frame || frame.isDestroyed() || frame.detached || frame !== webContents.mainFrame) {
+            return undefined;
+        }
+
+        const mattermostView = ViewManager.getView(view.id);
+        if (!mattermostView || mattermostView.serverId !== view.serverId) {
+            return undefined;
+        }
+
+        const server = ServerManager.getServer(mattermostView.serverId);
+        const frameURL = parseURL(frame.url);
+        if (!server || !frameURL || frame.origin !== frameURL.origin || !isInternalURL(frameURL, server.url)) {
+            return undefined;
+        }
+
+        const serverPath = getFormattedPathName(server.url.pathname);
+        const framePath = getFormattedPathName(frameURL.pathname);
+        if (!framePath.startsWith(serverPath)) {
+            return undefined;
+        }
+
+        return {
+            viewId: mattermostView.id,
+            serverId: mattermostView.serverId,
+            viewType: mattermostView.type,
+            webContents,
+            frame,
+            scope: mattermostView.type === ViewType.TAB ? 'main-tab' : 'popout',
+        };
     };
 
     getFocusedView = (): MattermostWebContentsView | undefined => {
@@ -117,7 +191,9 @@ export class WebContentsManager {
         webContentsView.load(view.getLoadingURL());
 
         this.addViewToMap(webContentsView);
-        WebContentsEventManager.addWebContentsEventListeners(webContentsView.getWebContentsView().webContents);
+        const webContents = webContentsView.getWebContentsView().webContents;
+        this.addDesktopThemeLifecycleListeners(webContents);
+        WebContentsEventManager.addWebContentsEventListeners(webContents);
         return webContentsView;
     };
 
@@ -131,6 +207,7 @@ export class WebContentsManager {
         view.destroy();
         this.webContentsViews.delete(viewId);
         this.webContentsIdToView.delete(view.webContentsId);
+        ThemeManager.handleDesktopThemeViewInvalidated(viewId);
     };
 
     clearCacheAndReloadView = (viewId: string) => {
@@ -302,27 +379,104 @@ export class WebContentsManager {
     };
 
     private handleUpdateServerTheme = (event: IpcMainEvent, theme: Theme) => {
-        const view = this.getViewByWebContentsId(event.sender.id);
-        if (!view) {
+        const document = this.getAuthenticatedDesktopThemeDocument(event);
+        if (!document || document.viewType === ViewType.WINDOW) {
             return;
         }
-        if (ViewManager.getView(view.id)?.type === ViewType.WINDOW) {
-            return;
-        }
-        ServerManager.updateTheme(view.serverId, theme);
+        const legacyTheme = {...theme, isUsingSystemTheme: false};
+        ServerManager.updateTheme(document.serverId, legacyTheme);
     };
 
     private handleUpdateTheme = (event: IpcMainEvent, theme: Theme) => {
-        const view = this.getViewByWebContentsId(event.sender.id);
-        if (!view) {
+        const document = this.getAuthenticatedDesktopThemeDocument(event);
+        if (!document || ThemeManager.isDesktopThemeDocumentCutover(document)) {
             return;
         }
-        const viewType = ViewManager.getView(view.id)?.type;
-        if (viewType === ViewType.WINDOW) {
-            ThemeManager.updatePopoutTheme(view.id, theme);
+        if (document.viewType === ViewType.WINDOW) {
+            ThemeManager.updatePopoutTheme(document.viewId, theme);
         } else {
-            ServerManager.updateTheme(view.serverId, theme);
+            ServerManager.updateTheme(document.serverId, theme);
         }
+    };
+
+    private handleGetDesktopThemeCapabilities = (event: IpcMainInvokeEvent) => {
+        if (!this.getAuthenticatedDesktopThemeDocument(event)) {
+            return undefined;
+        }
+        return {protocolVersion: 1 as const};
+    };
+
+    private handleGetSystemAppearance = (event: IpcMainInvokeEvent) => {
+        const document = this.getAuthenticatedDesktopThemeDocument(event);
+        if (!document) {
+            return undefined;
+        }
+        this.appearanceConsumers.set(document.frame, document);
+        return SystemAppearanceMonitor.getSystemAppearance();
+    };
+
+    private handleRegisterDesktopThemeSurface = (event: IpcMainInvokeEvent) => {
+        const document = this.getAuthenticatedDesktopThemeDocument(event);
+        if (!document) {
+            return undefined;
+        }
+        this.appearanceConsumers.set(document.frame, document);
+        return ThemeManager.registerDesktopThemeSurface(document);
+    };
+
+    private handleApplyDesktopTheme = (event: IpcMainInvokeEvent, request: DesktopThemeApplyRequest) => {
+        const document = this.getAuthenticatedDesktopThemeDocument(event);
+        if (!document) {
+            return {
+                status: 'rejected' as const,
+                surfaceId: request.surfaceId,
+                leaseId: request.leaseId,
+                sequence: request.sequence,
+                reason: 'invalid-document' as const,
+            };
+        }
+        return ThemeManager.applyDesktopTheme(document, request);
+    };
+
+    private handleReleaseDesktopThemeSurface = (event: IpcMainInvokeEvent, surfaceId: string) => {
+        const document = this.getAuthenticatedDesktopThemeDocument(event);
+        if (!document) {
+            return {status: 'stale' as const};
+        }
+        return ThemeManager.releaseDesktopThemeSurface(document, surfaceId);
+    };
+
+    private handleSystemAppearanceInvalidated = (invalidation: SystemAppearanceInvalidation) => {
+        this.appearanceConsumers.forEach((document, frame) => {
+            if (document.webContents.isDestroyed() || frame.isDestroyed() || frame.detached || document.webContents.mainFrame !== frame) {
+                this.appearanceConsumers.delete(frame);
+                return;
+            }
+            try {
+                frame.send(SYSTEM_APPEARANCE_INVALIDATED, invalidation);
+            } catch {
+                this.appearanceConsumers.delete(frame);
+            }
+        });
+    };
+
+    private addDesktopThemeLifecycleListeners = (webContents: WebContents) => {
+        webContents.on('did-start-navigation', (details) => {
+            if (details.isMainFrame && !details.isSameDocument) {
+                this.handleDesktopThemeDocumentInvalidated(webContents, details.frame ?? undefined);
+            }
+        });
+        webContents.on('render-process-gone', () => this.handleDesktopThemeDocumentInvalidated(webContents));
+        webContents.on('destroyed', () => this.handleDesktopThemeDocumentInvalidated(webContents));
+    };
+
+    private handleDesktopThemeDocumentInvalidated = (webContents: WebContents, frame?: WebFrameMain) => {
+        this.appearanceConsumers.forEach((document, consumerFrame) => {
+            if (document.webContents === webContents && (!frame || consumerFrame === frame)) {
+                this.appearanceConsumers.delete(consumerFrame);
+            }
+        });
+        ThemeManager.handleDesktopThemeDocumentInvalidated(webContents, frame);
     };
 
     private handleDarkModeChanged = () => {

--- a/src/app/views/webContentsManager.ts
+++ b/src/app/views/webContentsManager.ts
@@ -463,7 +463,13 @@ export class WebContentsManager {
     private addDesktopThemeLifecycleListeners = (webContents: WebContents) => {
         webContents.on('did-start-navigation', (details) => {
             if (details.isMainFrame && !details.isSameDocument) {
-                this.handleDesktopThemeDocumentInvalidated(webContents, details.frame ?? undefined);
+                this.removeDesktopThemeAppearanceConsumers(webContents, details.frame ?? undefined);
+                ThemeManager.handleDesktopThemeDocumentNavigationStarted(webContents, details.frame ?? undefined);
+            }
+        });
+        webContents.on('did-frame-navigate', (_event, _url, _httpResponseCode, _httpStatusText, isMainFrame) => {
+            if (isMainFrame) {
+                ThemeManager.handleDesktopThemeDocumentNavigationCompleted(webContents);
             }
         });
         webContents.on('render-process-gone', () => this.handleDesktopThemeDocumentInvalidated(webContents));
@@ -471,12 +477,16 @@ export class WebContentsManager {
     };
 
     private handleDesktopThemeDocumentInvalidated = (webContents: WebContents, frame?: WebFrameMain) => {
+        this.removeDesktopThemeAppearanceConsumers(webContents, frame);
+        ThemeManager.handleDesktopThemeDocumentInvalidated(webContents, frame);
+    };
+
+    private removeDesktopThemeAppearanceConsumers = (webContents: WebContents, frame?: WebFrameMain) => {
         this.appearanceConsumers.forEach((document, consumerFrame) => {
             if (document.webContents === webContents && (!frame || consumerFrame === frame)) {
                 this.appearanceConsumers.delete(consumerFrame);
             }
         });
-        ThemeManager.handleDesktopThemeDocumentInvalidated(webContents, frame);
     };
 
     private handleDarkModeChanged = () => {

--- a/src/app/views/webContentsManager.ts
+++ b/src/app/views/webContentsManager.ts
@@ -461,15 +461,9 @@ export class WebContentsManager {
     };
 
     private addDesktopThemeLifecycleListeners = (webContents: WebContents) => {
-        webContents.on('did-start-navigation', (details) => {
-            if (details.isMainFrame && !details.isSameDocument) {
-                this.removeDesktopThemeAppearanceConsumers(webContents, details.frame ?? undefined);
-                ThemeManager.handleDesktopThemeDocumentNavigationStarted(webContents, details.frame ?? undefined);
-            }
-        });
         webContents.on('did-frame-navigate', (_event, _url, _httpResponseCode, _httpStatusText, isMainFrame) => {
             if (isMainFrame) {
-                ThemeManager.handleDesktopThemeDocumentNavigationCompleted(webContents);
+                this.handleDesktopThemeDocumentInvalidated(webContents);
             }
         });
         webContents.on('render-process-gone', () => this.handleDesktopThemeDocumentInvalidated(webContents));

--- a/src/common/Validator.test.js
+++ b/src/common/Validator.test.js
@@ -439,16 +439,16 @@ describe('common/Validator', () => {
             expect(Validator.desktopThemeApplyRequestSchema.validate(request).error).toBeUndefined();
         });
 
-        it.each(Object.keys(shellTheme).filter((field) => field !== 'codeTheme'))('rejects a malformed %s color', (field) => {
-            const invalidRequest = {
+        it.each(['#123', 'rgb(18,52,86)', 'rgba(18,52,86,0.5)'])('accepts an imported %s theme color', (centerChannelBg) => {
+            const importedRequest = {
                 ...request,
                 directive: {
                     ...request.directive,
-                    shellTheme: {...shellTheme, [field]: 'red'},
+                    shellTheme: {...shellTheme, centerChannelBg, sidebarBg: ''},
                 },
             };
 
-            expect(Validator.desktopThemeApplyRequestSchema.validate(invalidRequest).error).toBeDefined();
+            expect(Validator.desktopThemeApplyRequestSchema.validate(importedRequest).error).toBeUndefined();
         });
 
         it.each([
@@ -457,7 +457,6 @@ describe('common/Validator', () => {
             {...request, sequence: 0},
             {...request, sequence: '1'},
             {...request, directive: {...request.directive, unexpected: true}},
-            {...request, directive: {...request.directive, shellTheme: {...shellTheme, centerChannelBg: 'red'}}},
             {...request, directive: {...request.directive, shellTheme: {...shellTheme, unexpected: true}}},
             {...request, directive: {...request.directive, shellTheme: {...shellTheme, sidebarBg: undefined}}},
         ])('rejects malformed or extended directives', (invalidRequest) => {

--- a/src/common/Validator.test.js
+++ b/src/common/Validator.test.js
@@ -451,6 +451,18 @@ describe('common/Validator', () => {
             expect(Validator.desktopThemeApplyRequestSchema.validate(importedRequest).error).toBeUndefined();
         });
 
+        it('accepts code theme strings within the server preference envelope', () => {
+            const importedRequest = {
+                ...request,
+                directive: {
+                    ...request.directive,
+                    shellTheme: {...shellTheme, codeTheme: 'a'.repeat(20_000)},
+                },
+            };
+
+            expect(Validator.desktopThemeApplyRequestSchema.validate(importedRequest).error).toBeUndefined();
+        });
+
         it.each([
             undefined,
             {...request, unexpected: true},

--- a/src/common/Validator.test.js
+++ b/src/common/Validator.test.js
@@ -439,40 +439,43 @@ describe('common/Validator', () => {
             expect(Validator.desktopThemeApplyRequestSchema.validate(request).error).toBeUndefined();
         });
 
-        it.each(['#123', 'rgb(18,52,86)', 'rgba(18, 52, 86, 0.5)'])('accepts an imported %s theme color', (centerChannelBg) => {
+        it('accepts imported theme color syntax', () => {
             const importedRequest = {
                 ...request,
                 directive: {
                     ...request.directive,
-                    shellTheme: {...shellTheme, centerChannelBg, sidebarBg: ''},
+                    shellTheme: {...shellTheme, centerChannelBg: 'rgba(18, 52, 86, 0.5)', sidebarBg: ''},
                 },
             };
 
             expect(Validator.desktopThemeApplyRequestSchema.validate(importedRequest).error).toBeUndefined();
         });
 
-        it.each(['rgb(256,52,86)', 'rgba(18,52,86,.)', 'rgba(18,52,86,1.2.3)'])('rejects an invalid %s center background', (centerChannelBg) => {
+        it('rejects an invalid center background', () => {
             const invalidRequest = {
                 ...request,
                 directive: {
                     ...request.directive,
-                    shellTheme: {...shellTheme, centerChannelBg},
+                    shellTheme: {...shellTheme, centerChannelBg: 'rgba(18,52,86,1.2.3)'},
                 },
             };
 
             expect(Validator.desktopThemeApplyRequestSchema.validate(invalidRequest).error).toBeDefined();
         });
 
-        it('accepts code theme strings within the server preference envelope', () => {
+        it.each([
+            [20_000, false],
+            [20_001, true],
+        ])('bounds code theme strings at the server preference envelope', (length, hasError) => {
             const importedRequest = {
                 ...request,
                 directive: {
                     ...request.directive,
-                    shellTheme: {...shellTheme, codeTheme: 'a'.repeat(20_000)},
+                    shellTheme: {...shellTheme, codeTheme: 'a'.repeat(length)},
                 },
             };
 
-            expect(Validator.desktopThemeApplyRequestSchema.validate(importedRequest).error).toBeUndefined();
+            expect(Boolean(Validator.desktopThemeApplyRequestSchema.validate(importedRequest).error)).toBe(hasError);
         });
 
         it.each([
@@ -481,7 +484,6 @@ describe('common/Validator', () => {
             {...request, sequence: 0},
             {...request, sequence: '1'},
             {...request, directive: {...request.directive, unexpected: true}},
-            {...request, directive: {...request.directive, shellTheme: {...shellTheme, centerChannelBg: 'red'}}},
             {...request, directive: {...request.directive, shellTheme: {...shellTheme, unexpected: true}}},
             {...request, directive: {...request.directive, shellTheme: {...shellTheme, sidebarBg: undefined}}},
         ])('rejects malformed or extended directives', (invalidRequest) => {

--- a/src/common/Validator.test.js
+++ b/src/common/Validator.test.js
@@ -439,6 +439,18 @@ describe('common/Validator', () => {
             expect(Validator.desktopThemeApplyRequestSchema.validate(request).error).toBeUndefined();
         });
 
+        it.each(Object.keys(shellTheme).filter((field) => field !== 'codeTheme'))('rejects a malformed %s color', (field) => {
+            const invalidRequest = {
+                ...request,
+                directive: {
+                    ...request.directive,
+                    shellTheme: {...shellTheme, [field]: 'red'},
+                },
+            };
+
+            expect(Validator.desktopThemeApplyRequestSchema.validate(invalidRequest).error).toBeDefined();
+        });
+
         it.each([
             undefined,
             {...request, unexpected: true},

--- a/src/common/Validator.test.js
+++ b/src/common/Validator.test.js
@@ -439,7 +439,7 @@ describe('common/Validator', () => {
             expect(Validator.desktopThemeApplyRequestSchema.validate(request).error).toBeUndefined();
         });
 
-        it.each(['#123', 'rgb(18,52,86)', 'rgba(18,52,86,0.5)'])('accepts an imported %s theme color', (centerChannelBg) => {
+        it.each(['#123', 'rgb(18,52,86)', 'rgba(18, 52, 86, 0.5)'])('accepts an imported %s theme color', (centerChannelBg) => {
             const importedRequest = {
                 ...request,
                 directive: {
@@ -449,6 +449,18 @@ describe('common/Validator', () => {
             };
 
             expect(Validator.desktopThemeApplyRequestSchema.validate(importedRequest).error).toBeUndefined();
+        });
+
+        it.each(['rgb(256,52,86)', 'rgba(18,52,86,.)', 'rgba(18,52,86,1.2.3)'])('rejects an invalid %s center background', (centerChannelBg) => {
+            const invalidRequest = {
+                ...request,
+                directive: {
+                    ...request.directive,
+                    shellTheme: {...shellTheme, centerChannelBg},
+                },
+            };
+
+            expect(Validator.desktopThemeApplyRequestSchema.validate(invalidRequest).error).toBeDefined();
         });
 
         it('accepts code theme strings within the server preference envelope', () => {

--- a/src/common/Validator.test.js
+++ b/src/common/Validator.test.js
@@ -325,6 +325,18 @@ describe('common/Validator', () => {
             expect(handler).not.toHaveBeenCalled();
         });
 
+        it('throws on invalid arguments when requested', () => {
+            const handler = jest.fn();
+            const wrapped = Validator.ipcValidate(
+                handler,
+                [Joi.string().required()],
+                {throwOnError: true},
+            );
+
+            expect(() => wrapped(event, 42)).toThrow('Invalid IPC arguments');
+            expect(handler).not.toHaveBeenCalled();
+        });
+
         it('drops the call when a required object arg is null', () => {
             const handler = jest.fn();
             const wrapped = Validator.ipcValidate(handler, [Joi.object().required()]);
@@ -383,6 +395,61 @@ describe('common/Validator', () => {
 
             expect(wrapped(event, 'Title', 'Body', '', '', '', false, '')).toBe('ok');
             expect(handler).toHaveBeenCalledWith(event, 'Title', 'Body', '', '', '', false, '');
+        });
+    });
+
+    describe('desktopThemeApplyRequestSchema', () => {
+        const shellTheme = {
+            sidebarBg: '#111111',
+            sidebarText: '#ffffff',
+            sidebarUnreadText: '#ffffff',
+            sidebarTextHoverBg: '#222222',
+            sidebarTextActiveBorder: '#333333',
+            sidebarTextActiveColor: '#ffffff',
+            sidebarHeaderBg: '#111111',
+            sidebarTeamBarBg: '#111111',
+            sidebarHeaderTextColor: '#ffffff',
+            onlineIndicator: '#00ff00',
+            awayIndicator: '#ffff00',
+            dndIndicator: '#ff0000',
+            mentionBg: '#333333',
+            mentionColor: '#ffffff',
+            centerChannelBg: '#123456',
+            centerChannelColor: '#ffffff',
+            newMessageSeparator: '#ff0000',
+            linkColor: '#0000ff',
+            buttonBg: '#0000ff',
+            buttonColor: '#ffffff',
+            errorTextColor: '#ff0000',
+            mentionHighlightBg: '#333333',
+            mentionHighlightLink: '#0000ff',
+            codeTheme: 'monokai',
+        };
+        const request = {
+            surfaceId: 'surface-id',
+            leaseId: 'lease-id',
+            sequence: 1,
+            directive: {
+                mode: 'system',
+                shellTheme,
+            },
+        };
+
+        it('accepts a complete bounded directive', () => {
+            expect(Validator.desktopThemeApplyRequestSchema.validate(request).error).toBeUndefined();
+        });
+
+        it.each([
+            undefined,
+            {...request, unexpected: true},
+            {...request, sequence: 0},
+            {...request, sequence: '1'},
+            {...request, directive: {...request.directive, unexpected: true}},
+            {...request, directive: {...request.directive, shellTheme: {...shellTheme, centerChannelBg: 'red'}}},
+            {...request, directive: {...request.directive, shellTheme: {...shellTheme, unexpected: true}}},
+            {...request, directive: {...request.directive, shellTheme: {...shellTheme, sidebarBg: undefined}}},
+        ])('rejects malformed or extended directives', (invalidRequest) => {
+            expect(Validator.desktopThemeApplyRequestSchema.validate(invalidRequest).error).toBeDefined();
         });
     });
 });

--- a/src/common/Validator.test.js
+++ b/src/common/Validator.test.js
@@ -457,6 +457,7 @@ describe('common/Validator', () => {
             {...request, sequence: 0},
             {...request, sequence: '1'},
             {...request, directive: {...request.directive, unexpected: true}},
+            {...request, directive: {...request.directive, shellTheme: {...shellTheme, centerChannelBg: 'red'}}},
             {...request, directive: {...request.directive, shellTheme: {...shellTheme, unexpected: true}}},
             {...request, directive: {...request.directive, shellTheme: {...shellTheme, sidebarBg: undefined}}},
         ])('rejects malformed or extended directives', (invalidRequest) => {

--- a/src/common/Validator.ts
+++ b/src/common/Validator.ts
@@ -426,11 +426,12 @@ export const themeSchema = Joi.object({
 }).unknown(true);
 
 const opaqueDesktopThemeIdSchema = Joi.string().min(1).max(256).required().strict();
-export const desktopShellThemeSchema = Joi.object<DesktopShellTheme>(themeFields).
-    fork(Object.keys(themeFields), (schema) => (schema as Joi.StringSchema).max(256).required()).
-    keys({
-        centerChannelBg: Joi.string().pattern(/^#[0-9a-f]{6}$/i).required(),
-    }).
+const desktopShellThemeColorFields = Object.keys(themeFields).filter((field) => field !== 'codeTheme');
+export const desktopShellThemeSchema = Joi.object<DesktopShellTheme>({
+    ...themeFields,
+    codeTheme: Joi.string().max(256).required().strict(),
+}).
+    fork(desktopShellThemeColorFields, () => Joi.string().pattern(/^#[0-9a-f]{6}$/i).required().strict()).
     unknown(false);
 
 export const desktopThemeApplyRequestSchema = Joi.object<DesktopThemeApplyRequest>({

--- a/src/common/Validator.ts
+++ b/src/common/Validator.ts
@@ -430,6 +430,7 @@ const opaqueDesktopThemeIdSchema = Joi.string().min(1).max(256).required().stric
 export const desktopShellThemeSchema = Joi.object<DesktopShellTheme>(themeFields).
     fork(Object.keys(themeFields), (schema) => (schema as Joi.StringSchema).max(256).required()).
     keys({
+        codeTheme: Joi.string().max(20_000).required().strict(),
         centerChannelBg: Joi.string().max(256).required().strict().custom((value, helpers) => (
             parseThemeColor(value) ? value : helpers.error('string.pattern.base')
         )),

--- a/src/common/Validator.ts
+++ b/src/common/Validator.ts
@@ -6,6 +6,7 @@ import Joi from 'joi';
 import type {DesktopShellTheme, DesktopThemeApplyRequest} from '@mattermost/desktop-api';
 
 import {Logger} from 'common/log';
+import {parseThemeColor} from 'common/utils/theme';
 import {isValidURL} from 'common/utils/url';
 
 import type {AppState} from 'types/appState';
@@ -428,6 +429,11 @@ export const themeSchema = Joi.object({
 const opaqueDesktopThemeIdSchema = Joi.string().min(1).max(256).required().strict();
 export const desktopShellThemeSchema = Joi.object<DesktopShellTheme>(themeFields).
     fork(Object.keys(themeFields), (schema) => (schema as Joi.StringSchema).max(256).required()).
+    keys({
+        centerChannelBg: Joi.string().max(256).required().strict().custom((value, helpers) => (
+            parseThemeColor(value) ? value : helpers.error('string.pattern.base')
+        )),
+    }).
     unknown(false);
 
 export const desktopThemeApplyRequestSchema = Joi.object<DesktopThemeApplyRequest>({

--- a/src/common/Validator.ts
+++ b/src/common/Validator.ts
@@ -426,12 +426,8 @@ export const themeSchema = Joi.object({
 }).unknown(true);
 
 const opaqueDesktopThemeIdSchema = Joi.string().min(1).max(256).required().strict();
-const desktopShellThemeColorFields = Object.keys(themeFields).filter((field) => field !== 'codeTheme');
-export const desktopShellThemeSchema = Joi.object<DesktopShellTheme>({
-    ...themeFields,
-    codeTheme: Joi.string().max(256).required().strict(),
-}).
-    fork(desktopShellThemeColorFields, () => Joi.string().pattern(/^#[0-9a-f]{6}$/i).required().strict()).
+export const desktopShellThemeSchema = Joi.object<DesktopShellTheme>(themeFields).
+    fork(Object.keys(themeFields), (schema) => (schema as Joi.StringSchema).max(256).required()).
     unknown(false);
 
 export const desktopThemeApplyRequestSchema = Joi.object<DesktopThemeApplyRequest>({

--- a/src/common/Validator.ts
+++ b/src/common/Validator.ts
@@ -3,6 +3,8 @@
 
 import Joi from 'joi';
 
+import type {DesktopShellTheme, DesktopThemeApplyRequest} from '@mattermost/desktop-api';
+
 import {Logger} from 'common/log';
 import {isValidURL} from 'common/utils/url';
 
@@ -375,19 +377,23 @@ function validateAgainstSchema<T>(data: T, schema: Joi.ObjectSchema<T> | Joi.Arr
 export function ipcValidate<E, A extends unknown[], R>(
     handler: (event: E, ...args: A) => R,
     schemas: Joi.Schema[],
+    options: {throwOnError?: boolean} = {},
 ): (event: E, ...args: A) => R {
     return (event: E, ...args: A) => {
         for (let i = 0; i < schemas.length; i++) {
             const {error} = schemas[i].validate(args[i]);
             if (error) {
                 log.error(`IPC validation failed at argument ${i}: ${error.message}`);
+                if (options.throwOnError) {
+                    throw new Error('Invalid IPC arguments');
+                }
                 return undefined as R;
             }
         }
         return handler(event, ...args);
     };
 }
-export const themeSchema = Joi.object({
+const themeFields = {
     sidebarBg: Joi.string().allow(''),
     sidebarText: Joi.string().allow(''),
     sidebarUnreadText: Joi.string().allow(''),
@@ -412,8 +418,32 @@ export const themeSchema = Joi.object({
     mentionHighlightBg: Joi.string().allow(''),
     mentionHighlightLink: Joi.string().allow(''),
     codeTheme: Joi.string().allow(''),
+};
+
+export const themeSchema = Joi.object({
+    ...themeFields,
     isUsingSystemTheme: Joi.boolean(),
 }).unknown(true);
+
+const opaqueDesktopThemeIdSchema = Joi.string().min(1).max(256).required().strict();
+export const desktopShellThemeSchema = Joi.object<DesktopShellTheme>(themeFields).
+    fork(Object.keys(themeFields), (schema) => (schema as Joi.StringSchema).max(256).required()).
+    keys({
+        centerChannelBg: Joi.string().pattern(/^#[0-9a-f]{6}$/i).required(),
+    }).
+    unknown(false);
+
+export const desktopThemeApplyRequestSchema = Joi.object<DesktopThemeApplyRequest>({
+    surfaceId: opaqueDesktopThemeIdSchema,
+    leaseId: opaqueDesktopThemeIdSchema,
+    sequence: Joi.number().integer().min(1).max(Number.MAX_SAFE_INTEGER).required(),
+    directive: Joi.object({
+        mode: Joi.string().valid('fixed', 'system').required(),
+        shellTheme: desktopShellThemeSchema.required(),
+    }).unknown(false).required(),
+}).unknown(false).strict().required();
+
+export const desktopThemeSurfaceIdSchema = opaqueDesktopThemeIdSchema;
 
 export const popoutViewPropsSchema = Joi.object({
     titleTemplate: Joi.string(),

--- a/src/common/communication.ts
+++ b/src/common/communication.ts
@@ -259,6 +259,13 @@ export const UPDATE_THEME = 'update-theme';
 export const UPDATE_SERVER_THEME = 'update-server-theme';
 export const SERVER_THEME_CHANGED = 'server-theme-changed';
 export const RESET_THEME = 'reset-theme';
+export const GET_DESKTOP_THEME_CAPABILITIES = 'get-desktop-theme-capabilities';
+export const GET_SYSTEM_APPEARANCE = 'get-system-appearance';
+export const SYSTEM_APPEARANCE_INVALIDATED = 'system-appearance-invalidated';
+export const REGISTER_DESKTOP_THEME_SURFACE = 'register-desktop-theme-surface';
+export const DESKTOP_THEME_SURFACE_STATE_CHANGED = 'desktop-theme-surface-state-changed';
+export const APPLY_DESKTOP_THEME = 'apply-desktop-theme';
+export const RELEASE_DESKTOP_THEME_SURFACE = 'release-desktop-theme-surface';
 
 // Session attributes events
 export const SESSION_ATTRIBUTES_MANIFEST_INVALIDATED = 'session-attributes-manifest-invalidated';

--- a/src/common/utils/theme.test.ts
+++ b/src/common/utils/theme.test.ts
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {parseThemeColor} from './theme';
+
+describe('parseThemeColor', () => {
+    it.each([
+        ['#123456', {red: 18, green: 52, blue: 86}],
+        ['123456', {red: 18, green: 52, blue: 86}],
+        ['#abc', {red: 170, green: 187, blue: 204}],
+        ['rgb(18,52,86)', {red: 18, green: 52, blue: 86}],
+        ['rgba(18,52,86,0.5)', {red: 18, green: 52, blue: 86}],
+    ])('parses %s', (color, expected) => {
+        expect(parseThemeColor(color)).toEqual(expected);
+    });
+
+    it.each(['', 'red', '#12', 'rgb(1,2)', 'rgba(1,2,3,bad)'])('rejects %s', (color) => {
+        expect(parseThemeColor(color)).toBeUndefined();
+    });
+});

--- a/src/common/utils/theme.test.ts
+++ b/src/common/utils/theme.test.ts
@@ -10,11 +10,22 @@ describe('parseThemeColor', () => {
         ['#abc', {red: 170, green: 187, blue: 204}],
         ['rgb(18,52,86)', {red: 18, green: 52, blue: 86}],
         ['rgba(18,52,86,0.5)', {red: 18, green: 52, blue: 86}],
+        ['rgba(18, 52, 86, .5)', {red: 18, green: 52, blue: 86}],
     ])('parses %s', (color, expected) => {
         expect(parseThemeColor(color)).toEqual(expected);
     });
 
-    it.each(['', 'red', '#12', 'rgb(1,2)', 'rgba(1,2,3,bad)'])('rejects %s', (color) => {
+    it.each([
+        '',
+        'red',
+        '#12',
+        'rgb(1,2)',
+        'rgb(256,2,3)',
+        'rgba(1,2,3,bad)',
+        'rgba(1,2,3,.)',
+        'rgba(1,2,3,1.2)',
+        'rgba(1,2,3,1.2.3)',
+    ])('rejects %s', (color) => {
         expect(parseThemeColor(color)).toBeUndefined();
     });
 });

--- a/src/common/utils/theme.ts
+++ b/src/common/utils/theme.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+const rgbPattern = /^rgba?\((\d+),(\d+),(\d+)(?:,([\d.]+))?\)$/;
+const hexPattern = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+export function parseThemeColor(color: string) {
+    const rgb = rgbPattern.exec(color);
+    if (rgb) {
+        return {
+            red: parseInt(rgb[1], 10),
+            green: parseInt(rgb[2], 10),
+            blue: parseInt(rgb[3], 10),
+        };
+    }
+
+    const hex = hexPattern.exec(color)?.[1];
+    if (!hex) {
+        return undefined;
+    }
+    const normalized = hex.length === 3 ? [...hex].map((component) => component.repeat(2)).join('') : hex;
+    return {
+        red: parseInt(normalized.slice(0, 2), 16),
+        green: parseInt(normalized.slice(2, 4), 16),
+        blue: parseInt(normalized.slice(4, 6), 16),
+    };
+}

--- a/src/common/utils/theme.ts
+++ b/src/common/utils/theme.ts
@@ -1,16 +1,22 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-const rgbPattern = /^rgba?\((\d+),(\d+),(\d+)(?:,([\d.]+))?\)$/;
+const rgbPattern = /^rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$/;
+const rgbaPattern = /^rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*((?:\d+(?:\.\d+)?|\.\d+))\s*\)$/;
 const hexPattern = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i;
 
 export function parseThemeColor(color: string) {
-    const rgb = rgbPattern.exec(color);
+    const rgb = rgbPattern.exec(color) ?? rgbaPattern.exec(color);
     if (rgb) {
+        const components = rgb.slice(1, 4).map((component) => parseInt(component, 10));
+        const alpha = rgb[4] === undefined ? 1 : parseFloat(rgb[4]);
+        if (components.some((component) => component > 255) || alpha > 1) {
+            return undefined;
+        }
         return {
-            red: parseInt(rgb[1], 10),
-            green: parseInt(rgb[2], 10),
-            blue: parseInt(rgb[3], 10),
+            red: components[0],
+            green: components[1],
+            blue: components[2],
         };
     }
 

--- a/src/main/app/app.test.js
+++ b/src/main/app/app.test.js
@@ -28,6 +28,12 @@ jest.mock('main/app/utils', () => ({
 jest.mock('main/sentryHandler', () => ({
     flush: jest.fn(),
 }));
+jest.mock('main/systemAppearanceMonitor', () => ({
+    destroy: jest.fn(),
+}));
+jest.mock('main/themeManager', () => ({
+    shutdown: jest.fn(),
+}));
 jest.mock('main/updateNotifier', () => ({}));
 
 jest.mock('main/security/certificateStore', () => ({

--- a/src/main/app/app.test.js
+++ b/src/main/app/app.test.js
@@ -6,9 +6,11 @@ import {app, dialog} from 'electron';
 import MainWindow from 'app/mainWindow/mainWindow';
 import WebContentsManager from 'app/views/webContentsManager';
 import ServerManager from 'common/servers/serverManager';
-import {handleAppActivate, handleAppWillFinishLaunching, handleAppCertificateError, certificateErrorCallbacks} from 'main/app/app';
+import {handleAppActivate, handleAppBeforeQuit, handleAppWillFinishLaunching, handleAppCertificateError, certificateErrorCallbacks} from 'main/app/app';
 import {getDeeplinkingURL, openDeepLink} from 'main/app/utils';
 import CertificateStore from 'main/security/certificateStore';
+import SystemAppearanceMonitor from 'main/systemAppearanceMonitor';
+import ThemeManager from 'main/themeManager';
 
 jest.mock('electron', () => ({
     app: {
@@ -46,7 +48,9 @@ jest.mock('main/security/certificateStore', () => ({
 jest.mock('main/i18nManager', () => ({
     localizeMessage: jest.fn(),
 }));
-jest.mock('app/system/tray/tray', () => ({}));
+jest.mock('app/system/tray/tray', () => ({
+    destroy: jest.fn(),
+}));
 jest.mock('app/mainWindow/mainWindow', () => ({
     get: jest.fn(),
     show: jest.fn(),
@@ -66,6 +70,15 @@ jest.mock('common/views/viewManager', () => ({
 }));
 
 describe('main/app/app', () => {
+    describe('handleAppBeforeQuit', () => {
+        it('shuts down theme lifecycle state', () => {
+            handleAppBeforeQuit();
+
+            expect(ThemeManager.shutdown).toHaveBeenCalled();
+            expect(SystemAppearanceMonitor.destroy).toHaveBeenCalled();
+        });
+    });
+
     describe('handleAppActivate', () => {
         afterEach(() => {
             jest.resetAllMocks();

--- a/src/main/app/app.ts
+++ b/src/main/app/app.ts
@@ -13,6 +13,8 @@ import {parseURL} from 'common/utils/url';
 import {localizeMessage} from 'main/i18nManager';
 import CertificateStore from 'main/security/certificateStore';
 import sentryHandler from 'main/sentryHandler';
+import SystemAppearanceMonitor from 'main/systemAppearanceMonitor';
+import ThemeManager from 'main/themeManager';
 
 import {getDeeplinkingURL, openDeepLink, resizeScreen} from './utils';
 
@@ -86,6 +88,9 @@ export function handleAppWillFinishLaunching() {
 
 export function handleAppBeforeQuit() {
     log.debug('handleAppBeforeQuit');
+
+    ThemeManager.shutdown();
+    SystemAppearanceMonitor.destroy();
 
     // Make sure tray icon gets removed if the user exits via CTRL-Q
     sentryHandler.flush();

--- a/src/main/app/initialize.test.js
+++ b/src/main/app/initialize.test.js
@@ -84,6 +84,15 @@ jest.mock('electron', () => ({
 jest.mock('main/performanceMonitor', () => ({
     init: jest.fn(),
 }));
+jest.mock('main/systemAppearanceAdapter', () => ({
+    createSystemAppearanceAdapter: jest.fn(() => ({})),
+}));
+jest.mock('main/systemAppearanceMonitor', () => ({
+    replaceAdapter: jest.fn(),
+}));
+jest.mock('main/themeManager', () => ({
+    initializeLifecycle: jest.fn(),
+}));
 jest.mock('main/i18nManager', () => ({
     localizeMessage: jest.fn(),
     setLocale: jest.fn(),

--- a/src/main/app/initialize.test.js
+++ b/src/main/app/initialize.test.js
@@ -8,6 +8,9 @@ import {app, session} from 'electron';
 import NavigationManager from 'app/navigationManager';
 import Config from 'common/config';
 import parseArgs from 'main/ParseArgs';
+import {createSystemAppearanceAdapter} from 'main/systemAppearanceAdapter';
+import SystemAppearanceMonitor from 'main/systemAppearanceMonitor';
+import ThemeManager from 'main/themeManager';
 
 import {initialize} from './initialize';
 import {clearAppCache, getDeeplinkingURL, wasUpdated} from './utils';
@@ -269,6 +272,7 @@ describe('main/app/initialize', () => {
     });
     beforeEach(() => {
         parseArgs.mockReturnValue({});
+        createSystemAppearanceAdapter.mockReturnValue({});
         Config.once.mockImplementation((event, cb) => {
             if (event === 'update') {
                 cb();
@@ -299,8 +303,14 @@ describe('main/app/initialize', () => {
         global.process = originalProcess;
     });
 
-    it('should initialize without errors', async () => {
+    it('should initialize the theme lifecycle', async () => {
+        const adapter = {};
+        createSystemAppearanceAdapter.mockReturnValue(adapter);
+
         await initialize();
+
+        expect(SystemAppearanceMonitor.replaceAdapter).toHaveBeenCalledWith(adapter);
+        expect(ThemeManager.initializeLifecycle).toHaveBeenCalled();
     });
 
     describe('initializeArgs', () => {

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -62,6 +62,9 @@ import PermissionsManager from 'main/security/permissionsManager';
 import PreAuthManager from 'main/security/preAuthManager';
 import sentryHandler from 'main/sentryHandler';
 import SessionAttributesManager from 'main/sessionAttributes/sessionAttributesManager';
+import {createSystemAppearanceAdapter} from 'main/systemAppearanceAdapter';
+import SystemAppearanceMonitor from 'main/systemAppearanceMonitor';
+import ThemeManager from 'main/themeManager';
 import updateNotifier from 'main/updateNotifier';
 import UserActivityMonitor from 'main/UserActivityMonitor';
 
@@ -283,6 +286,8 @@ function initializeInterCommunicationEventListeners() {
 
 async function initializeAfterAppReady() {
     maybeRegisterE2eHooks();
+    SystemAppearanceMonitor.replaceAdapter(createSystemAppearanceAdapter());
+    ThemeManager.initializeLifecycle();
 
     // Block all NTLM/Negotiate requests by default
     session.defaultSession.allowNTLMCredentialsForDomains('');

--- a/src/main/desktopThemeBroker.test.ts
+++ b/src/main/desktopThemeBroker.test.ts
@@ -204,6 +204,30 @@ describe('Desktop theme broker', () => {
         })).resolves.toMatchObject({status: 'applied'});
     });
 
+    it('retains failed reset evidence while a view becomes a popout', async () => {
+        let viewType = ViewType.TAB;
+        jest.mocked(ViewManager.getView).mockImplementation((viewId) => ({
+            id: viewId,
+            serverId: 'server-id',
+            type: viewType,
+        }) as never);
+        const shell = createDocument('internal-shell');
+        manager.registerMainWindowView(shell.webContents);
+        const registration = await manager.registerDesktopThemeSurface(owner);
+        jest.mocked(shell.webContents.send).mockImplementation((channel) => {
+            if (channel === RESET_THEME) {
+                throw new Error('send failed');
+            }
+        });
+
+        viewType = ViewType.WINDOW;
+        manager.handleDesktopThemeViewTypeChanged(owner.viewId, viewType);
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+
+        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({scope: 'main-tab', status: 'standby', reason: 'theme-reset-failed'});
+        expect(manager.isDesktopThemeDocumentCutover({...owner, scope: 'popout'})).toBe(true);
+    });
+
     it('applies a directive once and rejects duplicate sequence numbers', async () => {
         const shell = createDocument('internal-shell');
         manager.registerMainWindowView(shell.webContents);

--- a/src/main/desktopThemeBroker.test.ts
+++ b/src/main/desktopThemeBroker.test.ts
@@ -324,6 +324,19 @@ describe('Desktop theme broker', () => {
         expect(latestSurfaceState(owner, replacement.surfaceId)).toMatchObject({status: 'granted'});
     });
 
+    it('does not clear cutover when the replacement registers during navigation commit', async () => {
+        await manager.registerDesktopThemeSurface(owner);
+        manager.handleDesktopThemeDocumentNavigationStarted(owner.webContents, owner.frame);
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+
+        const replacement = await manager.registerDesktopThemeSurface(owner);
+        manager.handleDesktopThemeDocumentNavigationCompleted(owner.webContents);
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+
+        expect(manager.isDesktopThemeDocumentCutover(owner)).toBe(true);
+        expect(latestSurfaceState(owner, replacement.surfaceId)).toMatchObject({status: 'granted'});
+    });
+
     it('has no owner after the committed view loses its server', async () => {
         const registration = await manager.registerDesktopThemeSurface(owner);
         jest.mocked(ServerManager.getServer).mockReturnValue(undefined);

--- a/src/main/desktopThemeBroker.test.ts
+++ b/src/main/desktopThemeBroker.test.ts
@@ -337,13 +337,16 @@ describe('Desktop theme broker', () => {
         await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
         expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
 
-        jest.mocked(shell.webContents.send).mockImplementation(() => undefined);
         manager.handleCommittedMainViewChanged();
         jest.mocked(shell.webContents.send).mockClear();
-        await manager.releaseDesktopThemeSurface(owner, registration.surfaceId);
+        await expect(manager.releaseDesktopThemeSurface(owner, registration.surfaceId)).rejects.toThrow('Failed to release Desktop theme output');
 
         expect(shell.webContents.send).toHaveBeenCalledWith(RESET_THEME);
         expect(shell.webContents.send).toHaveBeenLastCalledWith(UPDATE_THEME, legacyTheme);
+        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
+
+        jest.mocked(shell.webContents.send).mockImplementation(() => undefined);
+        await expect(manager.releaseDesktopThemeSurface(owner, registration.surfaceId)).resolves.toEqual({status: 'released'});
     });
 
     it('keeps the cached legacy path until the current document registers', async () => {

--- a/src/main/desktopThemeBroker.test.ts
+++ b/src/main/desktopThemeBroker.test.ts
@@ -316,6 +316,40 @@ describe('Desktop theme broker', () => {
         expect(replacement.state).toMatchObject({status: 'granted'});
     });
 
+    it('does not reset the current owner when a failed background surface registers again', async () => {
+        const shell = createDocument('internal-shell');
+        const replacementOwner = createDocument('replacement-view');
+        manager.registerMainWindowView(shell.webContents);
+        const registration = await manager.registerDesktopThemeSurface(owner);
+        jest.mocked(shell.webContents.send).mockImplementation((channel) => {
+            if (channel === RESET_THEME) {
+                throw new Error('send failed');
+            }
+        });
+
+        manager.setCommittedMainViewResolver(() => ({viewId: replacementOwner.viewId, webContents: replacementOwner.webContents}));
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
+
+        jest.mocked(shell.webContents.send).mockImplementation(() => undefined);
+        const replacement = await manager.registerDesktopThemeSurface(replacementOwner);
+        const leaseId = replacement.state.status === 'granted' ? replacement.state.leaseId : '';
+        await expect(manager.applyDesktopTheme(replacementOwner, {
+            surfaceId: replacement.surfaceId,
+            leaseId,
+            sequence: 1,
+            directive: {mode: 'fixed', shellTheme},
+        })).resolves.toMatchObject({status: 'applied'});
+
+        jest.mocked(shell.webContents.send).mockClear();
+        const failedRetry = await manager.registerDesktopThemeSurface(owner);
+        expect(failedRetry).toEqual({
+            surfaceId: registration.surfaceId,
+            state: expect.objectContaining({status: 'standby', reason: 'theme-reset-failed'}),
+        });
+        expect(shell.webContents.send).not.toHaveBeenCalledWith(RESET_THEME);
+    });
+
     it('does not revive a failed registration across view scope changes', async () => {
         let viewType = ViewType.TAB;
         jest.mocked(ViewManager.getView).mockImplementation((viewId) => ({

--- a/src/main/desktopThemeBroker.test.ts
+++ b/src/main/desktopThemeBroker.test.ts
@@ -292,6 +292,44 @@ describe('Desktop theme broker', () => {
         expect(replacement.state.status === 'granted' && replacement.state.leaseId).not.toBe(firstLease);
     });
 
+    it('does not revive a failed registration across view scope changes', async () => {
+        let viewType = ViewType.TAB;
+        jest.mocked(ViewManager.getView).mockImplementation((viewId) => ({
+            id: viewId,
+            serverId: 'server-id',
+            type: viewType,
+        }) as never);
+        const shell = createDocument('internal-shell');
+        manager.registerMainWindowView(shell.webContents);
+        const registration = await manager.registerDesktopThemeSurface(owner);
+        const leaseId = registration.state.status === 'granted' ? registration.state.leaseId : '';
+        jest.mocked(shell.webContents.send).mockImplementation((channel) => {
+            if (channel === UPDATE_THEME) {
+                throw new Error('send failed');
+            }
+        });
+        await manager.applyDesktopTheme(owner, {
+            surfaceId: registration.surfaceId,
+            leaseId,
+            sequence: 1,
+            directive: {mode: 'fixed', shellTheme},
+        });
+
+        viewType = ViewType.WINDOW;
+        manager.handleDesktopThemeViewTypeChanged(owner.viewId, viewType);
+        viewType = ViewType.TAB;
+        manager.handleDesktopThemeViewTypeChanged(owner.viewId, viewType);
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+
+        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'apply-failed'});
+        await expect(manager.applyDesktopTheme(owner, {
+            surfaceId: registration.surfaceId,
+            leaseId,
+            sequence: 2,
+            directive: {mode: 'fixed', shellTheme},
+        })).resolves.toMatchObject({status: 'rejected', reason: 'unknown-surface'});
+    });
+
     it('revokes for shell-sync disablement and grants a fresh lease when re-enabled', async () => {
         const registration = await manager.registerDesktopThemeSurface(owner);
         const firstLease = registration.state.status === 'granted' ? registration.state.leaseId : '';

--- a/src/main/desktopThemeBroker.test.ts
+++ b/src/main/desktopThemeBroker.test.ts
@@ -250,6 +250,24 @@ describe('Desktop theme broker', () => {
         expect(nativeTheme.themeSource).toBe('system');
     });
 
+    it('retains a registration until release resets Desktop output', async () => {
+        const shell = createDocument('internal-shell');
+        manager.registerMainWindowView(shell.webContents);
+        const registration = await manager.registerDesktopThemeSurface(owner);
+        jest.mocked(shell.webContents.send).mockImplementation((channel) => {
+            if (channel === RESET_THEME) {
+                throw new Error('send failed');
+            }
+        });
+
+        await expect(manager.releaseDesktopThemeSurface(owner, registration.surfaceId)).rejects.toThrow('Failed to release Desktop theme output');
+        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
+
+        jest.mocked(shell.webContents.send).mockImplementation(() => undefined);
+        await expect(manager.releaseDesktopThemeSurface(owner, registration.surfaceId)).resolves.toEqual({status: 'released'});
+        await expect(manager.releaseDesktopThemeSurface(owner, registration.surfaceId)).resolves.toEqual({status: 'stale'});
+    });
+
     it('keeps the cached legacy path until the current document registers', async () => {
         const shell = createDocument('internal-shell');
         manager.registerMainWindowView(shell.webContents);

--- a/src/main/desktopThemeBroker.test.ts
+++ b/src/main/desktopThemeBroker.test.ts
@@ -231,6 +231,11 @@ describe('Desktop theme broker', () => {
         })).resolves.toMatchObject({status: 'failed', reason: 'desktop-shell-update'});
         expect(nativeTheme.themeSource).toBe('system');
         expect(latestSurfaceState(owner)).toMatchObject({status: 'standby', reason: 'apply-failed'});
+
+        jest.mocked(shell.webContents.send).mockImplementation(() => undefined);
+        manager.handleCommittedMainViewChanged();
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        expect(latestSurfaceState(owner)).toMatchObject({status: 'standby', reason: 'apply-failed'});
     });
 
     it('releases a registration without restoring legacy authority in that frame', async () => {
@@ -261,7 +266,7 @@ describe('Desktop theme broker', () => {
         expect(nativeTheme.themeSource).toBe('light');
     });
 
-    it('recovers from release failure only after a causal transition', async () => {
+    it('requires a fresh registration after a release failure', async () => {
         const shell = createDocument('internal-shell');
         manager.registerMainWindowView(shell.webContents);
         const registration = await manager.registerDesktopThemeSurface(owner);
@@ -279,8 +284,11 @@ describe('Desktop theme broker', () => {
         jest.mocked(shell.webContents.send).mockImplementation(() => undefined);
         manager.setCommittedMainViewResolver(() => ({viewId: owner.viewId, webContents: owner.webContents}));
         await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
-        expect(latestSurfaceState(owner)).toMatchObject({status: 'granted'});
-        expect(latestSurfaceState(owner).leaseId).not.toBe(firstLease);
+        expect(latestSurfaceState(owner)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
+
+        const replacement = await manager.registerDesktopThemeSurface(owner);
+        expect(replacement.state).toMatchObject({status: 'granted'});
+        expect(replacement.state.status === 'granted' && replacement.state.leaseId).not.toBe(firstLease);
     });
 
     it('revokes for shell-sync disablement and grants a fresh lease when re-enabled', async () => {

--- a/src/main/desktopThemeBroker.test.ts
+++ b/src/main/desktopThemeBroker.test.ts
@@ -309,7 +309,9 @@ describe('Desktop theme broker', () => {
         expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
 
         jest.mocked(shell.webContents.send).mockImplementation(() => undefined);
+        jest.mocked(shell.webContents.send).mockClear();
         const replacement = await manager.registerDesktopThemeSurface(owner);
+        expect(shell.webContents.send).toHaveBeenCalledWith(RESET_THEME);
         expect(replacement.surfaceId).not.toBe(registration.surfaceId);
         expect(replacement.state).toMatchObject({status: 'granted'});
     });

--- a/src/main/desktopThemeBroker.test.ts
+++ b/src/main/desktopThemeBroker.test.ts
@@ -299,9 +299,13 @@ describe('Desktop theme broker', () => {
         expect(latestSurfaceState(owner).leaseId).not.toBe(firstLease);
     });
 
-    it('invalidates a document generation without allowing delayed cleanup to remove its replacement', async () => {
+    it('keeps legacy authority suppressed until a replacement document commits', async () => {
         const first = await manager.registerDesktopThemeSurface(owner);
-        manager.handleDesktopThemeDocumentInvalidated(owner.webContents, owner.frame);
+        manager.handleDesktopThemeDocumentNavigationStarted(owner.webContents, owner.frame);
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        expect(manager.isDesktopThemeDocumentCutover(owner)).toBe(true);
+
+        manager.handleDesktopThemeDocumentNavigationCompleted(owner.webContents);
         await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
         expect(manager.isDesktopThemeDocumentCutover(owner)).toBe(false);
 

--- a/src/main/desktopThemeBroker.test.ts
+++ b/src/main/desktopThemeBroker.test.ts
@@ -1,0 +1,345 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {EventEmitter} from 'events';
+
+import type {WebContents, WebFrameMain} from 'electron';
+import {ipcMain, nativeTheme, powerMonitor} from 'electron';
+
+import type {DesktopShellTheme} from '@mattermost/desktop-api';
+
+import {
+    DESKTOP_THEME_SURFACE_STATE_CHANGED,
+    RESET_THEME,
+    UPDATE_THEME,
+} from 'common/communication';
+import Config from 'common/config';
+import ServerManager from 'common/servers/serverManager';
+import {ViewType} from 'common/views/MattermostView';
+import ViewManager from 'common/views/viewManager';
+import SystemAppearanceMonitor from 'main/systemAppearanceMonitor';
+import {ThemeManager, type DesktopThemeDocument} from 'main/themeManager';
+import {isLightColor} from 'main/utils';
+
+jest.mock('electron', () => {
+    const MockEventEmitter = jest.requireActual('events').EventEmitter;
+    const mockIpcMain = new MockEventEmitter();
+    Object.assign(mockIpcMain, {handle: jest.fn((event, handler) => mockIpcMain.on(event, handler))});
+    return {
+        ipcMain: mockIpcMain,
+        nativeTheme: {themeSource: 'system'},
+        powerMonitor: {on: jest.fn()},
+    };
+});
+
+jest.mock('common/config', () => ({themeSyncing: true}));
+jest.mock('common/servers/serverManager', () => {
+    const MockEventEmitter = jest.requireActual('events').EventEmitter;
+    const manager = new MockEventEmitter();
+    return Object.assign(manager, {
+        getCurrentServerId: jest.fn(),
+        getServer: jest.fn(() => ({id: 'server-id'})),
+        getAllServers: jest.fn(() => []),
+    });
+});
+jest.mock('common/views/viewManager', () => ({
+    getView: jest.fn(),
+    getViewsByServerId: jest.fn(() => []),
+}));
+jest.mock('main/systemAppearanceMonitor', () => ({
+    invalidate: jest.fn(),
+}));
+jest.mock('main/utils', () => ({
+    isLightColor: jest.fn(),
+}));
+
+const shellTheme: DesktopShellTheme = {
+    sidebarBg: '#111111',
+    sidebarText: '#111111',
+    sidebarUnreadText: '#111111',
+    sidebarTextHoverBg: '#111111',
+    sidebarTextActiveBorder: '#111111',
+    sidebarTextActiveColor: '#111111',
+    sidebarHeaderBg: '#111111',
+    sidebarTeamBarBg: '#111111',
+    sidebarHeaderTextColor: '#111111',
+    onlineIndicator: '#111111',
+    awayIndicator: '#111111',
+    dndIndicator: '#111111',
+    mentionBg: '#111111',
+    mentionColor: '#111111',
+    centerChannelBg: '#111111',
+    centerChannelColor: '#111111',
+    newMessageSeparator: '#111111',
+    linkColor: '#111111',
+    buttonBg: '#111111',
+    buttonColor: '#111111',
+    errorTextColor: '#111111',
+    mentionHighlightBg: '#111111',
+    mentionHighlightLink: '#111111',
+    codeTheme: 'github',
+};
+
+function createDocument(viewId: string, scope: DesktopThemeDocument['scope'] = 'main-tab') {
+    const frame = {
+        detached: false,
+        isDestroyed: jest.fn(() => false),
+        send: jest.fn(),
+    } as unknown as WebFrameMain;
+    const webContents = Object.assign(new EventEmitter(), {
+        id: Math.floor(Math.random() * 10000),
+        isDestroyed: jest.fn(() => false),
+        mainFrame: frame,
+        send: jest.fn(),
+    }) as unknown as WebContents;
+    return {viewId, scope, frame, webContents};
+}
+
+function latestSurfaceState(document: DesktopThemeDocument) {
+    const calls = jest.mocked(document.frame.send).mock.calls.filter(([channel]) => channel === DESKTOP_THEME_SURFACE_STATE_CHANGED);
+    return calls.at(-1)?.[1].state;
+}
+
+describe('Desktop theme broker', () => {
+    let manager: ThemeManager;
+    let owner: DesktopThemeDocument;
+    let sequence: number;
+
+    beforeEach(() => {
+        sequence = 0;
+        manager = new ThemeManager(() => `id-${++sequence}`);
+        owner = createDocument('owner-view');
+        jest.mocked(ViewManager.getView).mockImplementation((viewId) => ({
+            id: viewId,
+            serverId: 'server-id',
+            type: 'tab',
+        }) as never);
+        jest.mocked(ServerManager.getServer).mockReturnValue({id: 'server-id'} as never);
+        jest.mocked(isLightColor).mockReturnValue(true);
+        (Config as {themeSyncing: boolean}).themeSyncing = true;
+        nativeTheme.themeSource = 'system';
+        manager.setCommittedMainViewResolver(() => ({viewId: owner.viewId, webContents: owner.webContents}));
+    });
+
+    afterEach(() => {
+        ipcMain.removeAllListeners();
+        jest.clearAllMocks();
+    });
+
+    it('grants only the exact committed main document', async () => {
+        const background = createDocument('background-view');
+        const ownerRegistration = await manager.registerDesktopThemeSurface(owner);
+        const backgroundRegistration = await manager.registerDesktopThemeSurface(background);
+
+        expect(ownerRegistration.state).toMatchObject({scope: 'main-tab', status: 'granted'});
+        expect(backgroundRegistration.state).toMatchObject({scope: 'main-tab', status: 'standby', reason: 'not-current'});
+    });
+
+    it('marks popouts ineligible without disturbing the current lease', async () => {
+        const ownerRegistration = await manager.registerDesktopThemeSurface(owner);
+        const popoutRegistration = await manager.registerDesktopThemeSurface(createDocument('popout-view', 'popout'));
+
+        expect(ownerRegistration.state).toMatchObject({status: 'granted'});
+        expect(popoutRegistration.state).toMatchObject({scope: 'popout', status: 'ineligible', reason: 'not-main-tab'});
+    });
+
+    it('preserves a surface while its view moves between the main window and a popout', async () => {
+        let viewType = ViewType.TAB;
+        jest.mocked(ViewManager.getView).mockImplementation((viewId) => ({
+            id: viewId,
+            serverId: 'server-id',
+            type: viewType,
+        }) as never);
+        const registration = await manager.registerDesktopThemeSurface(owner);
+        const firstLeaseId = registration.state.status === 'granted' ? registration.state.leaseId : '';
+
+        viewType = ViewType.WINDOW;
+        manager.handleDesktopThemeViewTypeChanged(owner.viewId, viewType);
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        expect(latestSurfaceState(owner)).toMatchObject({scope: 'popout', status: 'ineligible', reason: 'not-main-tab'});
+        await expect(manager.applyDesktopTheme(owner, {
+            surfaceId: registration.surfaceId,
+            leaseId: firstLeaseId,
+            sequence: 1,
+            directive: {mode: 'fixed', shellTheme},
+        })).resolves.toMatchObject({status: 'rejected', reason: 'not-owner'});
+
+        viewType = ViewType.TAB;
+        manager.handleDesktopThemeViewTypeChanged(owner.viewId, viewType);
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        const restoredState = latestSurfaceState(owner);
+        expect(restoredState).toMatchObject({scope: 'main-tab', status: 'granted'});
+        expect(restoredState.leaseId).not.toBe(firstLeaseId);
+
+        await expect(manager.applyDesktopTheme(owner, {
+            surfaceId: registration.surfaceId,
+            leaseId: restoredState.leaseId,
+            sequence: 1,
+            directive: {mode: 'fixed', shellTheme},
+        })).resolves.toMatchObject({status: 'applied'});
+    });
+
+    it('applies a directive once and rejects duplicate sequence numbers', async () => {
+        const shell = createDocument('internal-shell');
+        manager.registerMainWindowView(shell.webContents);
+        const registration = await manager.registerDesktopThemeSurface(owner);
+        const leaseId = registration.state.status === 'granted' ? registration.state.leaseId : '';
+        const request = {
+            surfaceId: registration.surfaceId,
+            leaseId,
+            sequence: 1,
+            directive: {mode: 'fixed' as const, shellTheme},
+        };
+
+        await expect(manager.applyDesktopTheme(owner, request)).resolves.toMatchObject({status: 'applied'});
+        expect(shell.webContents.send).toHaveBeenLastCalledWith(UPDATE_THEME, {...shellTheme, isUsingSystemTheme: false});
+        await expect(manager.applyDesktopTheme(owner, request)).resolves.toMatchObject({status: 'rejected', reason: 'stale-sequence'});
+        await expect(manager.applyDesktopTheme(owner, {...request, sequence: 0})).resolves.toMatchObject({status: 'rejected', reason: 'stale-sequence'});
+    });
+
+    it('revokes and resets before granting a replacement owner', async () => {
+        const replacement = createDocument('replacement-view');
+        await manager.registerDesktopThemeSurface(owner);
+        await manager.registerDesktopThemeSurface(replacement);
+
+        manager.setCommittedMainViewResolver(() => undefined);
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        expect(latestSurfaceState(owner)).toMatchObject({status: 'standby', reason: 'not-current'});
+        expect(nativeTheme.themeSource).toBe('system');
+
+        manager.setCommittedMainViewResolver(() => ({viewId: replacement.viewId, webContents: replacement.webContents}));
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        expect(latestSurfaceState(replacement)).toMatchObject({status: 'granted'});
+    });
+
+    it('rolls back and revokes when shell publication fails', async () => {
+        const shell = createDocument('internal-shell');
+        manager.registerMainWindowView(shell.webContents);
+        const registration = await manager.registerDesktopThemeSurface(owner);
+        const leaseId = registration.state.status === 'granted' ? registration.state.leaseId : '';
+        jest.mocked(shell.webContents.send).mockImplementation((channel) => {
+            if (channel === UPDATE_THEME) {
+                throw new Error('send failed');
+            }
+        });
+
+        await expect(manager.applyDesktopTheme(owner, {
+            surfaceId: registration.surfaceId,
+            leaseId,
+            sequence: 1,
+            directive: {mode: 'fixed', shellTheme},
+        })).resolves.toMatchObject({status: 'failed', reason: 'desktop-shell-update'});
+        expect(nativeTheme.themeSource).toBe('system');
+        expect(latestSurfaceState(owner)).toMatchObject({status: 'standby', reason: 'apply-failed'});
+    });
+
+    it('releases a registration without restoring legacy authority in that frame', async () => {
+        const registration = await manager.registerDesktopThemeSurface(owner);
+        await expect(manager.releaseDesktopThemeSurface(owner, registration.surfaceId)).resolves.toEqual({status: 'released'});
+
+        jest.mocked(ServerManager.getCurrentServerId).mockReturnValue('server-id');
+        jest.mocked(ServerManager.getServer).mockReturnValue({id: 'server-id', theme: {...shellTheme, isUsingSystemTheme: false}} as never);
+        manager.handleCommittedMainViewChanged();
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        expect(nativeTheme.themeSource).toBe('system');
+    });
+
+    it('keeps the cached legacy path until the current document registers', async () => {
+        const shell = createDocument('internal-shell');
+        manager.registerMainWindowView(shell.webContents);
+        jest.mocked(ServerManager.getCurrentServerId).mockReturnValue('server-id');
+        jest.mocked(ServerManager.getServer).mockReturnValue({id: 'server-id', theme: {...shellTheme, isUsingSystemTheme: false}} as never);
+
+        manager.handleCommittedMainViewChanged();
+        expect(shell.webContents.send).toHaveBeenLastCalledWith(UPDATE_THEME, {...shellTheme, isUsingSystemTheme: false});
+        expect(nativeTheme.themeSource).toBe('light');
+
+        jest.mocked(shell.webContents.send).mockClear();
+        const registration = await manager.registerDesktopThemeSurface(owner);
+        expect(registration.state).toMatchObject({status: 'granted'});
+        expect(shell.webContents.send).not.toHaveBeenCalled();
+        expect(nativeTheme.themeSource).toBe('light');
+    });
+
+    it('recovers from release failure only after a causal transition', async () => {
+        const shell = createDocument('internal-shell');
+        manager.registerMainWindowView(shell.webContents);
+        const registration = await manager.registerDesktopThemeSurface(owner);
+        const firstLease = registration.state.status === 'granted' ? registration.state.leaseId : '';
+        jest.mocked(shell.webContents.send).mockImplementation((channel) => {
+            if (channel === RESET_THEME) {
+                throw new Error('send failed');
+            }
+        });
+
+        manager.setCommittedMainViewResolver(() => undefined);
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        expect(latestSurfaceState(owner)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
+
+        jest.mocked(shell.webContents.send).mockImplementation(() => undefined);
+        manager.setCommittedMainViewResolver(() => ({viewId: owner.viewId, webContents: owner.webContents}));
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        expect(latestSurfaceState(owner)).toMatchObject({status: 'granted'});
+        expect(latestSurfaceState(owner).leaseId).not.toBe(firstLease);
+    });
+
+    it('revokes for shell-sync disablement and grants a fresh lease when re-enabled', async () => {
+        const registration = await manager.registerDesktopThemeSurface(owner);
+        const firstLease = registration.state.status === 'granted' ? registration.state.leaseId : '';
+
+        (Config as {themeSyncing: boolean}).themeSyncing = false;
+        manager.handleCommittedMainViewChanged();
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        expect(latestSurfaceState(owner)).toMatchObject({status: 'standby', reason: 'desktop-sync-disabled'});
+
+        (Config as {themeSyncing: boolean}).themeSyncing = true;
+        manager.handleCommittedMainViewChanged();
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        expect(latestSurfaceState(owner)).toMatchObject({status: 'granted'});
+        expect(latestSurfaceState(owner).leaseId).not.toBe(firstLease);
+    });
+
+    it('invalidates a document generation without allowing delayed cleanup to remove its replacement', async () => {
+        const first = await manager.registerDesktopThemeSurface(owner);
+        manager.handleDesktopThemeDocumentInvalidated(owner.webContents, owner.frame);
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        expect(manager.isDesktopThemeDocumentCutover(owner)).toBe(false);
+
+        const replacement = await manager.registerDesktopThemeSurface(owner);
+        expect(replacement.surfaceId).not.toBe(first.surfaceId);
+        await expect(manager.releaseDesktopThemeSurface(owner, first.surfaceId)).resolves.toEqual({status: 'stale'});
+        expect(latestSurfaceState(owner)).toMatchObject({status: 'granted'});
+    });
+
+    it('has no owner after the committed view loses its server', async () => {
+        await manager.registerDesktopThemeSurface(owner);
+        jest.mocked(ServerManager.getServer).mockReturnValue(undefined);
+        manager.handleCommittedMainViewChanged();
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+
+        expect(latestSurfaceState(owner)).toMatchObject({status: 'standby', reason: 'not-current'});
+        expect(nativeTheme.themeSource).toBe('system');
+    });
+
+    it('nests lock and suspend blockers and grants a fresh lease after both clear', async () => {
+        const registration = await manager.registerDesktopThemeSurface(owner);
+        const firstLease = registration.state.status === 'granted' ? registration.state.leaseId : '';
+        manager.initializeLifecycle();
+        const listener = (event: string) => jest.mocked(powerMonitor.on).mock.calls.find(([name]) => name === event)?.[1] as () => void;
+
+        listener('lock-screen')();
+        listener('suspend')();
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        expect(latestSurfaceState(owner)).toMatchObject({status: 'standby', reason: 'screen-locked'});
+
+        listener('unlock-screen')();
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        expect(latestSurfaceState(owner)).toMatchObject({status: 'standby', reason: 'system-suspended'});
+
+        listener('resume')();
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        expect(latestSurfaceState(owner)).toMatchObject({status: 'granted'});
+        expect(latestSurfaceState(owner).leaseId).not.toBe(firstLease);
+        expect(SystemAppearanceMonitor.invalidate).toHaveBeenCalledTimes(4);
+    });
+});

--- a/src/main/desktopThemeBroker.test.ts
+++ b/src/main/desktopThemeBroker.test.ts
@@ -95,8 +95,9 @@ function createDocument(viewId: string, scope: DesktopThemeDocument['scope'] = '
     return {viewId, scope, frame, webContents};
 }
 
-function latestSurfaceState(document: DesktopThemeDocument) {
-    const calls = jest.mocked(document.frame.send).mock.calls.filter(([channel]) => channel === DESKTOP_THEME_SURFACE_STATE_CHANGED);
+function latestSurfaceState(document: DesktopThemeDocument, surfaceId: string) {
+    const calls = jest.mocked(document.frame.send).mock.calls.filter(([channel, event]) =>
+        channel === DESKTOP_THEME_SURFACE_STATE_CHANGED && event.surfaceId === surfaceId);
     return calls.at(-1)?.[1].state;
 }
 
@@ -156,7 +157,7 @@ describe('Desktop theme broker', () => {
         viewType = ViewType.WINDOW;
         manager.handleDesktopThemeViewTypeChanged(owner.viewId, viewType);
         await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
-        expect(latestSurfaceState(owner)).toMatchObject({scope: 'popout', status: 'ineligible', reason: 'not-main-tab'});
+        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({scope: 'popout', status: 'ineligible', reason: 'not-main-tab'});
         await expect(manager.applyDesktopTheme(owner, {
             surfaceId: registration.surfaceId,
             leaseId: firstLeaseId,
@@ -167,7 +168,7 @@ describe('Desktop theme broker', () => {
         viewType = ViewType.TAB;
         manager.handleDesktopThemeViewTypeChanged(owner.viewId, viewType);
         await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
-        const restoredState = latestSurfaceState(owner);
+        const restoredState = latestSurfaceState(owner, registration.surfaceId);
         expect(restoredState).toMatchObject({scope: 'main-tab', status: 'granted'});
         expect(restoredState.leaseId).not.toBe(firstLeaseId);
 
@@ -199,17 +200,17 @@ describe('Desktop theme broker', () => {
 
     it('revokes and resets before granting a replacement owner', async () => {
         const replacement = createDocument('replacement-view');
-        await manager.registerDesktopThemeSurface(owner);
-        await manager.registerDesktopThemeSurface(replacement);
+        const ownerRegistration = await manager.registerDesktopThemeSurface(owner);
+        const replacementRegistration = await manager.registerDesktopThemeSurface(replacement);
 
         manager.setCommittedMainViewResolver(() => undefined);
         await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
-        expect(latestSurfaceState(owner)).toMatchObject({status: 'standby', reason: 'not-current'});
+        expect(latestSurfaceState(owner, ownerRegistration.surfaceId)).toMatchObject({status: 'standby', reason: 'not-current'});
         expect(nativeTheme.themeSource).toBe('system');
 
         manager.setCommittedMainViewResolver(() => ({viewId: replacement.viewId, webContents: replacement.webContents}));
         await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
-        expect(latestSurfaceState(replacement)).toMatchObject({status: 'granted'});
+        expect(latestSurfaceState(replacement, replacementRegistration.surfaceId)).toMatchObject({status: 'granted'});
     });
 
     it('rolls back and revokes when shell publication fails', async () => {
@@ -230,12 +231,12 @@ describe('Desktop theme broker', () => {
             directive: {mode: 'fixed', shellTheme},
         })).resolves.toMatchObject({status: 'failed', reason: 'desktop-shell-update'});
         expect(nativeTheme.themeSource).toBe('system');
-        expect(latestSurfaceState(owner)).toMatchObject({status: 'standby', reason: 'apply-failed'});
+        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'apply-failed'});
 
         jest.mocked(shell.webContents.send).mockImplementation(() => undefined);
         manager.handleCommittedMainViewChanged();
         await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
-        expect(latestSurfaceState(owner)).toMatchObject({status: 'standby', reason: 'apply-failed'});
+        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'apply-failed'});
     });
 
     it('releases a registration without restoring legacy authority in that frame', async () => {
@@ -279,12 +280,12 @@ describe('Desktop theme broker', () => {
 
         manager.setCommittedMainViewResolver(() => undefined);
         await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
-        expect(latestSurfaceState(owner)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
+        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
 
         jest.mocked(shell.webContents.send).mockImplementation(() => undefined);
         manager.setCommittedMainViewResolver(() => ({viewId: owner.viewId, webContents: owner.webContents}));
         await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
-        expect(latestSurfaceState(owner)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
+        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
 
         const replacement = await manager.registerDesktopThemeSurface(owner);
         expect(replacement.state).toMatchObject({status: 'granted'});
@@ -298,13 +299,13 @@ describe('Desktop theme broker', () => {
         (Config as {themeSyncing: boolean}).themeSyncing = false;
         manager.handleCommittedMainViewChanged();
         await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
-        expect(latestSurfaceState(owner)).toMatchObject({status: 'standby', reason: 'desktop-sync-disabled'});
+        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'desktop-sync-disabled'});
 
         (Config as {themeSyncing: boolean}).themeSyncing = true;
         manager.handleCommittedMainViewChanged();
         await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
-        expect(latestSurfaceState(owner)).toMatchObject({status: 'granted'});
-        expect(latestSurfaceState(owner).leaseId).not.toBe(firstLease);
+        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'granted'});
+        expect(latestSurfaceState(owner, registration.surfaceId).leaseId).not.toBe(firstLease);
     });
 
     it('keeps legacy authority suppressed until a replacement document commits', async () => {
@@ -320,16 +321,16 @@ describe('Desktop theme broker', () => {
         const replacement = await manager.registerDesktopThemeSurface(owner);
         expect(replacement.surfaceId).not.toBe(first.surfaceId);
         await expect(manager.releaseDesktopThemeSurface(owner, first.surfaceId)).resolves.toEqual({status: 'stale'});
-        expect(latestSurfaceState(owner)).toMatchObject({status: 'granted'});
+        expect(latestSurfaceState(owner, replacement.surfaceId)).toMatchObject({status: 'granted'});
     });
 
     it('has no owner after the committed view loses its server', async () => {
-        await manager.registerDesktopThemeSurface(owner);
+        const registration = await manager.registerDesktopThemeSurface(owner);
         jest.mocked(ServerManager.getServer).mockReturnValue(undefined);
         manager.handleCommittedMainViewChanged();
         await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
 
-        expect(latestSurfaceState(owner)).toMatchObject({status: 'standby', reason: 'not-current'});
+        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'not-current'});
         expect(nativeTheme.themeSource).toBe('system');
     });
 
@@ -342,16 +343,16 @@ describe('Desktop theme broker', () => {
         listener('lock-screen')();
         listener('suspend')();
         await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
-        expect(latestSurfaceState(owner)).toMatchObject({status: 'standby', reason: 'screen-locked'});
+        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'screen-locked'});
 
         listener('unlock-screen')();
         await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
-        expect(latestSurfaceState(owner)).toMatchObject({status: 'standby', reason: 'system-suspended'});
+        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'system-suspended'});
 
         listener('resume')();
         await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
-        expect(latestSurfaceState(owner)).toMatchObject({status: 'granted'});
-        expect(latestSurfaceState(owner).leaseId).not.toBe(firstLease);
+        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'granted'});
+        expect(latestSurfaceState(owner, registration.surfaceId).leaseId).not.toBe(firstLease);
         expect(SystemAppearanceMonitor.invalidate).toHaveBeenCalledTimes(4);
     });
 });

--- a/src/main/desktopThemeBroker.test.ts
+++ b/src/main/desktopThemeBroker.test.ts
@@ -292,6 +292,28 @@ describe('Desktop theme broker', () => {
         expect(replacement.state.status === 'granted' && replacement.state.leaseId).not.toBe(firstLease);
     });
 
+    it('does not replace an active registration when its reset fails', async () => {
+        const shell = createDocument('internal-shell');
+        manager.registerMainWindowView(shell.webContents);
+        const registration = await manager.registerDesktopThemeSurface(owner);
+        jest.mocked(shell.webContents.send).mockImplementation((channel) => {
+            if (channel === RESET_THEME) {
+                throw new Error('send failed');
+            }
+        });
+
+        const failedReplacement = await manager.registerDesktopThemeSurface(owner);
+
+        expect(failedReplacement.surfaceId).toBe(registration.surfaceId);
+        expect(failedReplacement.state).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
+        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
+
+        jest.mocked(shell.webContents.send).mockImplementation(() => undefined);
+        const replacement = await manager.registerDesktopThemeSurface(owner);
+        expect(replacement.surfaceId).not.toBe(registration.surfaceId);
+        expect(replacement.state).toMatchObject({status: 'granted'});
+    });
+
     it('does not revive a failed registration across view scope changes', async () => {
         let viewType = ViewType.TAB;
         jest.mocked(ViewManager.getView).mockImplementation((viewId) => ({

--- a/src/main/desktopThemeBroker.test.ts
+++ b/src/main/desktopThemeBroker.test.ts
@@ -288,6 +288,40 @@ describe('Desktop theme broker', () => {
         expect(shell.webContents.send).toHaveBeenCalledWith(RESET_THEME);
     });
 
+    it('restores the current legacy owner after recovering failed V1 output', async () => {
+        const shell = createDocument('internal-shell');
+        const legacyOwner = createDocument('legacy-view');
+        const legacyTheme = {...shellTheme, centerChannelBg: '#eeeeee', isUsingSystemTheme: false};
+        manager.registerMainWindowView(shell.webContents);
+        jest.mocked(ServerManager.getCurrentServerId).mockReturnValue('server-id');
+        jest.mocked(ServerManager.getServer).mockReturnValue({id: 'server-id', theme: legacyTheme} as never);
+        const registration = await manager.registerDesktopThemeSurface(owner);
+        const leaseId = registration.state.status === 'granted' ? registration.state.leaseId : '';
+        await manager.applyDesktopTheme(owner, {
+            surfaceId: registration.surfaceId,
+            leaseId,
+            sequence: 1,
+            directive: {mode: 'fixed', shellTheme},
+        });
+        jest.mocked(shell.webContents.send).mockImplementation((channel) => {
+            if (channel === RESET_THEME) {
+                throw new Error('send failed');
+            }
+        });
+
+        manager.setCommittedMainViewResolver(() => ({viewId: legacyOwner.viewId, webContents: legacyOwner.webContents}));
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
+
+        jest.mocked(shell.webContents.send).mockImplementation(() => undefined);
+        manager.handleCommittedMainViewChanged();
+        jest.mocked(shell.webContents.send).mockClear();
+        await manager.releaseDesktopThemeSurface(owner, registration.surfaceId);
+
+        expect(shell.webContents.send).toHaveBeenCalledWith(RESET_THEME);
+        expect(shell.webContents.send).toHaveBeenLastCalledWith(UPDATE_THEME, legacyTheme);
+    });
+
     it('keeps the cached legacy path until the current document registers', async () => {
         const shell = createDocument('internal-shell');
         manager.registerMainWindowView(shell.webContents);

--- a/src/main/desktopThemeBroker.test.ts
+++ b/src/main/desktopThemeBroker.test.ts
@@ -268,6 +268,26 @@ describe('Desktop theme broker', () => {
         await expect(manager.releaseDesktopThemeSurface(owner, registration.surfaceId)).resolves.toEqual({status: 'stale'});
     });
 
+    it('retries a failed reset when a former owner releases', async () => {
+        const shell = createDocument('internal-shell');
+        manager.registerMainWindowView(shell.webContents);
+        const registration = await manager.registerDesktopThemeSurface(owner);
+        jest.mocked(shell.webContents.send).mockImplementation((channel) => {
+            if (channel === RESET_THEME) {
+                throw new Error('send failed');
+            }
+        });
+
+        manager.setCommittedMainViewResolver(() => undefined);
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
+
+        jest.mocked(shell.webContents.send).mockImplementation(() => undefined);
+        jest.mocked(shell.webContents.send).mockClear();
+        await expect(manager.releaseDesktopThemeSurface(owner, registration.surfaceId)).resolves.toEqual({status: 'released'});
+        expect(shell.webContents.send).toHaveBeenCalledWith(RESET_THEME);
+    });
+
     it('keeps the cached legacy path until the current document registers', async () => {
         const shell = createDocument('internal-shell');
         manager.registerMainWindowView(shell.webContents);
@@ -334,7 +354,7 @@ describe('Desktop theme broker', () => {
         expect(replacement.state).toMatchObject({status: 'granted'});
     });
 
-    it('does not reset the current owner when a failed background surface registers again', async () => {
+    it('retires failed background evidence without resetting the current owner', async () => {
         const shell = createDocument('internal-shell');
         const replacementOwner = createDocument('replacement-view');
         manager.registerMainWindowView(shell.webContents);
@@ -361,11 +381,56 @@ describe('Desktop theme broker', () => {
 
         jest.mocked(shell.webContents.send).mockClear();
         const failedRetry = await manager.registerDesktopThemeSurface(owner);
-        expect(failedRetry).toEqual({
-            surfaceId: registration.surfaceId,
-            state: expect.objectContaining({status: 'standby', reason: 'theme-reset-failed'}),
-        });
+        expect(failedRetry.surfaceId).not.toBe(registration.surfaceId);
+        expect(failedRetry.state).toMatchObject({status: 'standby', reason: 'not-current'});
         expect(shell.webContents.send).not.toHaveBeenCalledWith(RESET_THEME);
+    });
+
+    it('recovers failed output before granting a different owner', async () => {
+        const shell = createDocument('internal-shell');
+        const replacementOwner = createDocument('replacement-view');
+        manager.registerMainWindowView(shell.webContents);
+        const registration = await manager.registerDesktopThemeSurface(owner);
+        jest.mocked(shell.webContents.send).mockImplementation((channel) => {
+            if (channel === RESET_THEME) {
+                throw new Error('send failed');
+            }
+        });
+
+        manager.setCommittedMainViewResolver(() => ({viewId: replacementOwner.viewId, webContents: replacementOwner.webContents}));
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
+
+        const blockedReplacement = await manager.registerDesktopThemeSurface(replacementOwner);
+        expect(blockedReplacement.state).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
+
+        jest.mocked(shell.webContents.send).mockImplementation(() => undefined);
+        jest.mocked(shell.webContents.send).mockClear();
+        const replacement = await manager.registerDesktopThemeSurface(replacementOwner);
+        expect(shell.webContents.send).toHaveBeenCalledWith(RESET_THEME);
+        expect(replacement.state).toMatchObject({status: 'granted'});
+        await expect(manager.releaseDesktopThemeSurface(owner, registration.surfaceId)).resolves.toEqual({status: 'stale'});
+    });
+
+    it('retains failed output evidence through document invalidation', async () => {
+        const shell = createDocument('internal-shell');
+        manager.registerMainWindowView(shell.webContents);
+        const registration = await manager.registerDesktopThemeSurface(owner);
+        jest.mocked(shell.webContents.send).mockImplementation((channel) => {
+            if (channel === RESET_THEME) {
+                throw new Error('send failed');
+            }
+        });
+
+        manager.handleDesktopThemeDocumentInvalidated(owner.webContents, owner.frame);
+        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
+
+        jest.mocked(shell.webContents.send).mockImplementation(() => undefined);
+        jest.mocked(shell.webContents.send).mockClear();
+        const replacement = await manager.registerDesktopThemeSurface(owner);
+        expect(shell.webContents.send).toHaveBeenCalledWith(RESET_THEME);
+        expect(replacement.state).toMatchObject({status: 'granted'});
     });
 
     it('does not revive a failed registration across view scope changes', async () => {

--- a/src/main/desktopThemeBroker.test.ts
+++ b/src/main/desktopThemeBroker.test.ts
@@ -368,32 +368,24 @@ describe('Desktop theme broker', () => {
         expect(latestSurfaceState(owner, registration.surfaceId).leaseId).not.toBe(firstLease);
     });
 
-    it('keeps legacy authority suppressed until a replacement document commits', async () => {
+    it('invalidates the current document when its replacement commits', async () => {
         const first = await manager.registerDesktopThemeSurface(owner);
-        manager.handleDesktopThemeDocumentNavigationStarted(owner.webContents, owner.frame);
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        const leaseId = first.state.status === 'granted' ? first.state.leaseId : '';
         expect(manager.isDesktopThemeDocumentCutover(owner)).toBe(true);
+        await expect(manager.applyDesktopTheme(owner, {
+            surfaceId: first.surfaceId,
+            leaseId,
+            sequence: 1,
+            directive: {mode: 'fixed', shellTheme},
+        })).resolves.toMatchObject({status: 'applied'});
 
-        manager.handleDesktopThemeDocumentNavigationCompleted(owner.webContents);
+        manager.handleDesktopThemeDocumentInvalidated(owner.webContents, owner.frame);
         await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
         expect(manager.isDesktopThemeDocumentCutover(owner)).toBe(false);
 
         const replacement = await manager.registerDesktopThemeSurface(owner);
         expect(replacement.surfaceId).not.toBe(first.surfaceId);
         await expect(manager.releaseDesktopThemeSurface(owner, first.surfaceId)).resolves.toEqual({status: 'stale'});
-        expect(latestSurfaceState(owner, replacement.surfaceId)).toMatchObject({status: 'granted'});
-    });
-
-    it('does not clear cutover when the replacement registers during navigation commit', async () => {
-        await manager.registerDesktopThemeSurface(owner);
-        manager.handleDesktopThemeDocumentNavigationStarted(owner.webContents, owner.frame);
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
-
-        const replacement = await manager.registerDesktopThemeSurface(owner);
-        manager.handleDesktopThemeDocumentNavigationCompleted(owner.webContents);
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
-
-        expect(manager.isDesktopThemeDocumentCutover(owner)).toBe(true);
         expect(latestSurfaceState(owner, replacement.surfaceId)).toMatchObject({status: 'granted'});
     });
 

--- a/src/main/desktopThemeBroker.test.ts
+++ b/src/main/desktopThemeBroker.test.ts
@@ -101,12 +101,29 @@ function latestSurfaceState(document: DesktopThemeDocument, surfaceId: string) {
     return calls.at(-1)?.[1].state;
 }
 
+function surfaceStateEventCount(document: DesktopThemeDocument, surfaceId: string) {
+    return jest.mocked(document.frame.send).mock.calls.filter(([channel, event]) =>
+        channel === DESKTOP_THEME_SURFACE_STATE_CHANGED && event.surfaceId === surfaceId).length;
+}
+
+async function settleBroker(manager: ThemeManager) {
+    await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+}
+
 describe('Desktop theme broker', () => {
     let manager: ThemeManager;
     let owner: DesktopThemeDocument;
     let sequence: number;
 
     beforeEach(() => {
+        let nativeThemeSource = 'system';
+        Object.defineProperty(nativeTheme, 'themeSource', {
+            configurable: true,
+            get: () => nativeThemeSource,
+            set: (value) => {
+                nativeThemeSource = value;
+            },
+        });
         sequence = 0;
         manager = new ThemeManager(() => `id-${++sequence}`);
         owner = createDocument('owner-view');
@@ -124,6 +141,7 @@ describe('Desktop theme broker', () => {
 
     afterEach(() => {
         ipcMain.removeAllListeners();
+        ServerManager.removeAllListeners();
         jest.clearAllMocks();
     });
 
@@ -180,7 +198,7 @@ describe('Desktop theme broker', () => {
 
         viewType = ViewType.WINDOW;
         manager.handleDesktopThemeViewTypeChanged(owner.viewId, viewType);
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        await settleBroker(manager);
         expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({scope: 'popout', status: 'ineligible', reason: 'not-main-tab'});
         await expect(manager.applyDesktopTheme(owner, {
             surfaceId: registration.surfaceId,
@@ -191,7 +209,7 @@ describe('Desktop theme broker', () => {
 
         viewType = ViewType.TAB;
         manager.handleDesktopThemeViewTypeChanged(owner.viewId, viewType);
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        await settleBroker(manager);
         const restoredState = latestSurfaceState(owner, registration.surfaceId);
         expect(restoredState).toMatchObject({scope: 'main-tab', status: 'granted'});
         expect(restoredState.leaseId).not.toBe(firstLeaseId);
@@ -222,7 +240,7 @@ describe('Desktop theme broker', () => {
 
         viewType = ViewType.WINDOW;
         manager.handleDesktopThemeViewTypeChanged(owner.viewId, viewType);
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        await settleBroker(manager);
 
         expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({scope: 'main-tab', status: 'standby', reason: 'theme-reset-failed'});
         expect(manager.isDesktopThemeDocumentCutover({...owner, scope: 'popout'})).toBe(true);
@@ -247,18 +265,37 @@ describe('Desktop theme broker', () => {
     });
 
     it('revokes and resets before granting a replacement owner', async () => {
+        const shell = createDocument('internal-shell');
         const replacement = createDocument('replacement-view');
+        const transitionOrder: string[] = [];
+        manager.registerMainWindowView(shell.webContents);
         const ownerRegistration = await manager.registerDesktopThemeSurface(owner);
         const replacementRegistration = await manager.registerDesktopThemeSurface(replacement);
-
-        manager.setCommittedMainViewResolver(() => undefined);
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
-        expect(latestSurfaceState(owner, ownerRegistration.surfaceId)).toMatchObject({status: 'standby', reason: 'not-current'});
-        expect(nativeTheme.themeSource).toBe('system');
+        const leaseId = ownerRegistration.state.status === 'granted' ? ownerRegistration.state.leaseId : '';
+        await manager.applyDesktopTheme(owner, {
+            surfaceId: ownerRegistration.surfaceId,
+            leaseId,
+            sequence: 1,
+            directive: {mode: 'fixed', shellTheme},
+        });
+        jest.mocked(shell.webContents.send).mockImplementation((channel) => {
+            if (channel === RESET_THEME) {
+                transitionOrder.push('reset');
+            }
+        });
+        jest.mocked(replacement.frame.send).mockImplementation((channel, event) => {
+            if (channel === DESKTOP_THEME_SURFACE_STATE_CHANGED && event.state.status === 'granted') {
+                transitionOrder.push('grant');
+            }
+        });
 
         manager.setCommittedMainViewResolver(() => ({viewId: replacement.viewId, webContents: replacement.webContents}));
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        await settleBroker(manager);
+
+        expect(latestSurfaceState(owner, ownerRegistration.surfaceId)).toMatchObject({status: 'standby', reason: 'not-current'});
         expect(latestSurfaceState(replacement, replacementRegistration.surfaceId)).toMatchObject({status: 'granted'});
+        expect(transitionOrder).toEqual(['reset', 'grant']);
+        expect(nativeTheme.themeSource).toBe('system');
     });
 
     it('rolls back and revokes when shell publication fails', async () => {
@@ -280,11 +317,65 @@ describe('Desktop theme broker', () => {
         })).resolves.toMatchObject({status: 'failed', reason: 'desktop-shell-update'});
         expect(nativeTheme.themeSource).toBe('system');
         expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'apply-failed'});
+        const eventCount = surfaceStateEventCount(owner, registration.surfaceId);
 
         jest.mocked(shell.webContents.send).mockImplementation(() => undefined);
         manager.handleCommittedMainViewChanged();
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        await settleBroker(manager);
+        expect(surfaceStateEventCount(owner, registration.surfaceId)).toBe(eventCount);
+    });
+
+    it('rolls back and revokes when the native theme update fails', async () => {
+        const shell = createDocument('internal-shell');
+        manager.registerMainWindowView(shell.webContents);
+        const registration = await manager.registerDesktopThemeSurface(owner);
+        const leaseId = registration.state.status === 'granted' ? registration.state.leaseId : '';
+        Object.defineProperty(nativeTheme, 'themeSource', {
+            configurable: true,
+            get: () => 'system',
+            set: (value) => {
+                if (value !== 'system') {
+                    throw new Error('native update failed');
+                }
+            },
+        });
+
+        await expect(manager.applyDesktopTheme(owner, {
+            surfaceId: registration.surfaceId,
+            leaseId,
+            sequence: 1,
+            directive: {mode: 'fixed', shellTheme},
+        })).resolves.toMatchObject({status: 'failed', reason: 'native-theme-update'});
+        expect(shell.webContents.send).toHaveBeenLastCalledWith(RESET_THEME);
         expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'apply-failed'});
+    });
+
+    it('retains failed reset evidence when the native theme reset fails', async () => {
+        const shell = createDocument('internal-shell');
+        manager.registerMainWindowView(shell.webContents);
+        const registration = await manager.registerDesktopThemeSurface(owner);
+        const leaseId = registration.state.status === 'granted' ? registration.state.leaseId : '';
+        await manager.applyDesktopTheme(owner, {
+            surfaceId: registration.surfaceId,
+            leaseId,
+            sequence: 1,
+            directive: {mode: 'fixed', shellTheme},
+        });
+        Object.defineProperty(nativeTheme, 'themeSource', {
+            configurable: true,
+            get: () => 'light',
+            set: (value) => {
+                if (value === 'system') {
+                    throw new Error('native reset failed');
+                }
+            },
+        });
+
+        manager.setCommittedMainViewResolver(() => undefined);
+        await settleBroker(manager);
+
+        expect(shell.webContents.send).toHaveBeenLastCalledWith(RESET_THEME);
+        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
     });
 
     it('releases a registration without restoring legacy authority in that frame', async () => {
@@ -294,7 +385,7 @@ describe('Desktop theme broker', () => {
         jest.mocked(ServerManager.getCurrentServerId).mockReturnValue('server-id');
         jest.mocked(ServerManager.getServer).mockReturnValue({id: 'server-id', theme: {...shellTheme, isUsingSystemTheme: false}} as never);
         manager.handleCommittedMainViewChanged();
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        await settleBroker(manager);
         expect(nativeTheme.themeSource).toBe('system');
     });
 
@@ -327,7 +418,7 @@ describe('Desktop theme broker', () => {
         });
 
         manager.setCommittedMainViewResolver(() => undefined);
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        await settleBroker(manager);
         expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
 
         jest.mocked(shell.webContents.send).mockImplementation(() => undefined);
@@ -358,8 +449,9 @@ describe('Desktop theme broker', () => {
         });
 
         manager.setCommittedMainViewResolver(() => ({viewId: legacyOwner.viewId, webContents: legacyOwner.webContents}));
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        await settleBroker(manager);
         expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
+        const eventCount = surfaceStateEventCount(owner, registration.surfaceId);
 
         manager.handleCommittedMainViewChanged();
         jest.mocked(shell.webContents.send).mockClear();
@@ -367,7 +459,7 @@ describe('Desktop theme broker', () => {
 
         expect(shell.webContents.send).toHaveBeenCalledWith(RESET_THEME);
         expect(shell.webContents.send).toHaveBeenLastCalledWith(UPDATE_THEME, legacyTheme);
-        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
+        expect(surfaceStateEventCount(owner, registration.surfaceId)).toBe(eventCount);
 
         jest.mocked(shell.webContents.send).mockImplementation(() => undefined);
         await expect(manager.releaseDesktopThemeSurface(owner, registration.surfaceId)).resolves.toEqual({status: 'released'});
@@ -402,13 +494,14 @@ describe('Desktop theme broker', () => {
         });
 
         manager.setCommittedMainViewResolver(() => undefined);
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        await settleBroker(manager);
         expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
+        const eventCount = surfaceStateEventCount(owner, registration.surfaceId);
 
         jest.mocked(shell.webContents.send).mockImplementation(() => undefined);
         manager.setCommittedMainViewResolver(() => ({viewId: owner.viewId, webContents: owner.webContents}));
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
-        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
+        await settleBroker(manager);
+        expect(surfaceStateEventCount(owner, registration.surfaceId)).toBe(eventCount);
 
         const replacement = await manager.registerDesktopThemeSurface(owner);
         expect(replacement.state).toMatchObject({status: 'granted'});
@@ -451,7 +544,7 @@ describe('Desktop theme broker', () => {
         });
 
         manager.setCommittedMainViewResolver(() => ({viewId: replacementOwner.viewId, webContents: replacementOwner.webContents}));
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        await settleBroker(manager);
         expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
 
         jest.mocked(shell.webContents.send).mockImplementation(() => undefined);
@@ -483,7 +576,7 @@ describe('Desktop theme broker', () => {
         });
 
         manager.setCommittedMainViewResolver(() => ({viewId: replacementOwner.viewId, webContents: replacementOwner.webContents}));
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        await settleBroker(manager);
         expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
 
         const blockedReplacement = await manager.registerDesktopThemeSurface(replacementOwner);
@@ -508,7 +601,7 @@ describe('Desktop theme broker', () => {
         });
 
         manager.handleDesktopThemeDocumentInvalidated(owner.webContents, owner.frame);
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        await settleBroker(manager);
         expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'theme-reset-failed'});
 
         jest.mocked(shell.webContents.send).mockImplementation(() => undefined);
@@ -545,9 +638,8 @@ describe('Desktop theme broker', () => {
         manager.handleDesktopThemeViewTypeChanged(owner.viewId, viewType);
         viewType = ViewType.TAB;
         manager.handleDesktopThemeViewTypeChanged(owner.viewId, viewType);
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        await settleBroker(manager);
 
-        expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'apply-failed'});
         await expect(manager.applyDesktopTheme(owner, {
             surfaceId: registration.surfaceId,
             leaseId,
@@ -562,12 +654,12 @@ describe('Desktop theme broker', () => {
 
         (Config as {themeSyncing: boolean}).themeSyncing = false;
         manager.handleCommittedMainViewChanged();
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        await settleBroker(manager);
         expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'desktop-sync-disabled'});
 
         (Config as {themeSyncing: boolean}).themeSyncing = true;
         manager.handleCommittedMainViewChanged();
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        await settleBroker(manager);
         expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'granted'});
         expect(latestSurfaceState(owner, registration.surfaceId).leaseId).not.toBe(firstLease);
     });
@@ -584,7 +676,7 @@ describe('Desktop theme broker', () => {
         })).resolves.toMatchObject({status: 'applied'});
 
         manager.handleDesktopThemeDocumentInvalidated(owner.webContents, owner.frame);
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        await settleBroker(manager);
         expect(manager.isDesktopThemeDocumentCutover(owner)).toBe(false);
 
         const replacement = await manager.registerDesktopThemeSurface(owner);
@@ -597,7 +689,7 @@ describe('Desktop theme broker', () => {
         const registration = await manager.registerDesktopThemeSurface(owner);
         jest.mocked(ServerManager.getServer).mockReturnValue(undefined);
         manager.handleCommittedMainViewChanged();
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        await settleBroker(manager);
 
         expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'not-current'});
         expect(nativeTheme.themeSource).toBe('system');
@@ -611,15 +703,15 @@ describe('Desktop theme broker', () => {
 
         listener('lock-screen')();
         listener('suspend')();
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        await settleBroker(manager);
         expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'screen-locked'});
 
         listener('unlock-screen')();
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        await settleBroker(manager);
         expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'standby', reason: 'system-suspended'});
 
         listener('resume')();
-        await (manager as unknown as {brokerTransition: Promise<void>}).brokerTransition;
+        await settleBroker(manager);
         expect(latestSurfaceState(owner, registration.surfaceId)).toMatchObject({status: 'granted'});
         expect(latestSurfaceState(owner, registration.surfaceId).leaseId).not.toBe(firstLease);
         expect(SystemAppearanceMonitor.invalidate).toHaveBeenCalledTimes(4);

--- a/src/main/desktopThemeBroker.test.ts
+++ b/src/main/desktopThemeBroker.test.ts
@@ -144,6 +144,30 @@ describe('Desktop theme broker', () => {
         expect(popoutRegistration.state).toMatchObject({scope: 'popout', status: 'ineligible', reason: 'not-main-tab'});
     });
 
+    it('keeps a cutover popout shell aligned with a legacy main owner', async () => {
+        const mainShell = createDocument('internal-shell');
+        const popoutDocument = createDocument('popout-view', 'popout');
+        const popoutShell = createDocument('popout-shell');
+        const legacyTheme = {...shellTheme, centerChannelBg: '#eeeeee', isUsingSystemTheme: false};
+        manager.registerMainWindowView(mainShell.webContents);
+        await manager.registerDesktopThemeSurface(popoutDocument);
+        manager.registerPopoutView(popoutShell.webContents, popoutDocument.viewId);
+        jest.mocked(ServerManager.getCurrentServerId).mockReturnValue('server-id');
+        jest.mocked(ServerManager.getServer).mockReturnValue({id: 'server-id', theme: legacyTheme} as never);
+
+        jest.mocked(mainShell.webContents.send).mockClear();
+        jest.mocked(popoutShell.webContents.send).mockClear();
+        manager.handleCommittedMainViewChanged();
+
+        expect(mainShell.webContents.send).toHaveBeenLastCalledWith(UPDATE_THEME, legacyTheme);
+        expect(popoutShell.webContents.send).toHaveBeenLastCalledWith(UPDATE_THEME, legacyTheme);
+
+        (Config as {themeSyncing: boolean}).themeSyncing = false;
+        manager.handleCommittedMainViewChanged();
+        expect(mainShell.webContents.send).toHaveBeenLastCalledWith(RESET_THEME);
+        expect(popoutShell.webContents.send).toHaveBeenLastCalledWith(RESET_THEME);
+    });
+
     it('preserves a surface while its view moves between the main window and a popout', async () => {
         let viewType = ViewType.TAB;
         jest.mocked(ViewManager.getView).mockImplementation((viewId) => ({

--- a/src/main/desktopThemeUtils.ts
+++ b/src/main/desktopThemeUtils.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {WebContents, WebFrameMain} from 'electron';
+
+import type {
+    DesktopThemeApplyRequest,
+    DesktopThemeApplyResult,
+    DesktopThemeDirective,
+    DesktopThemeRejectReason,
+    Theme,
+} from '@mattermost/desktop-api';
+
+import {isLightColor} from 'main/utils';
+
+export function getFixedDesktopThemeNativeSource(centerChannelBg: string) {
+    return isLightColor(centerChannelBg) ? 'light' as const : 'dark' as const;
+}
+
+export function getDesktopThemeNativeSource(directive: DesktopThemeDirective) {
+    return directive.mode === 'system' ? 'system' as const : getFixedDesktopThemeNativeSource(directive.shellTheme.centerChannelBg);
+}
+
+export function desktopThemeDirectiveToTheme(directive: DesktopThemeDirective): Theme {
+    return {
+        ...directive.shellTheme,
+        isUsingSystemTheme: directive.mode === 'system',
+    };
+}
+
+export function rejectDesktopThemeApply(request: DesktopThemeApplyRequest, reason: DesktopThemeRejectReason): DesktopThemeApplyResult {
+    return {
+        status: 'rejected',
+        surfaceId: request.surfaceId,
+        leaseId: request.leaseId,
+        sequence: request.sequence,
+        reason,
+    };
+}
+
+type DesktopThemeDocumentIdentity = {
+    viewId: string;
+    webContents: WebContents;
+    frame: WebFrameMain;
+};
+
+export function isLiveDesktopThemeDocument(document: DesktopThemeDocumentIdentity) {
+    return !document.webContents.isDestroyed() && !document.frame.isDestroyed() && !document.frame.detached && document.webContents.mainFrame === document.frame;
+}
+
+export function isSameDesktopThemeDocument(left?: DesktopThemeDocumentIdentity, right?: DesktopThemeDocumentIdentity) {
+    return Boolean(left && right && left.viewId === right.viewId && left.webContents === right.webContents && left.frame === right.frame);
+}

--- a/src/main/systemAppearanceAdapter.test.ts
+++ b/src/main/systemAppearanceAdapter.test.ts
@@ -42,6 +42,7 @@ describe('createSystemAppearanceAdapter', () => {
         adapter.subscribeInvalidation(jest.fn());
 
         await expect(adapter.read()).resolves.toEqual(expected);
+        expect(systemPreferences.getUserDefault).toHaveBeenCalledWith('AppleInterfaceStyle', 'string');
     });
 
     it('is unavailable when live invalidation cannot be subscribed', async () => {

--- a/src/main/systemAppearanceAdapter.test.ts
+++ b/src/main/systemAppearanceAdapter.test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {systemPreferences} from 'electron';
+
+import {createSystemAppearanceAdapter} from 'main/systemAppearanceAdapter';
+
+jest.mock('electron', () => ({
+    systemPreferences: {
+        getUserDefault: jest.fn(),
+        subscribeNotification: jest.fn(() => 7),
+        unsubscribeNotification: jest.fn(),
+    },
+}));
+
+describe('createSystemAppearanceAdapter', () => {
+    const originalPlatform = process.platform;
+
+    beforeEach(() => {
+        jest.mocked(systemPreferences.subscribeNotification).mockReturnValue(7);
+    });
+
+    afterEach(() => {
+        Object.defineProperty(process, 'platform', {value: originalPlatform});
+        jest.clearAllMocks();
+    });
+
+    it('returns unsupported outside macOS', async () => {
+        Object.defineProperty(process, 'platform', {value: 'linux'});
+
+        await expect(createSystemAppearanceAdapter().read()).resolves.toEqual({status: 'unknown', reason: 'unsupported'});
+    });
+
+    it.each([
+        ['', {status: 'known', value: 'light'}],
+        ['Dark', {status: 'known', value: 'dark'}],
+        ['Unexpected', {status: 'unknown', reason: 'invalid'}],
+    ])('normalizes the macOS value %p', async (value, expected) => {
+        Object.defineProperty(process, 'platform', {value: 'darwin'});
+        jest.mocked(systemPreferences.getUserDefault).mockReturnValue(value);
+        const adapter = createSystemAppearanceAdapter();
+        adapter.subscribeInvalidation(jest.fn());
+
+        await expect(adapter.read()).resolves.toEqual(expected);
+    });
+
+    it('is unavailable when live invalidation cannot be subscribed', async () => {
+        Object.defineProperty(process, 'platform', {value: 'darwin'});
+        jest.mocked(systemPreferences.subscribeNotification).mockImplementationOnce(() => {
+            throw new Error('unavailable');
+        });
+        const adapter = createSystemAppearanceAdapter();
+        adapter.subscribeInvalidation(jest.fn());
+
+        await expect(adapter.read()).resolves.toEqual({status: 'unknown', reason: 'unavailable'});
+        expect(systemPreferences.getUserDefault).not.toHaveBeenCalled();
+    });
+
+    it('turns the macOS notification into an invalidation subscription', () => {
+        Object.defineProperty(process, 'platform', {value: 'darwin'});
+        const invalidate = jest.fn();
+        const unsubscribe = createSystemAppearanceAdapter().subscribeInvalidation(invalidate);
+
+        expect(systemPreferences.subscribeNotification).toHaveBeenCalledWith('AppleInterfaceThemeChangedNotification', invalidate);
+        unsubscribe();
+        expect(systemPreferences.unsubscribeNotification).toHaveBeenCalledWith(7);
+    });
+});

--- a/src/main/systemAppearanceAdapter.ts
+++ b/src/main/systemAppearanceAdapter.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {systemPreferences} from 'electron';
+
+import {Logger} from 'common/log';
+import type {PlatformAppearanceAdapter, PlatformAppearanceRead} from 'main/systemAppearanceMonitor';
+import {unsupportedSystemAppearanceAdapter} from 'main/systemAppearanceMonitor';
+
+const APPLE_INTERFACE_STYLE = 'AppleInterfaceStyle';
+const APPLE_INTERFACE_THEME_CHANGED = 'AppleInterfaceThemeChangedNotification';
+const log = new Logger('SystemAppearanceAdapter');
+
+export function createSystemAppearanceAdapter(): PlatformAppearanceAdapter {
+    if (process.platform !== 'darwin') {
+        return unsupportedSystemAppearanceAdapter;
+    }
+
+    let subscribed = false;
+    return {
+        read: () => {
+            if (!subscribed) {
+                return Promise.resolve({status: 'unknown', reason: 'unavailable'});
+            }
+            return readMacOSAppearance();
+        },
+        subscribeInvalidation: (invalidate) => {
+            try {
+                const subscription = systemPreferences.subscribeNotification(APPLE_INTERFACE_THEME_CHANGED, invalidate);
+                subscribed = true;
+                return () => {
+                    subscribed = false;
+                    try {
+                        systemPreferences.unsubscribeNotification(subscription);
+                    } catch (error) {
+                        log.warn('Unable to unsubscribe from macOS appearance changes', {error});
+                    }
+                };
+            } catch (error) {
+                subscribed = false;
+                log.warn('Unable to subscribe to macOS appearance changes', {error});
+                return () => undefined;
+            }
+        },
+    };
+}
+
+async function readMacOSAppearance(): Promise<PlatformAppearanceRead> {
+    try {
+        const value: unknown = systemPreferences.getUserDefault(APPLE_INTERFACE_STYLE, 'string');
+        if (value === '') {
+            return {status: 'known', value: 'light'};
+        }
+        if (value === 'Dark') {
+            return {status: 'known', value: 'dark'};
+        }
+        return {status: 'unknown', reason: 'invalid'};
+    } catch {
+        return {status: 'unknown', reason: 'error'};
+    }
+}

--- a/src/main/systemAppearanceMonitor.test.ts
+++ b/src/main/systemAppearanceMonitor.test.ts
@@ -1,0 +1,134 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {PlatformAppearanceAdapter, PlatformAppearanceRead} from './systemAppearanceMonitor';
+import {SystemAppearanceMonitor} from './systemAppearanceMonitor';
+
+type Deferred<T> = {
+    promise: Promise<T>;
+    resolve: (value: T) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((resolver) => {
+        resolve = resolver;
+    });
+    return {promise, resolve};
+}
+
+function createAdapter(read: jest.Mock<Promise<PlatformAppearanceRead>, []>) {
+    let invalidate: () => void = () => undefined;
+    const unsubscribe = jest.fn();
+    const adapter: PlatformAppearanceAdapter = {
+        read,
+        subscribeInvalidation: jest.fn((listener) => {
+            invalidate = listener;
+            return unsubscribe;
+        }),
+    };
+    return {adapter, invalidate: () => invalidate(), unsubscribe};
+}
+
+describe('SystemAppearanceMonitor', () => {
+    it('reports unsupported without a qualified adapter', async () => {
+        const monitor = new SystemAppearanceMonitor();
+
+        await expect(monitor.getSystemAppearance()).resolves.toEqual({
+            revision: 1,
+            status: 'unknown',
+            reason: 'unsupported',
+        });
+    });
+
+    it('coalesces concurrent reads for one revision', async () => {
+        const pending = deferred<PlatformAppearanceRead>();
+        const {adapter} = createAdapter(jest.fn(() => pending.promise));
+        const monitor = new SystemAppearanceMonitor(adapter);
+
+        const first = monitor.getSystemAppearance();
+        const second = monitor.getSystemAppearance();
+        pending.resolve({status: 'known', value: 'dark'});
+
+        await expect(first).resolves.toEqual({revision: 1, status: 'known', value: 'dark'});
+        await expect(second).resolves.toEqual({revision: 1, status: 'known', value: 'dark'});
+        expect(adapter.read).toHaveBeenCalledTimes(1);
+    });
+
+    it('publishes an incremented revision without an appearance value', () => {
+        const {adapter, invalidate} = createAdapter(jest.fn(async (): Promise<PlatformAppearanceRead> => ({status: 'known', value: 'light'})));
+        const monitor = new SystemAppearanceMonitor(adapter);
+        const listener = jest.fn();
+        monitor.subscribeInvalidation(listener);
+
+        invalidate();
+
+        expect(listener).toHaveBeenCalledWith({revision: 2, previousValueStatus: 'stale'});
+    });
+
+    it('retries a read that overlaps an invalidation', async () => {
+        const stale = deferred<PlatformAppearanceRead>();
+        const read = jest.fn().
+            mockImplementationOnce(() => stale.promise).
+            mockResolvedValueOnce({status: 'known', value: 'dark'});
+        const {adapter, invalidate} = createAdapter(read);
+        const monitor = new SystemAppearanceMonitor(adapter);
+
+        const result = monitor.getSystemAppearance();
+        invalidate();
+        stale.resolve({status: 'known', value: 'light'});
+
+        await expect(result).resolves.toEqual({revision: 2, status: 'known', value: 'dark'});
+        expect(read).toHaveBeenCalledTimes(2);
+    });
+
+    it('settles as unstable when every bounded read becomes stale', async () => {
+        const first = deferred<PlatformAppearanceRead>();
+        const second = deferred<PlatformAppearanceRead>();
+        const secondStarted = deferred<void>();
+        const read = jest.fn().
+            mockImplementationOnce(() => first.promise).
+            mockImplementationOnce(() => {
+                secondStarted.resolve();
+                return second.promise;
+            });
+        const {adapter, invalidate} = createAdapter(read);
+        const monitor = new SystemAppearanceMonitor(adapter);
+
+        const result = monitor.getSystemAppearance();
+        invalidate();
+        first.resolve({status: 'known', value: 'light'});
+        await secondStarted.promise;
+        invalidate();
+        second.resolve({status: 'known', value: 'dark'});
+
+        await expect(result).resolves.toEqual({revision: 3, status: 'unknown', reason: 'unstable'});
+    });
+
+    it('invalidates the previous value and drops old adapter work on replacement', async () => {
+        const stale = deferred<PlatformAppearanceRead>();
+        const oldAdapter = createAdapter(jest.fn(() => stale.promise));
+        const newAdapter = createAdapter(jest.fn(async (): Promise<PlatformAppearanceRead> => ({status: 'known', value: 'dark'})));
+        const monitor = new SystemAppearanceMonitor(oldAdapter.adapter);
+        const listener = jest.fn();
+        monitor.subscribeInvalidation(listener);
+
+        const result = monitor.getSystemAppearance();
+        monitor.replaceAdapter(newAdapter.adapter);
+        stale.resolve({status: 'known', value: 'light'});
+
+        await expect(result).resolves.toEqual({revision: 2, status: 'known', value: 'dark'});
+        expect(oldAdapter.unsubscribe).toHaveBeenCalledTimes(1);
+        expect(listener).toHaveBeenCalledWith({revision: 2, previousValueStatus: 'invalid'});
+    });
+
+    it.each([
+        [async () => ({status: 'known', value: 'blue'}), 'invalid'],
+        [async () => Promise.reject(new Error('read failed')), 'error'],
+    ])('maps invalid and failed adapter reads to unknown', async (read, reason) => {
+        const {adapter} = createAdapter(jest.fn(read) as jest.Mock<Promise<PlatformAppearanceRead>, []>);
+        const monitor = new SystemAppearanceMonitor(adapter);
+
+        await expect(monitor.getSystemAppearance()).resolves.toEqual({revision: 1, status: 'unknown', reason});
+    });
+});

--- a/src/main/systemAppearanceMonitor.test.ts
+++ b/src/main/systemAppearanceMonitor.test.ts
@@ -122,6 +122,20 @@ describe('SystemAppearanceMonitor', () => {
         expect(listener).toHaveBeenCalledWith({revision: 2, previousValueStatus: 'invalid'});
     });
 
+    it('destroys its adapter subscription and listeners once', () => {
+        const {adapter, invalidate, unsubscribe} = createAdapter(jest.fn(async (): Promise<PlatformAppearanceRead> => ({status: 'known', value: 'light'})));
+        const monitor = new SystemAppearanceMonitor(adapter);
+        const listener = jest.fn();
+        monitor.subscribeInvalidation(listener);
+
+        monitor.destroy();
+        monitor.destroy();
+        invalidate();
+
+        expect(unsubscribe).toHaveBeenCalledTimes(1);
+        expect(listener).not.toHaveBeenCalled();
+    });
+
     it.each([
         [async () => ({status: 'known', value: 'blue'}), 'invalid'],
         [async () => Promise.reject(new Error('read failed')), 'error'],

--- a/src/main/systemAppearanceMonitor.ts
+++ b/src/main/systemAppearanceMonitor.ts
@@ -1,0 +1,157 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {
+    SystemAppearanceInvalidation,
+    SystemAppearanceSnapshot,
+    SystemAppearanceUnknownReason,
+} from '@mattermost/desktop-api';
+
+export type PlatformAppearanceUnknownReason = Exclude<SystemAppearanceUnknownReason, 'unstable'>;
+
+export type PlatformAppearanceRead =
+    | {status: 'known'; value: 'light' | 'dark'}
+    | {status: 'unknown'; reason: PlatformAppearanceUnknownReason};
+
+export type PlatformAppearanceAdapter = {
+    read: () => Promise<PlatformAppearanceRead>;
+    subscribeInvalidation: (invalidate: () => void) => () => void;
+};
+
+type AppearanceRead = {
+    revision: number;
+    adapterGeneration: number;
+    promise: Promise<PlatformAppearanceRead>;
+};
+
+const MAX_READ_ATTEMPTS = 2;
+const platformUnknownReasons = new Set<PlatformAppearanceUnknownReason>([
+    'unsupported',
+    'unavailable',
+    'invalid',
+    'error',
+]);
+
+export const unsupportedSystemAppearanceAdapter: PlatformAppearanceAdapter = {
+    read: async () => ({status: 'unknown', reason: 'unsupported'}),
+    subscribeInvalidation: () => () => undefined,
+};
+
+export class SystemAppearanceMonitor {
+    private adapter: PlatformAppearanceAdapter;
+    private adapterGeneration = 1;
+    private revision = 1;
+    private inFlight?: AppearanceRead;
+    private listeners = new Set<(event: SystemAppearanceInvalidation) => void>();
+    private unsubscribeAdapter: () => void;
+    private destroyed = false;
+
+    constructor(adapter: PlatformAppearanceAdapter = unsupportedSystemAppearanceAdapter) {
+        this.adapter = adapter;
+        this.unsubscribeAdapter = adapter.subscribeInvalidation(this.handleAdapterInvalidation);
+    }
+
+    getSystemAppearance = (): Promise<SystemAppearanceSnapshot> => {
+        return this.readStableSnapshot(MAX_READ_ATTEMPTS);
+    };
+
+    private readStableSnapshot = async (attemptsRemaining: number): Promise<SystemAppearanceSnapshot> => {
+        const revision = this.revision;
+        const adapterGeneration = this.adapterGeneration;
+        const result = await this.readForRevision(revision, adapterGeneration);
+
+        if (revision === this.revision && adapterGeneration === this.adapterGeneration) {
+            if (result.status === 'known') {
+                return {revision, status: 'known', value: result.value};
+            }
+
+            return {revision, status: 'unknown', reason: result.reason};
+        }
+
+        if (attemptsRemaining > 1) {
+            return this.readStableSnapshot(attemptsRemaining - 1);
+        }
+
+        return {
+            revision: this.revision,
+            status: 'unknown',
+            reason: 'unstable',
+        };
+    };
+
+    subscribeInvalidation = (listener: (event: SystemAppearanceInvalidation) => void) => {
+        this.listeners.add(listener);
+        return () => {
+            this.listeners.delete(listener);
+        };
+    };
+
+    invalidate = (previousValueStatus: SystemAppearanceInvalidation['previousValueStatus']) => {
+        this.revision += 1;
+        this.inFlight = undefined;
+
+        const event = {revision: this.revision, previousValueStatus};
+        this.listeners.forEach((listener) => listener(event));
+    };
+
+    replaceAdapter = (adapter: PlatformAppearanceAdapter) => {
+        this.unsubscribeAdapter();
+        this.adapter = adapter;
+        this.adapterGeneration += 1;
+        this.invalidate('invalid');
+        this.unsubscribeAdapter = adapter.subscribeInvalidation(this.handleAdapterInvalidation);
+    };
+
+    destroy = () => {
+        if (this.destroyed) {
+            return;
+        }
+        this.destroyed = true;
+        this.unsubscribeAdapter();
+        this.listeners.clear();
+        this.inFlight = undefined;
+    };
+
+    private handleAdapterInvalidation = () => {
+        this.invalidate('stale');
+    };
+
+    private readForRevision = (revision: number, adapterGeneration: number) => {
+        if (this.inFlight?.revision === revision && this.inFlight.adapterGeneration === adapterGeneration) {
+            return this.inFlight.promise;
+        }
+
+        const adapter = this.adapter;
+        const promise = Promise.resolve().
+            then(() => adapter.read()).
+            then(normalizePlatformAppearanceRead, () => ({status: 'unknown' as const, reason: 'error' as const}));
+        const inFlight = {revision, adapterGeneration, promise};
+        this.inFlight = inFlight;
+        promise.finally(() => {
+            if (this.inFlight === inFlight) {
+                this.inFlight = undefined;
+            }
+        });
+
+        return promise;
+    };
+}
+
+function normalizePlatformAppearanceRead(value: unknown): PlatformAppearanceRead {
+    if (!value || typeof value !== 'object' || !('status' in value)) {
+        return {status: 'unknown', reason: 'invalid'};
+    }
+
+    if (value.status === 'known' && 'value' in value && (value.value === 'light' || value.value === 'dark')) {
+        return {status: 'known', value: value.value};
+    }
+
+    if (value.status === 'unknown' && 'reason' in value && platformUnknownReasons.has(value.reason as PlatformAppearanceUnknownReason)) {
+        return {status: 'unknown', reason: value.reason as PlatformAppearanceUnknownReason};
+    }
+
+    return {status: 'unknown', reason: 'invalid'};
+}
+
+const systemAppearanceMonitor = new SystemAppearanceMonitor();
+export default systemAppearanceMonitor;

--- a/src/main/themeManager.test.js
+++ b/src/main/themeManager.test.js
@@ -58,6 +58,7 @@ jest.mock('common/views/viewManager', () => {
     return {
         on: jest.fn((event, handler) => mockViewManager.on(event, handler)),
         emit: jest.fn((event, ...args) => mockViewManager.emit(event, ...args)),
+        getView: jest.fn(),
         getViewsByServerId: jest.fn(),
         mockViewManager,
     };
@@ -75,17 +76,31 @@ describe('ThemeManager', () => {
 
         mockWebContents = new EventEmitter();
         mockWebContents.send = jest.fn();
+        mockWebContents.isDestroyed = jest.fn(() => false);
         mockWebContents.id = 1;
+        mockWebContents.mainFrame = {
+            detached: false,
+            isDestroyed: jest.fn(() => false),
+            send: jest.fn(),
+        };
 
         mockWebContents2 = new EventEmitter();
         mockWebContents2.send = jest.fn();
+        mockWebContents2.isDestroyed = jest.fn(() => false);
         mockWebContents2.id = 2;
+        mockWebContents2.mainFrame = {
+            detached: false,
+            isDestroyed: jest.fn(() => false),
+            send: jest.fn(),
+        };
 
         // Mock getAllServers to return empty array by default
         ServerManager.getAllServers.mockReturnValue([]);
+        ServerManager.getServer.mockReturnValue({id: 'server-id'});
 
         // Mock ViewManager.getViewsByServerId to return empty array by default
         ViewManager.getViewsByServerId.mockReturnValue([]);
+        ViewManager.getView.mockReturnValue(undefined);
 
         themeManager = new ThemeManager();
     });
@@ -319,6 +334,92 @@ describe('ThemeManager', () => {
 
             expect(mockWebContents.send).toHaveBeenCalledWith(UPDATE_THEME, mockTheme);
             expect(mockWebContents2.send).toHaveBeenCalledWith(UPDATE_THEME, mockTheme);
+        });
+
+        it('uses the cached legacy theme with a committed view resolver', async () => {
+            const mockTheme = {centerChannelBg: '#111111', isUsingSystemTheme: false};
+            ServerManager.getCurrentServerId.mockReturnValue('owner-server-id');
+            ServerManager.getServer.mockReturnValue({id: 'owner-server-id', theme: mockTheme});
+            ViewManager.getView.mockReturnValue({
+                id: 'owner-view-id',
+                serverId: 'owner-server-id',
+                type: 'tab',
+            });
+            themeManager.setCommittedMainViewResolver(() => ({
+                viewId: 'owner-view-id',
+                webContents: mockWebContents,
+            }));
+
+            expect(mockWebContents.send).toHaveBeenLastCalledWith(UPDATE_THEME, mockTheme);
+            expect(mockWebContents.mainFrame.send).not.toHaveBeenCalled();
+        });
+
+        it('resets while there is no committed visible view', async () => {
+            themeManager.setCommittedMainViewResolver(() => undefined);
+            await themeManager.brokerTransition;
+
+            expect(mockWebContents.send).toHaveBeenLastCalledWith(RESET_THEME);
+        });
+
+        it('keeps the shell reset when theme syncing is disabled', async () => {
+            const Config = require('common/config');
+            Config.themeSyncing = false;
+            ServerManager.getServer.mockReturnValue({
+                theme: {centerChannelBg: '#111111', isUsingSystemTheme: false},
+            });
+            ViewManager.getView.mockReturnValue({
+                id: 'owner-view-id',
+                serverId: 'owner-server-id',
+                type: 'tab',
+            });
+
+            try {
+                themeManager.setCommittedMainViewResolver(() => ({
+                    viewId: 'owner-view-id',
+                    webContents: mockWebContents,
+                }));
+                await themeManager.brokerTransition;
+
+                expect(mockWebContents.send).toHaveBeenLastCalledWith(RESET_THEME);
+            } finally {
+                Config.themeSyncing = true;
+            }
+        });
+    });
+
+    describe('isCommittedMainView', () => {
+        it('matches the exact committed view and WebContents', () => {
+            ViewManager.getView.mockReturnValue({
+                id: 'owner-view-id',
+                serverId: 'server-id',
+                type: 'tab',
+            });
+            themeManager.setCommittedMainViewResolver(() => ({
+                viewId: 'owner-view-id',
+                webContents: mockWebContents,
+            }));
+
+            expect(themeManager.isCommittedMainView({
+                viewId: 'owner-view-id',
+                webContents: mockWebContents,
+            })).toBe(true);
+            expect(themeManager.isCommittedMainView({
+                viewId: 'background-view-id',
+                webContents: mockWebContents2,
+            })).toBe(false);
+            expect(themeManager.isCommittedMainView({
+                viewId: 'owner-view-id',
+                webContents: mockWebContents2,
+            })).toBe(false);
+        });
+
+        it('does not infer exact ownership before the resolver is installed', () => {
+            ServerManager.getCurrentServerId.mockReturnValue('server-id');
+
+            expect(themeManager.isCommittedMainView({
+                viewId: 'owner-view-id',
+                webContents: mockWebContents,
+            })).toBe(false);
         });
     });
 

--- a/src/main/themeManager.test.js
+++ b/src/main/themeManager.test.js
@@ -336,24 +336,6 @@ describe('ThemeManager', () => {
             expect(mockWebContents2.send).toHaveBeenCalledWith(UPDATE_THEME, mockTheme);
         });
 
-        it('uses the cached legacy theme with a committed view resolver', async () => {
-            const mockTheme = {centerChannelBg: '#111111', isUsingSystemTheme: false};
-            ServerManager.getCurrentServerId.mockReturnValue('owner-server-id');
-            ServerManager.getServer.mockReturnValue({id: 'owner-server-id', theme: mockTheme});
-            ViewManager.getView.mockReturnValue({
-                id: 'owner-view-id',
-                serverId: 'owner-server-id',
-                type: 'tab',
-            });
-            themeManager.setCommittedMainViewResolver(() => ({
-                viewId: 'owner-view-id',
-                webContents: mockWebContents,
-            }));
-
-            expect(mockWebContents.send).toHaveBeenLastCalledWith(UPDATE_THEME, mockTheme);
-            expect(mockWebContents.mainFrame.send).not.toHaveBeenCalled();
-        });
-
         it('resets while there is no committed visible view', async () => {
             themeManager.setCommittedMainViewResolver(() => undefined);
             await themeManager.brokerTransition;

--- a/src/main/themeManager.ts
+++ b/src/main/themeManager.ts
@@ -146,11 +146,9 @@ export class ThemeManager {
                         return {surfaceId: replaced.surfaceId, state: replaced.state};
                     }
                 } else if (
-                    replaced.state.scope === 'main-tab' &&
-                    replaced.state.status === 'standby' &&
-                    replaced.state.reason === 'theme-reset-failed'
+                    this.isDesktopThemeResetFailed(replaced)
                 ) {
-                    if (this.activeDesktopThemeLease || !this.resetDesktopOutput()) {
+                    if (!this.recoverDesktopThemeOutput()) {
                         return {surfaceId: replaced.surfaceId, state: replaced.state};
                     }
                 }
@@ -236,7 +234,10 @@ export class ThemeManager {
             if (wasActive && !this.revokeDesktopThemeLease('not-current')) {
                 throw new Error('Failed to release Desktop theme output');
             }
-            if (!wasActive && this.isCommittedMainView(registration) && !this.resetDesktopOutput()) {
+            if (!wasActive && this.isDesktopThemeResetFailed(registration) && !this.recoverDesktopThemeOutput()) {
+                throw new Error('Failed to release Desktop theme output');
+            }
+            if (!wasActive && !this.isDesktopThemeResetFailed(registration) && this.isCommittedMainView(registration) && !this.resetDesktopOutput()) {
                 this.setDesktopThemeStandby(registration, 'theme-reset-failed');
                 throw new Error('Failed to release Desktop theme output');
             }
@@ -257,11 +258,7 @@ export class ThemeManager {
         this.scheduleBrokerTransition(() => {
             const registrations = [...this.desktopThemeSurfaces.values()].filter((registration) => registration.viewId === viewId);
             registrations.forEach((registration) => {
-                const wasActive = this.activeDesktopThemeLease?.registration === registration;
-                this.removeDesktopThemeSurface(registration);
-                if (wasActive) {
-                    this.revokeDesktopThemeLease('not-current');
-                }
+                this.retireDesktopThemeSurface(registration);
             });
             this.cutoverDocuments.delete(viewId);
         });
@@ -278,7 +275,7 @@ export class ThemeManager {
             const registrationForFrame = this.desktopThemeSurfaceByFrame.get(document.frame);
             let registration = isSameDesktopThemeDocument(registrationForFrame, document) ? registrationForFrame : undefined;
             if (registration && this.isDesktopThemeRegistrationFailed(registration)) {
-                this.removeDesktopThemeSurface(registration);
+                this.retireDesktopThemeSurface(registration);
                 registration = undefined;
             }
             if (scope === 'popout' && registration && this.activeDesktopThemeLease?.registration === registration) {
@@ -526,6 +523,10 @@ export class ThemeManager {
             if (this.activeDesktopThemeLease?.registration === candidate) {
                 return;
             }
+            if (!this.recoverDesktopThemeOutput()) {
+                this.setDesktopThemeStandby(candidate, 'theme-reset-failed');
+                return;
+            }
 
             const leaseId = this.createId();
             this.activeDesktopThemeLease = {
@@ -574,16 +575,43 @@ export class ThemeManager {
             (registration.state.reason === 'apply-failed' || registration.state.reason === 'theme-reset-failed');
     };
 
+    private isDesktopThemeResetFailed = (registration: DesktopThemeSurface) => {
+        return registration.state.scope === 'main-tab' &&
+            registration.state.status === 'standby' &&
+            registration.state.reason === 'theme-reset-failed';
+    };
+
+    private recoverDesktopThemeOutput = () => {
+        const failedRegistrations = [...this.desktopThemeSurfaces.values()].filter(this.isDesktopThemeResetFailed);
+        if (failedRegistrations.length === 0) {
+            return true;
+        }
+
+        const activeLease = this.activeDesktopThemeLease;
+        if (activeLease ? !activeLease.directive : !this.resetDesktopOutput()) {
+            return false;
+        }
+
+        failedRegistrations.forEach(this.removeDesktopThemeSurface);
+        return true;
+    };
+
+    private retireDesktopThemeSurface = (registration: DesktopThemeSurface) => {
+        const wasActive = this.activeDesktopThemeLease?.registration === registration;
+        if (wasActive && !this.revokeDesktopThemeLease('not-current')) {
+            return false;
+        }
+        if (!wasActive && this.isDesktopThemeResetFailed(registration) && !this.recoverDesktopThemeOutput()) {
+            return false;
+        }
+        this.removeDesktopThemeSurface(registration);
+        return true;
+    };
+
     private removeDesktopThemeDocumentSurfaces = (webContents: WebContents, frame?: WebFrameMain) => {
         const registrations = [...this.desktopThemeSurfaces.values()].filter((registration) =>
             registration.webContents === webContents && (!frame || registration.frame === frame));
-        registrations.forEach((registration) => {
-            const wasActive = this.activeDesktopThemeLease?.registration === registration;
-            this.removeDesktopThemeSurface(registration);
-            if (wasActive) {
-                this.revokeDesktopThemeLease('not-current');
-            }
-        });
+        registrations.forEach(this.retireDesktopThemeSurface);
     };
 
     private removeDesktopThemeDocumentCutover = (webContents: WebContents, frame?: WebFrameMain) => {

--- a/src/main/themeManager.ts
+++ b/src/main/themeManager.ts
@@ -279,7 +279,9 @@ export class ThemeManager {
                 registration = undefined;
             }
             if (scope === 'popout' && registration && this.activeDesktopThemeLease?.registration === registration) {
-                this.revokeDesktopThemeLease('not-current');
+                if (!this.revokeDesktopThemeLease('not-current')) {
+                    registration = undefined;
+                }
             }
 
             this.cutoverDocuments.set(viewId, {...document, scope});

--- a/src/main/themeManager.ts
+++ b/src/main/themeManager.ts
@@ -235,23 +235,22 @@ export class ThemeManager {
         });
     };
 
+    handleDesktopThemeDocumentNavigationStarted = (webContents: WebContents, frame?: WebFrameMain) => {
+        this.scheduleBrokerTransition(() => {
+            this.removeDesktopThemeDocumentSurfaces(webContents, frame);
+        });
+    };
+
+    handleDesktopThemeDocumentNavigationCompleted = (webContents: WebContents) => {
+        this.scheduleBrokerTransition(() => {
+            this.removeDesktopThemeDocumentCutover(webContents);
+        });
+    };
+
     handleDesktopThemeDocumentInvalidated = (webContents: WebContents, frame?: WebFrameMain) => {
         this.scheduleBrokerTransition(() => {
-            const registrations = [...this.desktopThemeSurfaces.values()].filter((registration) =>
-                registration.webContents === webContents && (!frame || registration.frame === frame));
-            registrations.forEach((registration) => {
-                const wasActive = this.activeDesktopThemeLease?.registration === registration;
-                this.removeDesktopThemeSurface(registration);
-                if (wasActive) {
-                    this.revokeDesktopThemeLease('not-current');
-                }
-            });
-
-            [...this.cutoverDocuments.entries()].forEach(([viewId, document]) => {
-                if (document.webContents === webContents && (!frame || document.frame === frame)) {
-                    this.cutoverDocuments.delete(viewId);
-                }
-            });
+            this.removeDesktopThemeDocumentSurfaces(webContents, frame);
+            this.removeDesktopThemeDocumentCutover(webContents, frame);
         });
     };
 
@@ -555,6 +554,26 @@ export class ThemeManager {
             this.setDesktopThemeStandby(lease.registration, 'theme-reset-failed');
         }
         return released;
+    };
+
+    private removeDesktopThemeDocumentSurfaces = (webContents: WebContents, frame?: WebFrameMain) => {
+        const registrations = [...this.desktopThemeSurfaces.values()].filter((registration) =>
+            registration.webContents === webContents && (!frame || registration.frame === frame));
+        registrations.forEach((registration) => {
+            const wasActive = this.activeDesktopThemeLease?.registration === registration;
+            this.removeDesktopThemeSurface(registration);
+            if (wasActive) {
+                this.revokeDesktopThemeLease('not-current');
+            }
+        });
+    };
+
+    private removeDesktopThemeDocumentCutover = (webContents: WebContents, frame?: WebFrameMain) => {
+        [...this.cutoverDocuments.entries()].forEach(([viewId, document]) => {
+            if (document.webContents === webContents && (!frame || document.frame === frame)) {
+                this.cutoverDocuments.delete(viewId);
+            }
+        });
     };
 
     private failDesktopThemeApply = (

--- a/src/main/themeManager.ts
+++ b/src/main/themeManager.ts
@@ -584,8 +584,12 @@ export class ThemeManager {
             if (!activeLease.directive) {
                 return false;
             }
-        } else if (!this.resetDesktopOutput() || !this.restoreCurrentLegacyDesktopOutput()) {
-            return false;
+        } else {
+            const outputReset = this.resetDesktopOutput();
+            const legacyOutputRestored = this.restoreCurrentLegacyDesktopOutput();
+            if (!outputReset || !legacyOutputRestored) {
+                return false;
+            }
         }
 
         failedRegistrations.forEach(this.removeDesktopThemeSurface);

--- a/src/main/themeManager.ts
+++ b/src/main/themeManager.ts
@@ -148,10 +148,11 @@ export class ThemeManager {
                 } else if (
                     replaced.state.scope === 'main-tab' &&
                     replaced.state.status === 'standby' &&
-                    replaced.state.reason === 'theme-reset-failed' &&
-                    !this.resetDesktopOutput()
+                    replaced.state.reason === 'theme-reset-failed'
                 ) {
-                    return {surfaceId: replaced.surfaceId, state: replaced.state};
+                    if (this.activeDesktopThemeLease || !this.resetDesktopOutput()) {
+                        return {surfaceId: replaced.surfaceId, state: replaced.state};
+                    }
                 }
                 this.removeDesktopThemeSurface(replaced);
             }

--- a/src/main/themeManager.ts
+++ b/src/main/themeManager.ts
@@ -141,10 +141,12 @@ export class ThemeManager {
 
             const replaced = this.desktopThemeSurfaceByFrame.get(document.frame);
             if (replaced) {
-                this.removeDesktopThemeSurface(replaced);
                 if (this.activeDesktopThemeLease?.registration === replaced) {
-                    this.revokeDesktopThemeLease('not-current');
+                    if (!this.revokeDesktopThemeLease('not-current')) {
+                        return {surfaceId: replaced.surfaceId, state: replaced.state};
+                    }
                 }
+                this.removeDesktopThemeSurface(replaced);
             }
 
             this.cutoverDocuments.set(document.viewId, document);

--- a/src/main/themeManager.ts
+++ b/src/main/themeManager.ts
@@ -237,25 +237,6 @@ export class ThemeManager {
         });
     };
 
-    handleDesktopThemeDocumentNavigationStarted = (webContents: WebContents, frame?: WebFrameMain) => {
-        this.scheduleBrokerTransition(() => {
-            this.removeDesktopThemeDocumentSurfaces(webContents, frame);
-        });
-    };
-
-    handleDesktopThemeDocumentNavigationCompleted = (webContents: WebContents) => {
-        this.scheduleBrokerTransition(() => {
-            [...this.cutoverDocuments.entries()].forEach(([viewId, document]) => {
-                if (
-                    document.webContents === webContents &&
-                    !isSameDesktopThemeDocument(this.desktopThemeSurfaceByFrame.get(document.frame), document)
-                ) {
-                    this.cutoverDocuments.delete(viewId);
-                }
-            });
-        });
-    };
-
     handleDesktopThemeDocumentInvalidated = (webContents: WebContents, frame?: WebFrameMain) => {
         this.scheduleBrokerTransition(() => {
             this.removeDesktopThemeDocumentSurfaces(webContents, frame);

--- a/src/main/themeManager.ts
+++ b/src/main/themeManager.ts
@@ -1,13 +1,26 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {IpcMainEvent, IpcMainInvokeEvent, WebContents} from 'electron';
-import {ipcMain, nativeTheme} from 'electron';
+import {randomUUID} from 'crypto';
 
-import type {Theme} from '@mattermost/desktop-api';
+import type {IpcMainEvent, IpcMainInvokeEvent, WebContents, WebFrameMain} from 'electron';
+import {ipcMain, nativeTheme, powerMonitor} from 'electron';
+
+import type {
+    DesktopThemeApplyRequest,
+    DesktopThemeApplyResult,
+    DesktopThemeDirective,
+    DesktopThemeFailureReason,
+    DesktopThemeReleaseResult,
+    DesktopThemeSurfaceRegistration,
+    DesktopThemeSurfaceState,
+    DesktopThemeSurfaceStateEvent,
+    Theme,
+} from '@mattermost/desktop-api';
 
 import {
     DARK_MODE_CHANGE,
+    DESKTOP_THEME_SURFACE_STATE_CHANGED,
     EMIT_CONFIGURATION,
     GET_THEME,
     RESET_THEME,
@@ -16,22 +29,71 @@ import {
     UPDATE_THEME,
 } from 'common/communication';
 import Config from 'common/config';
+import {Logger} from 'common/log';
 import ServerManager from 'common/servers/serverManager';
 import {ViewType} from 'common/views/MattermostView';
 import ViewManager from 'common/views/viewManager';
+import {
+    desktopThemeDirectiveToTheme,
+    getDesktopThemeNativeSource,
+    isLiveDesktopThemeDocument,
+    isSameDesktopThemeDocument,
+    rejectDesktopThemeApply,
+} from 'main/desktopThemeUtils';
+import SystemAppearanceMonitor from 'main/systemAppearanceMonitor';
 import {isLightColor} from 'main/utils';
 
 import type {CombinedConfig} from 'types/config';
+
+export type CommittedMainView = {
+    viewId: string;
+    webContents: WebContents;
+};
+
+export type DesktopThemeDocument = CommittedMainView & {
+    frame: WebFrameMain;
+    scope: DesktopThemeSurfaceState['scope'];
+};
+
+type DesktopThemeSurface = DesktopThemeDocument & {
+    surfaceId: string;
+    state: DesktopThemeSurfaceState;
+};
+
+type DesktopThemeLease = {
+    registration: DesktopThemeSurface;
+    leaseId: string;
+    lastSequence: number;
+    directive?: DesktopThemeDirective;
+};
+
+type LifecycleBlocker = 'locked' | 'suspended';
+
+type MainStandbyState = Omit<Extract<DesktopThemeSurfaceState, {scope: 'main-tab'; status: 'standby'}>, 'revision'>;
+
+const log = new Logger('ThemeManager');
 
 export class ThemeManager {
     private mainWindowViews: Set<WebContents>;
     private popoutViews: Map<string, Set<WebContents>>;
     private popoutThemes: Map<string, Theme>;
+    private committedMainViewResolver?: () => CommittedMainView | undefined;
+    private desktopThemeSurfaces = new Map<string, DesktopThemeSurface>();
+    private desktopThemeSurfaceByFrame = new Map<WebFrameMain, DesktopThemeSurface>();
+    private cutoverDocuments = new Map<string, DesktopThemeDocument>();
+    private activeDesktopThemeLease?: DesktopThemeLease;
+    private desktopThemeStateRevision = 0;
+    private lifecycleBlockers = new Set<LifecycleBlocker>();
+    private brokerTransition = Promise.resolve();
+    private lifecycleInitialized = false;
+    private quitting = false;
+    private readonly createId: () => string;
 
-    constructor() {
+    constructor(createId: () => string = randomUUID) {
         this.mainWindowViews = new Set();
         this.popoutViews = new Map();
         this.popoutThemes = new Map();
+        this.createId = createId;
 
         ipcMain.on(EMIT_CONFIGURATION, this.handleEmitConfiguration);
         ipcMain.handle(GET_THEME, this.handleGetTheme);
@@ -40,11 +102,215 @@ export class ThemeManager {
         ServerManager.on(SERVER_SWITCHED, this.updateMainViews);
     }
 
+    setCommittedMainViewResolver = (resolver: () => CommittedMainView | undefined) => {
+        this.committedMainViewResolver = resolver;
+        this.handleCommittedMainViewChanged();
+    };
+
+    handleCommittedMainViewChanged = () => {
+        this.updateMainViews();
+    };
+
+    isCommittedMainView = ({viewId, webContents}: CommittedMainView) => {
+        const committedMainView = this.resolveCommittedMainView();
+        return committedMainView?.viewId === viewId && committedMainView.webContents === webContents;
+    };
+
+    initializeLifecycle = () => {
+        if (this.lifecycleInitialized) {
+            return;
+        }
+        this.lifecycleInitialized = true;
+        powerMonitor.on('lock-screen', this.handleLockScreen);
+        powerMonitor.on('unlock-screen', this.handleUnlockScreen);
+        powerMonitor.on('suspend', this.handleSuspend);
+        powerMonitor.on('resume', this.handleResume);
+    };
+
+    shutdown = () => {
+        this.quitting = true;
+        this.activeDesktopThemeLease = undefined;
+        this.resetDesktopOutput();
+    };
+
+    registerDesktopThemeSurface = (document: DesktopThemeDocument): Promise<DesktopThemeSurfaceRegistration> => {
+        return this.enqueueBrokerTransition(() => {
+            if (!isLiveDesktopThemeDocument(document)) {
+                throw new Error('Desktop theme surface document is no longer live');
+            }
+
+            const replaced = this.desktopThemeSurfaceByFrame.get(document.frame);
+            if (replaced) {
+                this.removeDesktopThemeSurface(replaced);
+                if (this.activeDesktopThemeLease?.registration === replaced) {
+                    this.revokeDesktopThemeLease('not-current');
+                }
+            }
+
+            this.cutoverDocuments.set(document.viewId, document);
+
+            const surfaceId = this.createId();
+            const state = document.scope === 'popout' ? this.createPopoutState() : this.createStandbyState(this.currentStandbyReason());
+            const registration = {...document, surfaceId, state};
+            this.desktopThemeSurfaces.set(surfaceId, registration);
+            this.desktopThemeSurfaceByFrame.set(document.frame, registration);
+            this.publishDesktopThemeState(registration);
+
+            if (document.scope === 'main-tab') {
+                this.reconcileDesktopThemeOwner();
+            } else {
+                this.updatePopoutViews(document.viewId);
+            }
+
+            return {surfaceId, state: registration.state};
+        });
+    };
+
+    applyDesktopTheme = (document: DesktopThemeDocument, request: DesktopThemeApplyRequest): Promise<DesktopThemeApplyResult> => {
+        return this.enqueueBrokerTransition(() => {
+            const registration = this.desktopThemeSurfaces.get(request.surfaceId);
+            if (!registration) {
+                return rejectDesktopThemeApply(request, 'unknown-surface');
+            }
+            if (!isSameDesktopThemeDocument(registration, document) || !isLiveDesktopThemeDocument(registration)) {
+                return rejectDesktopThemeApply(request, 'invalid-document');
+            }
+            if (!this.isCommittedMainView(registration)) {
+                return rejectDesktopThemeApply(request, 'not-owner');
+            }
+            if (!Config.themeSyncing) {
+                return rejectDesktopThemeApply(request, 'desktop-sync-disabled');
+            }
+            const lifecycleReason = this.currentLifecycleReason();
+            if (lifecycleReason) {
+                return rejectDesktopThemeApply(request, lifecycleReason);
+            }
+
+            const lease = this.activeDesktopThemeLease;
+            if (!lease || lease.registration !== registration || lease.leaseId !== request.leaseId) {
+                return rejectDesktopThemeApply(request, 'stale-lease');
+            }
+            if (request.sequence <= lease.lastSequence) {
+                return rejectDesktopThemeApply(request, 'stale-sequence');
+            }
+
+            const nativeSource = getDesktopThemeNativeSource(request.directive);
+            if (!this.setNativeThemeSource(nativeSource)) {
+                return this.failDesktopThemeApply(lease, request, 'native-theme-update');
+            }
+
+            const theme = desktopThemeDirectiveToTheme(request.directive);
+            if (!this.publishDesktopShellTheme(theme)) {
+                return this.failDesktopThemeApply(lease, request, 'desktop-shell-update');
+            }
+
+            lease.lastSequence = request.sequence;
+            lease.directive = request.directive;
+            return {
+                status: 'applied',
+                surfaceId: request.surfaceId,
+                leaseId: request.leaseId,
+                sequence: request.sequence,
+            };
+        });
+    };
+
+    releaseDesktopThemeSurface = (document: DesktopThemeDocument, surfaceId: string): Promise<DesktopThemeReleaseResult> => {
+        return this.enqueueBrokerTransition(() => {
+            const registration = this.desktopThemeSurfaces.get(surfaceId);
+            if (!registration || !isSameDesktopThemeDocument(registration, document)) {
+                return {status: 'stale'};
+            }
+
+            const wasActive = this.activeDesktopThemeLease?.registration === registration;
+            this.removeDesktopThemeSurface(registration);
+            if (wasActive && !this.revokeDesktopThemeLease('not-current')) {
+                throw new Error('Failed to release Desktop theme output');
+            }
+            if (!wasActive && this.isCommittedMainView(registration) && !this.resetDesktopOutput()) {
+                throw new Error('Failed to release Desktop theme output');
+            }
+
+            return {status: 'released'};
+        });
+    };
+
+    handleDesktopThemeDocumentInvalidated = (webContents: WebContents, frame?: WebFrameMain) => {
+        this.scheduleBrokerTransition(() => {
+            const registrations = [...this.desktopThemeSurfaces.values()].filter((registration) =>
+                registration.webContents === webContents && (!frame || registration.frame === frame));
+            registrations.forEach((registration) => {
+                const wasActive = this.activeDesktopThemeLease?.registration === registration;
+                this.removeDesktopThemeSurface(registration);
+                if (wasActive) {
+                    this.revokeDesktopThemeLease('not-current');
+                }
+            });
+
+            [...this.cutoverDocuments.entries()].forEach(([viewId, document]) => {
+                if (document.webContents === webContents && (!frame || document.frame === frame)) {
+                    this.cutoverDocuments.delete(viewId);
+                }
+            });
+        });
+    };
+
+    handleDesktopThemeViewInvalidated = (viewId: string) => {
+        this.scheduleBrokerTransition(() => {
+            const registrations = [...this.desktopThemeSurfaces.values()].filter((registration) => registration.viewId === viewId);
+            registrations.forEach((registration) => {
+                const wasActive = this.activeDesktopThemeLease?.registration === registration;
+                this.removeDesktopThemeSurface(registration);
+                if (wasActive) {
+                    this.revokeDesktopThemeLease('not-current');
+                }
+            });
+            this.cutoverDocuments.delete(viewId);
+        });
+    };
+
+    handleDesktopThemeViewTypeChanged = (viewId: string, type: ViewType) => {
+        const scope = type === ViewType.TAB ? 'main-tab' : 'popout';
+        this.scheduleBrokerTransition(() => {
+            const document = this.cutoverDocuments.get(viewId);
+            if (!document || document.scope === scope) {
+                return;
+            }
+
+            const registrationForFrame = this.desktopThemeSurfaceByFrame.get(document.frame);
+            const registration = isSameDesktopThemeDocument(registrationForFrame, document) ? registrationForFrame : undefined;
+            if (scope === 'popout' && registration && this.activeDesktopThemeLease?.registration === registration) {
+                this.revokeDesktopThemeLease('not-current');
+            }
+
+            this.cutoverDocuments.set(viewId, {...document, scope});
+            if (registration) {
+                registration.scope = scope;
+                if (scope === 'popout') {
+                    registration.state = this.createPopoutState();
+                    this.publishDesktopThemeState(registration);
+                }
+            }
+
+            this.reconcileDesktopThemeOwner();
+            if (scope === 'popout') {
+                this.updatePopoutViews(viewId);
+            }
+        });
+    };
+
+    isDesktopThemeDocumentCutover = (document: DesktopThemeDocument) => {
+        return isSameDesktopThemeDocument(this.cutoverDocuments.get(document.viewId), document);
+    };
+
     registerMainWindowView = (webContents: WebContents) => {
         this.mainWindowViews.add(webContents);
         webContents.on('destroyed', () => {
             this.mainWindowViews.delete(webContents);
         });
+        if (this.committedMainViewResolver) {
+            this.sendCurrentDesktopShellState(webContents);
+        }
     };
 
     registerPopoutView = (webContents: WebContents, viewId: string) => {
@@ -55,6 +321,9 @@ export class ThemeManager {
         webContents.on('destroyed', () => {
             this.popoutViews.get(viewId)?.delete(webContents);
         });
+        if (this.cutoverDocuments.get(viewId)?.scope === 'popout') {
+            this.updatePopoutViews(viewId);
+        }
     };
 
     updatePopoutTheme = (viewId: string, theme: Theme) => {
@@ -68,10 +337,7 @@ export class ThemeManager {
                 this.handleServerThemeChanged(server.id);
             });
         } else {
-            this.resetThemeSource();
-            this.mainWindowViews.forEach((view) => {
-                view.send(RESET_THEME);
-            });
+            this.updateMainViews();
             this.popoutViews.forEach((views) => {
                 views.forEach((view) => {
                     view.send(RESET_THEME);
@@ -102,6 +368,25 @@ export class ThemeManager {
     };
 
     private updateMainViews = () => {
+        const committedMainView = this.resolveCommittedMainView();
+        const document = committedMainView && this.getCommittedDesktopThemeDocument(committedMainView);
+        if (this.activeDesktopThemeLease || (document && this.isDesktopThemeDocumentCutover(document))) {
+            this.scheduleBrokerTransition(this.reconcileDesktopThemeOwner);
+            return;
+        }
+
+        this.updateLegacyMainViews();
+    };
+
+    private updateLegacyMainViews = () => {
+        if (!Config.themeSyncing) {
+            this.resetThemeSource();
+            this.mainWindowViews.forEach((view) => {
+                view.send(RESET_THEME);
+            });
+            return;
+        }
+
         const serverId = ServerManager.getCurrentServerId();
         if (!serverId) {
             this.resetThemeSource();
@@ -132,6 +417,18 @@ export class ThemeManager {
     private updatePopoutViews = (viewId: string) => {
         const popoutViews = this.popoutViews.get(viewId);
         if (popoutViews) {
+            if (this.cutoverDocuments.get(viewId)?.scope === 'popout') {
+                const currentTheme = this.getCurrentDesktopShellTheme();
+                popoutViews.forEach((view) => {
+                    if (currentTheme) {
+                        view.send(UPDATE_THEME, currentTheme);
+                    } else {
+                        view.send(RESET_THEME);
+                    }
+                });
+                return;
+            }
+
             let theme = this.popoutThemes.get(viewId);
             if (!theme) {
                 theme = ServerManager.getServer(viewId)?.theme;
@@ -160,11 +457,18 @@ export class ThemeManager {
             }
         });
         if (popoutServerId) {
+            if (this.cutoverDocuments.get(popoutServerId)?.scope === 'popout') {
+                return this.getCurrentDesktopShellTheme();
+            }
             const server = ServerManager.getServer(popoutServerId);
             if (!server) {
                 return undefined;
             }
             return server.theme;
+        }
+
+        if (this.committedMainViewResolver) {
+            return this.getCurrentDesktopShellTheme();
         }
 
         const serverId = ServerManager.getCurrentServerId();
@@ -176,6 +480,325 @@ export class ThemeManager {
             return undefined;
         }
         return server.theme;
+    };
+
+    private reconcileDesktopThemeOwner = () => {
+        if (this.quitting) {
+            return;
+        }
+
+        const committedMainView = this.resolveCommittedMainView();
+        const candidate = committedMainView && [...this.desktopThemeSurfaces.values()].find((registration) =>
+            registration.scope === 'main-tab' &&
+            registration.viewId === committedMainView.viewId &&
+            registration.webContents === committedMainView.webContents &&
+            registration.frame === committedMainView.webContents.mainFrame &&
+            isLiveDesktopThemeDocument(registration));
+        const standbyReason = this.currentStandbyReason();
+
+        [...this.desktopThemeSurfaces.values()].forEach((registration) => {
+            if (registration.scope === 'main-tab' && registration !== candidate) {
+                this.setDesktopThemeStandby(registration, standbyReason === 'not-current' ? 'not-current' : standbyReason);
+            }
+        });
+
+        const lease = this.activeDesktopThemeLease;
+        if (lease && (lease.registration !== candidate || !Config.themeSyncing || this.lifecycleBlockers.size > 0)) {
+            this.revokeDesktopThemeLease(standbyReason);
+        }
+
+        if (candidate && (!Config.themeSyncing || this.lifecycleBlockers.size > 0)) {
+            this.setDesktopThemeStandby(candidate, standbyReason);
+        }
+
+        if (candidate && Config.themeSyncing && this.lifecycleBlockers.size === 0) {
+            if (this.activeDesktopThemeLease?.registration === candidate) {
+                return;
+            }
+
+            const leaseId = this.createId();
+            this.activeDesktopThemeLease = {
+                registration: candidate,
+                leaseId,
+                lastSequence: 0,
+            };
+            this.setDesktopThemeGranted(candidate, leaseId);
+            return;
+        }
+
+        if (!committedMainView || !Config.themeSyncing || this.lifecycleBlockers.size > 0) {
+            this.resetDesktopOutput();
+            return;
+        }
+
+        const legacyDocument = this.getCommittedDesktopThemeDocument(committedMainView);
+        if (!legacyDocument || this.isDesktopThemeDocumentCutover(legacyDocument)) {
+            this.resetDesktopOutput();
+            return;
+        }
+
+        this.updateLegacyMainViews();
+    };
+
+    private revokeDesktopThemeLease = (reason: MainStandbyState['reason']) => {
+        const lease = this.activeDesktopThemeLease;
+        if (!lease) {
+            return this.resetDesktopOutput();
+        }
+
+        this.activeDesktopThemeLease = undefined;
+        if (this.desktopThemeSurfaces.get(lease.registration.surfaceId) === lease.registration) {
+            this.setDesktopThemeStandby(lease.registration, reason);
+        }
+        const released = this.resetDesktopOutput();
+        if (!released && this.desktopThemeSurfaces.get(lease.registration.surfaceId) === lease.registration) {
+            this.setDesktopThemeStandby(lease.registration, 'theme-reset-failed');
+        }
+        return released;
+    };
+
+    private failDesktopThemeApply = (
+        lease: DesktopThemeLease,
+        request: DesktopThemeApplyRequest,
+        reason: DesktopThemeFailureReason,
+    ): DesktopThemeApplyResult => {
+        this.activeDesktopThemeLease = undefined;
+        this.setDesktopThemeStandby(lease.registration, 'apply-failed');
+        const rolledBack = this.resetDesktopOutput();
+        return {
+            status: 'failed',
+            surfaceId: request.surfaceId,
+            leaseId: request.leaseId,
+            sequence: request.sequence,
+            reason: rolledBack ? reason : 'theme-reset',
+        };
+    };
+
+    private resetDesktopOutput = () => {
+        const nativeReset = this.setNativeThemeSource('system');
+        const shellReset = this.sendToDesktopShellTargets(RESET_THEME);
+        return nativeReset && shellReset;
+    };
+
+    private publishDesktopShellTheme = (theme: Theme) => {
+        return this.sendToDesktopShellTargets(UPDATE_THEME, theme);
+    };
+
+    private sendToDesktopShellTargets = (channel: string, ...args: unknown[]) => {
+        let success = true;
+        this.mainWindowViews.forEach((view) => {
+            if (view.isDestroyed()) {
+                this.mainWindowViews.delete(view);
+                return;
+            }
+            try {
+                view.send(channel, ...args);
+            } catch (error) {
+                success = false;
+                log.warn('Unable to publish Desktop shell theme', {webContentsId: view.id, error});
+            }
+        });
+
+        this.cutoverDocuments.forEach((document, viewId) => {
+            if (document.scope !== 'popout') {
+                return;
+            }
+            this.popoutViews.get(viewId)?.forEach((view) => {
+                if (view.isDestroyed()) {
+                    this.popoutViews.get(viewId)?.delete(view);
+                    return;
+                }
+                try {
+                    view.send(channel, ...args);
+                } catch (error) {
+                    success = false;
+                    log.warn('Unable to publish Desktop popout shell theme', {webContentsId: view.id, error});
+                }
+            });
+        });
+        return success;
+    };
+
+    private setNativeThemeSource = (source: 'system' | 'light' | 'dark') => {
+        try {
+            if (nativeTheme.themeSource !== source) {
+                nativeTheme.themeSource = source;
+            }
+            return nativeTheme.themeSource === source;
+        } catch (error) {
+            log.warn('Unable to set native theme source', {source, error});
+            return false;
+        }
+    };
+
+    private getCurrentDesktopShellTheme = () => {
+        if (!Config.themeSyncing) {
+            return undefined;
+        }
+        if (this.activeDesktopThemeLease?.directive) {
+            return desktopThemeDirectiveToTheme(this.activeDesktopThemeLease.directive);
+        }
+
+        const committedMainView = this.resolveCommittedMainView();
+        const document = committedMainView && this.getCommittedDesktopThemeDocument(committedMainView);
+        if (document && this.isDesktopThemeDocumentCutover(document)) {
+            return undefined;
+        }
+
+        const serverId = ServerManager.getCurrentServerId();
+        return serverId ? ServerManager.getServer(serverId)?.theme : undefined;
+    };
+
+    private sendCurrentDesktopShellState = (webContents: WebContents) => {
+        const theme = this.getCurrentDesktopShellTheme();
+        if (theme) {
+            webContents.send(UPDATE_THEME, theme);
+        } else {
+            webContents.send(RESET_THEME);
+        }
+    };
+
+    private currentStandbyReason = (): MainStandbyState['reason'] => {
+        if (!Config.themeSyncing) {
+            return 'desktop-sync-disabled';
+        }
+        return this.currentLifecycleReason() ?? 'not-current';
+    };
+
+    private currentLifecycleReason = (): 'screen-locked' | 'system-suspended' | undefined => {
+        if (this.lifecycleBlockers.has('locked')) {
+            return 'screen-locked';
+        }
+        if (this.lifecycleBlockers.has('suspended')) {
+            return 'system-suspended';
+        }
+        return undefined;
+    };
+
+    private createStandbyState = (reason: MainStandbyState['reason']): DesktopThemeSurfaceState => ({
+        revision: ++this.desktopThemeStateRevision,
+        scope: 'main-tab',
+        status: 'standby',
+        reason,
+    });
+
+    private createPopoutState = (): DesktopThemeSurfaceState => ({
+        revision: ++this.desktopThemeStateRevision,
+        scope: 'popout',
+        status: 'ineligible',
+        reason: 'not-main-tab',
+    });
+
+    private setDesktopThemeStandby = (registration: DesktopThemeSurface, reason: MainStandbyState['reason']) => {
+        if (registration.state.scope === 'main-tab' && registration.state.status === 'standby' && registration.state.reason === reason) {
+            return;
+        }
+        registration.state = this.createStandbyState(reason);
+        this.publishDesktopThemeState(registration);
+    };
+
+    private setDesktopThemeGranted = (registration: DesktopThemeSurface, leaseId: string) => {
+        registration.state = {
+            revision: ++this.desktopThemeStateRevision,
+            scope: 'main-tab',
+            status: 'granted',
+            leaseId,
+        };
+        this.publishDesktopThemeState(registration);
+    };
+
+    private publishDesktopThemeState = (registration: DesktopThemeSurface) => {
+        const event: DesktopThemeSurfaceStateEvent = {
+            surfaceId: registration.surfaceId,
+            state: registration.state,
+        };
+        try {
+            registration.frame.send(DESKTOP_THEME_SURFACE_STATE_CHANGED, event);
+        } catch (error) {
+            log.warn('Unable to publish Desktop theme surface state', {viewId: registration.viewId, error});
+        }
+    };
+
+    private removeDesktopThemeSurface = (registration: DesktopThemeSurface) => {
+        this.desktopThemeSurfaces.delete(registration.surfaceId);
+        if (this.desktopThemeSurfaceByFrame.get(registration.frame) === registration) {
+            this.desktopThemeSurfaceByFrame.delete(registration.frame);
+        }
+    };
+
+    private getCommittedDesktopThemeDocument = (committedMainView: CommittedMainView): DesktopThemeDocument | undefined => {
+        const frame = committedMainView.webContents.mainFrame;
+        const document = {...committedMainView, frame, scope: 'main-tab' as const};
+        return isLiveDesktopThemeDocument(document) ? document : undefined;
+    };
+
+    private enqueueBrokerTransition = <T>(transition: () => T | Promise<T>): Promise<T> => {
+        const result = this.brokerTransition.then(() => {
+            if (this.quitting) {
+                throw new Error('Desktop theme broker is shutting down');
+            }
+            return transition();
+        });
+        this.brokerTransition = result.then(() => undefined, () => undefined);
+        return result;
+    };
+
+    private scheduleBrokerTransition = (transition: () => unknown | Promise<unknown>) => {
+        this.enqueueBrokerTransition(transition).catch((error) => {
+            log.error('Desktop theme broker transition failed', {error});
+        });
+    };
+
+    private handleLockScreen = () => {
+        if (this.lifecycleBlockers.has('locked')) {
+            return;
+        }
+        this.lifecycleBlockers.add('locked');
+        SystemAppearanceMonitor.invalidate('invalid');
+        this.updateMainViews();
+    };
+
+    private handleUnlockScreen = () => {
+        if (!this.lifecycleBlockers.delete('locked')) {
+            return;
+        }
+        SystemAppearanceMonitor.invalidate('invalid');
+        this.updateMainViews();
+    };
+
+    private handleSuspend = () => {
+        if (this.lifecycleBlockers.has('suspended')) {
+            return;
+        }
+        this.lifecycleBlockers.add('suspended');
+        SystemAppearanceMonitor.invalidate('invalid');
+        this.updateMainViews();
+    };
+
+    private handleResume = () => {
+        if (!this.lifecycleBlockers.delete('suspended')) {
+            return;
+        }
+        SystemAppearanceMonitor.invalidate('invalid');
+        this.updateMainViews();
+    };
+
+    private resolveCommittedMainView = () => {
+        if (!this.committedMainViewResolver) {
+            return undefined;
+        }
+
+        const committedMainView = this.committedMainViewResolver();
+        if (!committedMainView || committedMainView.webContents.isDestroyed()) {
+            return undefined;
+        }
+
+        const view = ViewManager.getView(committedMainView.viewId);
+        if (!view || view.type !== ViewType.TAB || !ServerManager.getServer(view.serverId)) {
+            return undefined;
+        }
+
+        return committedMainView;
     };
 
     private resetThemeSource = () => {

--- a/src/main/themeManager.ts
+++ b/src/main/themeManager.ts
@@ -284,7 +284,11 @@ export class ThemeManager {
             }
 
             const registrationForFrame = this.desktopThemeSurfaceByFrame.get(document.frame);
-            const registration = isSameDesktopThemeDocument(registrationForFrame, document) ? registrationForFrame : undefined;
+            let registration = isSameDesktopThemeDocument(registrationForFrame, document) ? registrationForFrame : undefined;
+            if (registration && this.isDesktopThemeRegistrationFailed(registration)) {
+                this.removeDesktopThemeSurface(registration);
+                registration = undefined;
+            }
             if (scope === 'popout' && registration && this.activeDesktopThemeLease?.registration === registration) {
                 this.revokeDesktopThemeLease('not-current');
             }

--- a/src/main/themeManager.ts
+++ b/src/main/themeManager.ts
@@ -233,13 +233,14 @@ export class ThemeManager {
             }
 
             const wasActive = this.activeDesktopThemeLease?.registration === registration;
-            this.removeDesktopThemeSurface(registration);
             if (wasActive && !this.revokeDesktopThemeLease('not-current')) {
                 throw new Error('Failed to release Desktop theme output');
             }
             if (!wasActive && this.isCommittedMainView(registration) && !this.resetDesktopOutput()) {
+                this.setDesktopThemeStandby(registration, 'theme-reset-failed');
                 throw new Error('Failed to release Desktop theme output');
             }
+            this.removeDesktopThemeSurface(registration);
 
             return {status: 'released'};
         });

--- a/src/main/themeManager.ts
+++ b/src/main/themeManager.ts
@@ -380,26 +380,20 @@ export class ThemeManager {
     private updateLegacyMainViews = () => {
         if (!Config.themeSyncing) {
             this.resetThemeSource();
-            this.mainWindowViews.forEach((view) => {
-                view.send(RESET_THEME);
-            });
+            this.sendToDesktopShellTargets(RESET_THEME);
             return;
         }
 
         const serverId = ServerManager.getCurrentServerId();
         if (!serverId) {
             this.resetThemeSource();
-            this.mainWindowViews.forEach((view) => {
-                view.send(RESET_THEME);
-            });
+            this.sendToDesktopShellTargets(RESET_THEME);
             return;
         }
         const server = ServerManager.getServer(serverId);
         if (!server || !server.theme) {
             this.resetThemeSource();
-            this.mainWindowViews.forEach((view) => {
-                view.send(RESET_THEME);
-            });
+            this.sendToDesktopShellTargets(RESET_THEME);
             return;
         }
         if (!server.theme.isUsingSystemTheme) {
@@ -408,9 +402,7 @@ export class ThemeManager {
                 nativeTheme.themeSource = themeSource;
             }
         }
-        this.mainWindowViews.forEach((view) => {
-            view.send(UPDATE_THEME, server.theme);
-        });
+        this.publishDesktopShellTheme(server.theme);
     };
 
     private updatePopoutViews = (viewId: string) => {

--- a/src/main/themeManager.ts
+++ b/src/main/themeManager.ts
@@ -145,6 +145,13 @@ export class ThemeManager {
                     if (!this.revokeDesktopThemeLease('not-current')) {
                         return {surfaceId: replaced.surfaceId, state: replaced.state};
                     }
+                } else if (
+                    replaced.state.scope === 'main-tab' &&
+                    replaced.state.status === 'standby' &&
+                    replaced.state.reason === 'theme-reset-failed' &&
+                    !this.resetDesktopOutput()
+                ) {
+                    return {surfaceId: replaced.surfaceId, state: replaced.state};
                 }
                 this.removeDesktopThemeSurface(replaced);
             }

--- a/src/main/themeManager.ts
+++ b/src/main/themeManager.ts
@@ -243,7 +243,14 @@ export class ThemeManager {
 
     handleDesktopThemeDocumentNavigationCompleted = (webContents: WebContents) => {
         this.scheduleBrokerTransition(() => {
-            this.removeDesktopThemeDocumentCutover(webContents);
+            [...this.cutoverDocuments.entries()].forEach(([viewId, document]) => {
+                if (
+                    document.webContents === webContents &&
+                    !isSameDesktopThemeDocument(this.desktopThemeSurfaceByFrame.get(document.frame), document)
+                ) {
+                    this.cutoverDocuments.delete(viewId);
+                }
+            });
         });
     };
 

--- a/src/main/themeManager.ts
+++ b/src/main/themeManager.ts
@@ -496,14 +496,23 @@ export class ThemeManager {
         const standbyReason = this.currentStandbyReason();
 
         [...this.desktopThemeSurfaces.values()].forEach((registration) => {
-            if (registration.scope === 'main-tab' && registration !== candidate) {
+            if (registration.scope === 'main-tab' && registration !== candidate && !this.isDesktopThemeRegistrationFailed(registration)) {
                 this.setDesktopThemeStandby(registration, standbyReason === 'not-current' ? 'not-current' : standbyReason);
             }
         });
 
         const lease = this.activeDesktopThemeLease;
         if (lease && (lease.registration !== candidate || !Config.themeSyncing || this.lifecycleBlockers.size > 0)) {
-            this.revokeDesktopThemeLease(standbyReason);
+            if (!this.revokeDesktopThemeLease(standbyReason)) {
+                if (candidate && candidate !== lease.registration) {
+                    this.setDesktopThemeStandby(candidate, 'theme-reset-failed');
+                }
+                return;
+            }
+        }
+
+        if (candidate && this.isDesktopThemeRegistrationFailed(candidate)) {
+            return;
         }
 
         if (candidate && (!Config.themeSyncing || this.lifecycleBlockers.size > 0)) {
@@ -556,6 +565,12 @@ export class ThemeManager {
         return released;
     };
 
+    private isDesktopThemeRegistrationFailed = (registration: DesktopThemeSurface) => {
+        return registration.state.scope === 'main-tab' &&
+            registration.state.status === 'standby' &&
+            (registration.state.reason === 'apply-failed' || registration.state.reason === 'theme-reset-failed');
+    };
+
     private removeDesktopThemeDocumentSurfaces = (webContents: WebContents, frame?: WebFrameMain) => {
         const registrations = [...this.desktopThemeSurfaces.values()].filter((registration) =>
             registration.webContents === webContents && (!frame || registration.frame === frame));
@@ -582,8 +597,8 @@ export class ThemeManager {
         reason: DesktopThemeFailureReason,
     ): DesktopThemeApplyResult => {
         this.activeDesktopThemeLease = undefined;
-        this.setDesktopThemeStandby(lease.registration, 'apply-failed');
         const rolledBack = this.resetDesktopOutput();
+        this.setDesktopThemeStandby(lease.registration, rolledBack ? 'apply-failed' : 'theme-reset-failed');
         return {
             status: 'failed',
             surfaceId: request.surfaceId,

--- a/src/main/themeManager.ts
+++ b/src/main/themeManager.ts
@@ -588,12 +588,42 @@ export class ThemeManager {
         }
 
         const activeLease = this.activeDesktopThemeLease;
-        if (activeLease ? !activeLease.directive : !this.resetDesktopOutput()) {
+        if (activeLease) {
+            if (!activeLease.directive) {
+                return false;
+            }
+        } else if (!this.resetDesktopOutput() || !this.restoreCurrentLegacyDesktopOutput()) {
             return false;
         }
 
         failedRegistrations.forEach(this.removeDesktopThemeSurface);
         return true;
+    };
+
+    private restoreCurrentLegacyDesktopOutput = () => {
+        if (!Config.themeSyncing) {
+            return true;
+        }
+
+        const committedMainView = this.resolveCommittedMainView();
+        const document = committedMainView && this.getCommittedDesktopThemeDocument(committedMainView);
+        if (!committedMainView || (document && this.isDesktopThemeDocumentCutover(document))) {
+            return true;
+        }
+
+        const serverId = ServerManager.getCurrentServerId();
+        const theme = serverId ? ServerManager.getServer(serverId)?.theme : undefined;
+        if (!theme) {
+            return true;
+        }
+
+        let nativeSource: 'system' | 'light' | 'dark' = 'system';
+        if (!theme.isUsingSystemTheme) {
+            nativeSource = isLightColor(theme.centerChannelBg || '#fff') ? 'light' : 'dark';
+        }
+        const nativeRestored = this.setNativeThemeSource(nativeSource);
+        const shellRestored = this.publishDesktopShellTheme(theme);
+        return nativeRestored && shellRestored;
     };
 
     private retireDesktopThemeSurface = (registration: DesktopThemeSurface) => {

--- a/src/main/utils.test.ts
+++ b/src/main/utils.test.ts
@@ -1,13 +1,23 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {isRoutableAddress} from './utils';
+import {isLightColor, isRoutableAddress} from './utils';
 
 jest.mock('electron', () => ({
     app: {},
 }));
 
 describe('main/utils', () => {
+    describe('isLightColor', () => {
+        it.each(['#ffffff', '#fff', 'rgb(255,255,255)', 'rgba(255,255,255,0.5)'])('identifies %s as light', (color) => {
+            expect(isLightColor(color)).toBe(true);
+        });
+
+        it.each(['#000000', '#000', 'rgb(0,0,0)', 'invalid'])('identifies %s as dark', (color) => {
+            expect(isLightColor(color)).toBe(false);
+        });
+    });
+
     describe('isRoutableAddress', () => {
         describe('IPv4', () => {
             it('accepts a public address', () => {

--- a/src/main/utils.test.ts
+++ b/src/main/utils.test.ts
@@ -9,12 +9,13 @@ jest.mock('electron', () => ({
 
 describe('main/utils', () => {
     describe('isLightColor', () => {
-        it.each(['#ffffff', '#fff', 'rgb(255,255,255)', 'rgba(255,255,255,0.5)'])('identifies %s as light', (color) => {
-            expect(isLightColor(color)).toBe(true);
-        });
-
-        it.each(['#000000', '#000', 'rgb(0,0,0)', 'invalid'])('identifies %s as dark', (color) => {
-            expect(isLightColor(color)).toBe(false);
+        it.each([
+            ['#fff', true],
+            ['#000', false],
+            ['rgba(255,255,255,0.5)', true],
+            ['invalid', false],
+        ])('classifies %s', (color, isLight) => {
+            expect(isLightColor(color)).toBe(isLight);
         });
     });
 

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -13,6 +13,7 @@ import {app} from 'electron';
 
 import {MAILTO_PREFIX} from 'common/constants';
 import {TAB_BAR_HEIGHT} from 'common/utils/constants';
+import {parseThemeColor} from 'common/utils/theme';
 
 import type {Args} from 'types/args';
 
@@ -147,17 +148,17 @@ export function isKDE() {
 }
 
 export function isLightColor(color: string) {
-    const hexColor = Number('0x' + color.slice(1));
-
-    const r = hexColor >> 16;
-    const g = (hexColor >> 8) & 255;
-    const b = hexColor & 255;
+    const components = parseThemeColor(color);
+    if (!components) {
+        return false;
+    }
+    const {red, green, blue} = components;
 
     // HSP equation from http://alienryderflex.com/hsp.html
     const hsp = Math.sqrt(
-        (0.299 * (r * r)) +
-        (0.587 * (g * g)) +
-        (0.114 * (b * b)),
+        (0.299 * (red * red)) +
+        (0.587 * (green * green)) +
+        (0.114 * (blue * blue)),
     );
 
     // Using the HSP value, determine whether the color is light or dark

--- a/src/renderer/utils.ts
+++ b/src/renderer/utils.ts
@@ -6,6 +6,8 @@ import type {IntlShape} from 'react-intl';
 
 import type {Theme} from '@mattermost/desktop-api';
 
+import {parseThemeColor} from 'common/utils/theme';
+
 import type {DownloadedItem} from 'types/downloads';
 
 import {Constants} from './constants';
@@ -200,9 +202,9 @@ const resetTheme = () => {
     document.body.style.removeProperty('--code-theme');
 };
 
-function toRgbValues(hexStr: string): string {
-    const rgbaStr = `${parseInt(hexStr.substring(1, 3), 16)}, ${parseInt(hexStr.substring(3, 5), 16)}, ${parseInt(hexStr.substring(5, 7), 16)}`;
-    return rgbaStr;
+function toRgbValues(color: string): string {
+    const components = parseThemeColor(color);
+    return components ? `${components.red}, ${components.green}, ${components.blue}` : '';
 }
 
 export {

--- a/src/types/externalAPI.ts
+++ b/src/types/externalAPI.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {DesktopThemeSurfaceStateEvent, SystemAppearanceInvalidation} from '@mattermost/desktop-api';
+
 export interface ExternalAPI {
     createListener(event: 'user-activity-update', listener: (
         userIsActive: boolean,
@@ -27,6 +29,8 @@ export interface ExternalAPI {
     createListener(event: 'calls-widget-open-user-settings', listener: () => void): () => void;
     createListener(event: 'metrics-send', listener: (metricsMap: Map<string, {cpu?: number; memory?: number}>) => void): () => void;
     createListener(event: 'dark-mode-change', listener: (darkMode: boolean) => void): () => void;
+    createListener(event: 'system-appearance-invalidated', listener: (event: SystemAppearanceInvalidation) => void): () => void;
+    createListener(event: 'desktop-theme-surface-state-changed', listener: (event: DesktopThemeSurfaceStateEvent) => void): () => void;
     createListener(event: 'message-from-parent', listener: (channel: string, ...args: unknown[]) => void): () => void;
     createListener(event: 'message-from-popout', listener: (id: string, channel: string, ...args: unknown[]) => void): () => void;
     createListener(event: 'popout-closed', listener: (id: string) => void): () => void;


### PR DESCRIPTION
Related: mattermost/mattermost#30382

## Problem

There is no "system theme" that a user can select. Not only is this a well-established pattern outside of mattermost but demand for it in this project has already been established in the above (now defunct) PR.

Closes #15975

## Goals

- Work cross OS (windows, mac, linux)
- Do not glitch/stutter due to feedback loops (problem in linked pr)
- Reject stale updates across tab switches, navigation, shutdown, etc.
- Expose a versioned, future-proof desktop API that web can use
- Version compatibility: maintain old legacy theme logic for older clients

## Non-goals

- Implement the (a) UI
- Support mobile (duh)
- Implement OS appearance detection for Windows or Linux (help needed)
- Remove or redesign the existing legacy Desktop theme API (for later?)
- Provide an entrypoint/way to enable automatic theme switching (job for mattermost/mattermost)

## Design Overview

The PR is quite large, so here's a quick overview of the main decisions and data flow. The most important flow is as follows:

1. Hypothetically (not now), a web page would call `registerDesktopThemeSurface`. A lease would be granted (see below) if it's registered for V1, displayed, and has theme syncing enabled.
  - For example, a background tab registering receives a lease with status "standby". A popout has an "ineligible" lease type; the main tab has a "granted" lease, meaning it can apply the theme.
2. Granted surfaces receive a "lease" (permission to update appearance) from the desktop.
3. The surface applies the desktop theme with [`applyDesktopTheme`](https://github.com/mattermost/desktop/blob/b22245d48850c55a28133beadacb5f00e381fd6c/src/main/themeManager.ts#L169-L216).
4. The desktop verifies and then updates desktop + electron atomically

Some more implementation details:

- Desktop uses an [OS adapter boundary](https://github.com/mattermost/desktop/blob/b22245d48850c55a28133beadacb5f00e381fd6c/src/main/systemAppearanceAdapter.ts#L14-L60) to read the real macOS appearance setting. It does not infer the setting from Electron’s effective theme, avoiding the feedback loop manifesting as a visual trip in the original PR.

- The web app receives a [small, versioned API](https://github.com/mattermost/desktop/blob/b22245d48850c55a28133beadacb5f00e381fd6c/api-types/index.ts#L42-L164) for reading appearance and registering, etc. the theme surface. Desktop [authenticates the server](https://github.com/mattermost/desktop/blob/b22245d48850c55a28133beadacb5f00e381fd6c/src/app/views/webContentsManager.ts#L129-L165) before accepting any of those operations.

- The currently displayed main tab is the only controller of the shared Desktop appearance. Also, [lease IDs and monotonically increasing sequences](https://github.com/mattermost/desktop/blob/b22245d48850c55a28133beadacb5f00e381fd6c/src/main/themeManager.ts#L136-L215) reject updates from old tabs/replaced documents/delayed requests. The [coordinator interacts (grants, revokes) leases](https://github.com/mattermost/desktop/blob/b22245d48850c55a28133beadacb5f00e381fd6c/src/main/themeManager.ts#L485-L527) throughout the app lifecycle.

- Desktop cleanly applies the result to Electron’s native appearance and its own chrome atomically. If either half cannot be updated, it [revokes both](https://github.com/mattermost/desktop/blob/b22245d48850c55a28133beadacb5f00e381fd6c/src/main/themeManager.ts#L543-L570).

- Compatibility is achieved on a per-loaded-document granularity. For example, older MM versions continue through the [existing cached theme-sync path](https://github.com/mattermost/desktop/blob/b22245d48850c55a28133beadacb5f00e381fd6c/src/main/themeManager.ts#L370-L415). But, once a document registers for V1, Desktop [**stops accepting its legacy theme messages**](https://github.com/mattermost/desktop/blob/b22245d48850c55a28133beadacb5f00e381fd6c/src/app/views/webContentsManager.ts#L381-L400) (no conflicts).

- Popouts keep their MM page theme, but don't control Electron’s appearance. Specifically, for example when a live tab is moved into or out of a popout, Desktop [preserves its registration and changes its eligibility](https://github.com/mattermost/desktop/blob/b22245d48850c55a28133beadacb5f00e381fd6c/src/main/themeManager.ts#L272-L299); returning as the active main tab produces a fresh "lease".

```mermaid
flowchart LR
    Mac[macOS appearance setting] --> MacAdapter[macOS adapter<br/>reads the OS directly]
    Other[Windows / Linux] --> Unsupported[unsupported adapter<br/>returns unknown]

    MacAdapter --> Monitor[system appearance monitor]
    Unsupported --> Monitor

    Monitor -- Desktop API v1<br/>light · dark · unknown + changes --> Tab[Mattermost web app<br/>inside a tab]
    Tab -- resolved theme --> Coordinator[Desktop theme coordinator]

    Current[currently displayed<br/>Mattermost tab] -- only this tab may<br/>update shared UI --> Coordinator
    Older[older Mattermost web app<br/>without API v1] -- existing theme-sync path --> Coordinator

    Coordinator --> Native[Electron native appearance<br/>menus · context menus · controls]
    Coordinator --> Shell[Desktop-owned UI<br/>top bar · modals · popout chrome]

    classDef external fill:#F8F9FA,stroke:#868E96,color:#212529;
    classDef desktop fill:#E7F0FF,stroke:#1C58D9,stroke-width:1.5px,color:#102A43;
    classDef compatibility fill:#FFF4E6,stroke:#D9480F,color:#5F2A0A;
    classDef output fill:#E8F7EE,stroke:#2B8A3E,stroke-width:1.5px,color:#173C21;

    class Mac,Other,Tab,Current external;
    class MacAdapter,Unsupported,Monitor,Coordinator desktop;
    class Older compatibility;
    class Native,Shell output;
```


## Todo

- [ ] **Windows and Linux compatibility**: currently unsupported (handled gracefully). I suppose I can use a VM but it would be convenient to be assigned a Linux reviewer, at least. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added desktop theme support for applying and releasing themes across supported desktop surfaces.
  - Added light/dark system appearance detection with change notifications.
  - Added theme surface registration, status updates, capability negotiation, and typed operation results.
- **Bug Fixes**
  - Improved theme synchronization when views change, close, navigate, or lose ownership.
  - Added stronger validation and authentication for theme requests.
  - Improved support for RGB, RGBA, and shorthand hexadecimal colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->