### PR TITLE
Backports to release-5.13

### DIFF
--- a/src/app/serverViewState.test.js
+++ b/src/app/serverViewState.test.js
@@ -534,6 +534,22 @@ describe('app/serverViewState', () => {
             expect(result.validatedURL).toBe('https://mainserver.com/');
         });
 
+        it('should not update the users URL when the Site URL cannot be parsed', async () => {
+            ServerInfo.mockImplementation(() => ({
+                fetchConfigData: jest.fn().mockImplementation(() => {
+                    return {
+                        serverVersion: '7.8.0',
+                        siteName: 'Mattermost',
+                        siteURL: 'not-a-url',
+                    };
+                }),
+            }));
+
+            const result = await serverViewState.handleServerURLValidation({}, 'https://server.com');
+            expect(result.status).toBe(URLValidationStatus.OK);
+            expect(result.validatedURL).toBe('https://server.com/');
+        });
+
         it('should not update the users URL when the Site URL is blank', async () => {
             ServerInfo.mockImplementation(() => ({
                 fetchConfigData: jest.fn().mockImplementation(() => {

--- a/src/app/serverViewState.ts
+++ b/src/app/serverViewState.ts
@@ -333,24 +333,22 @@ export class ServerViewState {
         }
 
         // If the URL doesn't match the Site URL, set the URL to the correct one
-        if (remoteInfo.siteURL && remoteURL.toString() !== new URL(remoteInfo.siteURL).toString()) {
-            const parsedSiteURL = parseURL(remoteInfo.siteURL);
-            if (parsedSiteURL) {
-                // Check the Site URL as well to see if it's already pre-configured
-                const existingServer = ServerManager.lookupViewByURL(parsedSiteURL, true);
-                if (existingServer && existingServer.server.id !== currentId) {
-                    return {status: URLValidationStatus.URLExists, existingServerName: existingServer.server.name, validatedURL: existingServer.server.url.toString()};
-                }
+        const parsedSiteURL = remoteInfo.siteURL ? parseURL(remoteInfo.siteURL) : undefined;
+        if (parsedSiteURL && remoteURL.toString() !== parsedSiteURL.toString()) {
+            // Check the Site URL as well to see if it's already pre-configured
+            const existingServer = ServerManager.lookupViewByURL(parsedSiteURL, true);
+            if (existingServer && existingServer.server.id !== currentId) {
+                return {status: URLValidationStatus.URLExists, existingServerName: existingServer.server.name, validatedURL: existingServer.server.url.toString()};
+            }
 
-                // If we can't reach the remote Site URL, there's probably a configuration issue
-                const remoteSiteURLInfo = await this.testRemoteServer(parsedSiteURL);
-                if (!remoteSiteURLInfo) {
-                    return {status: URLValidationStatus.URLNotMatched, serverVersion: remoteInfo.serverVersion, serverName: remoteServerName, validatedURL: remoteURL.toString()};
-                }
+            // If we can't reach the remote Site URL, there's probably a configuration issue
+            const remoteSiteURLInfo = await this.testRemoteServer(parsedSiteURL);
+            if (!remoteSiteURLInfo) {
+                return {status: URLValidationStatus.URLNotMatched, serverVersion: remoteInfo.serverVersion, serverName: remoteServerName, validatedURL: remoteURL.toString()};
             }
 
             // Otherwise fix it for them and return
-            return {status: URLValidationStatus.URLUpdated, serverVersion: remoteInfo.serverVersion, serverName: remoteServerName, validatedURL: remoteInfo.siteURL};
+            return {status: URLValidationStatus.URLUpdated, serverVersion: remoteInfo.serverVersion, serverName: remoteServerName, validatedURL: parsedSiteURL.toString()};
         }
 
         return {status: URLValidationStatus.OK, serverVersion: remoteInfo.serverVersion, serverName: remoteServerName, validatedURL: remoteURL.toString()};

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -63,3 +63,9 @@ export const ModalConstants = {
     PROXY_LOGIN_MODAL: 'proxyLoginModal',
     PERMISSION_MODAL: 'permissionModal',
 };
+
+export const FILTERED_PROTOCOLS = new Set(['http:', 'https:', 'ws:', 'wss:']);
+export const WEBSOCKET_PROTOCOL_EQUIVALENTS: {[protocol: string]: string} = {
+    'ws:': 'http:',
+    'wss:': 'https:',
+};

--- a/src/common/servers/MattermostServer.ts
+++ b/src/common/servers/MattermostServer.ts
@@ -24,11 +24,12 @@ export class MattermostServer {
         this.initialLoadURL = initialLoadURL;
     }
 
-    updateURL = (url: string) => {
-        this.url = parseURL(url)!;
-        if (!this.url) {
+    updateURL = (url: string | URL) => {
+        const parsedURL = parseURL(url);
+        if (!parsedURL) {
             throw new Error('Invalid url for creating a server');
         }
+        this.url = parsedURL;
     };
 
     toUniqueServer = (): UniqueServer => {

--- a/src/common/servers/serverManager.test.js
+++ b/src/common/servers/serverManager.test.js
@@ -40,6 +40,13 @@ describe('common/servers/serverManager', () => {
             serverManager.viewOrder = new Map([['server-1', ['view-1', 'view-2', 'view-3']]]);
             serverManager.persistServers = jest.fn();
             Utils.isVersionGreaterThanOrEqualTo.mockImplementation((version) => version === '6.0.0');
+            parseURL.mockImplementation((url) => {
+                try {
+                    return new URL(url);
+                } catch (e) {
+                    return undefined;
+                }
+            });
         });
 
         it('should not save when there is nothing to update', () => {
@@ -62,6 +69,18 @@ describe('common/servers/serverManager', () => {
             }]]));
 
             expect(serverManager.servers.get('server-1').url.toString()).toBe('http://server-2.com/');
+        });
+
+        it('should not throw or update server URL when the site URL cannot be parsed', () => {
+            expect(() => serverManager.updateRemoteInfos(new Map([['server-1', {
+                siteURL: 'not-a-url',
+                serverVersion: '6.0.0',
+                hasPlaybooks: true,
+                hasFocalboard: true,
+            }]]))).not.toThrow();
+
+            expect(serverManager.servers.get('server-1').url.toString()).toBe('http://server-1.com/');
+            expect(serverManager.persistServers).not.toHaveBeenCalled();
         });
     });
 

--- a/src/common/servers/serverManager.ts
+++ b/src/common/servers/serverManager.ts
@@ -370,8 +370,9 @@ export class ServerManager extends EventEmitter {
             return false;
         }
 
-        if (remoteInfo.siteURL && server.url.toString() !== new URL(remoteInfo.siteURL).toString()) {
-            server.updateURL(remoteInfo.siteURL);
+        const siteURL = remoteInfo.siteURL ? parseURL(remoteInfo.siteURL) : undefined;
+        if (siteURL && server.url.toString() !== siteURL.toString()) {
+            server.updateURL(siteURL);
             this.servers.set(serverId, server);
             return true;
         }

--- a/src/main/app/initialize.test.js
+++ b/src/main/app/initialize.test.js
@@ -6,11 +6,14 @@ import path from 'path';
 import {app, session} from 'electron';
 
 import Config from 'common/config';
+import ServerManager from 'common/servers/serverManager';
 import parseArgs from 'main/ParseArgs';
 import ViewManager from 'main/views/viewManager';
 
 import {initialize} from './initialize';
 import {clearAppCache, getDeeplinkingURL, wasUpdated} from './utils';
+
+let mockOnBeforeRequestHandler;
 
 jest.mock('fs', () => ({
     accessSync: jest.fn(),
@@ -65,6 +68,9 @@ jest.mock('electron', () => ({
     session: {
         defaultSession: {
             webRequest: {
+                onBeforeRequest: jest.fn((handler) => {
+                    mockOnBeforeRequestHandler = handler;
+                }),
                 onHeadersReceived: jest.fn(),
             },
             setSpellCheckerDictionaryDownloadURL: jest.fn(),
@@ -274,6 +280,65 @@ describe('main/app/initialize', () => {
             });
 
             expect(ViewManager.handleDeepLink).toHaveBeenCalledWith('mattermost://server-1.com');
+        });
+
+        describe('local network request filter (onBeforeRequest)', () => {
+            const SERVER_WEBCONTENTS_ID = 1;
+
+            const getRegisteredHandler = async () => {
+                ServerManager.getAllServers.mockReturnValue([{url: new URL('http://127.0.0.1:8065')}]);
+                ViewManager.getViewByWebContentsId.mockImplementation((id) => (id === SERVER_WEBCONTENTS_ID ? {id} : undefined));
+                await initialize();
+                return mockOnBeforeRequestHandler;
+            };
+
+            it('cancels server-view requests to local/private targets (via webContentsId)', async () => {
+                const handler = await getRegisteredHandler();
+                const callback = jest.fn();
+
+                await handler({url: 'http://127.0.0.1:7777/secret', webContentsId: SERVER_WEBCONTENTS_ID, resourceType: 'xhr'}, callback);
+
+                expect(callback).toHaveBeenCalledWith({cancel: true});
+            });
+
+            it('allows requests to the configured server origin', async () => {
+                const handler = await getRegisteredHandler();
+                const callback = jest.fn();
+
+                await handler({url: 'http://127.0.0.1:8065/api/v4/system/ping', webContentsId: SERVER_WEBCONTENTS_ID, resourceType: 'xhr'}, callback);
+
+                expect(callback).toHaveBeenCalledWith({});
+            });
+
+            it('does not cancel requests from non-server web contents', async () => {
+                const handler = await getRegisteredHandler();
+                const callback = jest.fn();
+
+                await handler({url: 'http://127.0.0.1:7777/secret', webContentsId: 999, resourceType: 'xhr'}, callback);
+
+                expect(callback).toHaveBeenCalledWith({});
+            });
+
+            it('cancels unowned requests to local/private targets', async () => {
+                const handler = await getRegisteredHandler();
+                const callback = jest.fn();
+
+                await handler({url: 'http://127.0.0.1:7777/secret', resourceType: 'xhr'}, callback);
+
+                expect(callback).toHaveBeenCalledWith({cancel: true});
+            });
+
+            it('allows the request when the policy check throws', async () => {
+                const handler = await getRegisteredHandler();
+                ViewManager.getViewByWebContentsId.mockImplementation(() => {
+                    throw new Error('boom');
+                });
+                const callback = jest.fn();
+
+                await handler({url: 'http://127.0.0.1:7777/secret', webContentsId: SERVER_WEBCONTENTS_ID, resourceType: 'xhr'}, callback);
+
+                expect(callback).toHaveBeenCalledWith({});
+            });
         });
     });
 });

--- a/src/main/app/initialize.test.js
+++ b/src/main/app/initialize.test.js
@@ -7,6 +7,7 @@ import {app, session} from 'electron';
 
 import Config from 'common/config';
 import ServerManager from 'common/servers/serverManager';
+import LocalNetworkAccessManager from 'main/localNetworkAccess';
 import parseArgs from 'main/ParseArgs';
 import ViewManager from 'main/views/viewManager';
 
@@ -287,7 +288,8 @@ describe('main/app/initialize', () => {
 
             const getRegisteredHandler = async () => {
                 ServerManager.getAllServers.mockReturnValue([{url: new URL('http://127.0.0.1:8065')}]);
-                ViewManager.getViewByWebContentsId.mockImplementation((id) => (id === SERVER_WEBCONTENTS_ID ? {id} : undefined));
+                LocalNetworkAccessManager.clear();
+                LocalNetworkAccessManager.registerWebContents({id: SERVER_WEBCONTENTS_ID});
                 await initialize();
                 return mockOnBeforeRequestHandler;
             };
@@ -330,9 +332,7 @@ describe('main/app/initialize', () => {
 
             it('allows the request when the policy check throws', async () => {
                 const handler = await getRegisteredHandler();
-                ViewManager.getViewByWebContentsId.mockImplementation(() => {
-                    throw new Error('boom');
-                });
+                jest.spyOn(LocalNetworkAccessManager, 'shouldCancelLocalNetworkRequest').mockRejectedValueOnce(new Error('boom'));
                 const callback = jest.fn();
 
                 await handler({url: 'http://127.0.0.1:7777/secret', webContentsId: SERVER_WEBCONTENTS_ID, resourceType: 'xhr'}, callback);

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -49,7 +49,7 @@ import CriticalErrorHandler from 'main/CriticalErrorHandler';
 import DeveloperMode from 'main/developerMode';
 import downloadsManager from 'main/downloadsManager';
 import i18nManager from 'main/i18nManager';
-import {shouldCancelLocalNetworkRequest} from 'main/localNetworkAccess';
+import LocalNetworkAccessManager from 'main/localNetworkAccess';
 import NonceManager from 'main/nonceManager';
 import {getDoNotDisturb} from 'main/notifications';
 import parseArgs from 'main/ParseArgs';
@@ -332,7 +332,7 @@ async function initializeAfterAppReady() {
     const defaultSession = session.defaultSession;
     defaultSession.webRequest.onBeforeRequest(async (details, callback) => {
         try {
-            const shouldCancel = await shouldCancelLocalNetworkRequest(details);
+            const shouldCancel = await LocalNetworkAccessManager.shouldCancelLocalNetworkRequest(details);
 
             if (shouldCancel) {
                 log.warn('Blocked server content from accessing local or private network URL', {

--- a/src/main/app/initialize.ts
+++ b/src/main/app/initialize.ts
@@ -49,6 +49,7 @@ import CriticalErrorHandler from 'main/CriticalErrorHandler';
 import DeveloperMode from 'main/developerMode';
 import downloadsManager from 'main/downloadsManager';
 import i18nManager from 'main/i18nManager';
+import {shouldCancelLocalNetworkRequest} from 'main/localNetworkAccess';
 import NonceManager from 'main/nonceManager';
 import {getDoNotDisturb} from 'main/notifications';
 import parseArgs from 'main/ParseArgs';
@@ -329,6 +330,26 @@ async function initializeAfterAppReady() {
 
     app.setAppUserModelId('Mattermost.Desktop'); // Use explicit AppUserModelID
     const defaultSession = session.defaultSession;
+    defaultSession.webRequest.onBeforeRequest(async (details, callback) => {
+        try {
+            const shouldCancel = await shouldCancelLocalNetworkRequest(details);
+
+            if (shouldCancel) {
+                log.warn('Blocked server content from accessing local or private network URL', {
+                    resourceType: details.resourceType,
+                    origin: parseURL(details.url)?.origin,
+                    webContentsId: details.webContentsId,
+                });
+                callback({cancel: true});
+                return;
+            }
+        } catch (error) {
+            log.warn('Error while checking local network request policy', {error});
+        }
+
+        callback({});
+    });
+
     defaultSession.webRequest.onHeadersReceived((details, callback) => {
         const url = parseURL(details.url);
         if (url?.protocol === 'mattermost-desktop:' && url?.pathname.endsWith('html')) {

--- a/src/main/localNetworkAccess.test.ts
+++ b/src/main/localNetworkAccess.test.ts
@@ -1,0 +1,164 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {
+    isLocalOrPrivateIPAddress,
+    shouldCancelLocalNetworkRequest,
+    shouldBlockLocalNetworkRequest,
+} from './localNetworkAccess';
+
+jest.mock('main/views/viewManager', () => ({
+    getViewByWebContentsId: jest.fn(),
+}));
+
+jest.mock('common/servers/serverManager', () => ({
+    getAllServers: jest.fn(),
+}));
+
+describe('main/localNetworkAccess', () => {
+    const emptyLookup = jest.fn().mockResolvedValue([]);
+    const ViewManager = jest.requireMock('main/views/viewManager');
+    const ServerManager = jest.requireMock('common/servers/serverManager');
+
+    beforeEach(() => {
+        emptyLookup.mockClear();
+        ViewManager.getViewByWebContentsId.mockImplementation((webContentsId: number) => (webContentsId === 1 ? {id: 1} : undefined));
+        ServerManager.getAllServers.mockReturnValue([{url: new URL('http://127.0.0.1:8065')}]);
+    });
+
+    describe('isLocalOrPrivateIPAddress', () => {
+        it('detects IPv4 local and private ranges', () => {
+            expect(isLocalOrPrivateIPAddress('127.0.0.1')).toBe(true);
+            expect(isLocalOrPrivateIPAddress('10.0.0.1')).toBe(true);
+            expect(isLocalOrPrivateIPAddress('172.16.0.1')).toBe(true);
+            expect(isLocalOrPrivateIPAddress('172.31.255.255')).toBe(true);
+            expect(isLocalOrPrivateIPAddress('192.168.1.1')).toBe(true);
+            expect(isLocalOrPrivateIPAddress('169.254.169.254')).toBe(true);
+            expect(isLocalOrPrivateIPAddress('8.8.8.8')).toBe(false);
+        });
+
+        it('detects IPv6 local and private ranges', () => {
+            expect(isLocalOrPrivateIPAddress('::1')).toBe(true);
+            expect(isLocalOrPrivateIPAddress('fc00::1')).toBe(true);
+            expect(isLocalOrPrivateIPAddress('fd00::1')).toBe(true);
+            expect(isLocalOrPrivateIPAddress('fec0::1')).toBe(true);
+            expect(isLocalOrPrivateIPAddress('fe80::1')).toBe(true);
+            expect(isLocalOrPrivateIPAddress('::ffff:127.0.0.1')).toBe(true);
+            expect(isLocalOrPrivateIPAddress('2606:4700:4700::1111')).toBe(false);
+        });
+    });
+
+    describe('shouldBlockLocalNetworkRequest', () => {
+        it('blocks local hostnames and private IP literals', async () => {
+            await expect(shouldBlockLocalNetworkRequest('http://localhost:3000', [], emptyLookup)).resolves.toBe(true);
+            await expect(shouldBlockLocalNetworkRequest('http://127.0.0.1:3000', [], emptyLookup)).resolves.toBe(true);
+            await expect(shouldBlockLocalNetworkRequest('http://192.168.1.10', [], emptyLookup)).resolves.toBe(true);
+        });
+
+        it('allows configured server origins even when they are local', async () => {
+            await expect(shouldBlockLocalNetworkRequest(
+                'http://127.0.0.1:8065/api/v4/system/ping',
+                [new URL('http://127.0.0.1:8065')],
+                emptyLookup,
+            )).resolves.toBe(false);
+        });
+
+        it('blocks hostnames that resolve to private addresses', async () => {
+            const lookup = jest.fn().mockResolvedValue([{address: '10.0.0.5'}]);
+
+            await expect(shouldBlockLocalNetworkRequest('http://internal.example.com', [], lookup)).resolves.toBe(true);
+        });
+
+        it('allows public http targets and non-filtered protocols', async () => {
+            const lookup = jest.fn().mockResolvedValue([{address: '8.8.8.8'}]);
+
+            await expect(shouldBlockLocalNetworkRequest('https://mattermost.com', [], lookup)).resolves.toBe(false);
+            await expect(shouldBlockLocalNetworkRequest('mattermost-desktop://renderer/index.html', [], lookup)).resolves.toBe(false);
+        });
+
+        it('blocks WebSocket connections to local/private targets', async () => {
+            await expect(shouldBlockLocalNetworkRequest('ws://127.0.0.1:9000', [], emptyLookup)).resolves.toBe(true);
+            await expect(shouldBlockLocalNetworkRequest('wss://192.168.1.10/socket', [], emptyLookup)).resolves.toBe(true);
+            await expect(shouldBlockLocalNetworkRequest('ws://localhost:8080', [], emptyLookup)).resolves.toBe(true);
+        });
+
+        it('allows WebSocket connections to the configured server origin', async () => {
+            await expect(shouldBlockLocalNetworkRequest(
+                'wss://127.0.0.1:8065/api/v4/websocket',
+                [new URL('https://127.0.0.1:8065')],
+                emptyLookup,
+            )).resolves.toBe(false);
+
+            await expect(shouldBlockLocalNetworkRequest(
+                'ws://127.0.0.1:8065/api/v4/websocket',
+                [new URL('http://127.0.0.1:8065')],
+                emptyLookup,
+            )).resolves.toBe(false);
+        });
+
+        it('allows public WebSocket targets', async () => {
+            const lookup = jest.fn().mockResolvedValue([{address: '8.8.8.8'}]);
+            await expect(shouldBlockLocalNetworkRequest('wss://realtime.example.com', [], lookup)).resolves.toBe(false);
+        });
+    });
+
+    describe('shouldCancelLocalNetworkRequest', () => {
+        it('blocks server view requests using webContentsId', async () => {
+            await expect(shouldCancelLocalNetworkRequest(
+                {
+                    url: 'http://127.0.0.1:7777/secret',
+                    webContentsId: 1,
+                },
+                emptyLookup,
+            )).resolves.toBe(true);
+        });
+
+        it('allows configured server origins', async () => {
+            await expect(shouldCancelLocalNetworkRequest(
+                {
+                    url: 'http://127.0.0.1:8065/api/v4/system/ping',
+                    webContentsId: 1,
+                },
+                emptyLookup,
+            )).resolves.toBe(false);
+        });
+
+        it('allows requests that belong to a known non-server web contents', async () => {
+            await expect(shouldCancelLocalNetworkRequest(
+                {
+                    url: 'http://127.0.0.1:7777/secret',
+                    webContentsId: 2,
+                },
+                emptyLookup,
+            )).resolves.toBe(false);
+        });
+
+        it('blocks unowned requests to local/private targets', async () => {
+            await expect(shouldCancelLocalNetworkRequest(
+                {
+                    url: 'http://127.0.0.1:7777/secret',
+                },
+                emptyLookup,
+            )).resolves.toBe(true);
+        });
+
+        it('allows unowned requests to the configured server origin', async () => {
+            await expect(shouldCancelLocalNetworkRequest(
+                {
+                    url: 'http://127.0.0.1:8065/api/v4/websocket',
+                },
+                emptyLookup,
+            )).resolves.toBe(false);
+        });
+
+        it('allows unowned requests to public targets', async () => {
+            const lookup = jest.fn().mockResolvedValue([{address: '8.8.8.8'}]);
+            await expect(shouldCancelLocalNetworkRequest(
+                {
+                    url: 'https://mattermost.com',
+                },
+                lookup,
+            )).resolves.toBe(false);
+        });
+    });
+});

--- a/src/main/localNetworkAccess.test.ts
+++ b/src/main/localNetworkAccess.test.ts
@@ -1,15 +1,12 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {
-    isLocalOrPrivateIPAddress,
-    shouldCancelLocalNetworkRequest,
-    shouldBlockLocalNetworkRequest,
-} from './localNetworkAccess';
+import type {WebContents} from 'electron';
 
-jest.mock('main/views/viewManager', () => ({
-    getViewByWebContentsId: jest.fn(),
-}));
+import type {MattermostServer} from 'common/servers/MattermostServer';
+import ServerManager from 'common/servers/serverManager';
+
+import localNetworkAccessManager, {LocalNetworkAccessManager} from './localNetworkAccess';
 
 jest.mock('common/servers/serverManager', () => ({
     getAllServers: jest.fn(),
@@ -17,94 +14,143 @@ jest.mock('common/servers/serverManager', () => ({
 
 describe('main/localNetworkAccess', () => {
     const emptyLookup = jest.fn().mockResolvedValue([]);
-    const ViewManager = jest.requireMock('main/views/viewManager');
-    const ServerManager = jest.requireMock('common/servers/serverManager');
+    const mockServerManager = jest.mocked(ServerManager);
 
     beforeEach(() => {
         emptyLookup.mockClear();
-        ViewManager.getViewByWebContentsId.mockImplementation((webContentsId: number) => (webContentsId === 1 ? {id: 1} : undefined));
-        ServerManager.getAllServers.mockReturnValue([{url: new URL('http://127.0.0.1:8065')}]);
+        localNetworkAccessManager.clear();
+        mockServerManager.getAllServers.mockReturnValue([{url: new URL('http://127.0.0.1:8065')} as unknown as MattermostServer]);
+    });
+
+    describe('LocalNetworkAccessManager', () => {
+        it('registers webContents and tracks monitored status', () => {
+            const manager = new LocalNetworkAccessManager();
+            const mockWebContents = {
+                id: 10,
+                isDestroyed: () => false,
+            } as unknown as WebContents;
+
+            manager.registerWebContents(mockWebContents);
+            expect(manager.isMonitored(10)).toBe(true);
+            expect(manager.isMonitored(20)).toBe(false);
+        });
+
+        it('does not register if webContents is already destroyed', () => {
+            const manager = new LocalNetworkAccessManager();
+            const mockWebContents = {
+                id: 10,
+                isDestroyed: () => true,
+            } as unknown as WebContents;
+
+            manager.registerWebContents(mockWebContents);
+            expect(manager.isMonitored(10)).toBe(false);
+        });
+
+        it('unregisters webContents by id directly', () => {
+            const manager = new LocalNetworkAccessManager();
+            const mockWebContents = {
+                id: 10,
+                isDestroyed: () => false,
+            } as unknown as WebContents;
+
+            manager.registerWebContents(mockWebContents);
+            expect(manager.isMonitored(10)).toBe(true);
+
+            manager.unregisterWebContents(10);
+            expect(manager.isMonitored(10)).toBe(false);
+        });
     });
 
     describe('isLocalOrPrivateIPAddress', () => {
         it('detects IPv4 local and private ranges', () => {
-            expect(isLocalOrPrivateIPAddress('127.0.0.1')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('10.0.0.1')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('172.16.0.1')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('172.31.255.255')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('192.168.1.1')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('169.254.169.254')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('8.8.8.8')).toBe(false);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('127.0.0.1')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('10.0.0.1')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('172.16.0.1')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('172.31.255.255')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('192.168.1.1')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('169.254.169.254')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('8.8.8.8')).toBe(false);
         });
 
         it('detects IPv6 local and private ranges', () => {
-            expect(isLocalOrPrivateIPAddress('::1')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('fc00::1')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('fd00::1')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('fec0::1')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('fe80::1')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('::ffff:127.0.0.1')).toBe(true);
-            expect(isLocalOrPrivateIPAddress('2606:4700:4700::1111')).toBe(false);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('::1')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('fc00::1')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('fd00::1')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('fec0::1')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('fe80::1')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('::ffff:127.0.0.1')).toBe(true);
+            expect(localNetworkAccessManager.isLocalOrPrivateIPAddress('2606:4700:4700::1111')).toBe(false);
         });
     });
 
     describe('shouldBlockLocalNetworkRequest', () => {
         it('blocks local hostnames and private IP literals', async () => {
-            await expect(shouldBlockLocalNetworkRequest('http://localhost:3000', [], emptyLookup)).resolves.toBe(true);
-            await expect(shouldBlockLocalNetworkRequest('http://127.0.0.1:3000', [], emptyLookup)).resolves.toBe(true);
-            await expect(shouldBlockLocalNetworkRequest('http://192.168.1.10', [], emptyLookup)).resolves.toBe(true);
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest('http://localhost:3000', [], emptyLookup)).resolves.toBe(true);
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest('http://127.0.0.1:3000', [], emptyLookup)).resolves.toBe(true);
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest('http://192.168.1.10', [], emptyLookup)).resolves.toBe(true);
         });
 
         it('allows configured server origins even when they are local', async () => {
-            await expect(shouldBlockLocalNetworkRequest(
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest(
                 'http://127.0.0.1:8065/api/v4/system/ping',
                 [new URL('http://127.0.0.1:8065')],
+                emptyLookup,
+            )).resolves.toBe(false);
+
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest(
+                'http://localhost:8065/api/v4/system/ping',
+                [new URL('http://localhost:8065/team')],
                 emptyLookup,
             )).resolves.toBe(false);
         });
 
         it('blocks hostnames that resolve to private addresses', async () => {
             const lookup = jest.fn().mockResolvedValue([{address: '10.0.0.5'}]);
-
-            await expect(shouldBlockLocalNetworkRequest('http://internal.example.com', [], lookup)).resolves.toBe(true);
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest('http://printer.corp', [], lookup)).resolves.toBe(true);
         });
 
         it('allows public http targets and non-filtered protocols', async () => {
             const lookup = jest.fn().mockResolvedValue([{address: '8.8.8.8'}]);
-
-            await expect(shouldBlockLocalNetworkRequest('https://mattermost.com', [], lookup)).resolves.toBe(false);
-            await expect(shouldBlockLocalNetworkRequest('mattermost-desktop://renderer/index.html', [], lookup)).resolves.toBe(false);
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest('https://mattermost.com', [], lookup)).resolves.toBe(false);
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest('file:///etc/hosts', [], lookup)).resolves.toBe(false);
         });
 
         it('blocks WebSocket connections to local/private targets', async () => {
-            await expect(shouldBlockLocalNetworkRequest('ws://127.0.0.1:9000', [], emptyLookup)).resolves.toBe(true);
-            await expect(shouldBlockLocalNetworkRequest('wss://192.168.1.10/socket', [], emptyLookup)).resolves.toBe(true);
-            await expect(shouldBlockLocalNetworkRequest('ws://localhost:8080', [], emptyLookup)).resolves.toBe(true);
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest('ws://127.0.0.1:8065/websocket', [], emptyLookup)).resolves.toBe(true);
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest('wss://10.0.0.5/websocket', [], emptyLookup)).resolves.toBe(true);
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest('ws://localhost:3000', [], emptyLookup)).resolves.toBe(true);
         });
 
         it('allows WebSocket connections to the configured server origin', async () => {
-            await expect(shouldBlockLocalNetworkRequest(
-                'wss://127.0.0.1:8065/api/v4/websocket',
-                [new URL('https://127.0.0.1:8065')],
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest(
+                'ws://127.0.0.1:8065/api/v4/websocket',
+                [new URL('http://127.0.0.1:8065')],
                 emptyLookup,
             )).resolves.toBe(false);
 
-            await expect(shouldBlockLocalNetworkRequest(
-                'ws://127.0.0.1:8065/api/v4/websocket',
-                [new URL('http://127.0.0.1:8065')],
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest(
+                'wss://127.0.0.1:8065/api/v4/websocket',
+                [new URL('https://127.0.0.1:8065')],
                 emptyLookup,
             )).resolves.toBe(false);
         });
 
         it('allows public WebSocket targets', async () => {
             const lookup = jest.fn().mockResolvedValue([{address: '8.8.8.8'}]);
-            await expect(shouldBlockLocalNetworkRequest('wss://realtime.example.com', [], lookup)).resolves.toBe(false);
+            await expect(localNetworkAccessManager.shouldBlockLocalNetworkRequest('wss://realtime.example.com', [], lookup)).resolves.toBe(false);
         });
     });
 
     describe('shouldCancelLocalNetworkRequest', () => {
+        beforeEach(() => {
+            localNetworkAccessManager.registerWebContents({
+                id: 1,
+                isDestroyed: () => false,
+            } as unknown as WebContents);
+        });
+
         it('blocks server view requests using webContentsId', async () => {
-            await expect(shouldCancelLocalNetworkRequest(
+            await expect(localNetworkAccessManager.shouldCancelLocalNetworkRequest(
                 {
                     url: 'http://127.0.0.1:7777/secret',
                     webContentsId: 1,
@@ -114,7 +160,7 @@ describe('main/localNetworkAccess', () => {
         });
 
         it('allows configured server origins', async () => {
-            await expect(shouldCancelLocalNetworkRequest(
+            await expect(localNetworkAccessManager.shouldCancelLocalNetworkRequest(
                 {
                     url: 'http://127.0.0.1:8065/api/v4/system/ping',
                     webContentsId: 1,
@@ -124,7 +170,7 @@ describe('main/localNetworkAccess', () => {
         });
 
         it('allows requests that belong to a known non-server web contents', async () => {
-            await expect(shouldCancelLocalNetworkRequest(
+            await expect(localNetworkAccessManager.shouldCancelLocalNetworkRequest(
                 {
                     url: 'http://127.0.0.1:7777/secret',
                     webContentsId: 2,
@@ -134,7 +180,7 @@ describe('main/localNetworkAccess', () => {
         });
 
         it('blocks unowned requests to local/private targets', async () => {
-            await expect(shouldCancelLocalNetworkRequest(
+            await expect(localNetworkAccessManager.shouldCancelLocalNetworkRequest(
                 {
                     url: 'http://127.0.0.1:7777/secret',
                 },
@@ -143,7 +189,7 @@ describe('main/localNetworkAccess', () => {
         });
 
         it('allows unowned requests to the configured server origin', async () => {
-            await expect(shouldCancelLocalNetworkRequest(
+            await expect(localNetworkAccessManager.shouldCancelLocalNetworkRequest(
                 {
                     url: 'http://127.0.0.1:8065/api/v4/websocket',
                 },
@@ -153,7 +199,7 @@ describe('main/localNetworkAccess', () => {
 
         it('allows unowned requests to public targets', async () => {
             const lookup = jest.fn().mockResolvedValue([{address: '8.8.8.8'}]);
-            await expect(shouldCancelLocalNetworkRequest(
+            await expect(localNetworkAccessManager.shouldCancelLocalNetworkRequest(
                 {
                     url: 'https://mattermost.com',
                 },

--- a/src/main/localNetworkAccess.ts
+++ b/src/main/localNetworkAccess.ts
@@ -1,0 +1,126 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import dns from 'dns/promises';
+import {BlockList, isIP} from 'net';
+
+import ServerManager from 'common/servers/serverManager';
+import {parseURL} from 'common/utils/url';
+import ViewManager from 'main/views/viewManager';
+
+type LookupAddress = {
+    address: string;
+}
+
+type LookupFunction = (hostname: string) => Promise<LookupAddress[]>;
+
+export type LocalNetworkRequestDetails = {
+    url: string;
+    webContentsId?: number;
+}
+
+const defaultLookup: LookupFunction = (hostname: string) => dns.lookup(hostname, {all: true, verbatim: true});
+
+// Address ranges handled by the request policy.
+const LOCAL_NETWORK_BLOCKLIST = new BlockList();
+
+LOCAL_NETWORK_BLOCKLIST.addSubnet('0.0.0.0', 8, 'ipv4');
+LOCAL_NETWORK_BLOCKLIST.addSubnet('10.0.0.0', 8, 'ipv4');
+LOCAL_NETWORK_BLOCKLIST.addSubnet('127.0.0.0', 8, 'ipv4');
+LOCAL_NETWORK_BLOCKLIST.addSubnet('169.254.0.0', 16, 'ipv4');
+LOCAL_NETWORK_BLOCKLIST.addSubnet('172.16.0.0', 12, 'ipv4');
+LOCAL_NETWORK_BLOCKLIST.addSubnet('192.168.0.0', 16, 'ipv4');
+LOCAL_NETWORK_BLOCKLIST.addSubnet('::1', 128, 'ipv6');
+LOCAL_NETWORK_BLOCKLIST.addSubnet('fc00::', 7, 'ipv6');
+LOCAL_NETWORK_BLOCKLIST.addSubnet('fec0::', 10, 'ipv6');
+LOCAL_NETWORK_BLOCKLIST.addSubnet('fe80::', 10, 'ipv6');
+
+export async function shouldCancelLocalNetworkRequest(
+    details: LocalNetworkRequestDetails,
+    lookup: LookupFunction = defaultLookup,
+): Promise<boolean> {
+    if (details.webContentsId && !ViewManager.getViewByWebContentsId(details.webContentsId)) {
+        return false;
+    }
+
+    const serverURLs = ServerManager.getAllServers().map((server) => server.url);
+    return shouldBlockLocalNetworkRequest(details.url, serverURLs, lookup);
+}
+
+const FILTERED_PROTOCOLS = new Set(['http:', 'https:', 'ws:', 'wss:']);
+
+const WEBSOCKET_PROTOCOL_EQUIVALENTS: {[protocol: string]: string} = {
+    'ws:': 'http:',
+    'wss:': 'https:',
+};
+
+function getComparableOrigin(url: URL): string {
+    const protocol = WEBSOCKET_PROTOCOL_EQUIVALENTS[url.protocol] ?? url.protocol;
+    return `${protocol}//${url.host}`;
+}
+
+export function isAllowedServerOrigin(url: URL, serverURLs: URL[]): boolean {
+    const targetOrigin = getComparableOrigin(url);
+    return serverURLs.some((serverURL) => getComparableOrigin(serverURL) === targetOrigin);
+}
+
+export async function shouldBlockLocalNetworkRequest(
+    rawURL: string,
+    serverURLs: URL[],
+    lookup: LookupFunction = defaultLookup,
+): Promise<boolean> {
+    const url = parseURL(rawURL);
+    if (!url) {
+        return false;
+    }
+
+    if (!FILTERED_PROTOCOLS.has(url.protocol)) {
+        return false;
+    }
+
+    if (isAllowedServerOrigin(url, serverURLs)) {
+        return false;
+    }
+
+    return isLocalOrPrivateHostname(url.hostname, lookup);
+}
+
+export async function isLocalOrPrivateHostname(hostname: string, lookup: LookupFunction = defaultLookup): Promise<boolean> {
+    const normalizedHostname = normalizeHostname(hostname);
+
+    if (isLocalhostHostname(normalizedHostname)) {
+        return true;
+    }
+
+    if (isLocalOrPrivateIPAddress(normalizedHostname)) {
+        return true;
+    }
+
+    try {
+        const addresses = await lookup(normalizedHostname);
+        return addresses.some(({address}) => isLocalOrPrivateIPAddress(normalizeHostname(address)));
+    } catch {
+        return false;
+    }
+}
+
+function normalizeHostname(hostname: string): string {
+    return hostname.toLowerCase().replace(/^\[/, '').replace(/\]$/, '').split('%')[0];
+}
+
+function isLocalhostHostname(hostname: string): boolean {
+    return hostname === 'localhost' || hostname.endsWith('.localhost');
+}
+
+export function isLocalOrPrivateIPAddress(address: string): boolean {
+    const family = isIP(address);
+    if (family === 4) {
+        return LOCAL_NETWORK_BLOCKLIST.check(address, 'ipv4');
+    }
+
+    if (family === 6) {
+        return LOCAL_NETWORK_BLOCKLIST.check(address, 'ipv6');
+    }
+
+    return false;
+}

--- a/src/main/localNetworkAccess.ts
+++ b/src/main/localNetworkAccess.ts
@@ -4,123 +4,147 @@
 import dns from 'dns/promises';
 import {BlockList, isIP} from 'net';
 
+import type {WebContents} from 'electron';
+
+import {FILTERED_PROTOCOLS, WEBSOCKET_PROTOCOL_EQUIVALENTS} from 'common/constants';
 import ServerManager from 'common/servers/serverManager';
 import {parseURL} from 'common/utils/url';
-import ViewManager from 'main/views/viewManager';
 
-type LookupAddress = {
-    address: string;
-}
-
-type LookupFunction = (hostname: string) => Promise<LookupAddress[]>;
-
-export type LocalNetworkRequestDetails = {
+type LookupFunction = (hostname: string) => Promise<Array<{address: string}>>;
+type LocalNetworkRequestDetails = {
     url: string;
     webContentsId?: number;
-}
+};
 
 const defaultLookup: LookupFunction = (hostname: string) => dns.lookup(hostname, {all: true, verbatim: true});
 
-// Address ranges handled by the request policy.
-const LOCAL_NETWORK_BLOCKLIST = new BlockList();
+export class LocalNetworkAccessManager {
+    private monitoredWebContents: Set<number>;
+    private blockList: BlockList;
 
-LOCAL_NETWORK_BLOCKLIST.addSubnet('0.0.0.0', 8, 'ipv4');
-LOCAL_NETWORK_BLOCKLIST.addSubnet('10.0.0.0', 8, 'ipv4');
-LOCAL_NETWORK_BLOCKLIST.addSubnet('127.0.0.0', 8, 'ipv4');
-LOCAL_NETWORK_BLOCKLIST.addSubnet('169.254.0.0', 16, 'ipv4');
-LOCAL_NETWORK_BLOCKLIST.addSubnet('172.16.0.0', 12, 'ipv4');
-LOCAL_NETWORK_BLOCKLIST.addSubnet('192.168.0.0', 16, 'ipv4');
-LOCAL_NETWORK_BLOCKLIST.addSubnet('::1', 128, 'ipv6');
-LOCAL_NETWORK_BLOCKLIST.addSubnet('fc00::', 7, 'ipv6');
-LOCAL_NETWORK_BLOCKLIST.addSubnet('fec0::', 10, 'ipv6');
-LOCAL_NETWORK_BLOCKLIST.addSubnet('fe80::', 10, 'ipv6');
+    constructor() {
+        this.monitoredWebContents = new Set();
+        this.blockList = new BlockList();
+        this.blockList.addSubnet('0.0.0.0', 8, 'ipv4');
+        this.blockList.addSubnet('10.0.0.0', 8, 'ipv4');
+        this.blockList.addSubnet('127.0.0.0', 8, 'ipv4');
+        this.blockList.addSubnet('169.254.0.0', 16, 'ipv4');
+        this.blockList.addSubnet('172.16.0.0', 12, 'ipv4');
+        this.blockList.addSubnet('192.168.0.0', 16, 'ipv4');
+        this.blockList.addSubnet('::1', 128, 'ipv6');
+        this.blockList.addSubnet('fc00::', 7, 'ipv6');
+        this.blockList.addSubnet('fec0::', 10, 'ipv6');
+        this.blockList.addSubnet('fe80::', 10, 'ipv6');
+    }
 
-export async function shouldCancelLocalNetworkRequest(
-    details: LocalNetworkRequestDetails,
-    lookup: LookupFunction = defaultLookup,
-): Promise<boolean> {
-    if (details.webContentsId && !ViewManager.getViewByWebContentsId(details.webContentsId)) {
+    registerWebContents = (webContents: WebContents) => {
+        if (!webContents || webContents.isDestroyed?.()) {
+            return;
+        }
+        this.monitoredWebContents.add(webContents.id);
+    };
+
+    unregisterWebContents = (webContentsId: number) => {
+        this.monitoredWebContents.delete(webContentsId);
+    };
+
+    isMonitored = (webContentsId?: number): boolean => {
+        if (!webContentsId) {
+            return false;
+        }
+        return this.monitoredWebContents.has(webContentsId);
+    };
+
+    clear = () => {
+        this.monitoredWebContents.clear();
+    };
+
+    shouldCancelLocalNetworkRequest = async (
+        details: LocalNetworkRequestDetails,
+        lookup: LookupFunction = defaultLookup,
+    ): Promise<boolean> => {
+        if (details.webContentsId && !this.isMonitored(details.webContentsId)) {
+            return false;
+        }
+
+        const serverURLs = ServerManager.getAllServers().map((server) => server.url);
+        return this.shouldBlockLocalNetworkRequest(details.url, serverURLs, lookup);
+    };
+
+    shouldBlockLocalNetworkRequest = async (
+        rawURL: string,
+        serverURLs: URL[],
+        lookup: LookupFunction = defaultLookup,
+    ): Promise<boolean> => {
+        const url = parseURL(rawURL);
+        if (!url) {
+            return false;
+        }
+
+        if (!FILTERED_PROTOCOLS.has(url.protocol)) {
+            return false;
+        }
+
+        if (this.isAllowedServerOrigin(url, serverURLs)) {
+            return false;
+        }
+
+        return this.isLocalOrPrivateHostname(url.hostname, lookup);
+    };
+
+    isLocalOrPrivateIPAddress = (address: string): boolean => {
+        const family = isIP(address);
+        if (family === 4) {
+            return this.blockList.check(address, 'ipv4');
+        }
+
+        if (family === 6) {
+            return this.blockList.check(address, 'ipv6');
+        }
+
         return false;
-    }
+    };
 
-    const serverURLs = ServerManager.getAllServers().map((server) => server.url);
-    return shouldBlockLocalNetworkRequest(details.url, serverURLs, lookup);
+    private isAllowedServerOrigin = (url: URL, serverURLs: URL[]): boolean => {
+        const targetOrigin = this.getComparableOrigin(url);
+        return serverURLs.some((serverURL) => this.getComparableOrigin(serverURL) === targetOrigin);
+    };
+
+    private isLocalOrPrivateHostname = async (
+        hostname: string,
+        lookup: LookupFunction = defaultLookup,
+    ): Promise<boolean> => {
+        const normalizedHostname = this.normalizeHostname(hostname);
+
+        if (this.isLocalhostHostname(normalizedHostname)) {
+            return true;
+        }
+
+        if (this.isLocalOrPrivateIPAddress(normalizedHostname)) {
+            return true;
+        }
+
+        try {
+            const addresses = await lookup(normalizedHostname);
+            return addresses.some(({address}) => this.isLocalOrPrivateIPAddress(this.normalizeHostname(address)));
+        } catch {
+            return false;
+        }
+    };
+
+    private normalizeHostname = (hostname: string): string => {
+        return hostname.toLowerCase().replace(/^\[/, '').replace(/\]$/, '').split('%')[0];
+    };
+
+    private isLocalhostHostname = (hostname: string): boolean => {
+        return hostname === 'localhost' || hostname.endsWith('.localhost');
+    };
+
+    private getComparableOrigin = (url: URL): string => {
+        const protocol = WEBSOCKET_PROTOCOL_EQUIVALENTS[url.protocol] ?? url.protocol;
+        return `${protocol}//${url.host}`;
+    };
 }
 
-const FILTERED_PROTOCOLS = new Set(['http:', 'https:', 'ws:', 'wss:']);
-
-const WEBSOCKET_PROTOCOL_EQUIVALENTS: {[protocol: string]: string} = {
-    'ws:': 'http:',
-    'wss:': 'https:',
-};
-
-function getComparableOrigin(url: URL): string {
-    const protocol = WEBSOCKET_PROTOCOL_EQUIVALENTS[url.protocol] ?? url.protocol;
-    return `${protocol}//${url.host}`;
-}
-
-export function isAllowedServerOrigin(url: URL, serverURLs: URL[]): boolean {
-    const targetOrigin = getComparableOrigin(url);
-    return serverURLs.some((serverURL) => getComparableOrigin(serverURL) === targetOrigin);
-}
-
-export async function shouldBlockLocalNetworkRequest(
-    rawURL: string,
-    serverURLs: URL[],
-    lookup: LookupFunction = defaultLookup,
-): Promise<boolean> {
-    const url = parseURL(rawURL);
-    if (!url) {
-        return false;
-    }
-
-    if (!FILTERED_PROTOCOLS.has(url.protocol)) {
-        return false;
-    }
-
-    if (isAllowedServerOrigin(url, serverURLs)) {
-        return false;
-    }
-
-    return isLocalOrPrivateHostname(url.hostname, lookup);
-}
-
-export async function isLocalOrPrivateHostname(hostname: string, lookup: LookupFunction = defaultLookup): Promise<boolean> {
-    const normalizedHostname = normalizeHostname(hostname);
-
-    if (isLocalhostHostname(normalizedHostname)) {
-        return true;
-    }
-
-    if (isLocalOrPrivateIPAddress(normalizedHostname)) {
-        return true;
-    }
-
-    try {
-        const addresses = await lookup(normalizedHostname);
-        return addresses.some(({address}) => isLocalOrPrivateIPAddress(normalizeHostname(address)));
-    } catch {
-        return false;
-    }
-}
-
-function normalizeHostname(hostname: string): string {
-    return hostname.toLowerCase().replace(/^\[/, '').replace(/\]$/, '').split('%')[0];
-}
-
-function isLocalhostHostname(hostname: string): boolean {
-    return hostname === 'localhost' || hostname.endsWith('.localhost');
-}
-
-export function isLocalOrPrivateIPAddress(address: string): boolean {
-    const family = isIP(address);
-    if (family === 4) {
-        return LOCAL_NETWORK_BLOCKLIST.check(address, 'ipv4');
-    }
-
-    if (family === 6) {
-        return LOCAL_NETWORK_BLOCKLIST.check(address, 'ipv6');
-    }
-
-    return false;
-}
+const localNetworkAccessManager = new LocalNetworkAccessManager();
+export default localNetworkAccessManager;

--- a/src/main/views/MattermostWebContentsView.test.js
+++ b/src/main/views/MattermostWebContentsView.test.js
@@ -9,6 +9,7 @@ import {MattermostServer} from 'common/servers/MattermostServer';
 import ServerManager from 'common/servers/serverManager';
 import MessagingView from 'common/views/MessagingView';
 import {updateServerInfos} from 'main/app/utils';
+import LocalNetworkAccessManager from 'main/localNetworkAccess';
 import {getServerAPI} from 'main/server/serverAPI';
 
 import {MattermostWebContentsView} from './MattermostWebContentsView';
@@ -73,6 +74,13 @@ jest.mock('main/performanceMonitor', () => ({
     registerView: jest.fn(),
     registerServerView: jest.fn(),
     unregisterView: jest.fn(),
+}));
+jest.mock('main/localNetworkAccess', () => ({
+    __esModule: true,
+    default: {
+        registerWebContents: jest.fn(),
+        unregisterWebContents: jest.fn(),
+    },
 }));
 jest.mock('common/servers/serverManager', () => ({
     getRemoteInfo: jest.fn(),
@@ -424,8 +432,10 @@ describe('main/views/MattermostWebContentsView', () => {
 
         it('should remove browser view from window', () => {
             const mattermostView = new MattermostWebContentsView(view, {}, {});
+            expect(jest.mocked(LocalNetworkAccessManager.registerWebContents)).toHaveBeenCalledWith(mattermostView.webContentsView.webContents);
             mattermostView.webContentsView.webContents.close = jest.fn();
             mattermostView.destroy();
+            expect(jest.mocked(LocalNetworkAccessManager.unregisterWebContents)).toHaveBeenCalledWith(mattermostView.webContentsId);
             expect(window.contentView.removeChildView).toBeCalledWith(mattermostView.webContentsView);
         });
 

--- a/src/main/views/MattermostWebContentsView.ts
+++ b/src/main/views/MattermostWebContentsView.ts
@@ -26,6 +26,7 @@ import {isInternalURL, parseURL} from 'common/utils/url';
 import {TAB_MESSAGING, type MattermostView} from 'common/views/View';
 import {updateServerInfos} from 'main/app/utils';
 import DeveloperMode from 'main/developerMode';
+import LocalNetworkAccessManager from 'main/localNetworkAccess';
 import performanceMonitor from 'main/performanceMonitor';
 import {getServerAPI} from 'main/server/serverAPI';
 import MainWindow from 'main/windows/mainWindow';
@@ -75,6 +76,7 @@ export class MattermostWebContentsView extends EventEmitter {
         this.loggedIn = false;
         this.atRoot = true;
         this.webContentsView = new WebContentsView(this.options);
+        LocalNetworkAccessManager.registerWebContents(this.webContentsView.webContents);
         this.resetLoadingStatus();
 
         this.log = ServerManager.getViewLog(this.id, 'MattermostWebContentsView');
@@ -258,6 +260,7 @@ export class MattermostWebContentsView extends EventEmitter {
         WebContentsEventManager.removeWebContentsListeners(this.webContentsId);
         AppState.clear(this.id);
         performanceMonitor.unregisterView(this.webContentsView.webContents.id);
+        LocalNetworkAccessManager.unregisterWebContents(this.webContentsId);
         MainWindow.get()?.contentView.removeChildView(this.webContentsView);
         this.webContentsView.webContents.close();
 

--- a/src/main/views/pluginsPopUps.test.js
+++ b/src/main/views/pluginsPopUps.test.js
@@ -5,6 +5,7 @@ import {shell} from 'electron';
 
 import ServerViewState from 'app/serverViewState';
 import {parseURL} from 'common/utils/url';
+import LocalNetworkAccessManager from 'main/localNetworkAccess';
 import ViewManager from 'main/views/viewManager';
 
 import PluginsPopUpsManager from './pluginsPopUps';
@@ -47,6 +48,14 @@ jest.mock('../allowProtocolDialog', () => ({
     handleDialogEvent: jest.fn(),
 }));
 
+jest.mock('main/localNetworkAccess', () => ({
+    __esModule: true,
+    default: {
+        registerWebContents: jest.fn(),
+        unregisterWebContents: jest.fn(),
+    },
+}));
+
 describe('PluginsPopUpsManager', () => {
     afterEach(() => {
         jest.resetAllMocks();
@@ -84,6 +93,7 @@ describe('PluginsPopUpsManager', () => {
         expect(win.webContents.setWindowOpenHandler).toHaveBeenCalledWith(handlers['window-open']);
 
         expect(win.once).toHaveBeenCalledWith('closed', handlers.closed);
+        expect(jest.mocked(LocalNetworkAccessManager.registerWebContents)).toHaveBeenCalledWith(win.webContents);
 
         expect(mockContextMenuReload).toHaveBeenCalledTimes(1);
 
@@ -149,6 +159,7 @@ describe('PluginsPopUpsManager', () => {
 
         // Close
         handlers.closed();
+        expect(jest.mocked(LocalNetworkAccessManager.unregisterWebContents)).toHaveBeenCalledWith(45);
         expect(mockContextMenuDispose).toHaveBeenCalledTimes(1);
 
         // Verify the popout reference has been deleted

--- a/src/main/views/pluginsPopUps.ts
+++ b/src/main/views/pluginsPopUps.ts
@@ -16,6 +16,7 @@ import {
     parseURL,
 } from 'common/utils/url';
 import ContextMenu from 'main/contextMenu';
+import LocalNetworkAccessManager from 'main/localNetworkAccess';
 import ViewManager from 'main/views/viewManager';
 import {generateHandleConsoleMessage, isCustomProtocol} from 'main/views/webContentEventsCommon';
 import MainWindow from 'main/windows/mainWindow';
@@ -44,6 +45,7 @@ export class PluginsPopUpsManager {
             parentId,
             win,
         };
+        LocalNetworkAccessManager.registerWebContents(win.webContents);
 
         // We take a conservative approach for the time being and disallow most events coming from popups:
         // - Redirects
@@ -107,6 +109,7 @@ export class PluginsPopUpsManager {
         win.once('closed', () => {
             log.debug('removing popup window', details.url, webContentsId);
             Reflect.deleteProperty(this.popups, webContentsId);
+            LocalNetworkAccessManager.unregisterWebContents(webContentsId);
             contextMenu.dispose();
         });
 

--- a/src/main/views/webContentEvents.test.js
+++ b/src/main/views/webContentEvents.test.js
@@ -7,6 +7,7 @@ import {shell, BrowserWindow, dialog} from 'electron';
 
 import {getLevel} from 'common/log';
 import ContextMenu from 'main/contextMenu';
+import LocalNetworkAccessManager from 'main/localNetworkAccess';
 import ViewManager from 'main/views/viewManager';
 
 import PluginsPopUpsManager from './pluginsPopUps';
@@ -43,6 +44,14 @@ jest.mock('main/views/viewManager', () => ({
 jest.mock('main/views/pluginsPopUps', () => ({
     handleNewWindow: jest.fn(() => ({action: 'allow'})),
     generateHandleCreateWindow: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('main/localNetworkAccess', () => ({
+    __esModule: true,
+    default: {
+        registerWebContents: jest.fn(),
+        unregisterWebContents: jest.fn(),
+    },
 }));
 
 jest.mock('../utils', () => ({
@@ -272,6 +281,7 @@ describe('main/views/webContentsEvents', () => {
         it('should open popup window for plugins', () => {
             expect(newWindow({url: 'http://server-1.com/plugins/myplugin/login'})).toStrictEqual({action: 'deny'});
             expect(webContentsEventManager.popupWindow).toBeTruthy();
+            expect(jest.mocked(LocalNetworkAccessManager.registerWebContents)).toHaveBeenCalled();
         });
 
         it('should open popup window for managed resources', () => {

--- a/src/main/views/webContentEvents.test.js
+++ b/src/main/views/webContentEvents.test.js
@@ -42,6 +42,7 @@ jest.mock('main/views/viewManager', () => ({
 
 jest.mock('main/views/pluginsPopUps', () => ({
     handleNewWindow: jest.fn(() => ({action: 'allow'})),
+    generateHandleCreateWindow: jest.fn(() => jest.fn()),
 }));
 
 jest.mock('../utils', () => ({
@@ -114,6 +115,72 @@ describe('main/views/webContentsEvents', () => {
         it('should not allow navigation under any other circumstances', () => {
             willNavigate(event, 'http://someotherurl.com');
             expect(event.preventDefault).toBeCalled();
+        });
+    });
+
+    describe('addWebContentsEventListeners', () => {
+        const setupContents = () => {
+            const handlers = {};
+            const contents = {
+                id: 1,
+                on: jest.fn((eventName, handler) => {
+                    handlers[eventName] = handler;
+                }),
+                once: jest.fn(),
+                removeListener: jest.fn(),
+                setWindowOpenHandler: jest.fn(),
+            };
+            return {handlers, contents};
+        };
+
+        it('should attach distinct main-frame and subframe navigation guards and remove both', () => {
+            const webContentsEventManager = new WebContentsEventManager();
+            const {handlers, contents} = setupContents();
+
+            webContentsEventManager.addWebContentsEventListeners(contents);
+
+            expect(contents.on).toHaveBeenCalledWith('will-navigate', expect.any(Function));
+            expect(contents.on).toHaveBeenCalledWith('will-frame-navigate', expect.any(Function));
+
+            // Distinct from will-navigate so a main-frame navigation is not processed twice.
+            expect(handlers['will-frame-navigate']).not.toBe(handlers['will-navigate']);
+
+            webContentsEventManager.removeWebContentsListeners(1);
+
+            expect(contents.removeListener).toHaveBeenCalledWith('will-navigate', handlers['will-navigate']);
+            expect(contents.removeListener).toHaveBeenCalledWith('will-frame-navigate', handlers['will-frame-navigate']);
+        });
+
+        it('subframe guard ignores main-frame navigations (handled by will-navigate)', () => {
+            const webContentsEventManager = new WebContentsEventManager();
+            const {handlers, contents} = setupContents();
+            webContentsEventManager.addWebContentsEventListeners(contents);
+
+            const frameEvent = {preventDefault: jest.fn(), isMainFrame: true, url: 'https://example.com/anything'};
+            handlers['will-frame-navigate'](frameEvent);
+
+            expect(frameEvent.preventDefault).not.toHaveBeenCalled();
+        });
+
+        it('subframe guard allows web embeds (http/https/about) but blocks other protocols', () => {
+            const webContentsEventManager = new WebContentsEventManager();
+            const {handlers, contents} = setupContents();
+            webContentsEventManager.addWebContentsEventListeners(contents);
+            const willFrameNavigate = handlers['will-frame-navigate'];
+
+            const allowed = ['https://www.youtube.com/embed/abc', 'http://example.com/widget', 'about:blank', 'about:srcdoc'];
+            allowed.forEach((url) => {
+                const ev = {preventDefault: jest.fn(), isMainFrame: false, url};
+                willFrameNavigate(ev);
+                expect(ev.preventDefault).not.toHaveBeenCalled();
+            });
+
+            const blocked = ['tel:+15551234', 'mailto:user@example.com', 'custom://payload', 'file:///etc/passwd'];
+            blocked.forEach((url) => {
+                const ev = {preventDefault: jest.fn(), isMainFrame: false, url};
+                willFrameNavigate(ev);
+                expect(ev.preventDefault).toHaveBeenCalled();
+            });
         });
     });
 

--- a/src/main/views/webContentEvents.ts
+++ b/src/main/views/webContentEvents.ts
@@ -24,6 +24,7 @@ import {
 } from 'common/utils/url';
 import ContextMenu from 'main/contextMenu';
 import {localizeMessage} from 'main/i18nManager';
+import LocalNetworkAccessManager from 'main/localNetworkAccess';
 import PluginsPopUpsManager from 'main/views/pluginsPopUps';
 import ViewManager from 'main/views/viewManager';
 import CallsWidgetWindow from 'main/windows/callsWidgetWindow';
@@ -233,6 +234,7 @@ export class WebContentsEventManager {
                     };
 
                     popup = this.popupWindow.win;
+                    LocalNetworkAccessManager.registerWebContents(popup.webContents);
                     popup.webContents.on('will-redirect', (event, url) => {
                         const parsedURL = parseURL(url);
                         if (!parsedURL) {
@@ -247,7 +249,9 @@ export class WebContentsEventManager {
                     popup.webContents.on('will-navigate', this.generateWillNavigate(popup.webContents.id));
                     popup.webContents.on('will-frame-navigate', this.generateWillFrameNavigate(popup.webContents.id));
                     popup.webContents.setWindowOpenHandler(this.denyNewWindow);
+                    const popupWebContentsId = popup.webContents.id;
                     popup.once('closed', () => {
+                        LocalNetworkAccessManager.unregisterWebContents(popupWebContentsId);
                         this.popupWindow = undefined;
                     });
 

--- a/src/main/views/webContentEvents.ts
+++ b/src/main/views/webContentEvents.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {WebContents, Event} from 'electron';
+import type {WebContents, Event, WebContentsWillFrameNavigateEventParams} from 'electron';
 import {BrowserWindow, dialog, shell} from 'electron';
 
 import Config from 'common/config';
@@ -29,7 +29,7 @@ import ViewManager from 'main/views/viewManager';
 import CallsWidgetWindow from 'main/windows/callsWidgetWindow';
 import MainWindow from 'main/windows/mainWindow';
 
-import {generateHandleConsoleMessage, isCustomProtocol, isMattermostProtocol} from './webContentEventsCommon';
+import {generateHandleConsoleMessage, isAllowedSubframeNavigation, isCustomProtocol, isMattermostProtocol} from './webContentEventsCommon';
 
 import allowProtocolDialog from '../allowProtocolDialog';
 import {composeUserAgent} from '../utils';
@@ -101,6 +101,23 @@ export class WebContentsEventManager {
             }
 
             this.log(webContentsId).info('Prevented desktop from navigating to external URL');
+            event.preventDefault();
+        };
+    };
+
+    private generateWillFrameNavigate = (webContentsId: number) => {
+        return (event: Event<WebContentsWillFrameNavigateEventParams>) => {
+            // will-frame-navigate also fires for the main frame; defer that to will-navigate
+            // so the policy (and any protocol dialog) does not run twice.
+            if (event.isMainFrame) {
+                return;
+            }
+
+            if (isAllowedSubframeNavigation(event.url)) {
+                return;
+            }
+
+            this.log(webContentsId).debug('Prevented subframe from navigating to a blocked protocol');
             event.preventDefault();
         };
     };
@@ -228,6 +245,7 @@ export class WebContentsEventManager {
                         }
                     });
                     popup.webContents.on('will-navigate', this.generateWillNavigate(popup.webContents.id));
+                    popup.webContents.on('will-frame-navigate', this.generateWillFrameNavigate(popup.webContents.id));
                     popup.webContents.setWindowOpenHandler(this.denyNewWindow);
                     popup.once('closed', () => {
                         this.popupWindow = undefined;
@@ -280,7 +298,9 @@ export class WebContentsEventManager {
         }
 
         const willNavigate = this.generateWillNavigate(contents.id);
+        const willFrameNavigate = this.generateWillFrameNavigate(contents.id);
         contents.on('will-navigate', willNavigate);
+        contents.on('will-frame-navigate', willFrameNavigate);
 
         const spellcheck = Config.useSpellChecker;
         const newWindow = this.generateNewWindowListener(contents.id, spellcheck);
@@ -298,6 +318,7 @@ export class WebContentsEventManager {
         const removeWebContentsListeners = () => {
             try {
                 contents.removeListener('will-navigate', willNavigate);
+                contents.removeListener('will-frame-navigate', willFrameNavigate);
                 contents.removeListener('console-message', consoleMessage);
                 removeListeners?.(contents);
             } catch (e) {

--- a/src/main/views/webContentEventsCommon.ts
+++ b/src/main/views/webContentEventsCommon.ts
@@ -44,6 +44,27 @@ export function isCustomProtocol(url: URL) {
     return url.protocol !== 'http:' && url.protocol !== 'https:' && url.protocol !== `${scheme}:`;
 }
 
+// Subframes only guard against custom protocols launching external handlers; loopback/private
+// access is handled by the session request filter (main/localNetworkAccess). Allowing
+// http(s) here keeps ordinary embeds (YouTube, plugin iframes) working.
+const ALLOWED_SUBFRAME_PROTOCOLS = new Set(['http:', 'https:']);
+
+// Protocol-less document URLs for programmatic and srcdoc iframes.
+const ALLOWED_SUBFRAME_URLS = new Set(['about:blank', 'about:srcdoc']);
+
+export function isAllowedSubframeNavigation(rawURL?: string): boolean {
+    if (!rawURL || ALLOWED_SUBFRAME_URLS.has(rawURL)) {
+        return true;
+    }
+
+    const parsedURL = parseURL(rawURL);
+    if (!parsedURL) {
+        return false;
+    }
+
+    return ALLOWED_SUBFRAME_PROTOCOLS.has(parsedURL.protocol);
+}
+
 export function isMattermostProtocol(url: URL) {
     const scheme = protocols && protocols[0] && protocols[0].schemes && protocols[0].schemes[0];
     return url.protocol === `${scheme}:`;

--- a/src/main/windows/callsWidgetWindow.test.js
+++ b/src/main/windows/callsWidgetWindow.test.js
@@ -336,6 +336,38 @@ describe('main/windows/callsWidgetWindow', () => {
         expect(callsWidgetWindow.win.webContents.send).toHaveBeenCalledWith(CALLS_WIDGET_SHARE_SCREEN, 'sourceId', true);
     });
 
+    describe('handleCallsLeave', () => {
+        const callsWidgetWindow = new CallsWidgetWindow();
+
+        beforeEach(() => {
+            callsWidgetWindow.close = jest.fn();
+            callsWidgetWindow.mainView = {webContentsId: 'mainViewID'};
+            callsWidgetWindow.win = {webContents: {id: 'widgetID'}, isDestroyed: () => false};
+            callsWidgetWindow.popOut = undefined;
+        });
+
+        afterEach(() => {
+            jest.clearAllMocks();
+            delete callsWidgetWindow.mainView;
+            delete callsWidgetWindow.win;
+        });
+
+        it('should not close when the sender is a different server', () => {
+            callsWidgetWindow.handleCallsLeave({sender: {id: 'otherServerID'}});
+            expect(callsWidgetWindow.close).not.toHaveBeenCalled();
+        });
+
+        it('should close when the sender is the calls widget', () => {
+            callsWidgetWindow.handleCallsLeave({sender: {id: 'widgetID'}});
+            expect(callsWidgetWindow.close).toHaveBeenCalled();
+        });
+
+        it('should close when the sender is the main view of the call', () => {
+            callsWidgetWindow.handleCallsLeave({sender: {id: 'mainViewID'}});
+            expect(callsWidgetWindow.close).toHaveBeenCalled();
+        });
+    });
+
     describe('onPopOutOpen', () => {
         const callsWidgetWindow = new CallsWidgetWindow();
 

--- a/src/main/windows/callsWidgetWindow.test.js
+++ b/src/main/windows/callsWidgetWindow.test.js
@@ -17,6 +17,7 @@ import {
     CALLS_PLUGIN_ID,
 } from 'common/utils/constants';
 import urlUtils from 'common/utils/url';
+import LocalNetworkAccessManager from 'main/localNetworkAccess';
 import PermissionsManager from 'main/permissionsManager';
 import {
     resetScreensharePermissionsMacOS,
@@ -73,6 +74,13 @@ jest.mock('app/serverViewState', () => ({
 jest.mock('main/performanceMonitor', () => ({
     registerView: jest.fn(),
     unregisterView: jest.fn(),
+}));
+jest.mock('main/localNetworkAccess', () => ({
+    __esModule: true,
+    default: {
+        registerWebContents: jest.fn(),
+        unregisterWebContents: jest.fn(),
+    },
 }));
 jest.mock('main/views/viewManager', () => ({
     getView: jest.fn(),
@@ -482,6 +490,7 @@ describe('main/windows/callsWidgetWindow', () => {
 
         expect(callsWidgetWindow.popOut).toBe(popOut);
         expect(WebContentsEventManager.addWebContentsEventListeners).toHaveBeenCalledWith(popOut.webContents);
+        expect(jest.mocked(LocalNetworkAccessManager.registerWebContents)).toHaveBeenCalledWith(popOut.webContents);
         expect(redirectListener).toBeDefined();
         expect(frameFinishedLoadListener).toBeDefined();
         expect(mockContextMenuReload).toHaveBeenCalledTimes(1);
@@ -495,6 +504,7 @@ describe('main/windows/callsWidgetWindow', () => {
 
         closedListener();
         expect(callsWidgetWindow.popOut).not.toBeDefined();
+        expect(jest.mocked(LocalNetworkAccessManager.unregisterWebContents)).toHaveBeenCalledWith('webContentsId');
         expect(mockContextMenuDispose).toHaveBeenCalled();
 
         // Verify widget visibility has been toggled

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -570,8 +570,13 @@ export class CallsWidgetWindow {
         return promise;
     };
 
-    private handleCallsLeave = () => {
+    private handleCallsLeave = (event: IpcMainEvent) => {
         log.debug('handleCallsLeave');
+
+        if (!this.isCallsWidget(event.sender.id) && this.mainView?.webContentsId !== event.sender.id) {
+            log.debug('handleCallsLeave', 'blocked on wrong webContentsId');
+            return;
+        }
 
         this.close();
     };

--- a/src/main/windows/callsWidgetWindow.ts
+++ b/src/main/windows/callsWidgetWindow.ts
@@ -30,6 +30,7 @@ import {getFormattedPathName, isCallsPopOutURL, parseURL} from 'common/utils/url
 import Utils from 'common/utils/util';
 import {desktopSourcesOptsSchema, ipcValidate, joinCallOptsSchema} from 'common/Validator';
 import {localizeMessage} from 'main/i18nManager';
+import LocalNetworkAccessManager from 'main/localNetworkAccess';
 import performanceMonitor from 'main/performanceMonitor';
 import PermissionsManager from 'main/permissionsManager';
 import {
@@ -58,6 +59,7 @@ export class CallsWidgetWindow {
     private options?: CallsWidgetWindowConfig;
     private missingScreensharePermissions?: boolean;
     private seenErrorMessage?: boolean;
+    private webContentsId?: number;
 
     private popOut?: BrowserWindow;
     private boundsErr: Rectangle = {
@@ -204,6 +206,8 @@ export class CallsWidgetWindow {
             return;
         }
         performanceMonitor.registerView('CallsWidgetWindow', this.win.webContents);
+        this.webContentsId = this.win.webContents.id;
+        LocalNetworkAccessManager.registerWebContents(this.win.webContents);
         this.win?.loadURL(widgetURL, {
             userAgent: composeUserAgent(),
         }).catch((reason) => {
@@ -253,6 +257,10 @@ export class CallsWidgetWindow {
 
     private onClosed = () => {
         ipcMain.emit(UPDATE_SHORTCUT_MENU);
+        if (this.webContentsId) {
+            LocalNetworkAccessManager.unregisterWebContents(this.webContentsId);
+            delete this.webContentsId;
+        }
         delete this.win;
         delete this.mainView;
         delete this.options;
@@ -343,6 +351,7 @@ export class CallsWidgetWindow {
 
         // Let the webContentsEventManager handle links that try to open a new window.
         webContentsEventManager.addWebContentsEventListeners(this.popOut.webContents);
+        LocalNetworkAccessManager.registerWebContents(this.popOut.webContents);
 
         // Need to capture and handle redirects for security.
         this.popOut.webContents.on('will-redirect', (event: Event) => {
@@ -357,8 +366,10 @@ export class CallsWidgetWindow {
         // Update menu to show the developer tools option for this window.
         ipcMain.emit(UPDATE_SHORTCUT_MENU);
 
+        const popOutWebContentsId = win.webContents.id;
         this.popOut.on('closed', () => {
             ipcMain.emit(UPDATE_SHORTCUT_MENU);
+            LocalNetworkAccessManager.unregisterWebContents(popOutWebContentsId);
             delete this.popOut;
             contextMenu.dispose();
             this.setWidgetWindowStacking({onTop: true});


### PR DESCRIPTION
#### Summary
Backports the following PRs to `release-5.13`:

- [#3884](https://github.com/mattermost/desktop/pull/3884) - [MM-69253] Restrict call leave to the view that created it and the widget
- [#3872](https://github.com/mattermost/desktop/pull/3872) - [MM-69421] Scope server view network requests by origin and handle subframe navigation
- [#3951](https://github.com/mattermost/desktop/pull/3951) - [MM-70249] Validate SiteURL from remote config before constructing URLs
- [#3978](https://github.com/mattermost/desktop/pull/3978) - [MM-70566] Enforce local network access restrictions on all web contents

#### Release Note
```release-note
NONE
```

[MM-69253]: https://mattermost.atlassian.net/browse/MM-69253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MM-69421]: https://mattermost.atlassian.net/browse/MM-69421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MM-70249]: https://mattermost.atlassian.net/browse/MM-70249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MM-70566]: https://mattermost.atlassian.net/browse/MM-70566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟠 Medium

**Regression Risk:** Changes affect shared request filtering, navigation handling, server URL validation, and calls-widget lifecycle behavior. Automated coverage is broad, but the changes span multiple user-facing flows.

**QA Recommendation:** Manual QA can be skipped because automated coverage is comprehensive and rollback is straightforward.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->